### PR TITLE
feat(money-field): add high-precision price badge

### DIFF
--- a/i18n/core.json
+++ b/i18n/core.json
@@ -20,6 +20,7 @@
   "UIKit.LocalizedTextInput.collapse": "Hide languages ({remainingLanguages})",
   "UIKit.LocalizedTextInput.expand": "Show all languages ({remainingLanguages})",
   "UIKit.LocalizedTextInput.missingRequiredField": "This field is required. Provide at least one value.",
+  "UIKit.MoneyField.highPrecision": "High Precision Price",
   "UIKit.MoneyInput.chevronLabel": "Open/Close Dropdown",
   "UIKit.MultilineTextInput.collapse": "Collapse",
   "UIKit.MultilineTextInput.expand": "Expand",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -20,6 +20,7 @@
   "UIKit.LocalizedTextInput.collapse": "Sprachen verbergen",
   "UIKit.LocalizedTextInput.expand": "Alle Sprachen anzeigen",
   "UIKit.LocalizedTextInput.missingRequiredField": "Pflichtfeld*, Geben Sie mindestens einen Wert an",
+  "UIKit.MoneyField.highPrecision": "",
   "UIKit.MoneyInput.chevronLabel": "Dropdown öffnen/schliessen",
   "UIKit.MultilineTextInput.collapse": "Ausblenden",
   "UIKit.MultilineTextInput.expand": "Erweitern",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -20,6 +20,7 @@
   "UIKit.LocalizedTextInput.collapse": "Hide languages ({remainingLanguages})",
   "UIKit.LocalizedTextInput.expand": "Show all languages ({remainingLanguages})",
   "UIKit.LocalizedTextInput.missingRequiredField": "This field is required. Provide at least one value.",
+  "UIKit.MoneyField.highPrecision": "High Precision Price",
   "UIKit.MoneyInput.chevronLabel": "Open/Close Dropdown",
   "UIKit.MultilineTextInput.collapse": "Collapse",
   "UIKit.MultilineTextInput.expand": "Expand",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -20,6 +20,7 @@
   "UIKit.LocalizedTextInput.collapse": "Ocultar lenguajes ({remainingLanguages})",
   "UIKit.LocalizedTextInput.expand": "Mostrar todos los lenguajes ({remainingLanguages})",
   "UIKit.LocalizedTextInput.missingRequiredField": "Este campo es obligatorio. Proporcione un valor al menos.",
+  "UIKit.MoneyField.highPrecision": "",
   "UIKit.MoneyInput.chevronLabel": "Abrir/Cerrar menú desplegable",
   "UIKit.MultilineTextInput.collapse": "Contraer",
   "UIKit.MultilineTextInput.expand": "Expandir",

--- a/src/components/fields/money-field/messages.js
+++ b/src/components/fields/money-field/messages.js
@@ -1,0 +1,9 @@
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  highPrecision: {
+    id: 'UIKit.MoneyField.highPrecision',
+    description: 'Label of high precision bade in MoneyField',
+    defaultMessage: 'High Precision Price',
+  },
+});

