### PR TITLE
Add `isItalic` to `Text.Detail` and `Text.Body`

### DIFF
--- a/src/components/typography/text/README.md
+++ b/src/components/typography/text/README.md
@@ -45,7 +45,7 @@ Wraps the given text in the given HTML header `size`.
 | Props         | Type             | Required | Values         | Default |
 | ------------- | ---------------- | :------: | -------------- | ------- |
 | `elementType` | `String`         |    ✅    | `['h4', 'h5']` |         |
-| `isBold`      | `Boolean`        |    ✅    |                | `false` |
+| `isBold`      | `Boolean`        |          |                | `false` |
 | `children`    | `PropTypes.node` |    ✅    |                |         |
 | `truncate`    | `Bool`           |          | -              | `false` |
 
@@ -81,7 +81,8 @@ Wraps the given text in a `<p>` element, for normal content.
 
 | Props      | Type             | Required | Values                                               | Default |
 | ---------- | ---------------- | :------: | ---------------------------------------------------- | ------- |
-| `isBold`   | `Boolean`        |    ✅    |                                                      | `false` |
+| `isBold`   | `Boolean`        |          |                                                      | `false` |
+| `isItalic` | `Boolean`        |          |                                                      | `false` |
 | `tone`     | `String`         |          | `[''primary', 'secondary', 'positive', 'negative'']` |         |
 | `children` | `PropTypes.node` |    ✅    |                                                      |         |
 | `truncate` | `Bool`           |          | -                                                    | `false` |
@@ -106,7 +107,8 @@ properly style the text.
 
 | Props      | Type             | Required | Values                                                                      | Default |
 | ---------- | ---------------- | :------: | --------------------------------------------------------------------------- | ------- |
-| `isBold`   | `Boolean`        |    ✅    |                                                                             | `false` |
+| `isBold`   | `Boolean`        |          |                                                                             | `false` |
+| `isItalic` | `Boolean`        |          |                                                                             | `false` |
 | `tone`     | `String`         |          | `[''primary', 'secondary', 'positive', 'negative', 'inverted', 'warning'']` |         |
 | `children` | `PropTypes.node` |    ✅    |                                                                             |         |
 | `truncate` | `Bool`           |          | -                                                                           | `false` |

--- a/src/components/typography/text/README.md
+++ b/src/components/typography/text/README.md
@@ -24,7 +24,7 @@ Wraps the given text in the given HTML header `size`.
 | ------------- | ---------------- | :------: | -------------------- | ------- | -------------------------------------------------------------- |
 | `elementType` | `String`         |    ✅    | `['h1', 'h2', 'h3']` | -       | -                                                              |
 | `children`    | `PropTypes.node` |    ✅    | -                    | -       | -                                                              |
-| `truncate`    | `Bool`           |          | -                    | `false` | Option for truncate content in case the screen has small width |
+| `truncate`    | `Bool`           |    -     | -                    | `false` | Option for truncate content in case the screen has small width |
 
 #### Where to use
 
@@ -44,10 +44,10 @@ Wraps the given text in the given HTML header `size`.
 
 | Props         | Type             | Required | Values         | Default |
 | ------------- | ---------------- | :------: | -------------- | ------- |
-| `elementType` | `String`         |    ✅    | `['h4', 'h5']` |         |
-| `isBold`      | `Boolean`        |          |                | `false` |
-| `children`    | `PropTypes.node` |    ✅    |                |         |
-| `truncate`    | `Bool`           |          | -              | `false` |
+| `elementType` | `String`         |    ✅    | `['h4', 'h5']` | -       |
+| `isBold`      | `Boolean`        |    -     | -              | `false` |
+| `children`    | `PropTypes.node` |    ✅    | -              | -       |
+| `truncate`    | `Bool`           |    -     | -              | `false` |
 
 #### Where to use
 
@@ -81,11 +81,11 @@ Wraps the given text in a `<p>` element, for normal content.
 
 | Props      | Type             | Required | Values                                               | Default |
 | ---------- | ---------------- | :------: | ---------------------------------------------------- | ------- |
-| `isBold`   | `Boolean`        |          |                                                      | `false` |
-| `isItalic` | `Boolean`        |          |                                                      | `false` |
-| `tone`     | `String`         |          | `[''primary', 'secondary', 'positive', 'negative'']` |         |
-| `children` | `PropTypes.node` |    ✅    |                                                      |         |
-| `truncate` | `Bool`           |          | -                                                    | `false` |
+| `isBold`   | `Boolean`        |    -     | -                                                    | `false` |
+| `isItalic` | `Boolean`        |    -     | -                                                    | `false` |
+| `tone`     | `String`         |    -     | `[''primary', 'secondary', 'positive', 'negative'']` | -       |
+| `children` | `PropTypes.node` |    ✅    | -                                                    | -       |
+| `truncate` | `Bool`           |    -     | -                                                    | `false` |
 
 #### Where to use
 
