### PR TITLE
docs: add global locale knob

### DIFF
--- a/.storybook/decorators/intl/intl.js
+++ b/.storybook/decorators/intl/intl.js
@@ -1,4 +1,21 @@
 import React from 'react';
-import { IntlProvider } from 'react-intl';
+import { IntlProvider, addLocaleData } from 'react-intl';
+import { withKnobs, select } from '@storybook/addon-knobs';
+import en from 'react-intl/locale-data/en';
+import de from 'react-intl/locale-data/de';
+import es from 'react-intl/locale-data/es';
+import * as messages from '../../../i18n';
 
-export default storyFn => <IntlProvider locale="en">{storyFn()}</IntlProvider>;
+addLocaleData(en);
+addLocaleData(de);
+addLocaleData(es);
+const locales = Object.keys(messages);
+
+export default storyFn => {
+  const locale = select('global locale', locales, locales[0]);
+  return (
+    <IntlProvider locale={locale} messages={messages[locale]}>
+      {storyFn()}
+    </IntlProvider>
+  );
+};

--- a/src/components/fields/async-creatable-select-field/async-creatable-select-field.form.story.js
+++ b/src/components/fields/async-creatable-select-field/async-creatable-select-field.form.story.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Formik } from 'formik';
-import { IntlProvider } from 'react-intl';
 import { storiesOf } from '@storybook/react';
 import omitEmpty from 'omit-empty';
 import { action } from '@storybook/addon-actions';
@@ -82,71 +81,69 @@ storiesOf('Examples|Forms/Fields', module)
     });
     return (
       <Section key={isMulti}>
-        <IntlProvider locale="en">
-          <Formik
-            initialValues={{ animal: isMulti ? [] : undefined }}
-            validate={values => {
-              const errors = { animal: {} };
-              if (isMulti ? values.animal.length === 0 : !values.animal)
-                errors.animal.missing = true;
-              return omitEmpty(errors);
-            }}
-            onSubmit={(values, formik) => {
-              action('onSubmit')(values, formik);
-              formik.resetForm(values);
-            }}
-            render={formik => (
-              <Spacings.Stack scale="l">
-                <AsyncCreatableSelectField
-                  horizontalConstraint={select(
-                    'horizontalConstraint',
-                    ['xs', 's', 'm', 'l', 'xl', 'scale'],
-                    'm'
-                  )}
-                  errors={formik.errors.animal}
-                  isRequired={true}
-                  touched={formik.touched.animal}
-                  name="animal"
-                  value={formik.values.animal}
-                  onChange={formik.handleChange}
-                  onBlur={formik.handleBlur}
-                  isDisabled={formik.isSubmitting}
-                  isMulti={isMulti}
-                  title="Favourite animal"
-                  description="Bonus points if it is a mammal"
-                  isClearable={true}
-                  defaultOptions={[
-                    { value: 'dogs', label: 'Dogs' },
-                    { value: 'whales', label: 'Whales' },
-                  ]}
-                  loadOptions={searchText =>
-                    delay(delayTimeMs).then(() =>
-                      options.filter(option =>
-                        option.label
-                          .toLowerCase()
-                          .startsWith(searchText.toLowerCase())
-                      )
+        <Formik
+          initialValues={{ animal: isMulti ? [] : undefined }}
+          validate={values => {
+            const errors = { animal: {} };
+            if (isMulti ? values.animal.length === 0 : !values.animal)
+              errors.animal.missing = true;
+            return omitEmpty(errors);
+          }}
+          onSubmit={(values, formik) => {
+            action('onSubmit')(values, formik);
+            formik.resetForm(values);
+          }}
+          render={formik => (
+            <Spacings.Stack scale="l">
+              <AsyncCreatableSelectField
+                horizontalConstraint={select(
+                  'horizontalConstraint',
+                  ['xs', 's', 'm', 'l', 'xl', 'scale'],
+                  'm'
+                )}
+                errors={formik.errors.animal}
+                isRequired={true}
+                touched={formik.touched.animal}
+                name="animal"
+                value={formik.values.animal}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+                isDisabled={formik.isSubmitting}
+                isMulti={isMulti}
+                title="Favourite animal"
+                description="Bonus points if it is a mammal"
+                isClearable={true}
+                defaultOptions={[
+                  { value: 'dogs', label: 'Dogs' },
+                  { value: 'whales', label: 'Whales' },
+                ]}
+                loadOptions={searchText =>
+                  delay(delayTimeMs).then(() =>
+                    options.filter(option =>
+                      option.label
+                        .toLowerCase()
+                        .startsWith(searchText.toLowerCase())
                     )
-                  }
+                  )
+                }
+              />
+              <Spacings.Inline>
+                <SecondaryButton
+                  onClick={formik.handleReset}
+                  isDisabled={formik.isSubmitting}
+                  label="Reset"
                 />
-                <Spacings.Inline>
-                  <SecondaryButton
-                    onClick={formik.handleReset}
-                    isDisabled={formik.isSubmitting}
-                    label="Reset"
-                  />
-                  <PrimaryButton
-                    onClick={formik.handleSubmit}
-                    isDisabled={formik.isSubmitting || !formik.dirty}
-                    label="Submit"
-                  />
-                </Spacings.Inline>
-                <hr />
-                <FormikBox formik={formik} />
-              </Spacings.Stack>
-            )}
-          />
-        </IntlProvider>
+                <PrimaryButton
+                  onClick={formik.handleSubmit}
+                  isDisabled={formik.isSubmitting || !formik.dirty}
+                  label="Submit"
+                />
+              </Spacings.Inline>
+              <hr />
+              <FormikBox formik={formik} />
+            </Spacings.Stack>
+          )}
+        />
       </Section>
     );
   });

--- a/src/components/fields/async-select-field/async-select-field.form.story.js
+++ b/src/components/fields/async-select-field/async-select-field.form.story.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Formik } from 'formik';
-import { IntlProvider } from 'react-intl';
 import { storiesOf } from '@storybook/react';
 import omitEmpty from 'omit-empty';
 import { action } from '@storybook/addon-actions';
@@ -82,72 +81,70 @@ storiesOf('Examples|Forms/Fields', module)
     });
     return (
       <Section key={isMulti}>
-        <IntlProvider locale="en">
-          <Formik
-            initialValues={{ animal: isMulti ? [] : undefined }}
-            validate={values => {
-              const errors = { animal: {} };
-              if (isMulti ? values.animal.length === 0 : !values.animal)
-                errors.animal.missing = true;
-              return omitEmpty(errors);
-            }}
-            onSubmit={(values, formik) => {
-              action('onSubmit')(values, formik);
-              formik.resetForm(values);
-            }}
-            render={formik => (
-              <Spacings.Stack scale="l">
-                <AsyncSelectField
-                  horizontalConstraint={select(
-                    'horizontalConstraint',
-                    ['xs', 's', 'm', 'l', 'xl', 'scale'],
-                    'm'
-                  )}
-                  errors={formik.errors.animal}
-                  isRequired={true}
-                  touched={formik.touched.animal}
-                  name="animal"
-                  value={formik.values.animal}
-                  onChange={formik.handleChange}
-                  onBlur={formik.handleBlur}
-                  isDisabled={formik.isSubmitting}
-                  isMulti={isMulti}
-                  title="Favourite animal"
-                  description="Bonus points if it is a mammal"
-                  isClearable={true}
-                  cacheOptions={number('cacheOptions', 2)}
-                  defaultOptions={[
-                    { value: 'dogs', label: 'Dogs' },
-                    { value: 'whales', label: 'Whales' },
-                  ]}
-                  loadOptions={searchText =>
-                    delay(delayTimeMs).then(() =>
-                      options.filter(option =>
-                        option.label
-                          .toLowerCase()
-                          .startsWith(searchText.toLowerCase())
-                      )
+        <Formik
+          initialValues={{ animal: isMulti ? [] : undefined }}
+          validate={values => {
+            const errors = { animal: {} };
+            if (isMulti ? values.animal.length === 0 : !values.animal)
+              errors.animal.missing = true;
+            return omitEmpty(errors);
+          }}
+          onSubmit={(values, formik) => {
+            action('onSubmit')(values, formik);
+            formik.resetForm(values);
+          }}
+          render={formik => (
+            <Spacings.Stack scale="l">
+              <AsyncSelectField
+                horizontalConstraint={select(
+                  'horizontalConstraint',
+                  ['xs', 's', 'm', 'l', 'xl', 'scale'],
+                  'm'
+                )}
+                errors={formik.errors.animal}
+                isRequired={true}
+                touched={formik.touched.animal}
+                name="animal"
+                value={formik.values.animal}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+                isDisabled={formik.isSubmitting}
+                isMulti={isMulti}
+                title="Favourite animal"
+                description="Bonus points if it is a mammal"
+                isClearable={true}
+                cacheOptions={number('cacheOptions', 2)}
+                defaultOptions={[
+                  { value: 'dogs', label: 'Dogs' },
+                  { value: 'whales', label: 'Whales' },
+                ]}
+                loadOptions={searchText =>
+                  delay(delayTimeMs).then(() =>
+                    options.filter(option =>
+                      option.label
+                        .toLowerCase()
+                        .startsWith(searchText.toLowerCase())
                     )
-                  }
+                  )
+                }
+              />
+              <Spacings.Inline>
+                <SecondaryButton
+                  onClick={formik.handleReset}
+                  isDisabled={formik.isSubmitting}
+                  label="Reset"
                 />
-                <Spacings.Inline>
-                  <SecondaryButton
-                    onClick={formik.handleReset}
-                    isDisabled={formik.isSubmitting}
-                    label="Reset"
-                  />
-                  <PrimaryButton
-                    onClick={formik.handleSubmit}
-                    isDisabled={formik.isSubmitting || !formik.dirty}
-                    label="Submit"
-                  />
-                </Spacings.Inline>
-                <hr />
-                <FormikBox formik={formik} />
-              </Spacings.Stack>
-            )}
-          />
-        </IntlProvider>
+                <PrimaryButton
+                  onClick={formik.handleSubmit}
+                  isDisabled={formik.isSubmitting || !formik.dirty}
+                  label="Submit"
+                />
+              </Spacings.Inline>
+              <hr />
+              <FormikBox formik={formik} />
+            </Spacings.Stack>
+          )}
+        />
       </Section>
     );
   });

--- a/src/components/fields/creatable-select-field/creatable-select-field.form.story.js
+++ b/src/components/fields/creatable-select-field/creatable-select-field.form.story.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Formik } from 'formik';
-import { IntlProvider } from 'react-intl';
 import { storiesOf } from '@storybook/react';
 import omitEmpty from 'omit-empty';
 import { action } from '@storybook/addon-actions';
