### PR TITLE
refactor: replace invariant with tiny-invariant

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "dom-helpers": "3.3.1",
     "downshift": "2.2.3",
     "flatpickr": "4.5.2",
-    "invariant": "2.2.4",
+    "tiny-invariant": "1.0.1",
     "is-touch-device": "1.0.1",
     "lodash.flatmap": "4.5.0",
     "lodash.has": "4.5.2",

--- a/src/components/buttons/icon-button/icon-button.js
+++ b/src/components/buttons/icon-button/icon-button.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { compose } from 'recompose';
-import invariant from 'invariant';
+import invariant from 'tiny-invariant';
 import isNil from 'lodash.isnil';
 import withMouseDownState from '../../../hocs/with-mouse-down-state';
 import withMouseOverState from '../../../hocs/with-mouse-over-state';

--- a/src/components/buttons/secondary-button/secondary-button.js
+++ b/src/components/buttons/secondary-button/secondary-button.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import classnames from 'classnames';
 import { compose } from 'recompose';
-import invariant from 'invariant';
+import invariant from 'tiny-invariant';
 import isNil from 'lodash.isnil';
 import requiredIf from 'react-required-if';
 import Spacings from '../../spacings';

--- a/src/components/dropdowns/primary-action-dropdown/primary-action-dropdown.js
+++ b/src/components/dropdowns/primary-action-dropdown/primary-action-dropdown.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import invariant from 'invariant';
+import invariant from 'tiny-invariant';
 import classnames from 'classnames';
 import Text from '../../typography/text';
 import { CaretDownIcon, CaretUpIcon } from '../../icons';

--- a/src/components/icons/with-theme-prop.js
+++ b/src/components/icons/with-theme-prop.js
@@ -1,5 +1,5 @@
 import { mapProps } from 'recompose';
-import invariant from 'invariant';
+import invariant from 'tiny-invariant';
 import styles from './icons.mod.css';
 
 const getThemeClassName = theme => {

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import invariant from 'invariant';
+import invariant from 'tiny-invariant';
 import has from 'lodash.has';
 import isNumberish from '../../../utils/is-numberish';
 import filterDataAttributes from '../../../utils/filter-data-attributes';

--- a/src/components/inputs/number-input/number-input.js
+++ b/src/components/inputs/number-input/number-input.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import invariant from 'invariant';
+import invariant from 'tiny-invariant';
 import requiredIf from 'react-required-if';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import Constraints from '../../constraints';

--- a/src/components/panels/collapsible-panel/collapsible-panel.spec.js
+++ b/src/components/panels/collapsible-panel/collapsible-panel.spec.js
@@ -4,7 +4,7 @@ import Text from '../../typography/text';
 import CollapsiblePanelHeader from './collapsible-panel-header';
 import CollapsiblePanel from './collapsible-panel';
 
-jest.mock('invariant');
+jest.mock('tiny-invariant');
 
 describe('CollapsiblePanel', () => {
   const createTestProps = props => ({

--- a/src/components/switches/checkbox/checkbox.spec.js
+++ b/src/components/switches/checkbox/checkbox.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { Checkbox } from './checkbox';
 
-jest.mock('invariant');
+jest.mock('tiny-invariant');
 
 const createTestProps = custom => ({
   name: 'bar',

--- a/src/components/switches/radio/radio-group.js
+++ b/src/components/switches/radio/radio-group.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import invariant from 'invariant';
+import invariant from 'tiny-invariant';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import Spacings from '../../spacings';
 import Option from './radio-option';

--- a/src/components/switches/radio/radio-group.spec.js
+++ b/src/components/switches/radio/radio-group.spec.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import invariant from 'invariant';
+import invariant from 'tiny-invariant';
 import { shallow } from 'enzyme';
 import Option from './radio-option';
 import Group from './radio-group';
 
-jest.mock('invariant');
+jest.mock('tiny-invariant');
 
 const createOptionTestProps = custom => ({
   value: 'foo',

--- a/src/components/switches/radio/radio-option.spec.js
+++ b/src/components/switches/radio/radio-option.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { Option } from './radio-option';
 
-jest.mock('invariant');
+jest.mock('tiny-invariant');
 
 const createTestProps = custom => ({
   value: 'foo',

--- a/src/utils/localized.js
+++ b/src/utils/localized.js
@@ -1,4 +1,4 @@
-import invariant from 'invariant';
+import invariant from 'tiny-invariant';
 import without from 'lodash.without';
 import uniq from 'lodash.uniq';
 import filterDataAttributes from './filter-data-attributes';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6020,7 +6020,7 @@ intl-relativeformat@^2.1.0:
   dependencies:
     intl-messageformat "^2.0.0"
 
-invariant@2.2.4, invariant@^2.1.1, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.1.1, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -11718,6 +11718,10 @@ timers-browserify@^2.0.4:
 tiny-emitter@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.0.2.tgz#82d27468aca5ade8e5fd1e6d22b57dd43ebdfb7c"
+
+tiny-invariant@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.1.tgz#54700d039a0384ef2e83afd0e81af84c6d67b140"
 
 tinycolor2@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
#### Summary

This pull request replaces `invariant` with [`tiny-invariant`](https://github.com/alexreardon/tiny-invariant). A simpler, more lightweight solution. Not the biggest of our problems but it was on my list. Essentially `tiny-invariant` as the same API but does not allow placeholders in the string. Something we never used an if would use template literals for anyway.