### PR TITLE
Setup release scripts 🚀

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,16 @@ cache:
   directories:
     - node_modules
 
-script:
-    - yarn run jest --projects jest.*.config.js --maxWorkers=4
+script: yarn run jest --projects jest.*.config.js --maxWorkers=4
+
+before_deploy: yarn build
+
+deploy:
+  provider: npm
+  email: npmjs@commercetools.com
+  api_key:
+    secure: KSowahYa4Q4vtLEIaetRTdAZ9cdHwD4c5mnpK0DFi21L0BNUjBzcaocR5Hr3PV62fzdFDHViZ36I3vWojznCmlq1POODHHrFoNycWk+wpI3NJQ887zNbsDIhpDqwN4HPv0TuxfS1r5WiApE6ynm0g+f7DL42+1FAnIIDyKsTNHlimRWuQVk7psinvNs4AyjEyRbvHCEDyRHBXbphX48J1ZUu/uZ9xNIsiWG/1RH0WH1lcT6VHctpy9ZXvmLKw0UilMkbwrNen5OHLQVxp4SrT/4+rxh/msdGwkiH00hi6C0DZizkXxZ+8SGoi//r3l3qMMdhjahBcIp/CEqYu+g59CXIRU1mTEAGf1el9K2dG/cdt9U9D/pQJzlVKgDNsB8XN70wkpoIgdqy2GsEHvth589hsxOI7HlP4NyO36Cv0kIktJDQOwhNd7UQ11p4D5aK8laHcYSD1SUF5sTYpFb8UB8mruWVGf7/siQQsnv9Q+CVkjJKwxvVJlBDr52jQ84+w3FaCoTeVSwOAxTEuK5x9Q7V2KUSxWVDd4MgNWoQkijFEqfe2QbzCW4qpsI3qXSwNKaMYKclodSD93KaTX8thZPy4MCbBKLdX3z8a/ibCbZa4Z83yo1ASFLbFYDimQFjSlQdeV+sia9A36iZSOvSnHqPhj6vhsaFvzgSA06YIjk=
+  on:
+    tags: true
+
+after_deploy: yarn docs:publish

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ _coming soon_
 
 ## Release
 
-The relase process is _semi-automated_: you only need to **manually** trigger it and [Travis][travis] will take care of the rest.
+The release process is _semi-automated_: you only need to **manually** trigger it and [Travis][travis] will take care of the rest.
 
-The steps to prepare and trigger a release are the following:
+The steps to prepare and trigger a release are as follows:
 
-- ensure to be on the latest `master` branch
+- ensure you are on the latest `master` branch
 - update the `CHANGELOG.md`
   - run `yarn changelog` to get a code snippet of the important commits from the last release
   - copy that and paste it into `CHANGELOG.md` file

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h2 align="center">commercetools UIKit 💅</h2>
 <p align="center">
-  <i>Design System component library</i>
+  <i>✨ Design System component library 🛠</i>
 </p>
 
 <h2 align="center">🚧 Under construction 🚧</h2>