@@ -74,59 +73,57 @@ storiesOf('Examples|Forms/Fields', module)
     const isMulti = boolean('isMulti', true);
     return (
       <Section key={isMulti}>
-        <IntlProvider locale="en">
-          <Formik
-            initialValues={{ animal: isMulti ? [] : undefined }}
-            validate={values => {
-              const errors = { animal: {} };
-              if (isMulti ? values.animal.length === 0 : !values.animal)
-                errors.animal.missing = true;
-              return omitEmpty(errors);
-            }}
-            onSubmit={(values, formik) => {
-              action('onSubmit')(values, formik);
-              formik.resetForm(values);
-            }}
-            render={formik => (
-              <Spacings.Stack scale="l">
-                <CreatableSelectField
-                  horizontalConstraint={select(
-                    'horizontalConstraint',
-                    ['xs', 's', 'm', 'l', 'xl', 'scale'],
-                    'm'
-                  )}
-                  errors={formik.errors.animal}
-                  isRequired={true}
-                  touched={formik.touched.animal}
-                  name="animal"
-                  value={formik.values.animal}
-                  onChange={formik.handleChange}
-                  onBlur={formik.handleBlur}
+        <Formik
+          initialValues={{ animal: isMulti ? [] : undefined }}
+          validate={values => {
+            const errors = { animal: {} };
+            if (isMulti ? values.animal.length === 0 : !values.animal)
+              errors.animal.missing = true;
+            return omitEmpty(errors);
+          }}
+          onSubmit={(values, formik) => {
+            action('onSubmit')(values, formik);
+            formik.resetForm(values);
+          }}
+          render={formik => (
+            <Spacings.Stack scale="l">
+              <CreatableSelectField
+                horizontalConstraint={select(
+                  'horizontalConstraint',
+                  ['xs', 's', 'm', 'l', 'xl', 'scale'],
+                  'm'
+                )}
+                errors={formik.errors.animal}
+                isRequired={true}
+                touched={formik.touched.animal}
+                name="animal"
+                value={formik.values.animal}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+                isDisabled={formik.isSubmitting}
+                isMulti={isMulti}
+                options={options}
+                title="Favourite animal"
+                description="Bonus points if it is a mammal"
+                isClearable={true}
+              />
+              <Spacings.Inline>
+                <SecondaryButton
+                  onClick={formik.handleReset}
                   isDisabled={formik.isSubmitting}
-                  isMulti={isMulti}
-                  options={options}
-                  title="Favourite animal"
-                  description="Bonus points if it is a mammal"
-                  isClearable={true}
+                  label="Reset"
                 />
-                <Spacings.Inline>
-                  <SecondaryButton
-                    onClick={formik.handleReset}
-                    isDisabled={formik.isSubmitting}
-                    label="Reset"
-                  />
-                  <PrimaryButton
-                    onClick={formik.handleSubmit}
-                    isDisabled={formik.isSubmitting || !formik.dirty}
-                    label="Submit"
-                  />
-                </Spacings.Inline>
-                <hr />
-                <FormikBox formik={formik} />
-              </Spacings.Stack>
-            )}
-          />
-        </IntlProvider>
+                <PrimaryButton
+                  onClick={formik.handleSubmit}
+                  isDisabled={formik.isSubmitting || !formik.dirty}
+                  label="Submit"
+                />
+              </Spacings.Inline>
+              <hr />
+              <FormikBox formik={formik} />
+            </Spacings.Stack>
+          )}
+        />
       </Section>
     );
   });

--- a/src/components/fields/money-field/money-field.form.story.js
+++ b/src/components/fields/money-field/money-field.form.story.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Formik } from 'formik';
-import { IntlProvider } from 'react-intl';
 import { storiesOf } from '@storybook/react';
 import omitEmpty from 'omit-empty';
 import { action } from '@storybook/addon-actions';
@@ -26,85 +25,83 @@ storiesOf('Examples|Forms/Fields', module)
     );
     return (
       <Section>
-        <IntlProvider locale="en">
-          <Formik
-            initialValues={{
-              price: { ...MoneyField.parseMoneyValue() },
-              pricePerTon: { ...MoneyField.parseMoneyValue() },
-            }}
-            validate={values => {
-              const errors = { price: {}, pricePerTon: {} };
-              if (MoneyField.isEmpty(values.price)) errors.price.missing = true;
-              else if (MoneyField.isHighPrecision(values.price))
-                errors.price.unsupportedHighPrecision = true;
+        <Formik
+          initialValues={{
+            price: { ...MoneyField.parseMoneyValue() },
+            pricePerTon: { ...MoneyField.parseMoneyValue() },
+          }}
+          validate={values => {
+            const errors = { price: {}, pricePerTon: {} };
+            if (MoneyField.isEmpty(values.price)) errors.price.missing = true;
+            else if (MoneyField.isHighPrecision(values.price))
+              errors.price.unsupportedHighPrecision = true;
 
-              if (MoneyField.isEmpty(values.pricePerTon))
-                errors.pricePerTon.missing = true;
+            if (MoneyField.isEmpty(values.pricePerTon))
+              errors.pricePerTon.missing = true;
 
-              console.log(values, omitEmpty(errors));
-              return omitEmpty(errors);
-            }}
-            onSubmit={(values, formik) => {
-              action('onSubmit')(values, formik);
-              formik.resetForm(values);
-            }}
-            render={formik => (
-              <Spacings.Stack scale="l">
-                <MoneyField
-                  title="Regular Price"
-                  description={'How much is the fish?'}
-                  hint="It is better to pay in EUR"
-                  name="price"
-                  isRequired={true}
-                  value={formik.values.price}
-                  currencies={currencies}
-                  onChange={formik.handleChange}
-                  onBlur={formik.handleBlur}
-                  touched={formik.touched.price}
-                  horizontalConstraint={horizontalConstraint}
-                  errors={formik.errors.price}
-                  renderError={key => {
-                    switch (key) {
-                      // these could also use <FormattedMessage />
-                      case 'unsupportedHighPrecision':
-                        return 'No high precision prices are allowed here.';
-                      default:
-                        return null;
-                    }
-                  }}
+            console.log(values, omitEmpty(errors));
+            return omitEmpty(errors);
+          }}
+          onSubmit={(values, formik) => {
+            action('onSubmit')(values, formik);
+            formik.resetForm(values);
+          }}
+          render={formik => (
+            <Spacings.Stack scale="l">
+              <MoneyField
+                title="Regular Price"
+                description={'How much is the fish?'}
+                hint="It is better to pay in EUR"
+                name="price"
+                isRequired={true}
+                value={formik.values.price}
+                currencies={currencies}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+                touched={formik.touched.price}
+                horizontalConstraint={horizontalConstraint}
+                errors={formik.errors.price}
+                renderError={key => {
+                  switch (key) {
+                    // these could also use <FormattedMessage />
+                    case 'unsupportedHighPrecision':
+                      return 'No high precision prices are allowed here.';
+                    default:
+                      return null;
+                  }
+                }}
+              />
+              <MoneyField
+                title="Price per ton (High Precision)"
+                description={'How much is a ton of fish?'}
+                name="pricePerTon"
+                isRequired={true}
+                value={formik.values.pricePerTon}
+                currencies={currencies}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+                touched={formik.touched.pricePerTon}
+                horizontalConstraint={horizontalConstraint}
+                hasHighPrecisionBadge={true}
+                errors={formik.errors.pricePerTon}
+              />
+              <Spacings.Inline>
+                <SecondaryButton
+                  onClick={formik.handleReset}
+                  isDisabled={formik.isSubmitting}
+                  label="Reset"
                 />
-                <MoneyField
-                  title="Price per ton (High Precision)"
-                  description={'How much is a ton of fish?'}
-                  name="pricePerTon"
-                  isRequired={true}
-                  value={formik.values.pricePerTon}
-                  currencies={currencies}
-                  onChange={formik.handleChange}
-                  onBlur={formik.handleBlur}
-                  touched={formik.touched.pricePerTon}
-                  horizontalConstraint={horizontalConstraint}
-                  hasHighPrecisionBadge={true}
-                  errors={formik.errors.pricePerTon}
+                <PrimaryButton
+                  onClick={formik.handleSubmit}
+                  isDisabled={formik.isSubmitting || !formik.dirty}
+                  label="Submit"
                 />
-                <Spacings.Inline>
-                  <SecondaryButton
-                    onClick={formik.handleReset}
-                    isDisabled={formik.isSubmitting}
-                    label="Reset"
-                  />
-                  <PrimaryButton
-                    onClick={formik.handleSubmit}
-                    isDisabled={formik.isSubmitting || !formik.dirty}
-                    label="Submit"
-                  />
-                </Spacings.Inline>
-                <hr />
-                <FormikBox formik={formik} />
-              </Spacings.Stack>
-            )}
-          />
-        </IntlProvider>
+              </Spacings.Inline>
+              <hr />
+              <FormikBox formik={formik} />
+            </Spacings.Stack>
+          )}
+        />
       </Section>
     );
   });

--- a/src/components/fields/multiline-text-field/multiline-text-field.form.story.js
+++ b/src/components/fields/multiline-text-field/multiline-text-field.form.story.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Formik } from 'formik';
-import { IntlProvider } from 'react-intl';
 import { storiesOf } from '@storybook/react';
 import omitEmpty from 'omit-empty';
 import { action } from '@storybook/addon-actions';
@@ -19,66 +18,64 @@ storiesOf('Examples|Forms/Fields', module)
   .addDecorator(withReadme(Readme))
   .add('MultilineTextField', () => (
     <Section>
-      <IntlProvider locale="en">
-        <Formik
-          initialValues={{ description: '' }}
-          validate={values => {
-            const errors = { description: {} };
-            if (MultilineTextField.isEmpty(values.description))
-              errors.description.missing = true;
-            if (values.description.trim().length > 160)
-              errors.description.exceedsMaxLength = true;
-            return omitEmpty(errors);
-          }}
-          onSubmit={(values, formik, ...rest) => {
-            action('onSubmit')(values, formik, ...rest);
-            formik.resetForm(values);
-          }}
-          render={formik => (
-            <Spacings.Stack scale="l">
-              <MultilineTextField
-                title="Description"
-                description="Information about the product."
-                hint="Use 160 spaces at most."
-                name="description"
-                isRequired={true}
-                value={formik.values.description}
-                onChange={formik.handleChange}
-                onBlur={formik.handleBlur}
-                touched={formik.touched.description}
-                horizontalConstraint={select(
-                  'horizontalConstraint',
-                  ['xs', 's', 'm', 'l', 'xl', 'scale'],
-                  'm'
-                )}
-                errors={formik.errors.description}
-                renderError={key => {
-                  switch (key) {
-                    // these could also use <FormattedMessage />
-                    case 'exceedsMaxLength':
-                      return 'No more than 160 characters allowed';
-                    default:
-                      return null;
-                  }
-                }}
+      <Formik
+        initialValues={{ description: '' }}
+        validate={values => {
+          const errors = { description: {} };
+          if (MultilineTextField.isEmpty(values.description))
+            errors.description.missing = true;
+          if (values.description.trim().length > 160)
+            errors.description.exceedsMaxLength = true;
+          return omitEmpty(errors);
+        }}
+        onSubmit={(values, formik, ...rest) => {
+          action('onSubmit')(values, formik, ...rest);
+          formik.resetForm(values);
+        }}
+        render={formik => (
+          <Spacings.Stack scale="l">
+            <MultilineTextField
+              title="Description"
+              description="Information about the product."
+              hint="Use 160 spaces at most."
+              name="description"
+              isRequired={true}
+              value={formik.values.description}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+              touched={formik.touched.description}
+              horizontalConstraint={select(
+                'horizontalConstraint',
+                ['xs', 's', 'm', 'l', 'xl', 'scale'],
+                'm'
+              )}
+              errors={formik.errors.description}
+              renderError={key => {
+                switch (key) {
+                  // these could also use <FormattedMessage />
+                  case 'exceedsMaxLength':
+                    return 'No more than 160 characters allowed';
+                  default:
+                    return null;
+                }
+              }}
+            />
+            <Spacings.Inline>
+              <SecondaryButton
+                onClick={formik.handleReset}
+                isDisabled={formik.isSubmitting}
+                label="Reset"
               />
-              <Spacings.Inline>
-                <SecondaryButton
-                  onClick={formik.handleReset}
-                  isDisabled={formik.isSubmitting}
-                  label="Reset"
-                />
-                <PrimaryButton
-                  onClick={formik.handleSubmit}
-                  isDisabled={formik.isSubmitting || !formik.dirty}
-                  label="Submit"
-                />
-              </Spacings.Inline>
-              <hr />
-              <FormikBox formik={formik} />
-            </Spacings.Stack>
-          )}
-        />
-      </IntlProvider>
+              <PrimaryButton
+                onClick={formik.handleSubmit}
+                isDisabled={formik.isSubmitting || !formik.dirty}
+                label="Submit"
+              />
+            </Spacings.Inline>
+            <hr />
+            <FormikBox formik={formik} />
+          </Spacings.Stack>
+        )}
+      />
     </Section>
   ));

