### PR TITLE
fix(money-input): add formatting workaround

### DIFF
--- a/src/components/inputs/money-input/money-input.form.story.js
+++ b/src/components/inputs/money-input/money-input.form.story.js
@@ -33,20 +33,15 @@ storiesOf('Examples|Forms/Inputs', module)
     <Section>
       <IntlProvider locale="en">
         <Formik
-          initialValues={{
-            price: MoneyInput.parseMoneyValue({
-              currencyCode: 'EUR',
-              centAmount: 1200,
-            }),
-          }}
+          initialValues={{ price: { currencyCode: '', amount: '' } }}
           validate={validate}
-          onSubmit={(values, formik, ...rest) => {
+          onSubmit={(values, formik) => {
             // eslint-disable-next-line no-console
             console.log(
               'money value',
               MoneyInput.convertToMoneyValue(values.price)
             );
-            action('onSubmit')(values, formik, ...rest);
+            action('onSubmit')(values, formik);
             formik.resetForm(values);
           }}
           render={formik => (
@@ -58,6 +53,11 @@ storiesOf('Examples|Forms/Inputs', module)
                   value={formik.values.price}
                   onChange={formik.handleChange}
                   onBlur={formik.handleBlur}
+                  hasCurrencyError={Boolean(
+                    formik.touched.price &&
+                      formik.touched.price.currencyCode &&
+                      formik.errors.price
+                  )}
                   hasAmountError={Boolean(
                     formik.touched.price &&
                       formik.touched.price.amount &&

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -279,7 +279,17 @@ export default class MoneyInput extends React.Component {
               : formattedAmount,
           },
         };
-        this.props.onChange(fakeEvent);
+        // There is a bug in Formik at the moment where the validation will run
+        // with wrong values when "handleChange" is called consecutively before
+        // Formik gets a chance to rerun.
+        // PR with fix is open: https://github.com/jaredpalmer/formik/pull/939
+        // Once merged, we can remove the setTimeout call and call
+        // onChange directly.
+        // While the setTimeout workaround is in place, the error messages
+        // will flicker (appear and disappear) for a split-second.
+        setTimeout(() => {
+          this.props.onChange(fakeEvent);
+        }, 0);
       }
     }
     toggleMenu();


### PR DESCRIPTION
There is a bug in Formik which would result in MoneyInput's currency code update being lost when the amount was reformatted because of the currency code change.

The consequence of the bug is that the validation runs with the wrong `values` in case the change of the currency leads to the amount being reformatted (happens when user enters an unformatted amount before selecting a currency - and then selecting a currency). This leads to the wrong validation errors being shown and the form not being submittable.

We can remove the `setTimeout` workaround once the PR to Formik is merged: https://github.com/jaredpalmer/formik/pull/939

CodeSandbox: https://codesandbox.io/s/pk7mk0nny0