### PR TITLE
fix: fix i18n exports

### DIFF
--- a/i18n/index.js
+++ b/i18n/index.js
@@ -1,5 +1,5 @@
-import * as en from './en.json';
-import * as de from './de.json';
-import * as es from './es.json';
+import en from './en.json';
+import de from './de.json';
+import es from './es.json';
 
 export { en, de, es };


### PR DESCRIPTION
#### Summary

As discovered last week, we had a problem with our i18n exports, where the i18n data was being exported in the following form:

```javascript
{
  en: default: {
    'UIKit.Blah': 'Foo'
    }
}
```
I think this was happening due to us not properly using [rollup-plugin-json](https://github.com/rollup/rollup-plugin-json). 
I built my fix and copy pasted the dist files into MC-FE and the exports look correct now. Plus, if you check the compiled code, it looks better.

Compiled code now looks like 


```javascript
...lots of stuff
var index = /*#__PURE__*/Object.freeze({
  en: en,
  de: de$1,
  es: es
});
```

where as before it looked like

```javascript
...lots of stuff
var es$1 = /*#__PURE__*/Object.freeze({
  default: es
});

var index = /*#__PURE__*/Object.freeze({
  en: en$1,
  de: de$2,
  es: es$1
});
```