--- a/src/components/fields/number-field/number-field.form.story.js
+++ b/src/components/fields/number-field/number-field.form.story.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Formik } from 'formik';
-import { IntlProvider } from 'react-intl';
 import { storiesOf } from '@storybook/react';
 import omitEmpty from 'omit-empty';
 import { action } from '@storybook/addon-actions';
@@ -25,70 +24,68 @@ storiesOf('Examples|Forms/Fields', module)
   .addDecorator(withReadme(Readme))
   .add('NumberField', () => (
     <Section>
-      <IntlProvider locale="en">
-        <Formik
-          initialValues={{ age: '' }}
-          validate={values => {
-            const errors = { age: {} };
-            if (NumberField.isEmpty(values.age)) errors.age.missing = true;
-            else if (values.age < 0) errors.age.negative = true;
-            return omitEmpty(errors);
-          }}
-          onSubmit={(values, formik, ...rest) => {
-            action('onSubmit')(values, formik, ...rest);
-            formik.resetForm(values);
-          }}
-          render={formik => (
-            <Spacings.Stack scale="l">
-              <NumberField
-                title="Age"
-                description={
-                  boolean('Use ridiculously long description', false)
-                    ? 'The name you will have on our platform. Chose it wisely as it can not be changed once it is set. Do not pick something with unicors or a superhero, everybody is doing that :) So once again, chose wisely since this is permantent.'
-                    : 'The name you will have on our platform'
+      <Formik
+        initialValues={{ age: '' }}
+        validate={values => {
+          const errors = { age: {} };
+          if (NumberField.isEmpty(values.age)) errors.age.missing = true;
+          else if (values.age < 0) errors.age.negative = true;
+          return omitEmpty(errors);
+        }}
+        onSubmit={(values, formik, ...rest) => {
+          action('onSubmit')(values, formik, ...rest);
+          formik.resetForm(values);
+        }}
+        render={formik => (
+          <Spacings.Stack scale="l">
+            <NumberField
+              title="Age"
+              description={
+                boolean('Use ridiculously long description', false)
+                  ? 'The name you will have on our platform. Chose it wisely as it can not be changed once it is set. Do not pick something with unicors or a superhero, everybody is doing that :) So once again, chose wisely since this is permantent.'
+                  : 'The name you will have on our platform'
+              }
+              hint="Can not be negative"
+              name="age"
+              isRequired={true}
+              value={formik.values.age}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+              touched={formik.touched.age}
+              horizontalConstraint={select(
+                'horizontalConstraint',
+                ['xs', 's', 'm', 'l', 'xl', 'scale'],
+                'm'
+              )}
+              errors={formik.errors.age}
+              renderError={key => {
+                switch (key) {
+                  // these could also use <FormattedMessage />
+                  case 'negative':
+                    // we could also supply the "min" property instead
+                    // of creating validation for it.
+                    return 'No negative values allowed';
+                  default:
+                    return null;
                 }
-                hint="Can not be negative"
-                name="age"
-                isRequired={true}
-                value={formik.values.age}
-                onChange={formik.handleChange}
-                onBlur={formik.handleBlur}
-                touched={formik.touched.age}
-                horizontalConstraint={select(
-                  'horizontalConstraint',
-                  ['xs', 's', 'm', 'l', 'xl', 'scale'],
-                  'm'
-                )}
-                errors={formik.errors.age}
-                renderError={key => {
-                  switch (key) {
-                    // these could also use <FormattedMessage />
-                    case 'negative':
-                      // we could also supply the "min" property instead
-                      // of creating validation for it.
-                      return 'No negative values allowed';
-                    default:
-                      return null;
-                  }
-                }}
+              }}
+            />
+            <Spacings.Inline>
+              <SecondaryButton
+                onClick={formik.handleReset}
+                isDisabled={formik.isSubmitting}
+                label="Reset"
               />
-              <Spacings.Inline>
-                <SecondaryButton
-                  onClick={formik.handleReset}
-                  isDisabled={formik.isSubmitting}
-                  label="Reset"
-                />
-                <PrimaryButton
-                  onClick={formik.handleSubmit}
-                  isDisabled={formik.isSubmitting || !formik.dirty}
-                  label="Submit"
-                />
-              </Spacings.Inline>
-              <hr />
-              <FormikBox formik={formik} />
-            </Spacings.Stack>
-          )}
-        />
-      </IntlProvider>
+              <PrimaryButton
+                onClick={formik.handleSubmit}
+                isDisabled={formik.isSubmitting || !formik.dirty}
+                label="Submit"
+              />
+            </Spacings.Inline>
+            <hr />
+            <FormikBox formik={formik} />
+          </Spacings.Stack>
+        )}
+      />
     </Section>
   ));

--- a/src/components/fields/select-field/select-field.form.story.js
+++ b/src/components/fields/select-field/select-field.form.story.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Formik } from 'formik';
-import { IntlProvider } from 'react-intl';
 import { storiesOf } from '@storybook/react';
 import omitEmpty from 'omit-empty';
 import { action } from '@storybook/addon-actions';
@@ -74,59 +73,57 @@ storiesOf('Examples|Forms/Fields', module)
     const isMulti = boolean('isMulti', true);
     return (
       <Section key={isMulti}>
-        <IntlProvider locale="en">
-          <Formik
-            initialValues={{ animal: isMulti ? [] : undefined }}
-            validate={values => {
-              const errors = { animal: {} };
-              if (isMulti ? values.animal.length === 0 : !values.animal)
-                errors.animal.missing = true;
-              return omitEmpty(errors);
-            }}
-            onSubmit={(values, formik) => {
-              action('onSubmit')(values, formik);
-              formik.resetForm(values);
-            }}
-            render={formik => (
-              <Spacings.Stack scale="l">
-                <SelectField
-                  horizontalConstraint={select(
-                    'horizontalConstraint',
-                    ['xs', 's', 'm', 'l', 'xl', 'scale'],
-                    'm'
-                  )}
-                  errors={formik.errors.animal}
-                  isRequired={true}
-                  touched={formik.touched.animal}
-                  name="animal"
-                  value={formik.values.animal}
-                  onChange={formik.handleChange}
-                  onBlur={formik.handleBlur}
+        <Formik
+          initialValues={{ animal: isMulti ? [] : undefined }}
+          validate={values => {
+            const errors = { animal: {} };
+            if (isMulti ? values.animal.length === 0 : !values.animal)
+              errors.animal.missing = true;
+            return omitEmpty(errors);
+          }}
+          onSubmit={(values, formik) => {
+            action('onSubmit')(values, formik);
+            formik.resetForm(values);
+          }}
+          render={formik => (
+            <Spacings.Stack scale="l">
+              <SelectField
+                horizontalConstraint={select(
+                  'horizontalConstraint',
+                  ['xs', 's', 'm', 'l', 'xl', 'scale'],
+                  'm'
+                )}
+                errors={formik.errors.animal}
+                isRequired={true}
+                touched={formik.touched.animal}
+                name="animal"
+                value={formik.values.animal}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+                isDisabled={formik.isSubmitting}
+                isMulti={isMulti}
+                options={options}
+                title="Favourite animal"
+                description="Bonus points if it is a mammal"
+                isClearable={true}
+              />
+              <Spacings.Inline>
+                <SecondaryButton
+                  onClick={formik.handleReset}
                   isDisabled={formik.isSubmitting}
-                  isMulti={isMulti}
-                  options={options}
-                  title="Favourite animal"
-                  description="Bonus points if it is a mammal"
-                  isClearable={true}
+                  label="Reset"
                 />
-                <Spacings.Inline>
-                  <SecondaryButton
-                    onClick={formik.handleReset}
-                    isDisabled={formik.isSubmitting}
-                    label="Reset"
-                  />
-                  <PrimaryButton
-                    onClick={formik.handleSubmit}
-                    isDisabled={formik.isSubmitting || !formik.dirty}
-                    label="Submit"
-                  />
-                </Spacings.Inline>
-                <hr />
-                <FormikBox formik={formik} />
-              </Spacings.Stack>
-            )}
-          />
-        </IntlProvider>
+                <PrimaryButton
+                  onClick={formik.handleSubmit}
+                  isDisabled={formik.isSubmitting || !formik.dirty}
+                  label="Submit"
+                />
+              </Spacings.Inline>
+              <hr />
+              <FormikBox formik={formik} />
+            </Spacings.Stack>
+          )}
+        />
       </Section>
     );
   });

--- a/src/components/fields/text-field/text-field.form.story.js
+++ b/src/components/fields/text-field/text-field.form.story.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Formik } from 'formik';
-import { IntlProvider } from 'react-intl';
 import { storiesOf } from '@storybook/react';
 import omitEmpty from 'omit-empty';
 import { action } from '@storybook/addon-actions';
@@ -26,74 +25,72 @@ storiesOf('Examples|Forms/Fields', module)
   .addDecorator(withReadme(Readme))
   .add('TextField', () => (
     <Section>
-      <IntlProvider locale="en">
-        <Formik
-          initialValues={{ userName: '' }}
-          validate={values => {
-            const errors = { userName: {} };
-            if (TextField.isEmpty(values.userName))
-              errors.userName.missing = true;
-            if (values.userName.trim().indexOf(' ') !== -1)
-              errors.userName.usesSpaces = true;
-            if (values.userName.trim().length > 10)
-              errors.userName.exceedsMaxLength = true;
-            return omitEmpty(errors);
-          }}
-          onSubmit={(values, formik, ...rest) => {
-            action('onSubmit')(values, formik, ...rest);
-            formik.resetForm(values);
-          }}
-          render={formik => (
-            <Spacings.Stack scale="l">
-              <TextField
-                title="Username"
-                description={
-                  boolean('Use ridiculously long description', false)
-                    ? 'The name you will have on our platform. Chose it wisely as it can not be changed once it is set. Do not pick something with unicors or a superhero, everybody is doing that :) So once again, chose wisely since this is permantent.'
-                    : 'The name you will have on our platform'
+      <Formik
+        initialValues={{ userName: '' }}
+        validate={values => {
+          const errors = { userName: {} };
+          if (TextField.isEmpty(values.userName))
+            errors.userName.missing = true;
+          if (values.userName.trim().indexOf(' ') !== -1)
+            errors.userName.usesSpaces = true;
+          if (values.userName.trim().length > 10)
+            errors.userName.exceedsMaxLength = true;
+          return omitEmpty(errors);
+        }}
+        onSubmit={(values, formik, ...rest) => {
+          action('onSubmit')(values, formik, ...rest);
+          formik.resetForm(values);
+        }}
+        render={formik => (
+          <Spacings.Stack scale="l">
+            <TextField
+              title="Username"
+              description={
+                boolean('Use ridiculously long description', false)
+                  ? 'The name you will have on our platform. Chose it wisely as it can not be changed once it is set. Do not pick something with unicors or a superhero, everybody is doing that :) So once again, chose wisely since this is permantent.'
+                  : 'The name you will have on our platform'
+              }
+              hint="No spaces allowed"
+              name="userName"
+              isRequired={true}
+              value={formik.values.userName}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+              touched={formik.touched.userName}
+              horizontalConstraint={select(
+                'horizontalConstraint',
+                ['xs', 's', 'm', 'l', 'xl', 'scale'],
+                'm'
+              )}
+              errors={formik.errors.userName}
+              renderError={key => {
+                switch (key) {
+                  // these could also use <FormattedMessage />
+                  case 'usesSpaces':
+                    return 'No spaces allowed';
+                  case 'exceedsMaxLength':
+                    return 'No more than 10 characters allowed';
+                  default:
+                    return null;
                 }
-                hint="No spaces allowed"
-                name="userName"
-                isRequired={true}
-                value={formik.values.userName}
-                onChange={formik.handleChange}
-                onBlur={formik.handleBlur}
-                touched={formik.touched.userName}
-                horizontalConstraint={select(
-                  'horizontalConstraint',
-                  ['xs', 's', 'm', 'l', 'xl', 'scale'],
-                  'm'
-                )}
-                errors={formik.errors.userName}
-                renderError={key => {
-                  switch (key) {
-                    // these could also use <FormattedMessage />
-                    case 'usesSpaces':
-                      return 'No spaces allowed';
-                    case 'exceedsMaxLength':
-                      return 'No more than 10 characters allowed';
-                    default:
-                      return null;
-                  }
-                }}
+              }}
+            />
+            <Spacings.Inline>
+              <SecondaryButton
+                onClick={formik.handleReset}
+                isDisabled={formik.isSubmitting}
+                label="Reset"
               />
-              <Spacings.Inline>
-                <SecondaryButton
-                  onClick={formik.handleReset}
-                  isDisabled={formik.isSubmitting}
-                  label="Reset"
-                />
-                <PrimaryButton
-                  onClick={formik.handleSubmit}
-                  isDisabled={formik.isSubmitting || !formik.dirty}
-                  label="Submit"
-                />
-              </Spacings.Inline>
-              <hr />
-              <FormikBox formik={formik} />
-            </Spacings.Stack>
-          )}
-        />
-      </IntlProvider>
+              <PrimaryButton
+                onClick={formik.handleSubmit}
+                isDisabled={formik.isSubmitting || !formik.dirty}
+                label="Submit"
+              />
+            </Spacings.Inline>
+            <hr />
+            <FormikBox formik={formik} />
+          </Spacings.Stack>
+        )}
+      />
     </Section>
   ));

--- a/src/components/inputs/async-creatable-select-input/async-creatable-select-input.form.story.js
+++ b/src/components/inputs/async-creatable-select-input/async-creatable-select-input.form.story.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Formik } from 'formik';
 import PropTypes from 'prop-types';
