### PR TITLE
MoneyInput: align dropdown caret & support isTouched(x, {all: true})

### DIFF
--- a/src/components/inputs/money-input/README.md
+++ b/src/components/inputs/money-input/README.md
@@ -209,15 +209,17 @@ return (
           onBlur={() => setFieldTouched('somePrice')}
           isDisabled={isSubmitting}
           onChange={value => setFieldValue('somePrice', value)}
-          hasAmountError={touched.somePrice && Boolean(errors.somePrice)}
+          hasAmountError={
+            MoneyInput.isTouched(touched.somePrice) && Boolean(errors.somePrice)
+          }
           horizontalConstraint="l"
         />
-        {touched.somePrice &&
+        {MoneyInput.isTouched(touched.somePrice) &&
           errors.somePrice &&
           errors.somePrice.missing && (
             <ErrorMessage>This field is required!</ErrorMessage>
           )}
-        {touched.somePrice &&
+        {MoneyInput.isTouched(touched.somePrice) &&
           errors.somePrice &&
           errors.somePrice.highPrecision && (
             <ErrorMessage>

--- a/src/components/inputs/money-input/money-input.form.story.js
+++ b/src/components/inputs/money-input/money-input.form.story.js
@@ -52,20 +52,19 @@ storiesOf('Examples|Forms/Inputs', module)
                 onChange={formik.handleChange}
                 onBlur={formik.handleBlur}
                 hasCurrencyError={Boolean(
-                  formik.touched.price &&
-                    formik.touched.price.currencyCode &&
-                    formik.errors.price
+                  MoneyInput.isTouched(formik.touched.price, { all: true }) &&
+                    formik.errors.price?.missing
                 )}
                 hasAmountError={Boolean(
-                  formik.touched.price &&
-                    formik.touched.price.amount &&
-                    formik.errors.price
+                  MoneyInput.isTouched(formik.touched.price, { all: true }) &&
+                    (formik.errors.price?.missing ||
+                      formik.errors.price?.unsupportedHighPrecision)
                 )}
                 horizontalConstraint="m"
               />
               {MoneyInput.isTouched(formik.touched.price) &&
-                formik.errors.price &&
-                formik.errors.price.missing && (
+                (formik.errors.price?.amount?.missing ||
+                  formik.errors.price?.currencyCode?.missing) && (
                   <ErrorMessage>Missing price</ErrorMessage>
                 )}
               {MoneyInput.isTouched(formik.touched.price) &&

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -218,7 +218,11 @@ export default class MoneyInput extends React.Component {
     return moneyValue && moneyValue.type === 'highPrecision';
   };
 
-  static isTouched = touched => touched && Object.values(touched).some(Boolean);
+  static isTouched = (touched, { all = false } = {}) =>
+    touched &&
+    (all
+      ? Object.values(touched).every(Boolean)
+      : Object.values(touched).some(Boolean));
 
   static propTypes = {
     id: PropTypes.string,

--- a/src/components/inputs/money-input/money-input.mod.css
+++ b/src/components/inputs/money-input/money-input.mod.css
@@ -121,10 +121,12 @@
   display: flex;
   flex: 1 0 100%;
   padding: var(--spacing-4) var(--spacing-8);
+  flex-direction: column;
 }
 
 .languagesDropdown > * {
   flex: 1;
+  align-self: flex-end;
 }
 
 .chevron {


### PR DESCRIPTION
Fixes the alignment of the caret in `MoneyInput` when no currency is selected.

**Before**
![bildschirmfoto 2018-10-17 um 17 48 10](https://user-images.githubusercontent.com/1765075/47099192-10b1fd80-d235-11e8-9054-7c4da96fc549.png)


**After**
![bildschirmfoto 2018-10-17 um 17 47 58](https://user-images.githubusercontent.com/1765075/47099183-0db70d00-d235-11e8-8d97-cfcd3e9ec2b2.png)

It is weird that only the caret can be clicked, and not the whole element. But I think this is for another time.


---

This PR also introduces `MoneyInput.isTouched(x, { all: true })` which only returns `true` in case all fields have been touched. Usually it returns `true` if at least one field has been touched.

Right now it is possible to make a difference between the left (currency) and the right (amount) when displaying errors. It is possible to have the red border on the left or right only. This introduces a lot of overhead for users of `MoneyInput` for a questionable gain in UX. Maybe we can get rid of this separation and just always make the input red? The displayed error message should clarify the error good enough for the user to figure out what went wrong in any case.

cc @filippobocik @Shecki ?