### PR TITLE
feat(build-process): add size snapshot to rollup config

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,0 +1,21 @@
+{
+  "dist/ui-kit.cjs.js": {
+    "bundled": 610617,
+    "minified": 509052,
+    "gzipped": 74331
+  },
+  "dist/ui-kit.esm.js": {
+    "bundled": 606431,
+    "minified": 505281,
+    "gzipped": 73848,
+    "treeshaked": {
+      "rollup": {
+        "code": 439883,
+        "import_statements": 1195
+      },
+      "webpack": {
+        "code": 452939
+      }
+    }
+  }
+}

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,20 +1,20 @@
 {
   "dist/ui-kit.cjs.js": {
-    "bundled": 610617,
-    "minified": 509052,
-    "gzipped": 74331
+    "bundled": 613930,
+    "minified": 511382,
+    "gzipped": 74974
   },
   "dist/ui-kit.esm.js": {
-    "bundled": 606431,
-    "minified": 505281,
-    "gzipped": 73848,
+    "bundled": 609708,
+    "minified": 507576,
+    "gzipped": 74487,
     "treeshaked": {
       "rollup": {
-        "code": 439883,
-        "import_statements": 1195
+        "code": 441179,
+        "import_statements": 1153
       },
       "webpack": {
-        "code": 452939
+        "code": 454226
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "rollup-plugin-peer-deps-external": "2.2.0",
     "rollup-plugin-postcss": "1.6.2",
     "rollup-plugin-replace": "2.0.0",
+    "rollup-plugin-size-snapshot": "0.7.0",
     "rollup-plugin-url": "2.0.0",
     "shelljs": "0.8.2",
     "storybook-readme": "4.0.0-beta1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,6 +13,7 @@ import postcssCustomProperties from 'postcss-custom-properties';
 import postcssCustomMediaQueries from 'postcss-custom-media';
 import postcssPostcssColorModFunction from 'postcss-color-mod-function';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
+import { sizeSnapshot } from 'rollup-plugin-size-snapshot';
 import svgrPlugin from '@svgr/rollup';
 import babelOptions from '@commercetools-frontend/babel-preset-mc-app';
 import pkg from './package.json';
@@ -116,6 +117,7 @@ const plugins = [
   // To remove comments, trim trailing spaces, compact empty lines,
   // and normalize line endings
   cleanup(),
+  sizeSnapshot(),
 ];
 
 // We need to define 2 separate configs (`esm` and `cjs`) so that each can be

--- a/yarn.lock
+++ b/yarn.lock
@@ -2770,7 +2770,7 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
-bytes@3.0.0:
+bytes@3.0.0, bytes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
@@ -5512,6 +5512,13 @@ gzip-size@4.1.0:
     duplexer "^0.1.1"
     pify "^3.0.0"
 
+gzip-size@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.0.0.tgz#a55ecd99222f4c48fd8c01c625ce3b349d0a0e80"
+  dependencies:
+    duplexer "^0.1.1"
+    pify "^3.0.0"
+
 h2x-core@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/h2x-core/-/h2x-core-1.1.0.tgz#dfbf2460043d8ab76c6fa90902a1557f8330221a"
@@ -7744,7 +7751,7 @@ memoize-one@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.2.tgz#3fb8db695aa14ab9c0f1644e1585a8806adc1aee"
 
-memory-fs@^0.4.0, memory-fs@~0.4.1:
+memory-fs@^0.4.0, memory-fs@^0.4.1, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
   dependencies:
@@ -10655,13 +10662,27 @@ rollup-plugin-postcss@1.6.2:
     rollup-pluginutils "^2.0.1"
     style-inject "^0.3.0"
 
-rollup-plugin-replace@2.0.0:
+rollup-plugin-replace@2.0.0, rollup-plugin-replace@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-2.0.0.tgz#19074089c8ed57184b8cc64e967a03d095119277"
   dependencies:
     magic-string "^0.22.4"
     minimatch "^3.0.2"
     rollup-pluginutils "^2.0.1"
+
+rollup-plugin-size-snapshot@0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-size-snapshot/-/rollup-plugin-size-snapshot-0.7.0.tgz#f0070e4aeee736f45f8eb6b96e12e6238705c13b"
+  dependencies:
+    acorn "^6.0.1"
+    bytes "^3.0.0"
+    chalk "^2.4.1"
+    gzip-size "^5.0.0"
+    jest-diff "^23.6.0"
+    memory-fs "^0.4.1"
+    rollup-plugin-replace "^2.0.0"
+    terser "^3.8.2"
+    webpack "^4.19.0"
 
 rollup-plugin-url@2.0.0:
   version "2.0.0"
@@ -11039,7 +11060,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.6:
+source-map-support@^0.5.6, source-map-support@~0.5.6:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
   dependencies:
@@ -11664,6 +11685,14 @@ tempfile@^1.1.1:
     os-tmpdir "^1.0.0"
     uuid "^2.0.1"
 
+terser@^3.8.2:
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-3.9.3.tgz#14d13207f58b7a25ba7dd11def76c9e73cca5036"
+  dependencies:
+    commander "~2.17.1"
+    source-map "~0.6.1"
+    source-map-support "~0.5.6"
+
 test-exclude@^4.1.1, test-exclude@^4.2.1:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.3.tgz#a9a5e64474e4398339245a0a769ad7c2f4a97c20"
@@ -12238,7 +12267,7 @@ webpack-sources@^1.1.0, webpack-sources@^1.3.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@4.20.2, webpack@^4.17.1:
+webpack@4.20.2, webpack@^4.17.1, webpack@^4.19.0:
   version "4.20.2"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.20.2.tgz#89f6486b6bb276a91b0823453d377501fc625b5a"
   dependencies:


### PR DESCRIPTION
### Summary

This lib seems to be used by a few libraries (material-ui, react-beautiful-dnd, ...), and could be useful for tracking bundle size. We could also use the file along with a dynamic badge from shields.io to show our bundle size ⚖️ 💪 