### PR TITLE
fix(bundling): add svg config for icons

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -75,6 +75,7 @@ module.exports = (storybookBaseConfig, configType) => {
             icon: false,
             svgoConfig: {
               plugins: [
+                { removeAttrs: { attrs: '(stroke|fill)' } },
                 { removeViewBox: false },
                 // Keeps ID's of svgs so they can be targeted with CSS
                 { cleanupIDs: false },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -106,6 +106,7 @@ const plugins = [
     icon: false,
     svgoConfig: {
       plugins: [
+        { removeAttrs: { attrs: '(stroke|fill)' } },
         { removeViewBox: false },
         // Keeps ID's of svgs so they can be targeted with CSS
         { cleanupIDs: false },


### PR DESCRIPTION
#### Summary

Icons are completely broken in master at the moment. Check [storybook](https://uikit.commercetools.com/?selectedKind=Icons&selectedStory=All%20Icons&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybook%2Factions%2Factions-panel) and try to change the colour. You should notice that the colours don't actually change.

#### Approach

If you look at the output of the pre a few weeks ago build, you'll notice that the svg output was slightly different, and wasn't including the stroke and the fill. So I added removeAttr for it.