@@ -26,7 +26,8 @@ import {
 
 #### Importing CSS modules
 
-In order to make use of our CSS variables defined in our CSS module files, you can require those files (from `/materials`) within your `.mod.css` files:
+When you are developing your application using the UIKit components, chances are that you want to use the same **CSS variables** based on our Design System.
+To do that, we expose those variables as a set of different files (e.g. `colors.mod.css`, `spacings.mod.css`, etc) from the `@commercetools-frontend/ui-kit/materials` package folder.
 
 ```css
 @import '@commercetools-frontend/ui-kit/materials/spacings.mod.css';
@@ -36,7 +37,35 @@ In order to make use of our CSS variables defined in our CSS module files, you c
 }
 ```
 
-> Please look into the package itself to inspect what variables are available (_documentation will be provided in the future_)
+Assuming that you are using [Webpack][webpack] to bundle your application, you might need to include the location to the `materials` folder in your [Webpack loaders](https://webpack.js.org/concepts/loaders/).
+
+```js
+// webpack.config.js
+{
+  module: {
+    rules: [
+      {
+        test: /\.mod\.css$/,
+        include: [
+          path.resolve(__dirname, 'src'),
+          // 👇 Include the materials folder to allow `postcss` to transpile those files as well
+          path.resolve(
+            require.resolve('@commercetools-frontend/ui-kit'),
+            '../../materials'
+          ),
+
+          // or `path.resolve(__dirname, 'node_modules/@commercetools-frontend/ui-kit/materials')`
+        ],
+        use: [
+          // postcss loaders
+        ],
+      },
+    ];
+  }
+}
+```
+
+> Please look into the package itself to inspect which variables are available (_documentation will be provided in the future_).
 
 #### Importing SVG images
 
@@ -60,6 +89,8 @@ import UnexpectedErrorSVG from '@commercetools-frontend/ui-kit/images/maintenanc
 ## Documentation
 
 _coming soon_
+
+For now look at https://uikit.commercetools.com.
 
 ## Release
 
@@ -86,12 +117,13 @@ From now on, [Travis][travis] will take over the release: build the bundles, pub
 
 The documentation is currently built with [Storybook][storybook] and is hosted on [Netlify][netlify].
 
-By default, only _Deploy Previews_ (Pull Requests) are deployed to [Netlify][netlify]. The _Production_ website is deployed from the branch `docs-production`.
+By default, only _Deploy Previews_ (Pull Requests) are deployed to [Netlify][netlify]. The _Production_ website is deployed from the branch `latest/docs`.
 
-> The reason for not having continuous deployment from `master` branch is to keep it the same as the _latest_ release.
+> The reason for not having continuous deployment from `master` branch is to keep it the same as the _latest_ npm release.
 
-Deployments for `docs-production` are automatically triggered from [Travis][travis] after the release was triggered (via **git tags**). [Travis][travis] will execute the `yarn docs:publish` command to update the production branch, which will trigger a deployment from [Netlify][netlify]
+Deployments for `latest/docs` are automatically triggered from [Travis][travis] after the release was triggered (via **git tags**). [Travis][travis] will execute the `yarn docs:publish` command to update the production branch, which will trigger a deployment from [Netlify][netlify]
 
-[storybook]: https://storybook.js.org/
+[webpack]: https://webpack.js.org
+[storybook]: https://storybook.js.org
 [netlify]: https://www.netlify.com
 [travis]: https://travis-ci.org/commercetools/ui-kit

--- a/README.md
+++ b/README.md
@@ -60,3 +60,38 @@ import UnexpectedErrorSVG from '@commercetools-frontend/ui-kit/images/maintenanc
 ## Documentation
 
 _coming soon_
+
+## Release
+
+The relase process is _semi-automated_: you only need to **manually** trigger it and [Travis][travis] will take care of the rest.
+
+The steps to prepare and trigger a release are the following:
+
+- ensure to be on the latest `master` branch
+- update the `CHANGELOG.md`
+  - run `yarn changelog` to get a code snippet of the important commits from the last release
+  - copy that and paste it into `CHANGELOG.md` file
+  - make sure that the git tag references are correctly defined and the top entry represents the _new_ tag that you are about to create
+  - add or modify the generated changelog to provide more context about the new release
+- bump the `version` in the `package.json`
+- make a commit and push it to `master` (e.g. `git commit -am "chore: bump version to 2.0.0, update changelog"`)
+  - if you can't push it directly to `master`, open a Pull Request first
+- at this point you can create the `tag`: `git tag -m "Version v2.0.0" v2.0.0`
+  - the tag name is the `version` string in the `package.json` plus the prefix `v`
+- push the tag: `git push --tags`
+
+From now on, [Travis][travis] will take over the release: build the bundles, publish to `npm` and update branch for the documentation website (see below).
+
+## Publishing documentation website
+
+The documentation is currently built with [Storybook][storybook] and is hosted on [Netlify][netlify].
+
+By default, only _Deploy Previews_ (Pull Requests) are deployed to [Netlify][netlify]. The _Production_ website is deployed from the branch `docs-production`.
+
+> The reason for not having continuous deployment from `master` branch is to keep it the same as the _latest_ release.
+
+Deployments for `docs-production` are automatically triggered from [Travis][travis] after the release was triggered (via **git tags**). [Travis][travis] will execute the `yarn docs:publish` command to update the production branch, which will trigger a deployment from [Netlify][netlify]
+
+[storybook]: https://storybook.js.org/
+[netlify]: https://www.netlify.com
+[travis]: https://travis-ci.org/commercetools/ui-kit

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "build": "rimraf dist && cross-env NODE_ENV=production rollup -c",
     "start": "yarn storybook:start",
     "storybook:start": "start-storybook -p 9002",
+    "docs:publish": "node scripts/publish-docs.js",
     "i18n:build": "mc-scripts extract-intl --build-translations --output-path=$(pwd)/i18n 'src/components/**/!(*.spec).js'",
     "lint": "jest --projects jest.eslint.config.js jest.stylelint.config.js",
     "lint:js": "jest --config jest.eslint.config.js",

--- a/scripts/publish-docs.js
+++ b/scripts/publish-docs.js
@@ -1,20 +1,25 @@
-const shelljs = require('shelljs');
-
 if (!process.env.TRAVIS_TAG) {
   throw new Error('This script can only be executed when a git tag is created');
 }
+
+const shelljs = require('shelljs');
+
+const userEmail = 'npmjs@commercetools.com';
+const userName = 'ct-release-bot';
+const docsOrigin = 'origin-docs';
+const docsBranch = 'latest/docs';
 
 if (process.env.TRAVIS === 'true') {
   const remoteUrl = `https://${
     process.env.GH_TOKEN
   }@github.com/commercetools/ui-kit.git`;
-  shelljs.exec('git config --global user.email "npmjs@commercetools.com"');
-  shelljs.exec('git config --global user.name "ct-release-bot"');
-  shelljs.exec(`git remote add origin-docs ${remoteUrl} > /dev/null 2>&1`);
+  shelljs.exec(`git config --global user.email "${userEmail}"`);
+  shelljs.exec(`git config --global user.name "${userName}"`);
+  shelljs.exec(`git remote add ${docsOrigin} ${remoteUrl} > /dev/null 2>&1`);
 }
 
-shelljs.exec('git checkout docs-production');
+shelljs.exec(`git checkout ${docsBranch}`);
 shelljs.exec('git pull -r');
 // This assumes that git is checked out at this branch tag.
 shelljs.exec(`git merge ${process.env.TRAVIS_TAG}`);
-shelljs.exec('git push --force-with-lease origin-docs docs-production');
+shelljs.exec(`git push --force-with-lease ${docsOrigin} ${docsBranch}`);

--- a/scripts/publish-docs.js
+++ b/scripts/publish-docs.js
@@ -1,0 +1,20 @@
+const shelljs = require('shelljs');
+
+if (!process.env.TRAVIS_TAG) {
+  throw new Error('This script can only be executed when a git tag is created');
+}
+
+if (process.env.TRAVIS === 'true') {
+  const remoteUrl = `https://${
+    process.env.GH_TOKEN
+  }@github.com/commercetools/ui-kit.git`;
+  shelljs.exec('git config --global user.email "npmjs@commercetools.com"');
+  shelljs.exec('git config --global user.name "ct-release-bot"');
+  shelljs.exec(`git remote add origin-docs ${remoteUrl} > /dev/null 2>&1`);
+}
+
+shelljs.exec('git checkout docs-production');
+shelljs.exec('git pull -r');
+// This assumes that git is checked out at this branch tag.
+shelljs.exec(`git merge ${process.env.TRAVIS_TAG}`);
+shelljs.exec('git push --force-with-lease origin-docs docs-production');


### PR DESCRIPTION
Closes #2 

See readme for documentation.

In short:
- the production website is triggered now from the `docs-production` branch (not `master`)
- publish only when a tag is created
- travis does the publishing to npm (token already encrypted)
- after publishing, the `docs-production` branch is updated (which triggers a netlify deployment)
  - github token is saved in the travis ui

PS: I haven't tested this yet, so I can only assume it works. After this is merged, I will try a test release.

Refs:
- https://docs.travis-ci.com/user/deployment/npm/
- https://docs.travis-ci.com/user/encryption-keys/