### PR TITLE
chore: specify React version for eslint-plugin-react

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -36,7 +36,10 @@ settings:
     # tests can do `import { render, fireEvent }` from '../test-utils'`.
     # Because we export the whole namespace, the `import/ignore` rule can't find
     # the named exports. So we disable the rule for imports of that file.
-    - test-utils.js
+    - test-utils.js  
+  react:
+    pragma: React
+    version: detect
 
 rules:
     'class-methods-use-this':


### PR DESCRIPTION
Specifies React version for `eslint-plugin-react` in `.eslintrc.yaml` to avoid a warning.

We use `detect` so that we don't need to upgrade the settings every time we upgrade React. The `detect` option was added to  `eslint-plugin-react` in https://github.com/yannickcr/eslint-plugin-react/pull/1978.

**Before**

![image](https://user-images.githubusercontent.com/1765075/47083799-0af6f080-d212-11e8-810d-506913afb19d.png)
see https://travis-ci.org/commercetools/ui-kit/builds/442629522?utm_source=github_status&utm_medium=notification

**After**

![image](https://user-images.githubusercontent.com/1765075/47083896-51e4e600-d212-11e8-8cb3-b743bf9345a4.png)

see https://travis-ci.org/commercetools/ui-kit/builds/442636937?utm_source=github_status&utm_medium=notification