### PR TITLE
fix: fix inline text 

### DIFF
--- a/src/components/typography/text/text.js
+++ b/src/components/typography/text/text.js
@@ -103,7 +103,7 @@ const Detail = props => (
     className={classnames({
       [styles.bold]: props.isBold,
       [styles.italic]: props.isItalic,
-      [styles.inline]: props.isInline,
+      [styles['inline-text']]: props.isInline,
       [styles[`${props.tone}`]]: props.tone,
       [styles.truncate]: props.truncate,
     })}

--- a/src/components/typography/text/text.mod.css
+++ b/src/components/typography/text/text.mod.css
@@ -107,7 +107,7 @@ small {
   color: var(--color-orange);
 }
 
-.inline {
+.inline-text {
   display: inline-block;
 }
 

--- a/src/components/typography/text/text.spec.js
+++ b/src/components/typography/text/text.spec.js
@@ -339,8 +339,8 @@ describe('<Detail>', () => {
     it('should not have "bold" class', () => {
       expect(wrapper).not.toContainClass(styles.bold);
     });
-    it('should have "inline" class', () => {
-      expect(wrapper).toContainClass(styles.inline);
+    it('should have "inline-text" class', () => {
+      expect(wrapper).toContainClass(styles['inline-text']);
     });
     it('should render given text', () => {
       expect(wrapper.text()).toMatch('Detail');
@@ -359,8 +359,8 @@ describe('<Detail>', () => {
       it('should have "bold" class', () => {
         expect(wrapper).toContainClass(styles.bold);
       });
-      it('should have "inline" class', () => {
-        expect(wrapper).toContainClass(styles.inline);
+      it('should have "inline-text" class', () => {
+        expect(wrapper).toContainClass(styles['inline-text']);
       });
       it('should render given text', () => {
         expect(wrapper).toHaveText('Detail');
@@ -381,8 +381,8 @@ describe('<Detail>', () => {
       it('should have "secondary" class', () => {
         expect(wrapper).toContainClass(styles.secondary);
       });
-      it('should have "inline" class', () => {
-        expect(wrapper).toContainClass(styles.inline);
+      it('should have "inline-text" class', () => {
+        expect(wrapper).toContainClass(styles['inline-text']);
       });
       it('should render given text', () => {
         expect(wrapper).toHaveText('Detail');

--- a/src/components/typography/typography.story.js
+++ b/src/components/typography/typography.story.js
@@ -60,6 +60,7 @@ storiesOf('Typography/Text', module)
     <Section>
       <Text.Body
         isBold={boolean('bold', false)}
+        isInline={boolean('inline', false)}
         isItalic={boolean('italic', false)}
         tone={select('Text tone', [
           'none',
@@ -80,6 +81,7 @@ storiesOf('Typography/Text', module)
     <Section>
       <Text.Detail
         isBold={boolean('bold', false)}
+        isInline={boolean('inline', false)}
         isItalic={boolean('italic', false)}
         tone={select('Text tone', [
           'none',


### PR DESCRIPTION
#### Summary

The `isInline` prop is currently broken for `Text` components. 

Inline seems to be some sort of reserved word in `stage 2` of `postcss-preset-env`. That's as far as my investigation got. If you switch to stage 3, then this doesn't happen. However, this doesn't happen in our webpack build, only in our rollup build.

when we build ui-kit with webpack (for storybook), it takes the following css

```
.inline {
  display: inline-block;
}
```

and it turns it into something like this

```
{
 inline: 'inline_mod_blah'
}
```

when we build ui-kit with webpack (for production), it takes the following css

```
.inline {
  display: inline-block;
}
```

and it turns it into something like this

```
{
 inline-left: 'inline_mod_blah',
 inline-right: 'inline_mod_blah',
}
```

It must be some sort of reserved word or something. I don't think it's worth further investigation.

#### Approach

Rename css class to `text-inline`. 