### PR TITLE
AsyncCreatableSelectInput: explicitly declare props

### DIFF
--- a/src/components/inputs/async-creatable-select-input/README.md
+++ b/src/components/inputs/async-creatable-select-input/README.md
@@ -1,9 +1,5 @@
 # AsyncCreatableSelectInput
 
-> ⚠️ This component is in beta!
-> We are still experimenting with the API, so it might change heavily.
-> The component is still unstyled and docs might be incomplete or outdated.
-
 #### Description
 
 An input component getting a selection from an asynchronously loaded list from the user, and where options can be created by the user.
@@ -50,21 +46,51 @@ Any parent component using `AsyncCreatableSelectInput` has to pass in a value, w
 
 #### Properties
 
+#### Properties
+
+| Props                     | Type                | Required | Values                             | Default  | Description                                                                                                                                                                                                                                                                                 |
+| ------------------------- | ------------------- | :------: | ---------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `horizontalConstraint`    | `object`            |    -     | `xs`, `s`, `m`, `l`, `xl`, `scale` | `scale`  | Horizontal size limit of the input fields.                                                                                                                                                                                                                                                  |
+| `hasError`                | `bool`              |    -     | -                                  | -        | Indicates the input field has an error                                                                                                                                                                                                                                                      |
+| `hasWarning`              | `bool`              |    -     | -                                  | -        | Indicates the input field has a warning                                                                                                                                                                                                                                                     |
+| `aria-label`              | `string`            |    -     | -                                  | -        | Aria label (for assistive tech)                                                                                                                                                                                                                                                             |
+| `aria-labelledby`         | `string`            |    -     | -                                  | -        | HTML ID of an element that should be used as the label (for assistive tech)                                                                                                                                                                                                                 |
+| `isAutofocussed`          | `bool`              |    -     | -                                  | -        | Focus the control when it is mounted                                                                                                                                                                                                                                                        |
+| `backspaceRemovesValue`   | `bool`              |    -     | -                                  | `true`   | Remove the currently focused option when the user presses backspace                                                                                                                                                                                                                         |
+| `components`              | `objectOf(func)`    |    -     | -                                  | -        | Map of components to overwrite the default ones, see [what components you can override](https://react-select.com/components)                                                                                                                                                                |
+| `filterOption`            | `func`              |    -     | -                                  | -        | Custom method to filter whether an option should be displayed in the menu                                                                                                                                                                                                                   |
+| `id`                      | `string`            |    -     | -                                  | -        | The id of the search input                                                                                                                                                                                                                                                                  |
+| `containerId`             | `string`            |    -     | -                                  | -        | The id to set on the SelectContainer component                                                                                                                                                                                                                                              |
+| `isClearable`             | `bool`              |    -     | -                                  | -        | Is the select value clearable                                                                                                                                                                                                                                                               |
+| `isDisabled`              | `bool`              |    -     | -                                  | -        | Is the select disabled                                                                                                                                                                                                                                                                      |
+| `isOptionDisabled`        | `func`              |    -     | -                                  | -        | Override the built-in logic to detect whether an option is disabled                                                                                                                                                                                                                         |
+| `isMulti`                 | `bool`              |    -     | -                                  | -        | Support multiple selected options                                                                                                                                                                                                                                                           |
+| `isSearchable`            | `bool`              |    -     | -                                  | `true`   | Whether to enable search functionality                                                                                                                                                                                                                                                      |
+| `maxMenuHeight`           | `number`            |    -     | -                                  | -        | Maximum height of the menu before scrolling                                                                                                                                                                                                                                                 |
+| `name`                    | `string`            |    -     | -                                  | -        | Name of the HTML Input (optional - without this, no input will be rendered)                                                                                                                                                                                                                 |
+| `noOptionsMessage`        | `func`              |    -     | -                                  | -        | Can be used to render a custom value when there are no options (either because of no search results, or all options have been used, or there were none in the first place). Gets called with `{ inputValue: String }`. `inputValue` will be an empty string when no search text is present. |
+| `onBlur`                  | `func`              |    -     | -                                  | -        | Handle blur events on the control                                                                                                                                                                                                                                                           |
+| `onChange`                | `func`              |    ✅    | -                                  | -        | Called with a fake event when value changes. The event's `target.name` will be the `name` supplied in props. The event's `target.value` will hold the value. The value will be the selected option, or an array of options in case `isMulti` is `true`.                                     |
+| `onFocus`                 | `func`              |    -     | -                                  | -        | Handle focus events on the control                                                                                                                                                                                                                                                          |
+| `onInputChange`           | `func`              |    -     | -                                  | -        | Handle change events on the input                                                                                                                                                                                                                                                           |
+| `placeholder`             | `string`            |    -     | -                                  | -        | Placeholder text for the select value                                                                                                                                                                                                                                                       |
+| `tabIndex`                | `string`            |    -     | -                                  | `"0"`    | Sets the tabIndex attribute on the input                                                                                                                                                                                                                                                    |
+| `tabSelectsValue`         | `bool`              |    -     | -                                  | `true`   | Select the currently focused option when the user presses tab                                                                                                                                                                                                                               |
+| `value`                   | `object` / `array`  |    -     | -                                  | -        | The value of the select; reflected by the selected option                                                                                                                                                                                                                                   |
+| `defaultOptions`          | `boolean` / `array` |    -     | -                                  | -        | The default set of options to show before the user starts searching. When set to true, the results for loadOptions('') will be autoloaded.                                                                                                                                                  |
+| `loadOptions`             | `function`          |    -     | -                                  | -        | Function that returns a promise, which is the set of options to be used once the promise resolves.                                                                                                                                                                                          |
+| `cacheOptions`            | `any`               |    -     | -                                  | -        | If cacheOptions is truthy, then the loaded data will be cached. The cache will remain until cacheOptions changes value.                                                                                                                                                                     |
+| `allowCreateWhileLoading` | `bool`              |    -     | -                                  | -        | Allow options to be created while the isLoading prop is true. Useful to prevent the "create new ..." option being displayed while async results are still being loaded.                                                                                                                     |
+| `formatCreateLabel`       | `func`              |    -     | -                                  | -        | Gets the label for the "create new ..." option in the menu. Is given the current input value.                                                                                                                                                                                               |
+| `isValidNewOption`        | `func`              |    -     | -                                  | -        | Determines whether the "create new ..." option should be displayed based on the current input value, select value and options array.                                                                                                                                                        |
+| `getNewOptionData`        | `func`              |    -     | -                                  | -        | Returns the data for the new option when it is created. Used to display the value, and is passed to onChange.                                                                                                                                                                               |
+| `onCreateOption`          | `func`              |    -     | -                                  | -        | If provided, this will be called with the input value when a new option is created, and onChange will not be called. Use this when you need more control over what happens when new options are created.                                                                                    |
+| `createOptionPosition`    | `string`            |    -     | `"first"`, `"last"`                | `"last"` | Sets the position of the createOption element in your options list.                                                                                                                                                                                                                         |
+
 This input is built on top of [`react-select`](https://github.com/JedWatson/react-select) v2.
-It supports the same properties as `react-select`, except for `onChange` and `onBlur` for which the behavior was changed.
+It supports mostly same properties as `react-select`. Behaviour for some props was changed, and support for others was dropped.
 
-##### Customized properties
-
-| Props                  | Type       | Required | Values                 | Default | Description                                                                                                                                                                                                                                                                                                                                                       |
-| ---------------------- | ---------- | :------: | ---------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `horizontalConstraint` | `string`   |    -     | xs, s, m, l, xl, scale | -       | Horizontal size limit of the input fields.                                                                                                                                                                                                                                                                                                                        |
-| `onChange`             | `function` |    ✅    | -                      | -       | Called with a fake event when value is changed by user. The event's `target.name` will be the `name` supplied in props. The event's `target.value` will hold the value. The value will be a the selected option, or an array of options in case `props.isMulti` is `true`. The second argument is an object containing information about the cause of the change. |
-| `onBlur`               | `function` |    -     | -                      | -       | Called with a fake event when input is blurred. The event's `target.name` will be the `name` supplied in props. In case `props.isMulti` is `true`, the name will have `.0` appended which helps with the formik integration.                                                                                                                                      |
-| `components`           | `object`   |    -     | -                      | -       | Overrides for `AsyncCreatableSelectInput` conponents , see [what components you can override](https://react-select.com/components)                                                                                                                                                                                                                                |
-| `hasWarning`           | `bool`     |    -     | -                      | -       | Indicates the input field has a warning                                                                                                                                                                                                                                                                                                                           |
-| `hasError`             | `bool`     |    -     | -                      | -       | Indicates the input field has an error                                                                                                                                                                                                                                                                                                                            |
-
-See the [official documentation](https://react-select.com/props) for all other properties.
+In case you need one of the currently excluded props, feel free to open a PR adding them.
 
 #### Static Properties
 
@@ -73,127 +99,37 @@ See the [official documentation](https://react-select.com/props) for all other p
 Expects to be called with an array or boolean.
 Returns `true` when truthy.
 
-##### `ClearIndicator`
+##### Components
 
-Default implementation of internal `ClearIndicator` component.
-See the [official documentation](https://react-select.com/components).
+It is possible to customize `SelectInput` by passing the `components` property.
+`SelectInput` exports the default underlying components as static exports.
 
-##### `Control`
+Components available as static exports are:
 
-Default implementation of internal `Control` component.
-See the [official documentation](https://react-select.com/components).
+- `ClearIndicator`
+- `Control`
+- `DropdownIndicator`
+- `DownChevron`
+- `CrossIcon`
+- `Group`
+- `GroupHeading`
+- `IndicatorsContainer`
+- `IndicatorSeparator`
+- `Input`
+- `LoadingIndicator`
+- `Menu`
+- `MenuList`
+- `MenuPortal`
+- `LoadingMessage`
+- `NoOptionsMessage`
+- `MultiValue`
+- `MultiValueContainer`
+- `MultiValueLabel`
+- `MultiValueRemove`
+- `Option`
+- `Placeholder`
+- `SelectContainer`
+- `SingleValue`
+- `ValueContainer`
 
-##### `DropdownIndicator`
-
-Default implementation of internal `DropdownIndicator` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `DownChevron`
-
-Default implementation of internal `DownChevron` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `CrossIcon`
-
-Default implementation of internal `CrossIcon` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `Group`
-
-Default implementation of internal `Group` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `GroupHeading`
-
-Default implementation of internal `GroupHeading` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `IndicatorsContainer`
-
-Default implementation of internal `IndicatorsContainer` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `IndicatorSeparator`
-
-Default implementation of internal `IndicatorSeparator` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `Input`
-
-Default implementation of internal `Input` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `LoadingIndicator`
-
-Default implementation of internal `LoadingIndicator` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `Menu`
-
-Default implementation of internal `Menu` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `MenuList`
-
-Default implementation of internal `MenuList` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `MenuPortal`
-
-Default implementation of internal `MenuPortal` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `LoadingMessage`
-
-Default implementation of internal `LoadingMessage` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `NoOptionsMessage`
-
-Default implementation of internal `NoOptionsMessage` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `MultiValue`
-
-Default implementation of internal `MultiValue` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `MultiValueContainer`
-
-Default implementation of internal `MultiValueContainer` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `MultiValueLabel`
-
-Default implementation of internal `MultiValueLabel` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `MultiValueRemove`
-
-Default implementation of internal `MultiValueRemove` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `Option`
-
-Default implementation of internal `Option` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `Placeholder`
-
-Default implementation of internal `Placeholder` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `SelectContainer`
-
-Default implementation of internal `SelectContainer` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `SingleValue`
-
-Default implementation of internal `SingleValue` component.
-See the [official documentation](https://react-select.com/components).
-
-##### `ValueContainer`
-
-Default implementation of internal `ValueContainer` component.
-See the [official documentation](https://react-select.com/components).
+See the [official documentation](https://react-select.com/components) for more information about the props they receive.

--- a/src/components/inputs/async-creatable-select-input/async-creatable-select-input.js
+++ b/src/components/inputs/async-creatable-select-input/async-creatable-select-input.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
-import omit from 'lodash.omit';
 import {
   components as defaultComponents,
   AsyncCreatable as AsyncCreatableSelect,
@@ -33,25 +32,65 @@ export class AsyncCreatableSelectInput extends React.Component {
 
   static displayName = 'AsyncCreatableSelectInput';
 
-  // Using "null" will ensure that the currently selected value disappears in
-  // case "undefined" gets passed as the next value
-  static defaultProps = { value: null };
+  static defaultProps = {
+    // Using "null" will ensure that the currently selected value disappears in
+    // case "undefined" gets passed as the next value
+    value: null,
+    isSearchable: true,
+  };
 
   static propTypes = {
     horizontalConstraint: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl', 'scale']),
+    intl: PropTypes.shape({
+      formatMessage: PropTypes.func.isRequired,
+    }).isRequired,
+    hasError: PropTypes.bool,
+    hasWarning: PropTypes.bool,
+
+    // react-select base props
+    //
+    // Currently unsupported props are commented out. In case you need one of
+    // these props when using UI Kit, you can submit a PR and enable the
+    // prop. Don't forget to add it to the story, docs and other select input
+    // components as well!
+    //
+    // See https://react-select.com/props#select-props
+    'aria-label': PropTypes.string,
+    'aria-labelledby': PropTypes.string,
+    isAutofocussed: PropTypes.bool, // original: autoFocus
+    backspaceRemovesValue: PropTypes.bool,
+    components: PropTypes.objectOf(PropTypes.func),
+    filterOption: PropTypes.func,
+    // This forwarded as react-select's "inputId"
+    id: PropTypes.string,
+    // This is forwarded as react-select's "id"
+    containerId: PropTypes.string,
+    isClearable: PropTypes.bool,
+    isDisabled: PropTypes.bool,
+    isOptionDisabled: PropTypes.func,
+    isMulti: PropTypes.bool,
+    isSearchable: PropTypes.bool,
+    maxMenuHeight: PropTypes.number,
     name: PropTypes.string,
+    noOptionsMessage: PropTypes.func,
+    onBlur: PropTypes.func,
+    onChange: PropTypes.func.isRequired,
+    onFocus: PropTypes.func,
+    onInputChange: PropTypes.func,
+    placeholder: PropTypes.string,
+    tabIndex: PropTypes.string,
+    tabSelectsValue: PropTypes.bool,
     value: (props, ...rest) =>
       props.isMulti
         ? PropTypes.arrayOf(
             PropTypes.shape({ value: PropTypes.string.isRequired })
-          ).isRequired(props, ...rest)
+          )(props, ...rest)
         : PropTypes.shape({ value: PropTypes.string.isRequired })(
             props,
             ...rest
           ),
-    options: PropTypes.objectOf(
-      PropTypes.shape({ value: PropTypes.string.isRequired })
-    ),
+
+    // Async props
     defaultOptions: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.arrayOf(
@@ -60,19 +99,16 @@ export class AsyncCreatableSelectInput extends React.Component {
         })
       ),
     ]),
-    onChange: PropTypes.func.isRequired,
-    onBlur: PropTypes.func,
     loadOptions: PropTypes.func.isRequired,
-    isMulti: PropTypes.bool,
+    cacheOptions: PropTypes.any,
 
-    components: PropTypes.object,
+    // Creatable props
+    allowCreateWhileLoading: PropTypes.bool,
     formatCreateLabel: PropTypes.func,
-    noOptionsMessage: PropTypes.func,
-    intl: PropTypes.shape({
-      formatMessage: PropTypes.func.isRequired,
-    }).isRequired,
-    hasError: PropTypes.bool,
-    hasWarning: PropTypes.bool,
+    isValidNewOption: PropTypes.func,
+    getNewOptionData: PropTypes.func,
+    onCreateOption: PropTypes.func,
+    createOptionPosition: PropTypes.string,
   };
 
   render() {
@@ -80,11 +116,10 @@ export class AsyncCreatableSelectInput extends React.Component {
       <Constraints.Horizontal constraint={this.props.horizontalConstraint}>
         <div {...filterDataAttributes(this.props)}>
           <AsyncCreatableSelect
-            {...omit(this.props, [
-              'horizontalConstraint',
-              'hasError',
-              'hasWarning',
-            ])}
+            aria-label={this.props['aria-label']}
+            aria-labelledby={this.props['aria-labelledby']}
+            autoFocus={this.props.isAutofocussed}
+            backspaceRemovesValue={this.props.backspaceRemovesValue}
             className={classnames('react-select', {
               // We use global styles here as the react-select styles are global
               // as well. This sucks.
@@ -93,22 +128,37 @@ export class AsyncCreatableSelectInput extends React.Component {
               'react-select-error': this.props.hasError,
               'react-select-warning': this.props.hasWarning,
             })}
+            classNamePrefix="react-select"
             components={{
               ...customizedComponents,
               ...this.props.components,
             }}
-            classNamePrefix="react-select"
-            onChange={(value, info) => {
-              this.props.onChange(
-                {
-                  target: { name: this.props.name, value },
-                  persist: () => {},
-                },
-                info
-              );
-            }}
-            value={this.props.value}
-            loadOptions={this.props.loadOptions}
+            filterOption={this.props.filterOption}
+            // react-select uses "id" (for the container) and "inputId" (for the input),
+            // but we use "id" (for the input) and "containerId" (for the container)
+            // instead.
+            // This makes it easier to less confusing to use with <label />s.
+            id={this.props.containerId}
+            inputId={this.props.id}
+            isClearable={this.props.isClearable}
+            isDisabled={this.props.isDisabled}
+            isOptionDisabled={this.props.isOptionDisabled}
+            isMulti={this.props.isMulti}
+            isSearchable={this.props.isSearchable}
+            maxMenuHeight={this.props.maxMenuHeight}
+            name={this.props.name}
+            noOptionsMessage={
+              this.props.noOptionsMessage ||
+              (({ inputValue }) =>
+                inputValue === ''
+                  ? this.props.intl.formatMessage(
+                      messages.noOptionsMessageWithoutInputValue
+                    )
+                  : this.props.intl.formatMessage(
+                      messages.noOptionsMessageWithInputValue,
+                      { inputValue }
+                    ))
+            }
             onBlur={
               this.props.onBlur
                 ? () => {
@@ -130,6 +180,27 @@ export class AsyncCreatableSelectInput extends React.Component {
                   }
                 : undefined
             }
+            onChange={(value, info) => {
+              this.props.onChange(
+                {
+                  target: { name: this.props.name, value },
+                  persist: () => {},
+                },
+                info
+              );
+            }}
+            onFocus={this.props.onFocus}
+            onInputChange={this.props.onInputChange}
+            placeholder={this.props.placeholder}
+            tabIndex={this.props.tabIndex}
+            tabSelectsValue={this.props.tabSelectsValue}
+            value={this.props.value}
+            // Async react-select props
+            defaultOptions={this.props.defaultOptions}
+            loadOptions={this.props.loadOptions}
+            cacheOptions={this.props.cacheOptions}
+            // Creatable props
+            allowCreateWhileLoading={this.props.allowCreateWhileLoading}
             formatCreateLabel={
               this.props.formatCreateLabel ||
               (inputValue =>
@@ -137,19 +208,10 @@ export class AsyncCreatableSelectInput extends React.Component {
                   inputValue,
                 }))
             }
-            noOptionsMessage={
-              this.props.noOptionsMessage ||
-              (({ inputValue }) =>
-                inputValue === ''
-                  ? this.props.intl.formatMessage(
-                      messages.noOptionsMessageWithoutInputValue
-                    )
-                  : this.props.intl.formatMessage(
-                      messages.noOptionsMessageWithInputValue,
-                      { inputValue }
-                    ))
-            }
-            isSearchable={true}
+            isValidNewOption={this.props.isValidNewOption}
+            getNewOptionData={this.props.getNewOptionData}
+            onCreateOption={this.props.onCreateOption}
+            createOptionPosition={this.props.createOptionPosition}
           />
         </div>
       </Constraints.Horizontal>

--- a/src/components/inputs/async-creatable-select-input/async-creatable-select-input.story.js
+++ b/src/components/inputs/async-creatable-select-input/async-creatable-select-input.story.js
@@ -3,7 +3,13 @@ import { Value } from 'react-value';
 import { storiesOf } from '@storybook/react';
 import { IntlProvider } from 'react-intl';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, text, select } from '@storybook/addon-knobs';
+import {
+  withKnobs,
+  boolean,
+  text,
+  select,
+  number,
+} from '@storybook/addon-knobs';
 import withReadme from 'storybook-readme/with-readme';
 import Section from '../../../../.storybook/decorators/section';
 import Readme from './README.md';
@@ -29,7 +35,7 @@ const filterColors = inputValue =>
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
-const promiseOptions = inputValue =>
+const loadOptions = inputValue =>
   delay(500).then(() => filterColors(inputValue));
 
 class SelectStory extends React.Component {
@@ -49,30 +55,53 @@ class SelectStory extends React.Component {
               render={(value, onChange) => (
                 <div>
                   <AsyncCreatableSelectInput
-                    name={text('name', 'form-field-name')}
-                    isMulti={isMulti}
-                    isClearable={boolean('isClearable', true)}
-                    createOptionPosition={select(
-                      'createOptionPosition',
-                      ['first', 'last'],
-                      'last'
-                    )}
-                    cacheOptions
-                    value={value}
-                    onChange={(event, info) => {
-                      action('onChange')(event, info);
-                      onChange(event.target.value);
-                    }}
-                    onBlur={action('onBlur')}
-                    loadOptions={promiseOptions}
-                    defaultOptions={defaultOptions}
                     horizontalConstraint={select(
                       'horizontalConstraint',
                       ['xs', 's', 'm', 'l', 'xl', 'scale'],
                       'scale'
                     )}
-                    placeholder={text('placeholder', 'Select..')}
+                    hasError={boolean('hasError', false)}
+                    hasWarning={boolean('hasWarning', false)}
+                    aria-label={text('aria-label', '')}
+                    aria-labelledby={text('aria-labelledby', '')}
+                    isAutofocussed={boolean('isAutofocussed', false)}
+                    backspaceRemovesValue={boolean(
+                      'backspaceRemovesValue',
+                      true
+                    )}
+                    id={text('id', '')}
+                    containerId={text('containerId', '')}
+                    isClearable={boolean('isClearable', false)}
                     isDisabled={boolean('isDisabled', false)}
+                    isMulti={isMulti}
+                    isSearchable={boolean('isSearchable', true)}
+                    maxMenuHeight={number('maxMenuHeight', 200)}
+                    name={text('name', 'form-field-name')}
+                    onBlur={action('onBlur')}
+                    onChange={(event, info) => {
+                      action('onChange')(event, info);
+                      onChange(event.target.value);
+                    }}
+                    onFocus={action('onFocus')}
+                    onInputChange={action('onInputChange')}
+                    placeholder={text('placeholder', 'Select..')}
+                    tabIndex={text('tabIndex', '0')}
+                    tabSelectsValue={boolean('tabSelectsValue', true)}
+                    value={value}
+                    // Async props
+                    defaultOptions={defaultOptions}
+                    loadOptions={loadOptions}
+                    cacheOptions={boolean('cacheOptions', false)}
+                    // Creatable props
+                    allowCreateWhileLoading={boolean(
+                      'allowCreateWhileLoading',
+                      false
+                    )}
+                    createOptionPosition={select(
+                      'createOptionPosition',
+                      ['first', 'last'],
+                      'last'
+                    )}
                   />
                 </div>
               )}


### PR DESCRIPTION
- move `AsyncCreatableSelectInput` out of beta
- explicitly declare props
- adapt docs and spec

Same as #119 but for `AsyncCreatableSelectInput`.