@@ -107,11 +107,11 @@ properly style the text.
 
 | Props      | Type             | Required | Values                                                                      | Default |
 | ---------- | ---------------- | :------: | --------------------------------------------------------------------------- | ------- |
-| `isBold`   | `Boolean`        |          |                                                                             | `false` |
-| `isItalic` | `Boolean`        |          |                                                                             | `false` |
-| `tone`     | `String`         |          | `[''primary', 'secondary', 'positive', 'negative', 'inverted', 'warning'']` |         |
-| `children` | `PropTypes.node` |    ✅    |                                                                             |         |
-| `truncate` | `Bool`           |          | -                                                                           | `false` |
+| `isBold`   | `Boolean`        |    -     | -                                                                           | `false` |
+| `isItalic` | `Boolean`        |    -     | -                                                                           | `false` |
+| `tone`     | `String`         |    -     | `[''primary', 'secondary', 'positive', 'negative', 'inverted', 'warning'']` | -       |
+| `children` | `PropTypes.node` |    ✅    | -                                                                           | -       |
+| `truncate` | `Bool`           |    -     | -                                                                           | `false` |
 
 #### Where to use
 

--- a/src/components/typography/text/README.md
+++ b/src/components/typography/text/README.md
@@ -79,13 +79,13 @@ Wraps the given text in a `<p>` element, for normal content.
 
 #### Properties
 
-| Props      | Type             | Required | Values                                               | Default |
-| ---------- | ---------------- | :------: | ---------------------------------------------------- | ------- |
-| `isBold`   | `Boolean`        |    -     | -                                                    | `false` |
-| `isItalic` | `Boolean`        |    -     | -                                                    | `false` |
-| `tone`     | `String`         |    -     | `[''primary', 'secondary', 'positive', 'negative'']` | -       |
-| `children` | `PropTypes.node` |    ✅    | -                                                    | -       |
-| `truncate` | `Bool`           |    -     | -                                                    | `false` |
+| Props      | Type             | Required | Values                                             | Default |
+| ---------- | ---------------- | :------: | -------------------------------------------------- | ------- |
+| `isBold`   | `Boolean`        |    -     | -                                                  | `false` |
+| `isItalic` | `Boolean`        |    -     | -                                                  | `false` |
+| `tone`     | `String`         |    -     | `['primary', 'secondary', 'positive', 'negative']` | -       |
+| `children` | `PropTypes.node` |    ✅    | -                                                  | -       |
+| `truncate` | `Bool`           |    -     | -                                                  | `false` |
 
 #### Where to use
 
@@ -105,13 +105,13 @@ properly style the text.
 
 #### Properties
 
-| Props      | Type             | Required | Values                                                                      | Default |
-| ---------- | ---------------- | :------: | --------------------------------------------------------------------------- | ------- |
-| `isBold`   | `Boolean`        |    -     | -                                                                           | `false` |
-| `isItalic` | `Boolean`        |    -     | -                                                                           | `false` |
-| `tone`     | `String`         |    -     | `[''primary', 'secondary', 'positive', 'negative', 'inverted', 'warning'']` | -       |
-| `children` | `PropTypes.node` |    ✅    | -                                                                           | -       |
-| `truncate` | `Bool`           |    -     | -                                                                           | `false` |
+| Props      | Type             | Required | Values                                                                     | Default |
+| ---------- | ---------------- | :------: | -------------------------------------------------------------------------- | ------- |
+| `isBold`   | `Boolean`        |    -     | -                                                                          | `false` |
+| `isItalic` | `Boolean`        |    -     | -                                                                          | `false` |
+| `tone`     | `String`         |    -     | `['primary', 'secondary', 'positive', 'negative', 'inverted', 'warning'']` | -       |
+| `children` | `PropTypes.node` |    ✅    | -                                                                          | -       |
+| `truncate` | `Bool`           |    -     | -                                                                          | `false` |
 
 #### Where to use
 

--- a/src/components/typography/text/text.js
+++ b/src/components/typography/text/text.js
@@ -62,6 +62,7 @@ const Body = props =>
     <span
       className={classnames(styles['body-text'], {
         [styles.bold]: props.isBold,
+        [styles.italic]: props.isItalic,
         [styles[`${props.tone}`]]: props.tone,
         [styles.truncate]: props.truncate,
       })}
@@ -72,6 +73,7 @@ const Body = props =>
     <p
       className={classnames(styles['body-text'], {
         [styles.bold]: props.isBold,
+        [styles.italic]: props.isItalic,
         [styles[`${props.tone}`]]: props.tone,
         [styles.truncate]: props.truncate,
       })}
