### PR TITLE
Fix lost updates of MoneyInput for Formik validation

### DIFF
--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -266,7 +266,19 @@ export default class MoneyInput extends React.Component {
         : formattedAmount;
 
       // change currency code
-      this.props.onChange(event);
+      // There is a bug in Formik at the moment where the validation will run
+      // with wrong values when "handleChange" is called before
+      // Formik gets a chance to rerun.
+      // PR with fix is open: https://github.com/jaredpalmer/formik/pull/939
+      // Once merged, we can remove the setTimeout call and call
+      // onChange directly.
+      // While the setTimeout workaround is in place, the error messages
+      // will flicker (appear and disappear) for a split-second.
+      // This setTimeout handles the case of the user entering a perfectly
+      // formatted number and then selecting a currency.
+      setTimeout(() => {
+        this.props.onChange(event);
+      }, 0);
 
       // change amount if necessary
       if (this.props.value.amount !== nextAmount) {
@@ -287,6 +299,8 @@ export default class MoneyInput extends React.Component {
         // onChange directly.
         // While the setTimeout workaround is in place, the error messages
         // will flicker (appear and disappear) for a split-second.
+        // This setTimeout handles the case of the user entering a non-formatted
+        // number and then selecting a currency.
         setTimeout(() => {
           this.props.onChange(fakeEvent);
         }, 0);

--- a/src/components/inputs/money-input/money-input.spec.js
+++ b/src/components/inputs/money-input/money-input.spec.js
@@ -550,7 +550,11 @@ describe('callbacks', () => {
           .prop('onClick')({ target: { value: '12' } });
       });
 
-      it('should call onChange with an event', () => {
+      it('should call onChange with an event', async () => {
+        // wait for onChange call which happens in setTimeout(fn ,0)
+        // This can be removed once the setTimeout workarounds are
+        // removed from money-input.
+        await new Promise(resolve => setTimeout(resolve, 1));
         expect(props.onChange).toHaveBeenCalledWith(
           expect.objectContaining({
             persist: expect.any(Function),


### PR DESCRIPTION
Validation was still being called with invalid values in case the user enters a perfectly formatted amount before selecting a currency.

<a href="https://cl.ly/81ddf56d1348" target="_blank"><img src="https://dzwonsemrish7.cloudfront.net/items/1k2v0P1X0t0J020S1W2f/Screen%20Recording%202018-09-28%20at%2009.49%20AM.gif" style="display: block;height: auto;width: 100%;"/></a>

This workaround can also be removed once https://github.com/jaredpalmer/formik/pull/939 is released.