### PR TITLE
renames all `Tag` tokens from plural to singular

### DIFF
--- a/materials/tokens/backgrounds.mod.css
+++ b/materials/tokens/backgrounds.mod.css
@@ -11,7 +11,7 @@
     * • Inputs
     *  ◦ Text fields
     *   ▪ Background Colors
-    * • Tags
+    * • Tag
     *  ◦ Background Colors
     */
 

--- a/materials/tokens/backgrounds.mod.css
+++ b/materials/tokens/backgrounds.mod.css
@@ -33,9 +33,9 @@
    ========================================================================== */
 
   /* Colors */
-  --token-background-color-tags-pristine: var(--color-gray-95);
-  --token-background-color-tags-warning: var(--color-orange-95);
-  --token-background-color-tags-disabled: var(--color-gray-95);
-  --token-background-color-tags-normal-hover: var(--color-gray-60);
-  --token-background-color-tags-warning-hover: var(--color-orange);
+  --token-background-color-tag-pristine: var(--color-gray-95);
+  --token-background-color-tag-warning: var(--color-orange-95);
+  --token-background-color-tag-disabled: var(--color-gray-95);
+  --token-background-color-tag-normal-hover: var(--color-gray-60);
+  --token-background-color-tag-warning-hover: var(--color-orange);
 }

--- a/materials/tokens/borders.mod.css
+++ b/materials/tokens/borders.mod.css
@@ -13,7 +13,7 @@
     *  ◦ Text fields
     *   ▪ Border Colors
     *   ▪ Border Radius
-    * • Tags
+    * • Tag
     *  ◦ Border Colors
     *  ◦ Border Radius
     * • Separator

--- a/materials/tokens/borders.mod.css
+++ b/materials/tokens/borders.mod.css
@@ -43,13 +43,13 @@
    ========================================================================== */
 
   /* Colors */
-  --token-border-color-tags-pristine: var(--color-gray-60);
-  --token-border-color-tags-warning: var(--color-orange);
-  --token-border-color-tags-focus: var(--color-green);
-  --token-border-color-tags-warning-hover: var(--color-orange);
+  --token-border-color-tag-pristine: var(--color-gray-60);
+  --token-border-color-tag-warning: var(--color-orange);
+  --token-border-color-tag-focus: var(--color-green);
+  --token-border-color-tag-warning-hover: var(--color-orange);
 
   /* Radius */
-  --token-border-radius-tags: var(--border-radius-2);
+  --token-border-radius-tag: var(--border-radius-2);
 
   /* ==========================================================================
    Separator

--- a/materials/tokens/shadows.mod.css
+++ b/materials/tokens/shadows.mod.css
@@ -18,5 +18,5 @@
    ========================================================================== */
 
   /* Colors */
-  --token-shadow-box-tags-hover: var(--shadow-1-first), var(--shadow-1-second);
+  --token-shadow-box-tag-hover: var(--shadow-1-first), var(--shadow-1-second);
 }

--- a/materials/tokens/shadows.mod.css
+++ b/materials/tokens/shadows.mod.css
@@ -9,7 +9,7 @@
     * Do not use these for border colors or background colors.
     *
     * Index
-    * • Tags
+    * • Tag
     *  ◦ Shadows Box
     */
 

--- a/materials/tokens/sizes.mod.css
+++ b/materials/tokens/sizes.mod.css
@@ -11,7 +11,7 @@
     * • Inputs
     *  ◦ Text fields
     *   ▪ Height
-      * • Tag
+      * • Tags
     *  ◦ Height
     */
 
@@ -30,5 +30,5 @@
    ========================================================================== */
 
   /* Height */
-  --token-size-height-tags: 26px;
+  --token-size-height-tag: 26px;
 }

--- a/materials/tokens/sizes.mod.css
+++ b/materials/tokens/sizes.mod.css
@@ -11,7 +11,7 @@
     * • Inputs
     *  ◦ Text fields
     *   ▪ Height
-      * • Tags
+    * • Tag
     *  ◦ Height
     */
 

--- a/src/components/internals/select.css
+++ b/src/components/internals/select.css
@@ -160,30 +160,30 @@
 }
 
 .react-select .react-select__multi-value {
-  height: var(--token-size-height-tags);
-  background-color: var(--token-background-color-tags-pristine);
+  height: var(--token-size-height-tag);
+  background-color: var(--token-background-color-tag-pristine);
   padding: 0;
 }
 
 .react-select .react-select__multi-value__label {
   font-size: var(--token-font-size-small);
   padding: var(--spacing-4) var(--spacing-8);
-  border-radius: var(--token-border-radius-tags);
-  border: 1px var(--token-border-color-tags-pristine) solid;
+  border-radius: var(--token-border-radius-tag);
+  border: 1px var(--token-border-color-tag-pristine) solid;
 }
 
 .react-select .react-select__multi-value__remove {
-  border-color: var(--token-border-color-tags-pristine);
+  border-color: var(--token-border-color-tag-pristine);
   padding: 0 var(--spacing-4);
-  border-radius: 0 var(--token-border-radius-tags)
-    var(--token-border-radius-tags) 0;
+  border-radius: 0 var(--token-border-radius-tag)
+    var(--token-border-radius-tag) 0;
   border-style: solid;
   border-width: 1px 1px 1px 0;
 }
 
 .react-select .react-select__multi-value__remove:hover {
-  background-color: var(--token-background-color-tags-normal-hover);
-  box-shadow: var(--token-shadow-box-tags-hover);
+  background-color: var(--token-background-color-tag-normal-hover);
+  box-shadow: var(--token-shadow-box-tag-hover);
 }
 
 /* Grouping */