@@ -82,6 +84,7 @@ const Body = props =>
 Body.displayName = 'TextBody';
 Body.propTypes = {
   isBold: PropTypes.bool,
+  isItalic: PropTypes.bool,
   isInline: PropTypes.bool,
   tone: PropTypes.oneOf([
     'primary',
@@ -99,6 +102,7 @@ const Detail = props => (
   <small
     className={classnames({
       [styles.bold]: props.isBold,
+      [styles.italic]: props.isItalic,
       [styles.inline]: props.isInline,
       [styles[`${props.tone}`]]: props.tone,
       [styles.truncate]: props.truncate,
@@ -110,6 +114,7 @@ const Detail = props => (
 Detail.displayName = 'TextDetail';
 Detail.propTypes = {
   isBold: PropTypes.bool,
+  isItalic: PropTypes.bool,
   isInline: PropTypes.bool,
   tone: PropTypes.oneOf([
     'primary',

--- a/src/components/typography/text/text.mod.css
+++ b/src/components/typography/text/text.mod.css
@@ -75,6 +75,10 @@ small {
   font-weight: bold;
 }
 
+.italic {
+  font-style: italic;
+}
+
 .information {
   color: var(--color-blue);
 }

--- a/src/components/typography/text/text.spec.js
+++ b/src/components/typography/text/text.spec.js
@@ -171,6 +171,20 @@ describe('<Body>', () => {
         expect(wrapper.text()).toMatch('Body');
       });
     });
+    describe('with italic text', () => {
+      beforeEach(() => {
+        wrapper = shallow(<Text.Body isItalic={true}>{'Body'}</Text.Body>);
+      });
+      it('should render element tag p', () => {
+        expect(wrapper.type()).toBe('p');
+      });
+      it('should have "italic" class', () => {
+        expect(wrapper).toContainClass(styles.italic);
+      });
+      it('should render given text', () => {
+        expect(wrapper.text()).toMatch('Body');
+      });
+    });
     describe('with tone', () => {
       beforeEach(() => {
         wrapper = shallow(<Text.Body tone="secondary">{'Detail'}</Text.Body>);
@@ -281,7 +295,22 @@ describe('<Detail>', () => {
         expect(wrapper).toHaveText('Detail');
       });
     });
-
+    describe('with italic text', () => {
+      beforeEach(() => {
+        wrapper = shallow(
+          <Text.Detail isItalic={true}>{'Detail'}</Text.Detail>
+        );
+      });
+      it('should render element tag small', () => {
+        expect(wrapper.type()).toBe('small');
+      });
+      it('should have "italic" class', () => {
+        expect(wrapper).toContainClass(styles.italic);
+      });
+      it('should render given text', () => {
+        expect(wrapper).toHaveText('Detail');
+      });
+    });
     describe('with tone', () => {
       beforeEach(() => {
         wrapper = shallow(

--- a/src/components/typography/typography.story.js
+++ b/src/components/typography/typography.story.js
@@ -21,7 +21,7 @@ storiesOf('Typography/Text', module)
         elementType={select('Element type', ['h1', 'h2', 'h3'], 'h1')}
         truncate={boolean('truncate', false)}
       >
-        {text('Text', 'Sample text <Headline>')}
+        {text('Text', 'Sample text Headline')}
       </Text.Headline>
     </Section>
   ))
@@ -40,7 +40,7 @@ storiesOf('Typography/Text', module)
         ])}
         truncate={boolean('truncate', false)}
       >
-        {text('Text', 'Sample text <Subheadline>')}
+        {text('Text', 'Sample text Subheadline')}
       </Text.Subheadline>
     </Section>
   ))
@@ -72,7 +72,7 @@ storiesOf('Typography/Text', module)
         ])}
         truncate={boolean('truncate', false)}
       >
-        {text('Text', 'Sample text <Body>')}
+        {text('Text', 'Sample text Body')}
       </Text.Body>
     </Section>
   ))
@@ -92,7 +92,7 @@ storiesOf('Typography/Text', module)
         ])}
         truncate={boolean('truncate', false)}
       >
-        {text('Text', 'Sample text')}
+        {text('Text', 'Sample text Detail')}
       </Text.Detail>
     </Section>
   ));

--- a/src/components/typography/typography.story.js
+++ b/src/components/typography/typography.story.js
@@ -60,6 +60,7 @@ storiesOf('Typography/Text', module)
     <Section>
       <Text.Body
         isBold={boolean('bold', false)}
+        isItalic={boolean('italic', false)}
         tone={select('Text tone', [
           'none',
           'primary',
@@ -79,6 +80,7 @@ storiesOf('Typography/Text', module)
     <Section>
       <Text.Detail
         isBold={boolean('bold', false)}
+        isItalic={boolean('italic', false)}
         tone={select('Text tone', [
           'none',
           'primary',


### PR DESCRIPTION
This pull request adds the ability to specify an `isItalic` prop on our `Text.Detail` and `Text.Body` component. Sometime a recent design requires. 

![2018-09-05 16 12 41](https://user-images.githubusercontent.com/1877073/45099247-1e00a600-b127-11e8-82a2-0ca5f63b392b.gif)

I don't anticipate headings having a need for italic text soon.

In the mean time I fixed the default messages which got escaped (since a recent version of React storybook).