-import { IntlProvider } from 'react-intl';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, boolean, number } from '@storybook/addon-knobs';
@@ -73,102 +72,100 @@ class AsyncCreatableSelectInputStory extends React.Component {
     });
     return (
       <Section>
-        <IntlProvider locale="en">
-          <FakeConnector key={isMulti} isMulti={isMulti}>
-            {({ product }) => (
-              <Formik
-                initialValues={docToForm(product, isMulti)}
-                validate={
-                  // we use this failing validation so that we can see the touched
-                  // shape
-                  () => (failValidation ? { category: true } : {})
-                }
-                onSubmit={(values, formik, ...rest) => {
-                  action('onSubmit')(values, formik, ...rest);
-                  formik.resetForm(values);
-                }}
-                render={formik => {
-                  const hasError = failValidation;
-                  const isTouched = AsyncCreatableSelectInput.isTouched(
-                    formik.touched.category
-                  );
-                  return (
-                    <Spacings.Stack scale="l">
-                      <Spacings.Stack scale="xs">
-                        <AsyncCreatableSelectInput
-                          name="category"
-                          isMulti={isMulti}
-                          isClearable={true}
-                          cacheOptions={number('cacheOptions', 2)}
-                          value={formik.values.category}
-                          onChange={formik.handleChange}
-                          onBlur={formik.handleBlur}
-                          hasError={hasError && isTouched}
-                          defaultOptions={[
+        <FakeConnector key={isMulti} isMulti={isMulti}>
+          {({ product }) => (
+            <Formik
+              initialValues={docToForm(product, isMulti)}
+              validate={
+                // we use this failing validation so that we can see the touched
+                // shape
+                () => (failValidation ? { category: true } : {})
+              }
+              onSubmit={(values, formik, ...rest) => {
+                action('onSubmit')(values, formik, ...rest);
+                formik.resetForm(values);
+              }}
+              render={formik => {
+                const hasError = failValidation;
+                const isTouched = AsyncCreatableSelectInput.isTouched(
+                  formik.touched.category
+                );
+                return (
+                  <Spacings.Stack scale="l">
+                    <Spacings.Stack scale="xs">
+                      <AsyncCreatableSelectInput
+                        name="category"
+                        isMulti={isMulti}
+                        isClearable={true}
+                        cacheOptions={number('cacheOptions', 2)}
+                        value={formik.values.category}
+                        onChange={formik.handleChange}
+                        onBlur={formik.handleBlur}
+                        hasError={hasError && isTouched}
+                        defaultOptions={[
+                          { value: 'dogs', label: 'Dogs' },
+                          { value: 'whales', label: 'Whales' },
+                        ]}
+                        loadOptions={searchText => {
+                          const items = [
                             { value: 'dogs', label: 'Dogs' },
                             { value: 'whales', label: 'Whales' },
-                          ]}
-                          loadOptions={searchText => {
-                            const items = [
-                              { value: 'dogs', label: 'Dogs' },
-                              { value: 'whales', label: 'Whales' },
-                              { value: 'antilopes', label: 'Antilopes' },
-                              { value: 'snakes', label: 'Snakes' },
-                            ];
+                            { value: 'antilopes', label: 'Antilopes' },
+                            { value: 'snakes', label: 'Snakes' },
+                          ];
 
-                            return delay(delayTimeMs).then(() =>
-                              items.filter(item =>
-                                item.label
-                                  .toLowerCase()
-                                  .startsWith(searchText.toLowerCase())
-                              )
-                            );
-                          }}
-                        />
-                        {hasError &&
-                          isTouched && (
-                            <ErrorMessage>Category is required</ErrorMessage>
-                          )}
-                      </Spacings.Stack>
-                      <div>
-                        <button
-                          onClick={() => {
-                            // additional data could be on cats
-                            const cats = { label: 'Cats', value: 'cats' };
-                            formik.setFieldValue(
-                              'category',
-                              isMulti ? [cats] : cats
-                            );
-                            formik.setFieldTouched(
-                              'category',
-                              isMulti ? [true] : true
-                            );
-                          }}
-                        >
-                          Select Cats
-                        </button>
-                      </div>
-                      <Spacings.Inline>
-                        <SecondaryButton
-                          onClick={formik.handleReset}
-                          isDisabled={formik.isSubmitting}
-                          label="Reset"
-                        />
-                        <PrimaryButton
-                          onClick={formik.handleSubmit}
-                          isDisabled={formik.isSubmitting || !formik.dirty}
-                          label="Submit"
-                        />
-                      </Spacings.Inline>
-                      <hr />
-                      <FormikBox formik={formik} />
+                          return delay(delayTimeMs).then(() =>
+                            items.filter(item =>
+                              item.label
+                                .toLowerCase()
+                                .startsWith(searchText.toLowerCase())
+                            )
+                          );
+                        }}
+                      />
+                      {hasError &&
+                        isTouched && (
+                          <ErrorMessage>Category is required</ErrorMessage>
+                        )}
                     </Spacings.Stack>
-                  );
-                }}
-              />
-            )}
-          </FakeConnector>
-        </IntlProvider>
+                    <div>
+                      <button
+                        onClick={() => {
+                          // additional data could be on cats
+                          const cats = { label: 'Cats', value: 'cats' };
+                          formik.setFieldValue(
+                            'category',
+                            isMulti ? [cats] : cats
+                          );
+                          formik.setFieldTouched(
+                            'category',
+                            isMulti ? [true] : true
+                          );
+                        }}
+                      >
+                        Select Cats
+                      </button>
+                    </div>
+                    <Spacings.Inline>
+                      <SecondaryButton
+                        onClick={formik.handleReset}
+                        isDisabled={formik.isSubmitting}
+                        label="Reset"
+                      />
+                      <PrimaryButton
+                        onClick={formik.handleSubmit}
+                        isDisabled={formik.isSubmitting || !formik.dirty}
+                        label="Submit"
+                      />
+                    </Spacings.Inline>
+                    <hr />
+                    <FormikBox formik={formik} />
+                  </Spacings.Stack>
+                );
+              }}
+            />
+          )}
+        </FakeConnector>
       </Section>
     );
   }

--- a/src/components/inputs/async-creatable-select-input/async-creatable-select-input.story.js
+++ b/src/components/inputs/async-creatable-select-input/async-creatable-select-input.story.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Value } from 'react-value';
 import { storiesOf } from '@storybook/react';
