### PR TITLE
Fix id generation in NumberField and TextField

### DIFF
--- a/src/components/fields/number-field/number-field.js
+++ b/src/components/fields/number-field/number-field.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import has from 'lodash.has';
 import requiredIf from 'react-required-if';
 import Constraints from '../../constraints';
 import Spacings from '../../spacings';
@@ -67,11 +66,11 @@ class NumberField extends React.Component {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: (() => {
-      if (has(props, 'id')) return props.id;
-      if (state.id) return state.id;
-      return sequentialId();
-    })(),
+    id: do {
+      if (props.id) props.id;
+      else if (state.id) state.id;
+      else sequentialId();
+    },
   });
 
   render() {

--- a/src/components/fields/number-field/number-field.spec.js
+++ b/src/components/fields/number-field/number-field.spec.js
@@ -52,7 +52,10 @@ describe('rendering', () => {
       wrapper = shallow(<NumberField {...props} />);
     });
     it('should add a default id attribute', () => {
-      expect(wrapper.find(NumberInput)).toHaveProp('id');
+      expect(wrapper.find(NumberInput)).toHaveProp(
+        'id',
+        expect.stringMatching(/.+/)
+      );
     });
     it('should add a default htmlFor attribute', () => {
       expect(wrapper.find(FieldLabel)).toHaveProp('htmlFor');

--- a/src/components/fields/text-field/README.md
+++ b/src/components/fields/text-field/README.md
@@ -8,7 +8,7 @@ states.
 ## Usage
 
 ```js
-import TextField from '@commercetools-frontend/ui-kit/fields/text-field';
+import { TextField } from '@commercetools-frontend/ui-kit';
 
 <TextField title="Username" value="foo" onChange={value => alert(value)} />;
 ```

--- a/src/components/fields/text-field/text-field.form.story.js
+++ b/src/components/fields/text-field/text-field.form.story.js
@@ -31,7 +31,7 @@ storiesOf('Examples|Forms/Fields', module)
           initialValues={{ userName: '' }}
           validate={values => {
             const errors = { userName: {} };
-            if (values.userName.trim().length === 0)
+            if (TextField.isEmpty(values.userName))
               errors.userName.missing = true;
             if (values.userName.trim().indexOf(' ') !== -1)
               errors.userName.usesSpaces = true;

--- a/src/components/fields/text-field/text-field.js
+++ b/src/components/fields/text-field/text-field.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import has from 'lodash.has';
 import requiredIf from 'react-required-if';
 import Constraints from '../../constraints';
 import Spacings from '../../spacings';
@@ -64,11 +63,11 @@ class TextField extends React.Component {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: (() => {
-      if (has(props, 'id')) return props.id;
-      if (state.id) return state.id;
-      return sequentialId();
-    })(),
+    id: do {
+      if (props.id) props.id;
+      else if (state.id) state.id;
+      else sequentialId();
+    },
   });
 
   render() {

--- a/src/components/fields/text-field/text-field.spec.js
+++ b/src/components/fields/text-field/text-field.spec.js
@@ -52,7 +52,10 @@ describe('rendering', () => {
       wrapper = shallow(<TextField {...props} />);
     });
     it('should add a default id attribute', () => {
-      expect(wrapper.find(TextInput)).toHaveProp('id');
+      expect(wrapper.find(TextInput)).toHaveProp(
+        'id',
+        expect.stringMatching(/.+/)
+      );
     });
     it('should add a default htmlFor attribute', () => {
       expect(wrapper.find(FieldLabel)).toHaveProp('htmlFor');


### PR DESCRIPTION
The `id` generation when no `id` prop is provided was broken in `NumberField` and `TextField`. The tests were not detecting this either.

This PR fixes the generation, the tests and introduces `do` expressions to replace the iife.