### PR TITLE
Add bundling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ typings/
 
 # Netlify
 netlify.toml
+
+# Build
+dist

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -33,9 +33,6 @@ module.exports = (storybookBaseConfig, configType) => {
         // improves compile time on larger projects
         Object.assign(
           {},
-          {
-            loader: require.resolve('thread-loader'),
-          },
           // Keep workers alive only for development mode
           configType === 'PRODUCTION'
             ? {}

--- a/package.json
+++ b/package.json
@@ -7,15 +7,17 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "src/index.js",
+  "main": "index.js",
   "scripts": {
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "precommit": "lint-staged",
     "prepublish": "node ./scripts/generate-icon-exports.js",
-    "prebuild": "node ./scripts/generate-base-colors.js && node ./scripts/generate-base-shadows.js && node ./scripts/generate-colors-for-story.js",
-    "prestart": "node ./scripts/generate-base-colors.js && node ./scripts/generate-base-shadows.js && node ./scripts/generate-colors-for-story.js",
-    "build": "build-storybook -o .public",
-    "start": "start-storybook -p 9002",
+    "prestorybook:build": "node ./scripts/generate-base-colors.js && node ./scripts/generate-base-shadows.js && node ./scripts/generate-colors-for-story.js",
+    "prestorybook:start": "node ./scripts/generate-base-colors.js && node ./scripts/generate-base-shadows.js && node ./scripts/generate-colors-for-story.js",
+    "build": "NODE_ENV=production webpack --config webpack.config.js",
+    "start": "yarn storybook:start",
+    "storybook:start": "start-storybook -p 9002",
+    "storybook:build": "build-storybook -o .public",
     "i18n:build": "mc-scripts extract-intl --build-translations --output-path=$(pwd)/i18n 'src/components/**/!(*.spec).js'",
     "lint": "jest --projects jest.eslint.config.js jest.stylelint.config.js",
     "lint:js": "jest --config jest.eslint.config.js",
@@ -67,7 +69,9 @@
     "@svgr/webpack": "2.2.1",
     "babel-loader": "8.0.2",
     "browserslist": "4.0.2",
+    "clean-webpack-plugin": "0.1.19",
     "common-tags": "1.8.0",
+    "copy-webpack-plugin": "4.5.2",
     "css": "2.2.3",
     "css-loader": "1.0.0",
     "enzyme": "3.5.0",
@@ -88,6 +92,7 @@
     "moment": "2.22.2",
     "moment-timezone": "0.5.21",
     "omit-empty": "0.4.1",
+    "peer-deps-externals-webpack-plugin": "1.0.4",
     "postcss": "7.0.2",
     "postcss-color-mod-function": "2.4.3",
     "postcss-import": "12.0.0",
@@ -108,8 +113,8 @@
     "stylelint-config-standard": "17.0.0",
     "stylelint-order": "0.8.1",
     "svg-url-loader": "2.3.2",
-    "thread-loader": "1.2.0",
-    "url-loader": "1.1.1"
+    "url-loader": "1.1.1",
+    "webpack-cli": "3.1.0"
   },
   "peerDependencies": {
     "moment": ">2.2",

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as filterDataAttributes } from './filter-data-attributes';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,233 @@
+const path = require('path');
+const CleanWebpackPlugin = require('clean-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const PeerDepsExternalsPlugin = require('peer-deps-externals-webpack-plugin');
+const postcssImport = require('postcss-import');
+const postcssPresetEnv = require('postcss-preset-env');
+const postcssReporter = require('postcss-reporter');
+const postcssCustomProperties = require('postcss-custom-properties');
+const postcssCustomMediaQueries = require('postcss-custom-media');
+const postcssPostcssColorModFunction = require('postcss-color-mod-function');
+
+const browserslist = {
+  development: ['chrome', 'firefox'].map(
+    browser => `last 2 ${browser} versions`
+  ),
+  production: ['>1%', 'not op_mini all', 'ie 11'],
+};
+
+const sourceFolders = [
+  path.resolve(__dirname),
+  path.resolve(__dirname, '../examples'),
+  path.resolve(__dirname, '../src'),
+];
+
+module.exports = {
+  entry: {
+    main: './src/index.js',
+    utils: './src/utils/index.js',
+  },
+  mode: 'production',
+  output: {
+    path: path.join(__dirname, 'dist'),
+    library: 'McUiKit',
+    libraryTarget: 'umd',
+    filename: chunkData =>
+      chunkData.chunk.name === 'main' ? 'index.js' : '[name]/index.js',
+  },
+  devtool: 'source-map',
+  plugins: [
+    new CleanWebpackPlugin(['dist']),
+    // We copy everything we want to be in the bundle to "dist",
+    // as we publish from "dist".
+    //
+    // We do this to enable consumers to import without having "lib"
+    // in the path, and to avoid having to bundle onto the main folder.
+    //
+    // This is also why the "main" field in package.json says
+    // "index.js" instead of "dist/index.js", as package.json gets copied
+    // to "dist" as well.
+    new CopyWebpackPlugin([
+      { from: './package.json' },
+      { from: './README.md' },
+    ]),
+    // Adds peerDependencies as externals
+    // See: https://webpack.js.org/guides/author-libraries/#externalize-lodash
+    new PeerDepsExternalsPlugin(),
+  ],
+  module: {
+    rules: [
+      // Disable require.ensure as it's not a standard language feature.
+      { parser: { requireEnsure: false } },
+      // Process JS with Babel.
+      {
+        test: /\.js$/,
+        include: sourceFolders,
+        use: [
+          {
+            loader: require.resolve('babel-loader'),
+            options: {
+              babelrc: false,
+              compact: false,
+              presets: [
+                require.resolve('@commercetools-frontend/babel-preset-mc-app'),
+              ],
+              // This is a feature of `babel-loader` for webpack (not Babel itself).
+              // It enables caching results in ./node_modules/.cache/babel-loader/
+              // directory for faster rebuilds.
+              cacheDirectory: true,
+              highlightCode: true,
+            },
+          },
+        ],
+      },
+      // For svg icons, we want to get them transformed into React components
+      // when we import them.
+      {
+        test: /\.react\.svg$/,
+        include: sourceFolders,
+        use: [
+          {
+            loader: require.resolve('babel-loader'),
+            options: {
+              babelrc: false,
+              presets: [
+                require.resolve('@commercetools-frontend/babel-preset-mc-app'),
+              ],
+              // This is a feature of `babel-loader` for webpack (not Babel itself).
+              // It enables caching results in ./node_modules/.cache/babel-loader/
+              // directory for faster rebuilds.
+              cacheDirectory: true,
+              highlightCode: true,
+            },
+          },
+          {
+            loader: require.resolve('@svgr/webpack'),
+            options: {
+              // NOTE: disable this and manually add `removeViewBox: false` in the SVGO plugins list
+              // See related PR: https://github.com/smooth-code/svgr/pull/137
+              icon: false,
+              svgoConfig: {
+                plugins: [
+                  { removeViewBox: false },
+                  // Keeps ID's of svgs so they can be targeted with CSS
+                  { cleanupIDs: false },
+                ],
+              },
+            },
+          },
+        ],
+      },
+      // For normal svg files (not icons) we should load the file normally
+      // and simply use it as a `<img src/>`.
+      {
+        test: function testForNormalSvgFiles(fileName) {
+          return (
+            // Use this only for plain SVG.
+            // For SVG as React components, see loader above.
+            fileName.endsWith('.svg') && !fileName.endsWith('.react.svg')
+          );
+        },
+        use: [
+          {
+            loader: require.resolve('svg-url-loader'),
+            options: { noquotes: true },
+          },
+        ],
+      },
+      // "url" loader works like "file" loader except that it embeds assets
+      // smaller than specified limit in bytes as data URLs to avoid requests.
+      // A missing `test` is equivalent to a match.
+      {
+        test: /\.png$/,
+        use: [require.resolve('url-loader')],
+      },
+      // "postcss" loader applies autoprefixer to our CSS
+      // "css" loader resolves paths in CSS and adds assets as dependencies.
+      // "style" loader turns CSS into JS modules that inject <style> tags.
+      {
+        test: /\.mod\.css$/,
+        include: sourceFolders,
+        use: [
+          require.resolve('style-loader'),
+          {
+            loader: require.resolve('css-loader'),
+            options: {
+              modules: true,
+              importLoaders: 1,
+              localIdentName: '[name]__[local]___[hash:base64:5]',
+            },
+          },
+          {
+            loader: require.resolve('postcss-loader'),
+            options: {
+              ident: 'postcss',
+              plugins: () => [
+                postcssImport({ path: sourceFolders }),
+                postcssPresetEnv({
+                  browsers: browserslist.development,
+                  autoprefixer: { grid: true },
+                }),
+                postcssCustomProperties({
+                  preserve: false,
+                }),
+                postcssCustomMediaQueries(),
+                postcssPostcssColorModFunction(),
+                postcssReporter(),
+              ],
+            },
+          },
+        ],
+      },
+      {
+        test: function testForNormalCssFiles(fileName) {
+          return (
+            // Use this only for plain CSS.
+            // For css-modules, see loader above.
+            fileName.endsWith('.css') && !fileName.endsWith('.mod.css')
+          );
+        },
+        // "postcss" loader applies autoprefixer to our CSS.
+        // "css" loader resolves paths in CSS and adds assets as dependencies.
+        // "style" loader turns CSS into JS modules that inject <style> tags.
+        oneOf: [
+          {
+            // Use "postcss" for all the included source folders.
+            include: sourceFolders,
+            use: [
+              require.resolve('style-loader'),
+              require.resolve('css-loader'),
+              {
+                loader: require.resolve('postcss-loader'),
+                options: {
+                  ident: 'postcss',
+                  plugins: () => [
+                    postcssImport(),
+                    postcssPresetEnv({
+                      browsers: browserslist.development,
+                      autoprefixer: { grid: true },
+                    }),
+                    postcssCustomProperties({
+                      preserve: false,
+                    }),
+                    postcssCustomMediaQueries(),
+                    postcssPostcssColorModFunction(),
+                    postcssReporter(),
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            // For all other vendor CSS, do not use "postcss" loader.
+            include: /node_modules/,
+            loaders: [
+              require.resolve('style-loader'),
+              require.resolve('css-loader'),
+            ],
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1892,7 +1892,7 @@ async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.4, async@^2.3.0:
+async@^2.1.4:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
   dependencies:
@@ -2792,6 +2792,10 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+
 cheerio@^1.0.0-rc.2:
   version "1.0.0-rc.2"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
@@ -2870,30 +2874,12 @@ clean-css@4.2.x:
   dependencies:
     source-map "~0.6.0"
 
-<<<<<<< HEAD
 clean-webpack-plugin@0.1.19:
   version "0.1.19"
   resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-0.1.19.tgz#ceda8bb96b00fe168e9b080272960d20fdcadd6d"
   dependencies:
     rimraf "^2.6.1"
 
-||||||| merged common ancestors
-clean-webpack-plugin@0.1.19:
-  version "0.1.19"
-  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-0.1.19.tgz#ceda8bb96b00fe168e9b080272960d20fdcadd6d"
-  dependencies:
-    rimraf "^2.6.1"
-
-cleave.js@1.3.8:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/cleave.js/-/cleave.js-1.3.8.tgz#871b7745039e025f7dc4120e1f5a026a7ba99c90"
-
-=======
-cleave.js@1.3.8:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/cleave.js/-/cleave.js-1.3.8.tgz#871b7745039e025f7dc4120e1f5a026a7ba99c90"
-
->>>>>>> refactor(storybook): use own webpack config, explicitly transpile color-mod. Fixes #16
 cli-cursor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
@@ -3162,6 +3148,19 @@ copy-to-clipboard@^3.0.8:
   resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.0.8.tgz#f4e82f4a8830dce4666b7eb8ded0c9bcc313aba9"
   dependencies:
     toggle-selection "^1.0.3"
+
+copy-webpack-plugin@4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-4.5.2.tgz#d53444a8fea2912d806e78937390ddd7e632ee5c"
+  dependencies:
+    cacache "^10.0.4"
+    find-cache-dir "^1.0.0"
+    globby "^7.1.1"
+    is-glob "^4.0.0"
+    loader-utils "^1.1.0"
+    minimatch "^3.0.4"
+    p-limit "^1.0.0"
+    serialize-javascript "^1.4.0"
 
 core-js@2.5.7, core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
   version "2.5.7"
@@ -3512,6 +3511,12 @@ decamelize@^1.0.0, decamelize@^1.1.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+decamelize@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-2.0.0.tgz#656d7bbc8094c4c788ea53c5840908c9c7d063c7"
+  dependencies:
+    xregexp "4.0.0"
+
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
@@ -3846,7 +3851,7 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@^4.1.0:
+enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz#41c7e0bfdfe74ac1ffe1e57ad6a5c6c9f3742a7f"
   dependencies:
@@ -4418,6 +4423,14 @@ external-editor@^2.0.4, external-editor@^2.1.0:
     iconv-lite "^0.4.17"
     tmp "^0.0.33"
 
+external-editor@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -4886,6 +4899,10 @@ global-dirs@^0.1.0:
   dependencies:
     ini "^1.3.4"
 
+global-modules-path@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/global-modules-path/-/global-modules-path-2.3.0.tgz#b0e2bac6beac39745f7db5c59d26a36a0b94f7dc"
+
 global-modules@1.0.0, global-modules@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
@@ -4942,7 +4959,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-globby@^7.0.0:
+globby@^7.0.0, globby@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
   dependencies:
@@ -5277,7 +5294,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   dependencies:
@@ -5441,6 +5458,24 @@ inquirer@^5.2.0:
     mute-stream "0.0.7"
     run-async "^2.2.0"
     rxjs "^5.5.2"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^6.0.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.0.tgz#51adcd776f661369dc1e894859c2560a224abdd8"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.0"
+    figures "^2.0.0"
+    lodash "^4.17.10"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.1.0"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
@@ -7688,7 +7723,7 @@ p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
-p-limit@^1.1.0:
+p-limit@^1.0.0, p-limit@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
   dependencies:
@@ -7878,6 +7913,10 @@ pbkdf2@^3.0.3:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+peer-deps-externals-webpack-plugin@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/peer-deps-externals-webpack-plugin/-/peer-deps-externals-webpack-plugin-1.0.4.tgz#191e8f116c70401364dbd8e6c44ab3f8844101dc"
 
 pegjs-jest@0.0.2:
   version "0.0.2"
@@ -10329,14 +10368,6 @@ text-table@0.2.0, text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
-thread-loader@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/thread-loader/-/thread-loader-1.2.0.tgz#35dedb23cf294afbbce6c45c1339b950ed17e7a4"
-  dependencies:
-    async "^2.3.0"
-    loader-runner "^2.3.0"
-    loader-utils "^1.1.0"
-
 throat@4.1.0, throat@^4.0.0, throat@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
@@ -10738,6 +10769,10 @@ uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
+v8-compile-cache@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz#a428b28bb26790734c4fc8bc9fa106fccebf6a6c"
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -10841,6 +10876,22 @@ watchpack@^1.5.0:
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+
+webpack-cli@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.1.0.tgz#d71a83687dcfeb758fdceeb0fe042f96bcf62994"
+  dependencies:
+    chalk "^2.4.1"
+    cross-spawn "^6.0.5"
+    enhanced-resolve "^4.0.0"
+    global-modules-path "^2.1.0"
+    import-local "^1.0.0"
+    inquirer "^6.0.0"
+    interpret "^1.1.0"
+    loader-utils "^1.1.0"
+    supports-color "^5.4.0"
+    v8-compile-cache "^2.0.0"
+    yargs "^12.0.1"
 
 webpack-dev-middleware@^3.2.0:
   version "3.2.0"
@@ -11032,6 +11083,10 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
 
+xregexp@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.0.0.tgz#e698189de49dd2a18cc5687b05e17c8e43943020"
+
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
@@ -11040,7 +11095,7 @@ y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
-y18n@^4.0.0:
+"y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
 
@@ -11052,7 +11107,7 @@ yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
 
-yargs-parser@^10.0.0:
+yargs-parser@^10.0.0, yargs-parser@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
   dependencies:
@@ -11080,6 +11135,23 @@ yargs@^11.0.0:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
+
+yargs@^12.0.1:
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.1.tgz#6432e56123bb4e7c3562115401e98374060261c2"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^2.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1 || ^4.0.0"
+    yargs-parser "^10.1.0"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
So far we were shipping untranspiled/unbundled code. This meant that all consumers of UI-Kit had to have the right webpack loaders in place in order to consume UI-Kit, which is quite bad of course. If we were to update any of our loaders, all consumers would have had to update them as well.

This PR makes it so that the UI-Kit ships as a standalone library, which can be consumed by any project which has the `peerDependencies` like `react` and `react-dom` of UI-Kit installed as regular dependencies.

### Usage

The available commands were moved around a bit. The main updates are:
- `yarn start`: an alias for `yarn storybook:start`
- `yarn build`: New command to build the ui-kit for production to `dist`
- `yarn storybook:start`: Starts the storybook locally
- `yarn storybook:build`: Builds storybook for production

### Consumers

#### Main export
Consumers of UI-Kit can use it by importing components from the main export:

```js
import { PrimaryButton } from '@commercetools-frontend/ui-kit'
```

#### Additional exports

Additionally, we make it possible to consume some utility functions by reaching in.

```js
import { filterDataAttributes } from '@commercetools-frontend/ui-kit/utils'
```

These are provided by additional `entry` points in the webpack config. They are not related to the folder structure inside the `src` folder.

### Publishing

The build gets put into the `dist` folder. As we don't want to force consumers to use ugly imports containing `dist` like `@commercetools-frontend/ui-kit/dist/utils`, we are doing a workaround to prevent this.

We copy all files which we want to be included in the npm module to the `dist` folder. Currently, this is the `README.md` and the `package.json`. We then publish from the `dist` folder.

You can try this out by running `yarn build; cd dist; yarn pack` (`yarn pack` is like `yarn publish`, except that it doesn't publish the created module). Then inspect the contents of the generated `.tar.gz` file which represent the module that would be published on npm.

Copying of `package.json` to `dist` and publishing from there lets consumers avoid the `dist` in imports as the folder is no longer part of the module.

`package.json` getting copied to `dist` is also why the `main` field in `package.js` contains `index.js` instead of `dist/index.js`.

This preparation should make it fairly easy to set up the release script in #2.

### `thread-loader`

I did some experimentation and it turns out that the build time is 20s faster on the initial build, and 4s faster on following builds (with filled cache) when not using `thread-loader`, so I removed it.

### Todo
- adapt netlify to execute the right command

### Possible Future Improvements:
- avoid compiling SVG
- extract CSS
- verify treeshaking works

Closes #7