### PR TITLE
feat(bundling): lower bundle size by discarding comments 

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "postcss-color-mod-function": "3.0.3",
     "postcss-custom-media": "7.0.6",
     "postcss-custom-properties": "8.0.8",
+    "postcss-discard-comments": "4.0.1",
     "postcss-import": "12.0.0",
     "postcss-loader": "3.0.0",
     "postcss-preset-env": "6.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,6 +12,7 @@ import replace from 'rollup-plugin-replace';
 import postcssCustomProperties from 'postcss-custom-properties';
 import postcssCustomMediaQueries from 'postcss-custom-media';
 import postcssPostcssColorModFunction from 'postcss-color-mod-function';
+import postcssDiscardComments from 'postcss-discard-comments';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 import svgrPlugin from '@svgr/rollup';
 import pkg from './package.json';
@@ -35,6 +36,12 @@ const postcssPlugins = [
     browsers: browserslist.production,
     autoprefixer: { grid: true },
   }),
+  // we need to place the postcssDiscardComments BEFORE postcssCustomProperties,
+  // otherwise we will end up with a bunch of empty :root elements
+  // wherever there are imported comments
+  // see https://github.com/postcss/postcss-custom-properties/issues/123
+  // and https://github.com/commercetools/ui-kit/pull/173
+  postcssDiscardComments(),
   postcssCustomProperties({
     preserve: false,
   }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -10017,6 +10017,12 @@ postcss-discard-comments@^2.0.4:
   dependencies:
     postcss "^5.0.14"
 
+postcss-discard-comments@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-4.0.1.tgz#30697735b0c476852a7a11050eb84387a67ef55d"
+  dependencies:
+    postcss "^7.0.0"
+
 postcss-discard-duplicates@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz#b9abf27b88ac188158a5eb12abcae20263b91932"


### PR DESCRIPTION
#### Summary
While working on #170, I found a quick way to improve our bundle.
We are using [postcss-custom-properties](https://github.com/postcss/postcss-custom-properties) to import css variables from other files. This is a common approach in most of our `mod.css`

```
@import '../../../../materials/colors/base-colors.mod.css';

h1.my-class {
   color: var(--color-green);
}
```

and the current output is as follows.

```

/* stylelint-disable comment-empty-line-before */

/* THIS IS AN AUTOGENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY.
  This file is created by 'scripts/generate-base-color.js' script. The real
  colors's values should be updated in '../materials/colors/decisions/base-colors.json';
  Also, This file is transformed to JSON version in order to list the colors
  in the UIKit. Color groups are indicated by a comment preceeding the group
  of colors. */

/* Base Colors */

:root {

}

h1.my-class {
   color: green
}

```

This is not ideal, as we end up with these comments (and empty root elements), everywhere. Leading to wasted bytes.

#### Approach

Use [postcss-discard-comments](https://github.com/ben-eb/postcss-discard-comments) to remove the comments. However, if we add this to the end of the plugin list, we will notice that we have removed these comments, but we still have empty root elements like this

```
:root{
}

:root{
}

:root{
}

:root{
}

:root{
}

:root{
}

.number-input-mod_transition-standard__2b_2_{
  -webkit-transition:all 0.2s ease;
  transition:all 0.2s ease;
  -webkit-transition:all 0.2s ease;
  transition:all 0.2s ease;
}
```

One root element per import in the file. We can solve this by placing our discard comment plugin BEFORE the postcss-custom-properties plugin.

Now the output is

```
.number-input-mod_transition-standard__2b_2_{
  -webkit-transition:all 0.2s ease;
  transition:all 0.2s ease;
  -webkit-transition:all 0.2s ease;
  transition:all 0.2s ease;
}
```

Beautiful, isn't it? Lowers the bundle size (esm) to 710KB from 813Kb.

TL:DR -> I lowered the bundle size by over 100kb by removing some css comments 😆 🤣 