### PR TITLE
Re-export `HorizontalConstraint` component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,6 +69,8 @@ export { default as TimeRangePicker } from './components/time-range-picker';
 
 export { default as Text } from './components/typography/text';
 
+export { default as HorizontalConstraint } from './components/constraints/horizontal';
+
 export { default as withMouseDownState } from './hocs/with-mouse-down-state';
 export { default as withMouseOverState } from './hocs/with-mouse-over-state';
 


### PR DESCRIPTION
#### Summary

This component is documented in our storybook but not exported. We so far only use it internally in UIKit through components taking a `horizontalConstraint`-prop. However, sometimes this can also be helpful to consumers of UIKit. As a result I would like to re-export it.