-import { IntlProvider } from 'react-intl';
 import { action } from '@storybook/addon-actions';
 import {
   withKnobs,
@@ -48,65 +47,60 @@ class SelectStory extends React.Component {
     return (
       <React.Fragment>
         <Section>
-          <IntlProvider locale="en">
-            <Value
-              key={`${isMulti}-${defaultOptions}`}
-              defaultValue={isMulti ? [] : undefined}
-              render={(value, onChange) => (
-                <div>
-                  <AsyncCreatableSelectInput
-                    horizontalConstraint={select(
-                      'horizontalConstraint',
-                      ['xs', 's', 'm', 'l', 'xl', 'scale'],
-                      'scale'
-                    )}
-                    hasError={boolean('hasError', false)}
-                    hasWarning={boolean('hasWarning', false)}
-                    aria-label={text('aria-label', '')}
-                    aria-labelledby={text('aria-labelledby', '')}
-                    isAutofocussed={boolean('isAutofocussed', false)}
-                    backspaceRemovesValue={boolean(
-                      'backspaceRemovesValue',
-                      true
-                    )}
-                    id={text('id', '')}
-                    containerId={text('containerId', '')}
-                    isClearable={boolean('isClearable', false)}
-                    isDisabled={boolean('isDisabled', false)}
-                    isMulti={isMulti}
-                    isSearchable={boolean('isSearchable', true)}
-                    maxMenuHeight={number('maxMenuHeight', 200)}
-                    name={text('name', 'form-field-name')}
-                    onBlur={action('onBlur')}
-                    onChange={(event, info) => {
-                      action('onChange')(event, info);
-                      onChange(event.target.value);
-                    }}
-                    onFocus={action('onFocus')}
-                    onInputChange={action('onInputChange')}
-                    placeholder={text('placeholder', 'Select..')}
-                    tabIndex={text('tabIndex', '0')}
-                    tabSelectsValue={boolean('tabSelectsValue', true)}
-                    value={value}
-                    // Async props
-                    defaultOptions={defaultOptions}
-                    loadOptions={loadOptions}
-                    cacheOptions={boolean('cacheOptions', false)}
-                    // Creatable props
-                    allowCreateWhileLoading={boolean(
-                      'allowCreateWhileLoading',
-                      false
-                    )}
-                    createOptionPosition={select(
-                      'createOptionPosition',
-                      ['first', 'last'],
-                      'last'
-                    )}
-                  />
-                </div>
-              )}
-            />
-          </IntlProvider>
+          <Value
+            key={`${isMulti}-${defaultOptions}`}
+            defaultValue={isMulti ? [] : undefined}
+            render={(value, onChange) => (
+              <div>
+                <AsyncCreatableSelectInput
+                  horizontalConstraint={select(
+                    'horizontalConstraint',
+                    ['xs', 's', 'm', 'l', 'xl', 'scale'],
+                    'scale'
+                  )}
+                  hasError={boolean('hasError', false)}
+                  hasWarning={boolean('hasWarning', false)}
+                  aria-label={text('aria-label', '')}
+                  aria-labelledby={text('aria-labelledby', '')}
+                  isAutofocussed={boolean('isAutofocussed', false)}
+                  backspaceRemovesValue={boolean('backspaceRemovesValue', true)}
+                  id={text('id', '')}
+                  containerId={text('containerId', '')}
+                  isClearable={boolean('isClearable', false)}
+                  isDisabled={boolean('isDisabled', false)}
+                  isMulti={isMulti}
+                  isSearchable={boolean('isSearchable', true)}
+                  maxMenuHeight={number('maxMenuHeight', 200)}
+                  name={text('name', 'form-field-name')}
+                  onBlur={action('onBlur')}
+                  onChange={(event, info) => {
+                    action('onChange')(event, info);
+                    onChange(event.target.value);
+                  }}
+                  onFocus={action('onFocus')}
+                  onInputChange={action('onInputChange')}
+                  placeholder={text('placeholder', 'Select..')}
+                  tabIndex={text('tabIndex', '0')}
+                  tabSelectsValue={boolean('tabSelectsValue', true)}
+                  value={value}
+                  // Async props
+                  defaultOptions={defaultOptions}
+                  loadOptions={loadOptions}
+                  cacheOptions={boolean('cacheOptions', false)}
+                  // Creatable props
+                  allowCreateWhileLoading={boolean(
+                    'allowCreateWhileLoading',
+                    false
+                  )}
+                  createOptionPosition={select(
+                    'createOptionPosition',
+                    ['first', 'last'],
+                    'last'
+                  )}
+                />
+              </div>
+            )}
+          />
         </Section>
       </React.Fragment>
     );

--- a/src/components/inputs/async-select-input/async-select-input.form.story.js
+++ b/src/components/inputs/async-select-input/async-select-input.form.story.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Formik } from 'formik';
 import PropTypes from 'prop-types';
-import { IntlProvider } from 'react-intl';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, boolean, number } from '@storybook/addon-knobs';
@@ -73,102 +72,100 @@ class AsyncSelectInputStory extends React.Component {
     });
     return (
       <Section>
-        <IntlProvider locale="en">
-          <FakeConnector key={isMulti} isMulti={isMulti}>
-            {({ product }) => (
-              <Formik
-                initialValues={docToForm(product, isMulti)}
-                validate={
-                  // we use this failing validation so that we can see the touched
-                  // shape
-                  () => (failValidation ? { category: true } : {})
-                }
-                onSubmit={(values, formik, ...rest) => {
-                  action('onSubmit')(values, formik, ...rest);
-                  formik.resetForm(values);
-                }}
-                render={formik => {
-                  const hasError = failValidation;
-                  const isTouched = AsyncSelectInput.isTouched(
-                    formik.touched.category
-                  );
-                  return (
-                    <Spacings.Stack scale="l">
-                      <div>
-                        <AsyncSelectInput
-                          name="category"
-                          isMulti={isMulti}
-                          isClearable={true}
-                          cacheOptions={number('cacheOptions', 2)}
-                          value={formik.values.category}
-                          onChange={formik.handleChange}
-                          onBlur={formik.handleBlur}
-                          hasError={hasError && isTouched}
-                          defaultOptions={[
+        <FakeConnector key={isMulti} isMulti={isMulti}>
+          {({ product }) => (
+            <Formik
+              initialValues={docToForm(product, isMulti)}
+              validate={
+                // we use this failing validation so that we can see the touched
+                // shape
+                () => (failValidation ? { category: true } : {})
+              }
+              onSubmit={(values, formik, ...rest) => {
+                action('onSubmit')(values, formik, ...rest);
+                formik.resetForm(values);
+              }}
+              render={formik => {
+                const hasError = failValidation;
+                const isTouched = AsyncSelectInput.isTouched(
+                  formik.touched.category
+                );
+                return (
+                  <Spacings.Stack scale="l">
+                    <div>
+                      <AsyncSelectInput
+                        name="category"
+                        isMulti={isMulti}
+                        isClearable={true}
+                        cacheOptions={number('cacheOptions', 2)}
+                        value={formik.values.category}
+                        onChange={formik.handleChange}
+                        onBlur={formik.handleBlur}
+                        hasError={hasError && isTouched}
+                        defaultOptions={[
+                          { value: 'dogs', label: 'Dogs' },
+                          { value: 'whales', label: 'Whales' },
+                        ]}
+                        loadOptions={searchText => {
+                          const items = [
                             { value: 'dogs', label: 'Dogs' },
                             { value: 'whales', label: 'Whales' },
-                          ]}
-                          loadOptions={searchText => {
-                            const items = [
-                              { value: 'dogs', label: 'Dogs' },
-                              { value: 'whales', label: 'Whales' },
-                              { value: 'antilopes', label: 'Antilopes' },
-                              { value: 'snakes', label: 'Snakes' },
-                            ];
+                            { value: 'antilopes', label: 'Antilopes' },
+                            { value: 'snakes', label: 'Snakes' },
+                          ];
 
-                            return delay(delayTimeMs).then(() =>
-                              items.filter(item =>
-                                item.label
-                                  .toLowerCase()
-                                  .startsWith(searchText.toLowerCase())
-                              )
-                            );
-                          }}
-                        />
-                        {hasError &&
-                          isTouched && (
-                            <ErrorMessage>Category is required</ErrorMessage>
-                          )}
-                      </div>
-                      <div>
-                        <button
-                          onClick={() => {
-                            // additional data could be on cats
-                            const cats = { label: 'Cats', value: 'cats' };
-                            formik.setFieldValue(
-                              'category',
-                              isMulti ? [cats] : cats
-                            );
-                            formik.setFieldTouched(
-                              'category',
-                              isMulti ? [true] : true
-                            );
-                          }}
-                        >
-                          Select Cats
-                        </button>
-                      </div>
-                      <Spacings.Inline>
-                        <SecondaryButton
-                          onClick={formik.handleReset}
-                          isDisabled={formik.isSubmitting}
-                          label="Reset"
-                        />
-                        <PrimaryButton
-                          onClick={formik.handleSubmit}
-                          isDisabled={formik.isSubmitting || !formik.dirty}
-                          label="Submit"
-                        />
-                      </Spacings.Inline>
-                      <hr />
-                      <FormikBox formik={formik} />
-                    </Spacings.Stack>
-                  );
-                }}
-              />
-            )}
-          </FakeConnector>
-        </IntlProvider>
+                          return delay(delayTimeMs).then(() =>
+                            items.filter(item =>
+                              item.label
+                                .toLowerCase()
+                                .startsWith(searchText.toLowerCase())
+                            )
+                          );
+                        }}
+                      />
+                      {hasError &&
+                        isTouched && (
+                          <ErrorMessage>Category is required</ErrorMessage>
+                        )}
+                    </div>
+                    <div>
+                      <button
+                        onClick={() => {
+                          // additional data could be on cats
+                          const cats = { label: 'Cats', value: 'cats' };
+                          formik.setFieldValue(
+                            'category',
+                            isMulti ? [cats] : cats
+                          );
+                          formik.setFieldTouched(
+                            'category',
+                            isMulti ? [true] : true
+                          );
+                        }}
+                      >
+                        Select Cats
+                      </button>
+                    </div>
+                    <Spacings.Inline>
+                      <SecondaryButton
+                        onClick={formik.handleReset}
+                        isDisabled={formik.isSubmitting}
+                        label="Reset"
+                      />
+                      <PrimaryButton
+                        onClick={formik.handleSubmit}
+                        isDisabled={formik.isSubmitting || !formik.dirty}
+                        label="Submit"
+                      />
+                    </Spacings.Inline>
+                    <hr />
+                    <FormikBox formik={formik} />
+                  </Spacings.Stack>
+                );
+              }}
+            />
+          )}
+        </FakeConnector>
       </Section>
     );
   }

--- a/src/components/inputs/async-select-input/async-select-input.story.js
+++ b/src/components/inputs/async-select-input/async-select-input.story.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Value } from 'react-value';
 import { storiesOf } from '@storybook/react';
