### PR TITLE
Add config for managing i18n keys in transifex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
 sudo: false
+
+addons:
+  apt:
+    update: true
+    sources:
+      - deadsnakes
+    packages:
+      - python3.6
+
 language: node_js
+
 node_js:
   - '10'
 
@@ -11,12 +21,21 @@ cache:
   directories:
     - node_modules
 
+before_install:
+  - curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.6
+  - (pip -V && pip3 -V && pip3.6 -V) | uniq
+  - python3.6 -m pip install --user transifex-client
+  - export PATH="$HOME/.local/bin:$PATH"
+
 script:
   # the jest.bundle.config.js tests run on the bundle,
   # so we need to build it first
   - yarn build
   - yarn run jest --projects jest.*.config.js --maxWorkers=4 --reporters jest-silent-reporter
   - "! test -f fail-tests-because-there-was-an-unhandled-rejection.lock"
+
+after_success:
+  - ./scripts/push_translations.sh
 
 before_deploy: yarn build
 

--- a/.tx/config
+++ b/.tx/config
@@ -6,3 +6,4 @@ file_filter = i18n/<lang>.json
 source_file = i18n/core.json
 source_lang = en_US
 type = KEYVALUEJSON
+

--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,8 @@
+[main]
+host = https://www.transifex.com
+
+[ui-kit.core]
+file_filter = i18n/<lang>.json
+source_file = i18n/core.json
+source_lang = en_US
+type = KEYVALUEJSON

