### PR TITLE
chore: new approach for publishing docs

### DIFF
--- a/scripts/publish-docs.js
+++ b/scripts/publish-docs.js
@@ -1,7 +1,3 @@
-if (!process.env.TRAVIS_TAG) {
-  throw new Error('This script can only be executed when a git tag is created');
-}
-
 const shelljs = require('shelljs');
 
 const docsOrigin = 'origin-docs';
@@ -16,10 +12,16 @@ if (process.env.TRAVIS === 'true') {
   shelljs.exec(`git config --global user.email "${userEmail}"`);
   shelljs.exec(`git config --global user.name "${userName}"`);
   shelljs.exec(`git remote add ${docsOrigin} ${remoteUrl} > /dev/null 2>&1`);
+} else {
+  shelljs.exec(
+    `git remote add ${docsOrigin} git@github.com:commercetools/ui-kit.git > /dev/null 2>&1`
+  );
 }
 
-shelljs.exec(`git checkout ${docsBranch}`);
-shelljs.exec('git pull -r');
-// This assumes that git is checked out at this branch tag.
-shelljs.exec(`git merge ${process.env.TRAVIS_TAG}`);
-shelljs.exec(`git push --force-with-lease ${docsOrigin} ${docsBranch}`);
+// Make sure there is no existing docs branch locally
+shelljs.exec(`git branch -D ${docsBranch} > /dev/null 2>&1`);
+// Checkout a new local branch for `latest/docs`
+shelljs.exec(`git checkout -b ${docsBranch}`);
+shelljs.exec(`git push --force ${docsOrigin} ${docsBranch}`);
+// Switch back to the previous branch (e.g. `master`)
+shelljs.exec(`git checkout -`);

--- a/scripts/publish-docs.js
+++ b/scripts/publish-docs.js
@@ -13,9 +13,10 @@ if (process.env.TRAVIS === 'true') {
   shelljs.exec(`git config --global user.name "${userName}"`);
   shelljs.exec(`git remote add ${docsOrigin} ${remoteUrl} > /dev/null 2>&1`);
 } else {
-  shelljs.exec(
-    `git remote add ${docsOrigin} git@github.com:commercetools/ui-kit.git > /dev/null 2>&1`
-  );
+  // This part is in case you run the script locally, in which case you don't
+  // need the `GH_TOKEN` and can simply use the ssh remote.
+  const remoteUrl = 'git@github.com:commercetools/ui-kit.git';
+  shelljs.exec(`git remote add ${docsOrigin} ${remoteUrl} > /dev/null 2>&1`);
 }
 
 // Make sure there is no existing docs branch locally

--- a/scripts/publish-docs.js
+++ b/scripts/publish-docs.js
@@ -24,5 +24,3 @@ shelljs.exec(`git branch -D ${docsBranch} > /dev/null 2>&1`);
 // Checkout a new local branch for `latest/docs`
 shelljs.exec(`git checkout -b ${docsBranch}`);
 shelljs.exec(`git push --force ${docsOrigin} ${docsBranch}`);
-// Switch back to the previous branch (e.g. `master`)
-shelljs.exec(`git checkout -`);


### PR DESCRIPTION
The current way of publishing the docs was not working well because of the way travis checks out the git repo.

<img width="942" alt="image" src="https://user-images.githubusercontent.com/1110551/45541453-744ca380-b80f-11e8-97ec-703c1bb85f39.png">

This new approach is more "_brutal_" but it should do its job

<img width="476" alt="image" src="https://user-images.githubusercontent.com/1110551/45541511-a8c05f80-b80f-11e8-8129-079512c2bf67.png">