-import { IntlProvider } from 'react-intl';
 import { action } from '@storybook/addon-actions';
 import {
   withKnobs,
@@ -48,55 +47,50 @@ class SelectStory extends React.Component {
     return (
       <React.Fragment>
         <Section>
-          <IntlProvider locale="en">
-            <Value
-              key={`${isMulti}-${defaultOptions}`}
-              defaultValue={isMulti ? [] : undefined}
-              render={(value, onChange) => (
-                <div>
-                  <AsyncSelectInput
-                    horizontalConstraint={select(
-                      'horizontalConstraint',
-                      ['xs', 's', 'm', 'l', 'xl', 'scale'],
-                      'scale'
-                    )}
-                    hasError={boolean('hasError', false)}
-                    hasWarning={boolean('hasWarning', false)}
-                    aria-label={text('aria-label', '')}
-                    aria-labelledby={text('aria-labelledby', '')}
-                    isAutofocussed={boolean('isAutofocussed', false)}
-                    backspaceRemovesValue={boolean(
-                      'backspaceRemovesValue',
-                      true
-                    )}
-                    id={text('id', '')}
-                    containerId={text('containerId', '')}
-                    isClearable={boolean('isClearable', false)}
-                    isDisabled={boolean('isDisabled', false)}
-                    isMulti={isMulti}
-                    isSearchable={boolean('isSearchable', true)}
-                    maxMenuHeight={number('maxMenuHeight', 200)}
-                    name={text('name', 'form-field-name')}
-                    onBlur={action('onBlur')}
-                    onChange={(event, info) => {
-                      action('onChange')(event, info);
-                      onChange(event.target.value);
-                    }}
-                    onFocus={action('onFocus')}
-                    onInputChange={action('onInputChange')}
-                    placeholder={text('placeholder', 'Select..')}
-                    tabIndex={text('tabIndex', '0')}
-                    tabSelectsValue={boolean('tabSelectsValue', true)}
-                    value={value}
-                    // Async props
-                    defaultOptions={defaultOptions}
-                    loadOptions={loadOptions}
-                    cacheOptions={boolean('cacheOptions', false)}
-                  />
-                </div>
-              )}
-            />
-          </IntlProvider>
+          <Value
+            key={`${isMulti}-${defaultOptions}`}
+            defaultValue={isMulti ? [] : undefined}
+            render={(value, onChange) => (
+              <div>
+                <AsyncSelectInput
+                  horizontalConstraint={select(
+                    'horizontalConstraint',
+                    ['xs', 's', 'm', 'l', 'xl', 'scale'],
+                    'scale'
+                  )}
+                  hasError={boolean('hasError', false)}
+                  hasWarning={boolean('hasWarning', false)}
+                  aria-label={text('aria-label', '')}
+                  aria-labelledby={text('aria-labelledby', '')}
+                  isAutofocussed={boolean('isAutofocussed', false)}
+                  backspaceRemovesValue={boolean('backspaceRemovesValue', true)}
+                  id={text('id', '')}
+                  containerId={text('containerId', '')}
+                  isClearable={boolean('isClearable', false)}
+                  isDisabled={boolean('isDisabled', false)}
+                  isMulti={isMulti}
+                  isSearchable={boolean('isSearchable', true)}
+                  maxMenuHeight={number('maxMenuHeight', 200)}
+                  name={text('name', 'form-field-name')}
+                  onBlur={action('onBlur')}
+                  onChange={(event, info) => {
+                    action('onChange')(event, info);
+                    onChange(event.target.value);
+                  }}
+                  onFocus={action('onFocus')}
+                  onInputChange={action('onInputChange')}
+                  placeholder={text('placeholder', 'Select..')}
+                  tabIndex={text('tabIndex', '0')}
+                  tabSelectsValue={boolean('tabSelectsValue', true)}
+                  value={value}
+                  // Async props
+                  defaultOptions={defaultOptions}
+                  loadOptions={loadOptions}
+                  cacheOptions={boolean('cacheOptions', false)}
+                />
+              </div>
+            )}
+          />
         </Section>
       </React.Fragment>
     );

--- a/src/components/inputs/creatable-select-input/creatable-select-input.form.story.js
+++ b/src/components/inputs/creatable-select-input/creatable-select-input.form.story.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Formik } from 'formik';
-import { IntlProvider } from 'react-intl';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, boolean } from '@storybook/addon-knobs';
@@ -75,83 +74,79 @@ storiesOf('Examples|Forms/Inputs', module)
 
     return (
       <Section>
-        <IntlProvider locale="en">
-          <Formik
-            key={`${isMulti}-${isPrefilled}`}
-            initialValues={{ state: initialState, colour: initialColour }}
-            validate={
-              // we use failing validation so that we can see the touched shape
-              // on form submission
-              () => (failValidation ? { state: true, colour: true } : {})
-            }
-            onSubmit={(values, formik, ...rest) => {
-              action('onSubmit')(values, formik, ...rest);
-              formik.resetForm(values);
-            }}
-            render={formik => {
-              const stateInput = {
-                hasError: failValidation,
-                isTouched: CreatableSelectInput.isTouched(formik.touched.state),
-              };
-              const colourInput = {
-                hasError: failValidation,
-                isTouched: CreatableSelectInput.isTouched(
-                  formik.touched.colour
-                ),
-              };
-              return (
-                <Spacings.Stack scale="l">
-                  <Spacings.Stack scale="xs">
-                    <CreatableSelectInput
-                      name="state"
-                      isMulti={isMulti}
-                      value={formik.values.state}
-                      onChange={formik.handleChange}
-                      onBlur={formik.handleBlur}
-                      options={stateOptions}
-                      hasError={stateInput.hasError && stateInput.isTouched}
-                      isClearable={true}
-                    />
-                    {stateInput.hasError &&
-                      stateInput.isTouched && (
-                        <ErrorMessage>State is not valid</ErrorMessage>
-                      )}
-                  </Spacings.Stack>
-                  <Spacings.Stack scale="xs">
-                    <CreatableSelectInput
-                      name="colour"
-                      isMulti={isMulti}
-                      value={formik.values.colour}
-                      onChange={formik.handleChange}
-                      onBlur={formik.handleBlur}
-                      options={groupedOptions}
-                      hasError={colourInput.hasError && colourInput.isTouched}
-                      isClearable={true}
-                    />
-                    {colourInput.hasError &&
-                      colourInput.isTouched && (
-                        <ErrorMessage>Colour is not valid</ErrorMessage>
-                      )}
-                  </Spacings.Stack>
-                  <Spacings.Inline>
-                    <SecondaryButton
-                      onClick={formik.handleReset}
-                      isDisabled={formik.isSubmitting}
-                      label="Reset"
-                    />
-                    <PrimaryButton
-                      onClick={formik.handleSubmit}
-                      isDisabled={formik.isSubmitting || !formik.dirty}
-                      label="Submit"
-                    />
-                  </Spacings.Inline>
-                  <hr />
-                  <FormikBox formik={formik} />
+        <Formik
+          key={`${isMulti}-${isPrefilled}`}
+          initialValues={{ state: initialState, colour: initialColour }}
+          validate={
+            // we use failing validation so that we can see the touched shape
+            // on form submission
+            () => (failValidation ? { state: true, colour: true } : {})
+          }
+          onSubmit={(values, formik, ...rest) => {
+            action('onSubmit')(values, formik, ...rest);
+            formik.resetForm(values);
+          }}
+          render={formik => {
+            const stateInput = {
+              hasError: failValidation,
+              isTouched: CreatableSelectInput.isTouched(formik.touched.state),
+            };
+            const colourInput = {
+              hasError: failValidation,
+              isTouched: CreatableSelectInput.isTouched(formik.touched.colour),
+            };
+            return (
+              <Spacings.Stack scale="l">
+                <Spacings.Stack scale="xs">
+                  <CreatableSelectInput
+                    name="state"
+                    isMulti={isMulti}
+                    value={formik.values.state}
+                    onChange={formik.handleChange}
+                    onBlur={formik.handleBlur}
+                    options={stateOptions}
+                    hasError={stateInput.hasError && stateInput.isTouched}
+                    isClearable={true}
+                  />
+                  {stateInput.hasError &&
+                    stateInput.isTouched && (
+                      <ErrorMessage>State is not valid</ErrorMessage>
+                    )}
                 </Spacings.Stack>
-              );
-            }}
-          />
-        </IntlProvider>
+                <Spacings.Stack scale="xs">
+                  <CreatableSelectInput
+                    name="colour"
+                    isMulti={isMulti}
+                    value={formik.values.colour}
+                    onChange={formik.handleChange}
+                    onBlur={formik.handleBlur}
+                    options={groupedOptions}
+                    hasError={colourInput.hasError && colourInput.isTouched}
+                    isClearable={true}
+                  />
+                  {colourInput.hasError &&
+                    colourInput.isTouched && (
+                      <ErrorMessage>Colour is not valid</ErrorMessage>
+                    )}
+                </Spacings.Stack>
+                <Spacings.Inline>
+                  <SecondaryButton
+                    onClick={formik.handleReset}
+                    isDisabled={formik.isSubmitting}
+                    label="Reset"
+                  />
+                  <PrimaryButton
+                    onClick={formik.handleSubmit}
+                    isDisabled={formik.isSubmitting || !formik.dirty}
+                    label="Submit"
+                  />
+                </Spacings.Inline>
+                <hr />
+                <FormikBox formik={formik} />
+              </Spacings.Stack>
+            );
+          }}
+        />
       </Section>
     );
   });

