### PR TITLE
Set `SelectInput` value to `null` if it was `undefined`

### DIFF
--- a/src/components/inputs/select-input/select-input.js
+++ b/src/components/inputs/select-input/select-input.js
@@ -70,14 +70,23 @@ export class SelectInput extends React.Component {
       option => (has(option, 'value') ? option : option.options)
     );
 
+    const selectedOptions = optionsWithoutGroups.filter(
+      option =>
+        props.isMulti
+          ? props.value.includes(option.value)
+          : has(option, 'value') && option.value === props.value
+    );
+
+    // We default to null, `type ValueType = OptionType | OptionsType | null | void`
+    /**
+     * we default to null
+     * > type ValueType = OptionType | OptionsType | null | void
+     * https://react-select.com/props#prop-types
+     */
     return {
       selectedOptions: props.isMulti
-        ? optionsWithoutGroups.filter(option =>
-            props.value.includes(option.value)
-          )
-        : optionsWithoutGroups.find(
-            option => has(option, 'value') && option.value === props.value
-          ),
+        ? selectedOptions
+        : selectedOptions[0] || null,
     };
   };
 

--- a/src/components/inputs/select-input/select-input.spec.js
+++ b/src/components/inputs/select-input/select-input.spec.js
@@ -61,6 +61,15 @@ describe('overwritten props', () => {
         });
       });
     });
+    describe('when value is `undefined`', () => {
+      beforeEach(() => {
+        props = createTestProps({ value: undefined });
+        wrapper = shallow(<SelectInput {...props} />);
+      });
+      it('should set `Select` value to null', () => {
+        expect(wrapper.find(Select)).toHaveProp('value', null);
+      });
+    });
   });
   describe('when in multi-value mode', () => {
     let wrapper;


### PR DESCRIPTION
fixes https://github.com/commercetools/ui-kit/issues/11

According to React select docs https://react-select.com/props#prop-types
> type ValueType = OptionType | OptionsType | null | void

In this PR we default the value to `null` if `value`  was not available.

To reproduce 
https://codesandbox.io/s/0ozvz9vvvl