### PR TITLE
chore: react-select not as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "lodash.without": "4.4.0",
     "prop-types": "15.6.2",
     "react-required-if": "1.0.3",
+    "react-select": "2.0.0",
     "react-textarea-autosize": "7.0.2",
     "react-virtualized": "9.20.1",
     "recompose": "0.26.0",
@@ -119,7 +120,6 @@
     "react-dom": "16.4.2",
     "react-intl": "2.4.0",
     "react-router-dom": "4.3.1",
-    "react-select": "2.0.0",
     "react-value": "0.2.0",
     "rimraf": "2.6.2",
     "rollup": "0.65.0",
@@ -147,7 +147,6 @@
     "react": ">=16",
     "react-dom": ">=16",
     "react-intl": ">=2",
-    "react-router-dom": ">=4",
-    "react-select": ">=2"
+    "react-router-dom": ">=4"
   }
 }

--- a/src/components/inputs/async-creatable-select-input/async-creatable-select-input.js
+++ b/src/components/inputs/async-creatable-select-input/async-creatable-select-input.js
@@ -2,8 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import omit from 'lodash.omit';
-import AsyncCreatableSelect from 'react-select/lib/AsyncCreatable';
-import { components as defaultComponents } from 'react-select';
+import {
+  components as defaultComponents,
+  AsyncCreatable as AsyncCreatableSelect,
+} from 'react-select';
 import classnames from 'classnames';
 import Constraints from '../../constraints';
 import filterDataAttributes from '../../../utils/filter-data-attributes';

--- a/src/components/inputs/async-creatable-select-input/async-creatable-select-input.spec.js
+++ b/src/components/inputs/async-creatable-select-input/async-creatable-select-input.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import AsyncCreatableSelect from 'react-select/lib/AsyncCreatable';
+import { AsyncCreatable as AsyncCreatableSelect } from 'react-select';
 import { AsyncCreatableSelectInput } from './async-creatable-select-input';
 
 const createTestProps = custom => ({

--- a/src/components/inputs/async-select-input/async-select-input.js
+++ b/src/components/inputs/async-select-input/async-select-input.js
@@ -2,8 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import omit from 'lodash.omit';
-import AsyncSelect from 'react-select/lib/Async';
-import { components as defaultComponents } from 'react-select';
+import {
+  components as defaultComponents,
+  Async as AsyncSelect,
+} from 'react-select';
 import classnames from 'classnames';
 import Constraints from '../../constraints';
 import filterDataAttributes from '../../../utils/filter-data-attributes';

--- a/src/components/inputs/async-select-input/async-select-input.spec.js
+++ b/src/components/inputs/async-select-input/async-select-input.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import AsynSelect from 'react-select/lib/Async';
+import { Async as AsynSelect } from 'react-select';
 import { AsyncSelectInput } from './async-select-input';
 
 const createTestProps = custom => ({

--- a/src/components/inputs/creatable-select-input/creatable-select-input.js
+++ b/src/components/inputs/creatable-select-input/creatable-select-input.js
@@ -2,8 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import classnames from 'classnames';
-import CreatableSelect from 'react-select/lib/Creatable';
-import { components as defaultComponents } from 'react-select';
+import {
+  components as defaultComponents,
+  Creatable as CreatableSelect,
+} from 'react-select';
 import omit from 'lodash.omit';
 import Constraints from '../../constraints';
 import filterDataAttributes from '../../../utils/filter-data-attributes';

--- a/src/components/inputs/creatable-select-input/creatable-select-input.spec.js
+++ b/src/components/inputs/creatable-select-input/creatable-select-input.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import CreatableSelect from 'react-select/lib/Creatable';
+import { Creatable as CreatableSelect } from 'react-select';
 import { CreatableSelectInput } from './creatable-select-input';
 
 const createTestProps = custom => ({


### PR DESCRIPTION
Making `react-select` a peer dependency requires that the consumer uses the latest version `2.0.0` of the library.

I think it's fine to make it a package dependency for now.