--- a/src/components/inputs/creatable-select-input/creatable-select-input.story.js
+++ b/src/components/inputs/creatable-select-input/creatable-select-input.story.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Value } from 'react-value';
-import { IntlProvider } from 'react-intl';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import {
@@ -77,57 +76,55 @@ storiesOf('Inputs', module)
     return (
       <Spacings.Stack scale="xl">
         <Section>
-          <IntlProvider locale="en">
-            <Value
-              key={isMulti}
-              defaultValue={isMulti ? [] : undefined}
-              render={(value, onChange) => (
-                <CreatableSelectInput
-                  horizontalConstraint={select(
-                    'horizontalConstraint',
-                    ['xs', 's', 'm', 'l', 'xl', 'scale'],
-                    'scale'
-                  )}
-                  hasError={boolean('hasError', false)}
-                  hasWarning={boolean('hasWarning', false)}
-                  aria-label={text('aria-label', '')}
-                  aria-labelledby={text('aria-labelledby', '')}
-                  autoFocus={boolean('isAutofocussed', false)}
-                  backspaceRemovesValue={boolean('backspaceRemovesValue', true)}
-                  id={text('id', '')}
-                  containerId={text('containerId', '')}
-                  isClearable={boolean('isClearable', false)}
-                  isDisabled={boolean('isDisabled', false)}
-                  isMulti={isMulti}
-                  isSearchable={boolean('isSearchable', true)}
-                  maxMenuHeight={number('maxMenuHeight', 200)}
-                  name={text('name', 'form-field-name')}
-                  onBlur={action('onBlur')}
-                  onChange={(event, ...args) => {
-                    action('onChange')(event, ...args);
-                    onChange(event.target.value);
-                  }}
-                  onFocus={action('onFocus')}
-                  onInputChange={action('onInputChange')}
-                  options={options}
-                  placeholder={text('placeholder', 'Select..')}
-                  tabIndex={text('tabIndex', '0')}
-                  tabSelectsValue={boolean('tabSelectsValue', true)}
-                  value={value}
-                  // Creatable props
-                  allowCreateWhileLoading={boolean(
-                    'allowCreateWhileLoading',
-                    false
-                  )}
-                  createOptionPosition={select(
-                    'createOptionPosition',
-                    ['first', 'last'],
-                    'last'
-                  )}
-                />
-              )}
-            />
-          </IntlProvider>
+          <Value
+            key={isMulti}
+            defaultValue={isMulti ? [] : undefined}
+            render={(value, onChange) => (
+              <CreatableSelectInput
+                horizontalConstraint={select(
+                  'horizontalConstraint',
+                  ['xs', 's', 'm', 'l', 'xl', 'scale'],
+                  'scale'
+                )}
+                hasError={boolean('hasError', false)}
+                hasWarning={boolean('hasWarning', false)}
+                aria-label={text('aria-label', '')}
+                aria-labelledby={text('aria-labelledby', '')}
+                autoFocus={boolean('isAutofocussed', false)}
+                backspaceRemovesValue={boolean('backspaceRemovesValue', true)}
+                id={text('id', '')}
+                containerId={text('containerId', '')}
+                isClearable={boolean('isClearable', false)}
+                isDisabled={boolean('isDisabled', false)}
+                isMulti={isMulti}
+                isSearchable={boolean('isSearchable', true)}
+                maxMenuHeight={number('maxMenuHeight', 200)}
+                name={text('name', 'form-field-name')}
+                onBlur={action('onBlur')}
+                onChange={(event, ...args) => {
+                  action('onChange')(event, ...args);
+                  onChange(event.target.value);
+                }}
+                onFocus={action('onFocus')}
+                onInputChange={action('onInputChange')}
+                options={options}
+                placeholder={text('placeholder', 'Select..')}
+                tabIndex={text('tabIndex', '0')}
+                tabSelectsValue={boolean('tabSelectsValue', true)}
+                value={value}
+                // Creatable props
+                allowCreateWhileLoading={boolean(
+                  'allowCreateWhileLoading',
+                  false
+                )}
+                createOptionPosition={select(
+                  'createOptionPosition',
+                  ['first', 'last'],
+                  'last'
+                )}
+              />
+            )}
+          />
         </Section>
         <Section>
           <LinkTo kind="Examples|Forms/Inputs" story="CreatableSelectInput">

--- a/src/components/inputs/date-input/date-input.story.js
+++ b/src/components/inputs/date-input/date-input.story.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { IntlProvider } from 'react-intl';
 import { action } from '@storybook/addon-actions';
 import withReadme from 'storybook-readme/with-readme';
 import { withKnobs, boolean, text, select } from '@storybook/addon-knobs';
@@ -13,7 +12,6 @@ storiesOf('Inputs', module)
   .addDecorator(withKnobs)
   .addDecorator(withReadme(Readme))
   .add('DateInput', () => {
-    const locale = select('locale', ['de', 'en'], 'en');
     const timeZone = select(
       'timeZone',
       ['Europe/Madrid', 'America/Los_Angeles'],
@@ -21,32 +19,30 @@ storiesOf('Inputs', module)
     );
     return (
       <Section>
-        <IntlProvider locale={locale}>
-          <Value
-            key={`${locale}-${timeZone}`}
-            defaultValue="2017-12-31"
-            render={(value, onChange) => (
-              <DateInput
-                id={text('id', '')}
-                placeholder={text('placeholder', 'Select a date...')}
-                mode={select('mode', ['single', 'multiple', 'range'], 'single')}
-                isDisabled={boolean('isDisabled', false)}
-                value={text('value (Date in UTC)', value)}
-                onChange={date => {
-                  action('onChange')(date);
-                  onChange(date);
-                }}
-                isInvalid={boolean('isInvalid?', false)}
-                timeZone={timeZone}
-                horizontalConstraint={select(
-                  'horizontalConstraint',
-                  ['xs', 's', 'm', 'l', 'xl', 'scale'],
-                  'm'
-                )}
-              />
-            )}
-          />
-        </IntlProvider>
+        <Value
+          key={timeZone}
+          defaultValue="2017-12-31"
+          render={(value, onChange) => (
+            <DateInput
+              id={text('id', '')}
+              placeholder={text('placeholder', 'Select a date...')}
+              mode={select('mode', ['single', 'multiple', 'range'], 'single')}
+              isDisabled={boolean('isDisabled', false)}
+              value={text('value (Date in UTC)', value)}
+              onChange={date => {
+                action('onChange')(date);
+                onChange(date);
+              }}
+              isInvalid={boolean('isInvalid?', false)}
+              timeZone={timeZone}
+              horizontalConstraint={select(
+                'horizontalConstraint',
+                ['xs', 's', 'm', 'l', 'xl', 'scale'],
+                'm'
+              )}
+            />
+          )}
+        />
       </Section>
     );
   });

--- a/src/components/inputs/date-time-input/date-time-input.story.js
+++ b/src/components/inputs/date-time-input/date-time-input.story.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { IntlProvider } from 'react-intl';
 import { action } from '@storybook/addon-actions';
 import withReadme from 'storybook-readme/with-readme';
 import { withKnobs, boolean, text, select } from '@storybook/addon-knobs';
@@ -13,7 +12,6 @@ storiesOf('Inputs', module)
   .addDecorator(withKnobs)
   .addDecorator(withReadme(Readme))
   .add('DateTimeInput', () => {
-    const locale = select('locale', ['de', 'en'], 'en');
     const timeZone = select(
       'timeZone',
       ['Europe/Madrid', 'America/Los_Angeles'],
@@ -21,33 +19,31 @@ storiesOf('Inputs', module)
     );
     return (
       <Section>
-        <IntlProvider locale={locale}>
-          <Value
-            key={`${locale}-${timeZone}`}
-            defaultValue="2017-12-31T16:02:50.000Z"
-            render={(value, onChange) => (
-              <DateTimeInput
-                key={`${locale}-${timeZone}`}
-                id={text('id', '')}
-                placeholder={text('placeholder', 'Select a date...')}
-                mode={select('mode', ['single', 'multiple', 'range'], 'single')}
-                isDisabled={boolean('isDisabled', false)}
-                value={text('value (Date in UTC)', value)}
-                onChange={datetime => {
-                  action('onChange')(datetime);
-                  onChange(datetime);
-                }}
-                isInvalid={boolean('isInvalid?', false)}
-                timeZone={timeZone}
-                horizontalConstraint={select(
-                  'horizontalConstraint',
-                  ['xs', 's', 'm', 'l', 'xl', 'scale'],
-                  'm'
-                )}
-              />
-            )}
-          />
-        </IntlProvider>
+        <Value
+          key={timeZone}
+          defaultValue="2017-12-31T16:02:50.000Z"
+          render={(value, onChange) => (
+            <DateTimeInput
+              key={timeZone}
+              id={text('id', '')}
+              placeholder={text('placeholder', 'Select a date...')}
+              mode={select('mode', ['single', 'multiple', 'range'], 'single')}
+              isDisabled={boolean('isDisabled', false)}
+              value={text('value (Date in UTC)', value)}
+              onChange={datetime => {
+                action('onChange')(datetime);
+                onChange(datetime);
+              }}
+              isInvalid={boolean('isInvalid?', false)}
+              timeZone={timeZone}
+              horizontalConstraint={select(
+                'horizontalConstraint',
+                ['xs', 's', 'm', 'l', 'xl', 'scale'],
+                'm'
+              )}
+            />
+          )}
+        />
       </Section>
     );
   });

--- a/src/components/inputs/money-input/money-input.form.story.js
+++ b/src/components/inputs/money-input/money-input.form.story.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Formik } from 'formik';
-import { IntlProvider } from 'react-intl';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs } from '@storybook/addon-knobs';
@@ -31,71 +30,69 @@ storiesOf('Examples|Forms/Inputs', module)
   .addDecorator(withReadme(Readme))
   .add('MoneyInput', () => (
     <Section>
-      <IntlProvider locale="en">
-        <Formik
-          initialValues={{ price: { currencyCode: '', amount: '' } }}
-          validate={validate}
-          onSubmit={(values, formik) => {
-            // eslint-disable-next-line no-console
-            console.log(
-              'money value',
-              MoneyInput.convertToMoneyValue(values.price)
-            );
-            action('onSubmit')(values, formik);
-            formik.resetForm(values);
-          }}
-          render={formik => (
-            <Spacings.Stack scale="l">
-              <Spacings.Stack scale="s">
-                <MoneyInput
-                  name="price"
-                  currencies={['EUR', 'USD', 'AED', 'KWD']}
-                  value={formik.values.price}
-                  onChange={formik.handleChange}
-                  onBlur={formik.handleBlur}
-                  hasCurrencyError={Boolean(
-                    formik.touched.price &&
-                      formik.touched.price.currencyCode &&
-                      formik.errors.price
-                  )}
-                  hasAmountError={Boolean(
-                    formik.touched.price &&
-                      formik.touched.price.amount &&
-                      formik.errors.price
-                  )}
-                  horizontalConstraint="m"
-                />
-                {MoneyInput.isTouched(formik.touched.price) &&
-                  formik.errors.price &&
-                  formik.errors.price.missing && (
-                    <ErrorMessage>Missing price</ErrorMessage>
-                  )}
-                {MoneyInput.isTouched(formik.touched.price) &&
-                  formik.errors.price &&
-                  formik.errors.price.unsupportedHighPrecision && (
-                    <ErrorMessage>
-                      This value is a high precision value. High precision
-                      pricing is not supported for products.
-                    </ErrorMessage>
-                  )}
-              </Spacings.Stack>
-              <Spacings.Inline>
-                <SecondaryButton
-                  onClick={formik.handleReset}
-                  isDisabled={formik.isSubmitting}
-                  label="Reset"
-                />
-                <PrimaryButton
-                  onClick={formik.handleSubmit}
-                  isDisabled={formik.isSubmitting || !formik.dirty}
-                  label="Submit"
-                />
-              </Spacings.Inline>
-              <hr />
-              <FormikBox formik={formik} />
+      <Formik
+        initialValues={{ price: { currencyCode: '', amount: '' } }}
+        validate={validate}
+        onSubmit={(values, formik) => {
+          // eslint-disable-next-line no-console
+          console.log(
+            'money value',
+            MoneyInput.convertToMoneyValue(values.price)
+          );
+          action('onSubmit')(values, formik);
+          formik.resetForm(values);
+        }}
+        render={formik => (
+          <Spacings.Stack scale="l">
+            <Spacings.Stack scale="s">
+              <MoneyInput
+                name="price"
+                currencies={['EUR', 'USD', 'AED', 'KWD']}
+                value={formik.values.price}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+                hasCurrencyError={Boolean(
+                  formik.touched.price &&
+                    formik.touched.price.currencyCode &&
+                    formik.errors.price
+                )}
+                hasAmountError={Boolean(
+                  formik.touched.price &&
+                    formik.touched.price.amount &&
+                    formik.errors.price
+                )}
+                horizontalConstraint="m"
+              />
+              {MoneyInput.isTouched(formik.touched.price) &&
+                formik.errors.price &&
+                formik.errors.price.missing && (
+                  <ErrorMessage>Missing price</ErrorMessage>
+                )}
+              {MoneyInput.isTouched(formik.touched.price) &&
+                formik.errors.price &&
+                formik.errors.price.unsupportedHighPrecision && (
+                  <ErrorMessage>
+                    This value is a high precision value. High precision pricing
+                    is not supported for products.
+                  </ErrorMessage>
+                )}
             </Spacings.Stack>
-          )}
-        />
-      </IntlProvider>
+            <Spacings.Inline>
+              <SecondaryButton
+                onClick={formik.handleReset}
+                isDisabled={formik.isSubmitting}
+                label="Reset"
+              />
+              <PrimaryButton
+                onClick={formik.handleSubmit}
+                isDisabled={formik.isSubmitting || !formik.dirty}
+                label="Submit"
+              />
+            </Spacings.Inline>
+            <hr />
+            <FormikBox formik={formik} />
+          </Spacings.Stack>
+        )}
+      />
     </Section>
   ));

--- a/src/components/inputs/number-input/number-input.form.story.js
+++ b/src/components/inputs/number-input/number-input.form.story.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Formik } from 'formik';
-import { IntlProvider } from 'react-intl';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs } from '@storybook/addon-knobs';
@@ -18,39 +17,37 @@ storiesOf('Examples|Forms/Inputs', module)
   .addDecorator(withReadme(Readme))
   .add('NumberInput', () => (
     <Section>
-      <IntlProvider locale="en">
-        <Formik
-          initialValues={{ age: '' }}
-          onSubmit={(values, formik, ...rest) => {
-            action('onSubmit')(values, formik, ...rest);
-            formik.resetForm(values);
-          }}
-          render={formik => (
-            <Spacings.Stack scale="l">
-              <NumberInput
-                name="age"
-                value={formik.values.age}
-                onChange={formik.handleChange}
-                onBlur={formik.handleBlur}
-                horizontalConstraint="m"
+      <Formik
+        initialValues={{ age: '' }}
+        onSubmit={(values, formik, ...rest) => {
+          action('onSubmit')(values, formik, ...rest);
+          formik.resetForm(values);
+        }}
+        render={formik => (
+          <Spacings.Stack scale="l">
+            <NumberInput
+              name="age"
+              value={formik.values.age}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+              horizontalConstraint="m"
+            />
+            <Spacings.Inline>
+              <SecondaryButton
+                onClick={formik.handleReset}
+                isDisabled={formik.isSubmitting}
+                label="Reset"
               />
-              <Spacings.Inline>
-                <SecondaryButton
-                  onClick={formik.handleReset}
-                  isDisabled={formik.isSubmitting}
-                  label="Reset"
-                />
-                <PrimaryButton
-                  onClick={formik.handleSubmit}
-                  isDisabled={formik.isSubmitting || !formik.dirty}
-                  label="Submit"
-                />
-              </Spacings.Inline>
-              <hr />
-              <FormikBox formik={formik} />
-            </Spacings.Stack>
-          )}
-        />
-      </IntlProvider>
+              <PrimaryButton
+                onClick={formik.handleSubmit}
+                isDisabled={formik.isSubmitting || !formik.dirty}
+                label="Submit"
+              />
+            </Spacings.Inline>
+            <hr />
+            <FormikBox formik={formik} />
+          </Spacings.Stack>
+        )}
+      />
     </Section>
   ));

