### PR TITLE
Fix MoneyInput caret alignment & clickable area

### DIFF
--- a/src/components/inputs/money-input/currency-dropdown.js
+++ b/src/components/inputs/money-input/currency-dropdown.js
@@ -39,7 +39,7 @@ const CurrencyDropdown = props => (
           isOpen,
         })}
       >
-        <div className={styles.languagesDropdown}>
+        <div className={styles.languagesDropdown} onClick={toggleMenu}>
           <Spacings.Inline scale="xs" alignItems="center">
             <Currency
               id={props.id}
@@ -47,15 +47,10 @@ const CurrencyDropdown = props => (
               isDisabled={props.isDisabled}
               hasError={props.hasCurrencyError}
               hasWarning={props.hasCurrencyWarning}
-              onClick={toggleMenu}
               currency={props.currencyCode}
             />
             {props.currencies.length > 0 && (
-              <DropdownChevron
-                onClick={toggleMenu}
-                isDisabled={props.isDisabled}
-                isOpen={isOpen}
-              />
+              <DropdownChevron isDisabled={props.isDisabled} isOpen={isOpen} />
             )}
           </Spacings.Inline>
         </div>

--- a/src/components/inputs/money-input/dropdown-chevron.js
+++ b/src/components/inputs/money-input/dropdown-chevron.js
@@ -9,7 +9,6 @@ import styles from './money-input.mod.css';
 export const DropdownChevron = props => (
   <AccessibleButton
     label={props.intl.formatMessage(messages.chevronLabel)}
-    onClick={props.onClick}
     isDisabled={props.isDisabled}
     isOpen={props.isOpen}
   >
@@ -31,7 +30,6 @@ export const DropdownChevron = props => (
 
 DropdownChevron.displayName = 'DropdownChevron';
 DropdownChevron.propTypes = {
-  onClick: PropTypes.func.isRequired,
   isDisabled: PropTypes.bool,
   isOpen: PropTypes.bool.isRequired,
   intl: PropTypes.shape({

--- a/src/components/inputs/money-input/money-input.mod.css
+++ b/src/components/inputs/money-input/money-input.mod.css
@@ -121,10 +121,12 @@
   display: flex;
   flex: 1 0 100%;
   padding: var(--spacing-4) var(--spacing-8);
+  flex-direction: column;
 }
 
 .languagesDropdown > * {
   flex: 1;
+  align-self: flex-end;
 }
 
 .chevron {


### PR DESCRIPTION
Fixes the alignment of the caret in `MoneyInput` when no currency is selected. Further makes the whole left side clickable.

**Before**
![bildschirmfoto 2018-10-17 um 17 48 10](https://user-images.githubusercontent.com/1765075/47099192-10b1fd80-d235-11e8-9054-7c4da96fc549.png)


**After**
![bildschirmfoto 2018-10-17 um 17 47 58](https://user-images.githubusercontent.com/1765075/47099183-0db70d00-d235-11e8-8d97-cfcd3e9ec2b2.png)


Follow-up of #171