### PR TITLE
fix: circle icon css fill

### DIFF
--- a/src/components/icons/icons.mod.css
+++ b/src/components/icons/icons.mod.css
@@ -1,42 +1,34 @@
 @import '../../../materials/colors/base-colors.mod.css';
 
-.theme-black path,
-.theme-black circle {
+.theme-black * {
   fill: var(--color-black);
 }
 
-.theme-grey path,
-.theme-grey circle {
+.theme-grey * {
   fill: var(--color-gray-60);
 }
 
-.theme-white path,
-.theme-white circle {
+.theme-white * {
   fill: var(--color-white);
 }
 
-.theme-blue path,
-.theme-blue circle {
+.theme-blue * {
   fill: var(--color-blue);
 }
 
-.theme-green path,
-.theme-green circle {
+.theme-green * {
   fill: var(--color-green);
 }
 
-.theme-green-light path,
-.theme-green-light circle {
+.theme-green-light * {
   fill: var(--color-green-40);
 }
 
-.theme-orange path,
-.theme-orange circle {
+.theme-orange * {
   fill: var(--color-orange);
 }
 
-.theme-red path,
-.theme-red circle {
+.theme-red * {
   fill: var(--color-red);
 }
 


### PR DESCRIPTION
#### Summary

Introduced in #139, we were targeting just `path`, but the circle icon uses `circle`.