--- a/src/components/fields/money-field/money-field.form.story.js
+++ b/src/components/fields/money-field/money-field.form.story.js
@@ -19,28 +19,39 @@ storiesOf('Examples|Forms/Fields', module)
   .addDecorator(withReadme(Readme))
   .add('MoneyField', () => {
     const currencies = ['EUR', 'USD', 'AED', 'KWD'];
+    const horizontalConstraint = select(
+      'horizontalConstraint',
+      ['xs', 's', 'm', 'l', 'xl', 'scale'],
+      'm'
+    );
     return (
       <Section>
         <IntlProvider locale="en">
           <Formik
             initialValues={{
-              price: { currencyCode: currencies[0], amount: '' },
+              price: { ...MoneyField.parseMoneyValue() },
+              pricePerTon: { ...MoneyField.parseMoneyValue() },
             }}
             validate={values => {
-              const errors = { price: {} };
+              const errors = { price: {}, pricePerTon: {} };
               if (MoneyField.isEmpty(values.price)) errors.price.missing = true;
               else if (MoneyField.isHighPrecision(values.price))
                 errors.price.unsupportedHighPrecision = true;
+
+              if (MoneyField.isEmpty(values.pricePerTon))
+                errors.pricePerTon.missing = true;
+
+              console.log(values, omitEmpty(errors));
               return omitEmpty(errors);
             }}
-            onSubmit={(values, formik, ...rest) => {
-              action('onSubmit')(values, formik, ...rest);
+            onSubmit={(values, formik) => {
+              action('onSubmit')(values, formik);
               formik.resetForm(values);
             }}
             render={formik => (
               <Spacings.Stack scale="l">
                 <MoneyField
-                  title="Price"
+                  title="Regular Price"
                   description={'How much is the fish?'}
                   hint="It is better to pay in EUR"
                   name="price"
@@ -50,11 +61,7 @@ storiesOf('Examples|Forms/Fields', module)
                   onChange={formik.handleChange}
                   onBlur={formik.handleBlur}
                   touched={formik.touched.price}
-                  horizontalConstraint={select(
-                    'horizontalConstraint',
-                    ['xs', 's', 'm', 'l', 'xl', 'scale'],
-                    'm'
-                  )}
+                  horizontalConstraint={horizontalConstraint}
                   errors={formik.errors.price}
                   renderError={key => {
                     switch (key) {
@@ -65,6 +72,20 @@ storiesOf('Examples|Forms/Fields', module)
                         return null;
                     }
                   }}
+                />
+                <MoneyField
+                  title="Price per ton (High Precision)"
+                  description={'How much is a ton of fish?'}
+                  name="pricePerTon"
+                  isRequired={true}
+                  value={formik.values.pricePerTon}
+                  currencies={currencies}
+                  onChange={formik.handleChange}
+                  onBlur={formik.handleBlur}
+                  touched={formik.touched.pricePerTon}
+                  horizontalConstraint={horizontalConstraint}
+                  showHighPrecisionBadge={true}
+                  errors={formik.errors.pricePerTon}
                 />
                 <Spacings.Inline>
                   <SecondaryButton

--- a/src/components/fields/money-field/money-field.form.story.js
+++ b/src/components/fields/money-field/money-field.form.story.js
@@ -84,7 +84,7 @@ storiesOf('Examples|Forms/Fields', module)
                   onBlur={formik.handleBlur}
                   touched={formik.touched.pricePerTon}
                   horizontalConstraint={horizontalConstraint}
-                  showHighPrecisionBadge={true}
+                  hasHighPrecisionBadge={true}
                   errors={formik.errors.pricePerTon}
                 />
                 <Spacings.Inline>

--- a/src/components/fields/money-field/money-field.js
+++ b/src/components/fields/money-field/money-field.js
@@ -76,7 +76,7 @@ class MoneyField extends React.Component {
     ),
     hintIcon: PropTypes.node,
     description: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-    showHighPrecisionBadge: PropTypes.bool,
+    hasHighPrecisionBadge: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -123,7 +123,7 @@ class MoneyField extends React.Component {
             onInfoButtonClick={this.props.onInfoButtonClick}
             hintIcon={this.props.hintIcon}
             badge={
-              this.props.showHighPrecisionBadge &&
+              this.props.hasHighPrecisionBadge &&
               !MoneyInput.isEmpty(this.props.value) &&
               MoneyInput.isHighPrecision(this.props.value) ? (
                 <Spacings.Inline scale="xs" alignItems="flexEnd">

--- a/src/components/fields/money-field/money-field.spec.js
+++ b/src/components/fields/money-field/money-field.spec.js
@@ -80,7 +80,6 @@ describe('rendering', () => {
         hintIcon: <AddBoldIcon />,
         description: 'A description',
         onInfoButtonClick: jest.fn(),
-        badge: <div>Some badge</div>,
 
         // MoneyField
         name: 'field1',
@@ -106,7 +105,6 @@ describe('rendering', () => {
         'onInfoButtonClick',
         props.onInfoButtonClick
       );
-      expect(fieldLabel).toHaveProp('badge', props.badge);
       expect(fieldLabel).toHaveProp('htmlFor', props.id);
 
       const moneyInput = wrapper.find(MoneyInput);
@@ -141,7 +139,7 @@ describe('rendering', () => {
     let wrapper;
     beforeEach(() => {
       props = createTestProps({
-        touched: { amount: true },
+        touched: { currencyCode: true, amount: true },
         errors: { missing: true },
       });
       wrapper = shallow(<MoneyField {...props} />);
@@ -159,7 +157,7 @@ describe('rendering', () => {
     let wrapper;
     beforeEach(() => {
       props = createTestProps({
-        touched: { amount: true },
+        touched: { currencyCode: true, amount: true },
         renderError: jest.fn(key => key),
         errors: { customError: 5 },
       });
@@ -170,6 +168,22 @@ describe('rendering', () => {
     });
     it('should forward the error', () => {
       expect(wrapper.find(FieldErrors)).toHaveProp('errors', props.errors);
+    });
+  });
+
+  describe('when a high-precision price badge should be shown', () => {
+    let props;
+    let wrapper;
+    beforeEach(() => {
+      props = createTestProps({
+        showHighPrecisionBadge: true,
+        value: { currencyCode: 'EUR', amount: '15.002' },
+        touched: { currencyCode: true, amount: true },
+      });
+      wrapper = shallow(<MoneyField {...props} />);
+    });
+    it('should show a high precision price badge', () => {
+      expect(wrapper.find(FieldLabel)).toHaveProp('badge');
     });
   });
 });

--- a/src/components/fields/money-field/money-field.spec.js
+++ b/src/components/fields/money-field/money-field.spec.js
@@ -176,7 +176,7 @@ describe('rendering', () => {
     let wrapper;
     beforeEach(() => {
       props = createTestProps({
-        showHighPrecisionBadge: true,
+        hasHighPrecisionBadge: true,
         value: { currencyCode: 'EUR', amount: '15.002' },
         touched: { currencyCode: true, amount: true },
       });

--- a/src/components/fields/money-field/money-field.story.js
+++ b/src/components/fields/money-field/money-field.story.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { Value } from 'react-value';
 import {
   withKnobs,
   boolean,
@@ -15,17 +14,37 @@ import MoneyFieldReadme from './README.md';
 import * as icons from '../../icons';
 import MoneyField from './money-field';
 
-storiesOf('Fields', module)
-  .addDecorator(withKnobs)
-  .addDecorator(withReadme(MoneyFieldReadme))
-  .add('MoneyField', () => {
+// This uses a dedicated story component to keep track of state instead of
+// react-value. The reason is that MoneyInput can call twice onChange before
+// the component rerenders, so we'd need to use two separate <Value />
+// components to not lose data. So we use a dedicated component instead.
+// That makes it easier to log the parsed value as well.
+class MoneyFieldStory extends React.Component {
+  static displayName = 'MoneyFieldStory';
+
+  state = {
+    currencyCode: '',
+    amount: '',
+  };
+
+  componentDidUpdate(prevState) {
+    if (
+      prevState.amount !== this.state.amount ||
+      prevState.currencyCode !== this.state.currencyCode
+    ) {
+      // eslint-disable-next-line no-console
+      console.log(
+        'parsed',
+        MoneyField.convertToMoneyValue({
+          amount: this.state.amount,
+          currencyCode: this.state.currencyCode,
+        })
+      );
+    }
+  }
+
+  render() {
     const currencies = ['EUR', 'USD', 'AED', 'KWD'];
-    const defaultCurrencyCode = select(
-      'default value currencyCode',
-      ['', ...currencies],
-      ''
-    );
-    const defaultAmount = text('default value amount', '');
     const name = text('name', '') || 'default-name';
     const hint = text('hint', 'How much is the fish?');
 
@@ -35,80 +54,68 @@ storiesOf('Fields', module)
     const hintIcon = icon ? React.createElement(icons[icon]) : undefined;
     return (
       <Section>
-        <Value
-          key={`${defaultCurrencyCode}-${defaultAmount}`}
-          defaultValue={{
-            amount: defaultAmount,
-            currencyCode: defaultCurrencyCode,
-          }}
-          render={(value, onChange) => (
-            <MoneyField
-              // MoneyField
-              id={name.trim() === '' ? undefined : name}
-              horizontalConstraint={select(
-                'horizontalConstraint',
-                ['xs', 's', 'm', 'l', 'xl', 'scale'],
-                'm'
-              )}
-              errors={object('errors', { missing: true, customError: true })}
-              renderError={key => {
-                switch (key) {
-                  case 'customError':
-                    return 'A custom error.';
-                  default:
-                    return null;
-                }
-              }}
-              isRequired={boolean('isRequired', false)}
-              touched={
-                boolean('touched', false)
-                  ? { amount: true, currencyCode: true }
-                  : { amount: false, currencyCode: false }
-              }
-              // MoneyInput
-              name={name}
-              value={value}
-              currencies={boolean('dropdown', true) ? currencies : undefined}
-              placeholder={text('placeholder', 'Placeholder')}
-              onBlur={(...args) => action('onBlur')(...args)}
-              isDisabled={boolean('isDisabled', false)}
-              onChange={event => {
-                action('onChange')(event);
-
-                const nextMoney = do {
-                  if (event.target.name.endsWith('.amount')) {
-                    ({ ...value, amount: event.target.value });
-                  } else if (event.target.name.endsWith('.currencyCode')) {
-                    ({ ...value, currencyCode: event.target.value });
-                  }
-                };
-
-                onChange(nextMoney);
-
-                // eslint-disable-next-line no-console
-                console.log(
-                  'parsed',
-                  MoneyField.convertToMoneyValue(nextMoney)
-                );
-              }}
-              hasCurrencyError={boolean('hasCurrencyError', false)}
-              hasCurrencyWarning={boolean('hasCurrencyWarning', false)}
-              hasAmountError={boolean('hasAmountError', false)}
-              hasAmountWarning={boolean('hasAmountWarning', false)}
-              // LabelField
-              title={text('title', 'Username')}
-              hint={hint}
-              description={text('description', '')}
-              onInfoButtonClick={
-                boolean('show info button', false)
-                  ? action('onInfoButtonClick')
-                  : undefined
-              }
-              hintIcon={hintIcon}
-              badge={text('badge', '')}
-            />
+        <MoneyField
+          // MoneyField
+          id={name.trim() === '' ? undefined : name}
+          horizontalConstraint={select(
+            'horizontalConstraint',
+            ['xs', 's', 'm', 'l', 'xl', 'scale'],
+            'm'
           )}
+          errors={object('errors', { missing: true, customError: true })}
+          renderError={key => {
+            switch (key) {
+              case 'customError':
+                return 'A custom error.';
+              default:
+                return null;
+            }
+          }}
+          isRequired={boolean('isRequired', false)}
+          touched={
+            boolean('touched', false)
+              ? { amount: true, currencyCode: true }
+              : { amount: false, currencyCode: false }
+          }
+          // MoneyInput
+          name={name}
+          value={{
+            amount: this.state.amount,
+            currencyCode: this.state.currencyCode,
+          }}
+          currencies={boolean('dropdown', true) ? currencies : undefined}
+          placeholder={text('placeholder', 'Placeholder')}
+          onBlur={action('onBlur')}
+          isDisabled={boolean('isDisabled', false)}
+          onChange={event => {
+            action('onChange')(event);
+
+            if (event.target.name.endsWith('.amount')) {
+              this.setState({ amount: event.target.value });
+            }
+
+            if (event.target.name.endsWith('.currencyCode')) {
+              this.setState({ currencyCode: event.target.value });
+            }
+          }}
+          // LabelField
+          title={text('title', 'Price')}
+          hint={hint}
+          description={text('description', '')}
+          onInfoButtonClick={
+            boolean('show info button', false)
+              ? action('onInfoButtonClick')
+              : undefined
+          }
+          hintIcon={hintIcon}
+          showHighPrecisionBadge={boolean('showHighPrecisionBadge', false)}
         />
       </Section>
     );
-  });
+  }
+}
+
+storiesOf('Fields', module)
+  .addDecorator(withKnobs)
+  .addDecorator(withReadme(MoneyFieldReadme))
+  .add('MoneyField', () => <MoneyFieldStory />);

--- a/src/components/fields/money-field/money-field.story.js
+++ b/src/components/fields/money-field/money-field.story.js
@@ -108,7 +108,7 @@ class MoneyFieldStory extends React.Component {
               : undefined
           }
           hintIcon={hintIcon}
-          showHighPrecisionBadge={boolean('showHighPrecisionBadge', false)}
+          hasHighPrecisionBadge={boolean('hasHighPrecisionBadge', false)}
         />
       </Section>
     );


### PR DESCRIPTION
- Removes the ability to pass in a badge manually
- Adds the `showHighPrecisionBadge` prop which will show the "high precision price" badge in case a high-precision price was entered.

![hppbadge](https://user-images.githubusercontent.com/1765075/46142187-6c045780-c256-11e8-847b-9754feb6c9a9.gif)
