### PR TITLE
fix: i18n build by adding missing dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@commercetools-frontend/babel-preset-mc-app": "1.0.0-beta.30",
     "@commercetools-frontend/eslint-config-mc-app": "1.0.0-beta.30",
     "@commercetools-frontend/jest-preset-mc-app": "1.0.0-beta.30",
+    "@commercetools-frontend/mc-scripts": "1.0.0-beta.30",
     "@commitlint/cli": "7.1.2",
     "@commitlint/config-conventional": "7.1.2",
     "@storybook/addon-actions": "4.0.0-alpha.20",


### PR DESCRIPTION
Woops. Sorry @qmateub.

We were missing mc-scripts dep so the command `yarn i18n:build` didn't work.

Closes [46](https://github.com/commercetools/ui-kit/issues/46#issuecomment-421257153)