--- a/README.md
+++ b/README.md
@@ -128,16 +128,4 @@ By default, only _Deploy Previews_ (Pull Requests) are deployed to [Netlify][net
 
 ## Translations (i18n)
 
-The UI Kit uses `react-intl`. The core messages are written down in `messages.js` files.
-
-The translations for the supported languages exist in the `/i18n` folder. We do not use any automated translation software.
-
-### Adding new messages
-
-In case you are working on a component and you want to add a completely new message, you should add it to (or create a) `messages.js` file. See the other `messages.js` files as a reference.
-
-After adding the message(s), you need to run `yarn i18n:build`. This will modify the language files in `/i18n` by adding empty translations for the message keys.
-
-### Editing translations
-
-If you want to modify an existing translation, you will need to manually edit the related files in `/i18n`.
+Check out [the i18n documentation](i18n/README.md).

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -1,0 +1,37 @@
+# Translations (i18n)
+
+The UI Kit uses `react-intl` to manage the messages and translations. The core messages are defined in `messages.js` files, usually colocated with the related React component.
+
+The translations for the supported languages are then pulled into `./i18n/{en,de,es}.json` files.
+
+> **DO NOT EDIT THOSE FILES DIRECTLY, TRANSLATIONS SHOULD BE DONE ONLY IN TRANSIFEX!!!**
+
+### Translation software (Transifex)
+
+Translations should be managed using the Transifex software: https://www.transifex.com/commercetools/ui-kit/
+
+## Structure
+
+This folder contains the **JSON** files with the translated messages. The key of the messages corresponds to the `message.id` defined in each `messages.js`.
+
+#### Localized files
+
+There is one file for each language (e.g. `en`, `de`, `es`, etc.).
+
+#### Source file
+
+There is one special file `core.json`, which is used by Transifex as the **source file**. The messages in this file are used as the base for translating to the other locale. When you add new messages in the React components, those message keys will first go into the `core.json` (_read below_).
+
+## Adding new messages
+
+When you add new messages in the React components `messages.js`, you need to run `yarn i18n:build` which will extract the new messages and put them into the `core.json`.
+Then you can push and merge the changes to `master`. At this point, there is a step in CI that will push the source file `core.json` to Transifex thus making the new keys available to the system.
+
+## Translating messages
+
+When new messages are pushed to Transifex, you can start translating them using the [translation software](https://www.transifex.com/commercetools/ui-kit/).
+Once the messages have been translated and reviewed, you can pull them into the repository by running the command `yarn i18n:pull`. The command will sync the `{locale}.json` files in case something changed and will sync `en.json` -> `core.json`. This is to ensure that the english source messages are up-to-date when there needs to be a translation to another language.
+
+## Can I update the JSON files manually?
+
+No, I must not do that! Make sure to always use the scripts `i18n:build` and `i18n:pull` to keep messages in sync.

--- a/i18n/core.json
+++ b/i18n/core.json
@@ -21,7 +21,6 @@
   "UIKit.LocalizedTextInput.expand": "Show all languages ({remainingLanguages})",
   "UIKit.LocalizedTextInput.missingRequiredField": "This field is required. Provide at least one value.",
   "UIKit.MoneyField.highPrecision": "High Precision Price",
-  "UIKit.MoneyInput.chevronLabel": "Open/Close Dropdown",
   "UIKit.MultilineTextInput.collapse": "Collapse",
   "UIKit.MultilineTextInput.expand": "Expand",
   "UIKit.SelectInput.noOptionsMessageWithInputValue": "No options",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -21,7 +21,6 @@
   "UIKit.LocalizedTextInput.expand": "Alle Sprachen anzeigen",
   "UIKit.LocalizedTextInput.missingRequiredField": "Pflichtfeld*, Geben Sie mindestens einen Wert an",
   "UIKit.MoneyField.highPrecision": "",
-  "UIKit.MoneyInput.chevronLabel": "Dropdown öffnen/schliessen",
   "UIKit.MultilineTextInput.collapse": "Ausblenden",
   "UIKit.MultilineTextInput.expand": "Erweitern",
   "UIKit.SelectInput.noOptionsMessageWithInputValue": "",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -21,7 +21,6 @@
   "UIKit.LocalizedTextInput.expand": "Show all languages ({remainingLanguages})",
   "UIKit.LocalizedTextInput.missingRequiredField": "This field is required. Provide at least one value.",
   "UIKit.MoneyField.highPrecision": "High Precision Price",
-  "UIKit.MoneyInput.chevronLabel": "Open/Close Dropdown",
   "UIKit.MultilineTextInput.collapse": "Collapse",
   "UIKit.MultilineTextInput.expand": "Expand",
   "UIKit.SelectInput.noOptionsMessageWithInputValue": "No options",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -21,7 +21,6 @@
   "UIKit.LocalizedTextInput.expand": "Mostrar todos los lenguajes ({remainingLanguages})",
   "UIKit.LocalizedTextInput.missingRequiredField": "Este campo es obligatorio. Proporcione un valor al menos.",
   "UIKit.MoneyField.highPrecision": "",
-  "UIKit.MoneyInput.chevronLabel": "Abrir/Cerrar menú desplegable",
   "UIKit.MultilineTextInput.collapse": "Contraer",
   "UIKit.MultilineTextInput.expand": "Expandir",
   "UIKit.SelectInput.noOptionsMessageWithInputValue": "Menú vacío",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "storybook:start": "start-storybook -p 9002",
     "docs:publish": "node scripts/publish-docs.js",
     "i18n:build": "node scripts/extract-intl.js --output-path=$(pwd)/i18n 'src/components/**/!(*.spec).js'",
+    "i18n:pull": "node scripts/pull-i18n.js",
     "lint": "jest --projects jest.eslint.config.js jest.stylelint.config.js",
     "lint:js": "jest --config jest.eslint.config.js",
     "lint:css": "jest --config jest.stylelint.config.js",

--- a/scripts/pull-i18n.js
+++ b/scripts/pull-i18n.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const shell = require('shelljs');
+const rcfile = require('rcfile');
+const prettier = require('prettier');
+
+const prettierConfig = rcfile('prettier');
+
+const writeFile = (filePath, data) => {
+  const prettifiedData = prettier.format(JSON.stringify(data, null, 2), {
+    ...prettierConfig,
+    parser: 'json',
+  });
+  fs.writeFileSync(filePath, prettifiedData, 'utf8');
+};
+const parseFile = filePath => JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+// 1. Pull reviewed translations
+console.log('=> Pulling from transifex');
+shell.exec(`tx pull --mode onlyreviewed`);
+
+// 2. Overwrite `core.json` with values from `en.json`
+// This is to ensure that reviewed translations are reflected on Core + Application translations has the same reference,
+// as we add new languages
+const enLocaleData = parseFile(path.join(__dirname, '../i18n', 'en.json'));
+const coreData = parseFile(path.join(__dirname, '../i18n', 'core.json'));
+const nextCoreData = Object.entries(coreData).reduce((nextCore, [coreKey]) => {
+  if (enLocaleData[coreKey]) {
+    return {
+      ...nextCore,
+      [coreKey]: enLocaleData[coreKey],
+    };
+  }
+  return nextCore;
+}, coreData);
+console.log('=> syncing `en.json` with `core.json`');
+writeFile(path.join(__dirname, '../i18n', `core.json`), nextCoreData);

--- a/scripts/push_translations.sh
+++ b/scripts/push_translations.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+: "${TRANSIFEX_PASSWORD?Required env variable TRANSIFEX_PASSWORD}"
+
+# Always skip it if it's not master branch
+if [ "$TRAVIS_BRANCH" == "master" ]; then
+  echo "Writing transifex configuration"
+  cat > "$TRAVIS_BUILD_DIR/.transifexrc" << EOF
+[https://www.transifex.com]
+hostname = https://www.transifex.com
+password = $TRANSIFEX_PASSWORD
+username = api
+EOF
+
+  echo "Pushing source file for translations"
+  tx push -s
+else
+  echo "Not on master branch, skipping job"
+fi


### PR DESCRIPTION
I created a new project in Transifex for UI Kit and pushed the messages/translations there.

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/1110551/46672968-052d5980-cbd9-11e8-9007-687b0076f9c0.png">

For now I won't add any automation script, but we have the option to use Transifex for managing those messages.