--- a/src/components/inputs/select-input/select-input.form.story.js
+++ b/src/components/inputs/select-input/select-input.form.story.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Formik } from 'formik';
-import { IntlProvider } from 'react-intl';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, boolean } from '@storybook/addon-knobs';
@@ -66,83 +65,81 @@ storiesOf('Examples|Forms/Inputs', module)
     ];
     return (
       <Section>
-        <IntlProvider locale="en">
-          <Formik
-            key={`${isMulti}-${isPrefilled}`}
-            initialValues={{ state: initialState, colour: initialColour }}
-            validate={
-              // we use failing validation so that we can see the touched shape
-              // on form submission
-              () => (failValidation ? { state: true, colour: true } : {})
-            }
-            onSubmit={(values, formik, ...rest) => {
-              action('onSubmit')(values, formik, ...rest);
-              formik.resetForm(values);
-            }}
-            render={formik => {
-              const stateInput = {
-                hasError: failValidation,
-                isTouched: SelectInput.isTouched(formik.touched.state),
-              };
-              const colourInput = {
-                hasError: failValidation,
-                isTouched: SelectInput.isTouched(formik.touched.colour),
-              };
-              return (
-                <Spacings.Stack scale="l">
-                  <Spacings.Stack scale="xs">
-                    <SelectInput
-                      name="state"
-                      isMulti={isMulti}
-                      value={formik.values.state}
-                      onChange={formik.handleChange}
-                      onBlur={formik.handleBlur}
-                      options={stateOptions}
-                      hasError={stateInput.hasError && stateInput.isTouched}
-                      isSearchable={false}
-                      isClearable={true}
-                    />
-                    {stateInput.hasError &&
-                      stateInput.isTouched && (
-                        <ErrorMessage>State is not valid</ErrorMessage>
-                      )}
-                  </Spacings.Stack>
-                  <Spacings.Stack scale="xs">
-                    <SelectInput
-                      name="colour"
-                      isMulti={isMulti}
-                      value={formik.values.colour}
-                      onChange={formik.handleChange}
-                      onBlur={formik.handleBlur}
-                      options={groupedOptions}
-                      hasError={colourInput.hasError && colourInput.isTouched}
-                      isSearchable={false}
-                      isClearable={true}
-                    />
-                    {colourInput.hasError &&
-                      colourInput.isTouched && (
-                        <ErrorMessage>Colour is not valid</ErrorMessage>
-                      )}
-                  </Spacings.Stack>
-                  <Spacings.Inline>
-                    <SecondaryButton
-                      onClick={formik.handleReset}
-                      isDisabled={formik.isSubmitting}
-                      label="Reset"
-                    />
-                    <PrimaryButton
-                      onClick={formik.handleSubmit}
-                      isDisabled={formik.isSubmitting || !formik.dirty}
-                      label="Submit"
-                    />
-                  </Spacings.Inline>
-                  <hr />
-                  <FormikBox formik={formik} />
+        <Formik
+          key={`${isMulti}-${isPrefilled}`}
+          initialValues={{ state: initialState, colour: initialColour }}
+          validate={
+            // we use failing validation so that we can see the touched shape
+            // on form submission
+            () => (failValidation ? { state: true, colour: true } : {})
+          }
+          onSubmit={(values, formik, ...rest) => {
+            action('onSubmit')(values, formik, ...rest);
+            formik.resetForm(values);
+          }}
+          render={formik => {
+            const stateInput = {
+              hasError: failValidation,
+              isTouched: SelectInput.isTouched(formik.touched.state),
+            };
+            const colourInput = {
+              hasError: failValidation,
+              isTouched: SelectInput.isTouched(formik.touched.colour),
+            };
+            return (
+              <Spacings.Stack scale="l">
+                <Spacings.Stack scale="xs">
+                  <SelectInput
+                    name="state"
+                    isMulti={isMulti}
+                    value={formik.values.state}
+                    onChange={formik.handleChange}
+                    onBlur={formik.handleBlur}
+                    options={stateOptions}
+                    hasError={stateInput.hasError && stateInput.isTouched}
+                    isSearchable={false}
+                    isClearable={true}
+                  />
+                  {stateInput.hasError &&
+                    stateInput.isTouched && (
+                      <ErrorMessage>State is not valid</ErrorMessage>
+                    )}
                 </Spacings.Stack>
-              );
-            }}
-          />
-        </IntlProvider>
+                <Spacings.Stack scale="xs">
+                  <SelectInput
+                    name="colour"
+                    isMulti={isMulti}
+                    value={formik.values.colour}
+                    onChange={formik.handleChange}
+                    onBlur={formik.handleBlur}
+                    options={groupedOptions}
+                    hasError={colourInput.hasError && colourInput.isTouched}
+                    isSearchable={false}
+                    isClearable={true}
+                  />
+                  {colourInput.hasError &&
+                    colourInput.isTouched && (
+                      <ErrorMessage>Colour is not valid</ErrorMessage>
+                    )}
+                </Spacings.Stack>
+                <Spacings.Inline>
+                  <SecondaryButton
+                    onClick={formik.handleReset}
+                    isDisabled={formik.isSubmitting}
+                    label="Reset"
+                  />
+                  <PrimaryButton
+                    onClick={formik.handleSubmit}
+                    isDisabled={formik.isSubmitting || !formik.dirty}
+                    label="Submit"
+                  />
+                </Spacings.Inline>
+                <hr />
+                <FormikBox formik={formik} />
+              </Spacings.Stack>
+            );
+          }}
+        />
       </Section>
     );
   });

--- a/src/components/inputs/select-input/select-input.story.js
+++ b/src/components/inputs/select-input/select-input.story.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Value } from 'react-value';
-import { IntlProvider } from 'react-intl';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import {
@@ -77,47 +76,45 @@ storiesOf('Inputs', module)
     return (
       <Spacings.Stack scale="xl">
         <Section>
-          <IntlProvider locale="en">
-            <Value
-              key={isMulti}
-              defaultValue={isMulti ? [] : undefined}
-              render={(value, onChange) => (
-                <SelectInput
-                  horizontalConstraint={select(
-                    'horizontalConstraint',
-                    ['xs', 's', 'm', 'l', 'xl', 'scale'],
-                    'scale'
-                  )}
-                  hasError={boolean('hasError', false)}
-                  hasWarning={boolean('hasWarning', false)}
-                  aria-label={text('aria-label', '')}
-                  aria-labelledby={text('aria-labelledby', '')}
-                  isAutofocussed={boolean('isAutofocussed', false)}
-                  backspaceRemovesValue={boolean('backspaceRemovesValue', true)}
-                  id={text('id', '')}
-                  containerId={text('containerId', '')}
-                  isClearable={boolean('isClearable', false)}
-                  isDisabled={boolean('isDisabled', false)}
-                  isMulti={isMulti}
-                  isSearchable={boolean('isSearchable', false)}
-                  maxMenuHeight={number('maxMenuHeight', 200)}
-                  name={text('name', 'form-field-name')}
-                  onBlur={action('onBlur')}
-                  onChange={(event, ...args) => {
-                    action('onChange')(event, ...args);
-                    onChange(event.target.value);
-                  }}
-                  onFocus={action('onFocus')}
-                  onInputChange={action('onInputChange')}
-                  options={options}
-                  placeholder={text('placeholder', 'Select..')}
-                  tabIndex={text('tabIndex', '0')}
-                  tabSelectsValue={boolean('tabSelectsValue', true)}
-                  value={value}
-                />
-              )}
-            />
-          </IntlProvider>
+          <Value
+            key={isMulti}
+            defaultValue={isMulti ? [] : undefined}
+            render={(value, onChange) => (
+              <SelectInput
+                horizontalConstraint={select(
+                  'horizontalConstraint',
+                  ['xs', 's', 'm', 'l', 'xl', 'scale'],
+                  'scale'
+                )}
+                hasError={boolean('hasError', false)}
+                hasWarning={boolean('hasWarning', false)}
+                aria-label={text('aria-label', '')}
+                aria-labelledby={text('aria-labelledby', '')}
+                isAutofocussed={boolean('isAutofocussed', false)}
+                backspaceRemovesValue={boolean('backspaceRemovesValue', true)}
+                id={text('id', '')}
+                containerId={text('containerId', '')}
+                isClearable={boolean('isClearable', false)}
+                isDisabled={boolean('isDisabled', false)}
+                isMulti={isMulti}
+                isSearchable={boolean('isSearchable', false)}
+                maxMenuHeight={number('maxMenuHeight', 200)}
+                name={text('name', 'form-field-name')}
+                onBlur={action('onBlur')}
+                onChange={(event, ...args) => {
+                  action('onChange')(event, ...args);
+                  onChange(event.target.value);
+                }}
+                onFocus={action('onFocus')}
+                onInputChange={action('onInputChange')}
+                options={options}
+                placeholder={text('placeholder', 'Select..')}
+                tabIndex={text('tabIndex', '0')}
+                tabSelectsValue={boolean('tabSelectsValue', true)}
+                value={value}
+              />
+            )}
+          />
         </Section>
         <Section>
           <LinkTo kind="Examples|Forms/Inputs" story="SelectInput">

--- a/src/components/inputs/time-input/time-input.story.js
+++ b/src/components/inputs/time-input/time-input.story.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { IntlProvider } from 'react-intl';
 import { action } from '@storybook/addon-actions';
 import withReadme from 'storybook-readme/with-readme';
 import { withKnobs, boolean, text, select } from '@storybook/addon-knobs';
@@ -13,7 +12,6 @@ storiesOf('Inputs', module)
   .addDecorator(withKnobs)
   .addDecorator(withReadme(Readme))
   .add('TimeInput', () => {
-    const locale = select('locale', ['de', 'en'], 'en');
     const timeZone = select(
       'timeZone',
       ['Europe/Madrid', 'America/Los_Angeles'],
@@ -21,33 +19,31 @@ storiesOf('Inputs', module)
     );
     return (
       <Section>
-        <IntlProvider locale={locale}>
-          <Value
-            key={`${locale}-${timeZone}`}
-            defaultValue="17:12:00.000"
-            render={(value, onChange) => (
-              <TimeInput
-                key={`${locale}-${timeZone}`}
-                id={text('id', '')}
-                placeholder={text('placeholder', 'Select a time...')}
-                mode={select('mode', ['single', 'multiple', 'range'], 'single')}
-                isDisabled={boolean('isDisabled', false)}
-                value={text('value (Date in UTC)', value)}
-                onChange={time => {
-                  action('onChange')(time);
-                  onChange(time);
-                }}
-                isInvalid={boolean('isInvalid?', false)}
-                timeZone={timeZone}
-                horizontalConstraint={select(
-                  'horizontalConstraint',
-                  ['xs', 's', 'm', 'l', 'xl', 'scale'],
-                  'm'
-                )}
-              />
-            )}
-          />
-        </IntlProvider>
+        <Value
+          key={timeZone}
+          defaultValue="17:12:00.000"
+          render={(value, onChange) => (
+            <TimeInput
+              key={timeZone}
+              id={text('id', '')}
+              placeholder={text('placeholder', 'Select a time...')}
+              mode={select('mode', ['single', 'multiple', 'range'], 'single')}
+              isDisabled={boolean('isDisabled', false)}
+              value={text('value (Date in UTC)', value)}
+              onChange={time => {
+                action('onChange')(time);
+                onChange(time);
+              }}
+              isInvalid={boolean('isInvalid?', false)}
+              timeZone={timeZone}
+              horizontalConstraint={select(
+                'horizontalConstraint',
+                ['xs', 's', 'm', 'l', 'xl', 'scale'],
+                'm'
+              )}
+            />
+          )}
+        />
       </Section>
     );
   });


### PR DESCRIPTION
So far we've been redefining `IntlProvider` for almost every story. Sometimes we added a knob to be able to change the locale. This is repetitive, cumbersome and in some cases unnecessary as we already have global `intl` decorator which wraps all stories in `IntlProvider` anyways.

I now refactored our global `intl` decorator to include a knob for selecting a locale. This means all stories now have a "global locale" selector and they don't need to define `IntlProvider` anymore.

Check out `.storybook/decorators/intl/intl.js` for the changed setup. The other changes are removing the unnecessary `IntlProvider` from all stories.

![image](https://user-images.githubusercontent.com/1765075/47005512-31def500-d134-11e8-97a9-eea8b8dde78b.png)

<sup>Intermediate loss of functionality: One thing to note is that `DateInput`, `DateTimeInput` and `DateRangeInput` were accessing the selected locale directly and adding it as a key to the components in order to rerender them in case the locale changes. This was done because the date-inputs have the flaw that they do not update when the locale changes. This is bad and no longer working. We would instead need to access apply `injectIntl` to the story and then pass `this.props.intl.locale` as the key. I didn't do that since our new date inputs will work with a changing locale ouf the box. The workaround in the meantime is to select a locale and then to reload the page, but I doubt anybody would need about this soon.</sup>
