### PR TITLE
chore: move dependancies to peer and dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,13 +42,8 @@
     "lodash.sortby": "4.7.0",
     "lodash.uniq": "4.5.0",
     "lodash.without": "4.4.0",
-    "moment": "2.22.2",
-    "moment-timezone": "0.5.21",
     "prop-types": "15.6.2",
-    "react": "16.4.2",
-    "react-intl": "2.4.0",
     "react-required-if": "1.0.3",
-    "react-router-dom": "4.3.1",
     "react-select": "2.0.0",
     "react-textarea-autosize": "7.0.2",
     "react-virtualized": "9.20.0",
@@ -88,10 +83,15 @@
     "lodash.mapvalues": "4.6.0",
     "lodash.upperfirst": "4.3.1",
     "markdown-loader": "3.0.0",
+    "moment": "2.22.2",
+    "moment-timezone": "0.5.21",
     "omit-empty": "0.4.1",
     "prettier": "1.14.2",
     "rcfile": "1.0.3",
+    "react": "16.4.2",
     "react-dom": "16.4.2",
+    "react-intl": "2.4.0",
+    "react-router-dom": "4.3.1",
     "react-value": "0.2.0",
     "storybook-readme": "4.0.0-beta1",
     "stylelint": "9.5.0",
@@ -99,5 +99,13 @@
     "stylelint-order": "0.8.1",
     "svg-url-loader": "2.3.2",
     "url-loader": "1.1.1"
+  },
+  "peerDependencies": {
+    "moment": ">2.2",
+    "moment-timezone": "^0.5",
+    "react": ">=16",
+    "react-dom": ">=16",
+    "react-intl": ">=2",
+    "react-router-dom": ">=4"
   }
 }


### PR DESCRIPTION
#### Summary

If we have too many big dependancies, our bundle size will be very big. This PR aims to start this movement by moving some "easy decision" deps to peer and dev.

Feel free to suggest others that could follow similar treatment.