### PR TITLE
CreatableSelectInput: explicitly declare props

### DIFF
--- a/src/components/inputs/creatable-select-input/README.md
+++ b/src/components/inputs/creatable-select-input/README.md
@@ -1,9 +1,5 @@
 # CreatableSelectInput
 
-> ⚠️ This component is in beta!
-> We are still experimenting with the API, so it might change heavily.
-> The component is still unstyled and docs might be incomplete or outdated.
-
 #### Description
 
 An input component getting a selection from the user, and where options can also be created by the user.
@@ -23,25 +19,47 @@ import { CreatableSelectInput } from '@commercetools-frontend/ui-kit';
 
 #### Properties
 
+| Props                     | Type               | Required | Values                             | Default  | Description                                                                                                                                                                                                                                                                                 |
+| ------------------------- | ------------------ | :------: | ---------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `horizontalConstraint`    | `object`           |    -     | `xs`, `s`, `m`, `l`, `xl`, `scale` | `scale`  | Horizontal size limit of the input fields.                                                                                                                                                                                                                                                  |
+| `hasError`                | `bool`             |    -     | -                                  | -        | Indicates the input field has an error                                                                                                                                                                                                                                                      |
+| `hasWarning`              | `bool`             |    -     | -                                  | -        | Indicates the input field has a warning                                                                                                                                                                                                                                                     |
+| `aria-label`              | `string`           |    -     | -                                  | -        | Aria label (for assistive tech)                                                                                                                                                                                                                                                             |
+| `aria-labelledby`         | `string`           |    -     | -                                  | -        | HTML ID of an element that should be used as the label (for assistive tech)                                                                                                                                                                                                                 |
+| `isAutofocussed`          | `bool`             |    -     | -                                  | -        | Focus the control when it is mounted                                                                                                                                                                                                                                                        |
+| `backspaceRemovesValue`   | `bool`             |    -     | -                                  | `true`   | Remove the currently focused option when the user presses backspace                                                                                                                                                                                                                         |
+| `components`              | `objectOf(func)`   |    -     | -                                  | -        | Map of components to overwrite the default ones, see [what components you can override](https://react-select.com/components)                                                                                                                                                                |
+| `filterOption`            | `func`             |    -     | -                                  | -        | Custom method to filter whether an option should be displayed in the menu                                                                                                                                                                                                                   |
+| `id`                      | `string`           |    -     | -                                  | -        | The id of the search input                                                                                                                                                                                                                                                                  |
+| `containerId`             | `string`           |    -     | -                                  | -        | The id to set on the SelectContainer component                                                                                                                                                                                                                                              |
+| `isClearable`             | `bool`             |    -     | -                                  | -        | Is the select value clearable                                                                                                                                                                                                                                                               |
+| `isDisabled`              | `bool`             |    -     | -                                  | -        | Is the select disabled                                                                                                                                                                                                                                                                      |
+| `isOptionDisabled`        | `func`             |    -     | -                                  | -        | Override the built-in logic to detect whether an option is disabled                                                                                                                                                                                                                         |
+| `isMulti`                 | `bool`             |    -     | -                                  | -        | Support multiple selected options                                                                                                                                                                                                                                                           |
+| `isSearchable`            | `bool`             |    -     | -                                  | `true`   | Whether to enable search functionality                                                                                                                                                                                                                                                      |
+| `maxMenuHeight`           | `number`           |    -     | -                                  | -        | Maximum height of the menu before scrolling                                                                                                                                                                                                                                                 |
+| `name`                    | `string`           |    -     | -                                  | -        | Name of the HTML Input (optional - without this, no input will be rendered)                                                                                                                                                                                                                 |
+| `noOptionsMessage`        | `func`             |    -     | -                                  | -        | Can be used to render a custom value when there are no options (either because of no search results, or all options have been used, or there were none in the first place). Gets called with `{ inputValue: String }`. `inputValue` will be an empty string when no search text is present. |
+| `onBlur`                  | `func`             |    -     | -                                  | -        | Handle blur events on the control                                                                                                                                                                                                                                                           |
+| `onChange`                | `func`             |    ✅    | -                                  | -        | Called with a fake event when value changes. The event's `target.name` will be the `name` supplied in props. The event's `target.value` will hold the value. The value will be the selected option, or an array of options in case `isMulti` is `true`.                                     |
+| `onFocus`                 | `func`             |    -     | -                                  | -        | Handle focus events on the control                                                                                                                                                                                                                                                          |
+| `onInputChange`           | `func`             |    -     | -                                  | -        | Handle change events on the input                                                                                                                                                                                                                                                           |
+| `options`                 | `arrayOf()`        |    -     | -                                  | -        | Array of options that populate the select menu                                                                                                                                                                                                                                              |
+| `placeholder`             | `string`           |    -     | -                                  | -        | Placeholder text for the select value                                                                                                                                                                                                                                                       |
+| `tabIndex`                | `string`           |    -     | -                                  | `"0"`    | Sets the tabIndex attribute on the input                                                                                                                                                                                                                                                    |
+| `tabSelectsValue`         | `bool`             |    -     | -                                  | `true`   | Select the currently focused option when the user presses tab                                                                                                                                                                                                                               |
+| `value`                   | `string` / `array` |    -     | -                                  | -        | The value of the select; reflected by the selected option                                                                                                                                                                                                                                   |
+| `allowCreateWhileLoading` | `bool`             |    -     | -                                  | -        | Allow options to be created while the isLoading prop is true. Useful to prevent the "create new ..." option being displayed while async results are still being loaded.                                                                                                                     |
+| `formatCreateLabel`       | `func`             |    -     | -                                  | -        | Gets the label for the "create new ..." option in the menu. Is given the current input value.                                                                                                                                                                                               |
+| `isValidNewOption`        | `func`             |    -     | -                                  | -        | Determines whether the "create new ..." option should be displayed based on the current input value, select value and options array.                                                                                                                                                        |
+| `getNewOptionData`        | `func`             |    -     | -                                  | -        | Returns the data for the new option when it is created. Used to display the value, and is passed to onChange.                                                                                                                                                                               |
+| `onCreateOption`          | `func`             |    -     | -                                  | -        | If provided, this will be called with the input value when a new option is created, and onChange will not be called. Use this when you need more control over what happens when new options are created.                                                                                    |
+| `createOptionPosition`    | `string`           |    -     | `"first"`, `"last"`                | `"last"` | Sets the position of the createOption element in your options list.                                                                                                                                                                                                                         |
+
 This input is built on top of [`react-select`](https://github.com/JedWatson/react-select) v2.
-It supports the same properties as `react-select`, except for `onChange` and `onBlur` for which the behavior was changed.
+It supports mostly same properties as `react-select`. Behaviour for some props was changed, and support for others was dropped.
 
-##### Customized properties
-
-| Props                  | Type       | Required | Values                             | Default | Description                                                                                                                                                                                                                                                                                 |
-| ---------------------- | ---------- | :------: | ---------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `horizontalConstraint` | `object`   |          | `xs`, `s`, `m`, `l`, `xl`, `scale` | `scale` | Horizontal size limit of the input fields.                                                                                                                                                                                                                                                  |
-| `name`                 | `string`   |          |                                    |         | Used as HTML `name` property                                                                                                                                                                                                                                                                |
-| `onChange`             | `function` |    ✅    | -                                  | -       | Called with a fake event when value changes. The event's `target.name` will be the `name` supplied in props. The event's `target.value` will hold the value. The value will be the selected option, or an array of options in case `isMulti` is `true`.                                     |
-| `onBlur`               | `function` |          | -                                  | -       | Called with a fake event when input is blurred. The event's `target.name` will be the `name` supplied in props. In case `isMulti` is `true`, the name will have `.0` appended which helps with the formik integration.                                                                      |
-| `isDisabled`           | `bool`     |          | -                                  | `false` | Indicates that the field cannot be used (e.g not authorised, or changes not saved)                                                                                                                                                                                                          |
-| `isMulti`              | `bool`     |          | -                                  | `false` | Multiple values can be selected when this option is checked. The `event` passed to `onChange` will contain an array of values then.                                                                                                                                                         |
-| `components`           | `object`   |    -     | -                                  | -       | Overrides for `CreatableSelectInput` conponents , see [what components you can override](https://react-select.com/components)                                                                                                                                                               |
-| `options`              | `array`    |          | Items should contain `value` key   |         | Selectable options                                                                                                                                                                                                                                                                          |
-| `noOptionsMessage`     | `function` |          |                                    |         | Can be used to render a custom value when there are no options (either because of no search results, or all options have been used, or there were none in the first place). Gets called with `{ inputValue: String }`. `inputValue` will be an empty string when no search text is present. |
-| `hasError`             | `bool`     |          | -                                  | -       | Indicates the input field has an error                                                                                                                                                                                                                                                      |
-
-See the [official documentation](https://react-select.com/props) for all other properties.
+In case you need one of the currently excluded props, feel free to open a PR adding them.
 
 ##### `options`
 
@@ -54,127 +72,37 @@ The options support a `isDisabled` property which will render the option with a 
 Expects to be called with an array or boolean.
 Returns `true` when truthy.
 
-##### `ClearIndicator`
+##### Components
 
-Default implementation of internal `ClearIndicator` component.
-See the [official documentation](https://react-select.com/components).
+It is possible to customize `SelectInput` by passing the `components` property.
+`SelectInput` exports the default underlying components as static exports.
 
-##### `Control`
+Components available as static exports are:
 
-Default implementation of internal `Control` component.
-See the [official documentation](https://react-select.com/components).
+- `ClearIndicator`
+- `Control`
+- `DropdownIndicator`
+- `DownChevron`
+- `CrossIcon`
+- `Group`
+- `GroupHeading`
+- `IndicatorsContainer`
+- `IndicatorSeparator`
+- `Input`
+- `LoadingIndicator`
+- `Menu`
+- `MenuList`
+- `MenuPortal`
+- `LoadingMessage`
+- `NoOptionsMessage`
+- `MultiValue`
+- `MultiValueContainer`
+- `MultiValueLabel`
+- `MultiValueRemove`
+- `Option`
+- `Placeholder`
+- `SelectContainer`
+- `SingleValue`
+- `ValueContainer`
 
-##### `DropdownIndicator`
-
-Default implementation of internal `DropdownIndicator` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `DownChevron`
-
-Default implementation of internal `DownChevron` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `CrossIcon`
-
-Default implementation of internal `CrossIcon` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `Group`
-
-Default implementation of internal `Group` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `GroupHeading`
-
-Default implementation of internal `GroupHeading` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `IndicatorsContainer`
-
-Default implementation of internal `IndicatorsContainer` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `IndicatorSeparator`
-
-Default implementation of internal `IndicatorSeparator` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `Input`
-
-Default implementation of internal `Input` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `LoadingIndicator`
-
-Default implementation of internal `LoadingIndicator` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `Menu`
-
-Default implementation of internal `Menu` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `MenuList`
-
-Default implementation of internal `MenuList` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `MenuPortal`
-
-Default implementation of internal `MenuPortal` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `LoadingMessage`
-
-Default implementation of internal `LoadingMessage` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `NoOptionsMessage`
-
-Default implementation of internal `NoOptionsMessage` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `MultiValue`
-
-Default implementation of internal `MultiValue` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `MultiValueContainer`
-
-Default implementation of internal `MultiValueContainer` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `MultiValueLabel`
-
-Default implementation of internal `MultiValueLabel` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `MultiValueRemove`
-
-Default implementation of internal `MultiValueRemove` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `Option`
-
-Default implementation of internal `Option` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `Placeholder`
-
-Default implementation of internal `Placeholder` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `SelectContainer`
-
-Default implementation of internal `SelectContainer` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `SingleValue`
-
-Default implementation of internal `SingleValue` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `ValueContainer`
-
-Default implementation of internal `ValueContainer` component.
-See the [official documentation](https://react-select.com/components).
+See the [official documentation](https://react-select.com/components) for more information about the props they receive.

--- a/src/components/inputs/creatable-select-input/creatable-select-input.story.js
+++ b/src/components/inputs/creatable-select-input/creatable-select-input.story.js
@@ -3,7 +3,13 @@ import { Value } from 'react-value';
 import { IntlProvider } from 'react-intl';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, text, select } from '@storybook/addon-knobs';
+import {
+  withKnobs,
+  boolean,
+  text,
+  select,
+  number,
+} from '@storybook/addon-knobs';
 import LinkTo from '@storybook/addon-links/react';
 import withReadme from 'storybook-readme/with-readme';
 import Section from '../../../../.storybook/decorators/section';
@@ -82,21 +88,42 @@ storiesOf('Inputs', module)
                     ['xs', 's', 'm', 'l', 'xl', 'scale'],
                     'scale'
                   )}
+                  hasError={boolean('hasError', false)}
+                  hasWarning={boolean('hasWarning', false)}
+                  aria-label={text('aria-label', '')}
+                  aria-labelledby={text('aria-labelledby', '')}
+                  autoFocus={boolean('isAutofocussed', false)}
+                  backspaceRemovesValue={boolean('backspaceRemovesValue', true)}
+                  id={text('id', '')}
+                  containerId={text('containerId', '')}
+                  isClearable={boolean('isClearable', false)}
+                  isDisabled={boolean('isDisabled', false)}
+                  isMulti={isMulti}
+                  isSearchable={boolean('isSearchable', true)}
+                  maxMenuHeight={number('maxMenuHeight', 200)}
                   name={text('name', 'form-field-name')}
-                  value={value}
+                  onBlur={action('onBlur')}
                   onChange={(event, ...args) => {
                     action('onChange')(event, ...args);
                     onChange(event.target.value);
                   }}
-                  onBlur={action('onBlur')}
-                  isMulti={isMulti}
-                  placeholder={text('placeholder', 'Select..')}
-                  isSearchable={boolean('isSearchable', true)}
-                  isDisabled={boolean('isDisabled', false)}
-                  isClearable={boolean('isClearable', false)}
-                  hasError={boolean('hasError', false)}
-                  hasWarning={boolean('hasWarning', false)}
+                  onFocus={action('onFocus')}
+                  onInputChange={action('onInputChange')}
                   options={options}
+                  placeholder={text('placeholder', 'Select..')}
+                  tabIndex={text('tabIndex', '0')}
+                  tabSelectsValue={boolean('tabSelectsValue', true)}
+                  value={value}
+                  // Creatable props
+                  allowCreateWhileLoading={boolean(
+                    'allowCreateWhileLoading',
+                    false
+                  )}
+                  createOptionPosition={select(
+                    'createOptionPosition',
+                    ['first', 'last'],
+                    'last'
+                  )}
                 />
               )}
             />


### PR DESCRIPTION
- Explicitly declares props of `CreatableSelectInput`
- Moves `CreatableSelectInput` out of beta
- Adapts story and README