--- a/src/components/tag/tag.mod.css
+++ b/src/components/tag/tag.mod.css
@@ -6,8 +6,8 @@
 .contentWrapper {
   display: flex;
   align-items: center;
-  height: var(--token-size-height-tags);
-  border-radius: var(--token-border-radius-tags);
+  height: var(--token-size-height-tag);
+  border-radius: var(--token-border-radius-tag);
   padding: 0 var(--spacing-8);
   cursor: default;
   font-family: inherit;
@@ -38,21 +38,21 @@
 /* Normal */
 
 .wrapperTypeNormal {
-  background-color: var(--token-background-color-tags-pristine);
+  background-color: var(--token-background-color-tag-pristine);
 }
 
 .contentWrapperNormal {
-  border-color: var(--token-border-color-tags-pristine);
+  border-color: var(--token-border-color-tag-pristine);
 }
 
 /* Warning */
 
 .wrapperTypeWarning {
-  background-color: var(--token-background-color-tags-warning);
+  background-color: var(--token-background-color-tag-warning);
 }
 
 .contentWrapperWarning {
-  border-color: var(--token-border-color-tags-warning);
+  border-color: var(--token-border-color-tag-warning);
 }
 
 /* Clickable */
@@ -62,24 +62,24 @@
 }
 
 .clickableContentWrapper:hover {
-  box-shadow: var(--token-shadow-box-tags-hover);
+  box-shadow: var(--token-shadow-box-tag-hover);
 }
 
 .clickableContentWrapperNormal:hover {
-  border-color: var(--token-border-color-tags-focus);
+  border-color: var(--token-border-color-tag-focus);
 }
 
 .clickableContentWrapperWarning:hover {
-  border-color: var(--token-border-color-tags-warning-hover);
-  border-right: 1px solid var(--token-border-color-tags-pristine);
+  border-color: var(--token-border-color-tag-warning-hover);
+  border-right: 1px solid var(--token-border-color-tag-pristine);
 }
 
 .clickableRemovableContentWrapperNormal:hover {
-  border-right: 1px solid var(--token-border-color-tags-pristine);
+  border-right: 1px solid var(--token-border-color-tag-pristine);
 }
 
 .clickableRemovableContentWrapperWarning {
-  border-right: 1px solid var(--token-border-color-tags-warning);
+  border-right: 1px solid var(--token-border-color-tag-warning);
 }
 
 /* Removable */
@@ -89,10 +89,10 @@
 }
 
 .removeWrapper {
-  border-color: var(--token-border-color-tags-pristine);
+  border-color: var(--token-border-color-tag-pristine);
   padding: 0 var(--spacing-4);
-  border-radius: 0 var(--token-border-radius-tags)
-    var(--token-border-radius-tags) 0;
+  border-radius: 0 var(--token-border-radius-tag)
+    var(--token-border-radius-tag) 0;
   display: flex;
   align-items: center;
   background: inherit;
@@ -101,16 +101,16 @@
 }
 
 .removeWrapper:hover {
-  background-color: var(--token-background-color-tags-normal-hover);
-  box-shadow: var(--token-shadow-box-tags-hover);
+  background-color: var(--token-background-color-tag-normal-hover);
+  box-shadow: var(--token-shadow-box-tag-hover);
 }
 
 .removeWrapperTypeWarning {
-  border-color: var(--token-border-color-tags-warning);
+  border-color: var(--token-border-color-tag-warning);
 }
 
 .removeWrapperTypeWarning:hover {
-  background-color: var(--token-background-color-tags-warning-hover);
+  background-color: var(--token-background-color-tag-warning-hover);
 }
 
 .removeWrapper svg {
@@ -120,7 +120,7 @@
 /* Disabled */
 
 .disabledWrapper {
-  background-color: var(--token-background-color-tags-disabled);
+  background-color: var(--token-background-color-tag-disabled);
 }
 
 .disabledContent {


### PR DESCRIPTION
As a followup to https://github.com/commercetools/ui-kit/pull/112, here we get rid of the plural naming and follow the singular standard