### PR TITLE
Redo MoneyInput (better UX, less error cases)

### DIFF
--- a/examples/form-fields.story.js
+++ b/examples/form-fields.story.js
@@ -274,6 +274,7 @@ class ProductForm extends React.Component {
           value={this.props.formik.values.inventory}
           onChange={this.props.formik.handleChange}
           onBlur={this.props.formik.handleBlur}
+          isDisabled={this.props.formik.isSubmitting}
           touched={this.props.formik.touched.inventory}
           errors={this.props.formik.errors.inventory}
           renderError={key => {
@@ -293,6 +294,7 @@ class ProductForm extends React.Component {
           value={this.props.formik.values.price}
           onChange={this.props.formik.handleChange}
           onBlur={this.props.formik.handleBlur}
+          isDisabled={this.props.formik.isSubmitting}
           currencies={currencies}
           touched={this.props.formik.touched.price}
           errors={this.props.formik.errors.price}
@@ -312,6 +314,7 @@ class ProductForm extends React.Component {
           value={this.props.formik.values.status}
           onChange={this.props.formik.handleChange}
           onBlur={this.props.formik.handleBlur}
+          isDisabled={this.props.formik.isSubmitting}
           options={[
             { value: 'unpublished', label: 'Unpublished' },
             { value: 'modified', label: 'Modified' },

--- a/examples/form-inputs.story.js
+++ b/examples/form-inputs.story.js
@@ -385,6 +385,7 @@ class ProductForm extends React.Component {
             value={this.props.formik.values.description}
             onChange={this.props.formik.handleChange}
             onBlur={this.props.formik.handleBlur}
+            isDisabled={this.props.formik.isSubmitting}
             hasError={
               this.props.formik.touched.description &&
               Boolean(this.props.formik.errors.description)
@@ -435,6 +436,7 @@ class ProductForm extends React.Component {
             value={this.props.formik.values.inventory}
             onChange={this.props.formik.handleChange}
             onBlur={this.props.formik.handleBlur}
+            isDisabled={this.props.formik.isSubmitting}
             hasError={
               this.props.formik.touched.inventory &&
               Boolean(this.props.formik.errors.inventory)
@@ -465,20 +467,17 @@ class ProductForm extends React.Component {
             onBlur={this.props.formik.handleBlur}
             currencies={currencies}
             isDisabled={this.props.formik.isSubmitting}
-            hasAmountError={Boolean(
-              this.props.formik.touched.price &&
-                this.props.formik.touched.price.amount &&
-                this.props.formik.errors.price
-            )}
+            hasError={
+              MoneyInput.isTouched(this.props.formik.touched.price) &&
+              Boolean(this.props.formik.errors.price)
+            }
           />
           {MoneyInput.isTouched(this.props.formik.touched.price) &&
-            this.props.formik.errors.price &&
-            this.props.formik.errors.price.missing && (
+            this.props.formik.errors.price?.missing && (
               <ErrorMessage>Missing price</ErrorMessage>
             )}
           {MoneyInput.isTouched(this.props.formik.touched.price) &&
-            this.props.formik.errors.price &&
-            this.props.formik.errors.price.unsupportedHighPrecision && (
+            this.props.formik.errors.price?.unsupportedHighPrecision && (
               <ErrorMessage>
                 This value is a high precision value. High precision pricing is
                 not supported for products.

--- a/src/components/fields/money-field/money-field.form.story.js
+++ b/src/components/fields/money-field/money-field.form.story.js
@@ -39,7 +39,6 @@ storiesOf('Examples|Forms/Fields', module)
             if (MoneyField.isEmpty(values.pricePerTon))
               errors.pricePerTon.missing = true;
 
-            console.log(values, omitEmpty(errors));
             return omitEmpty(errors);
           }}
           onSubmit={(values, formik) => {

--- a/src/components/fields/money-field/money-field.js
+++ b/src/components/fields/money-field/money-field.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import has from 'lodash.has';
 import requiredIf from 'react-required-if';
 import { FormattedMessage } from 'react-intl';
+import has from 'lodash.has';
 import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
@@ -98,21 +98,11 @@ class MoneyField extends React.Component {
   });
 
   render() {
-    // We could determine the errors of amount and currencyCode separately
-    // and forward hasCurrencyError / hasAmountError depending on the error.
-    // This would work for example for the known "missing" error.
-    // Doing so would lead to the correct part of the MoneyField being marked
-    // with a red border instead of the complete field.
-    // This is something we can do later / when somebody asks for it.
-    //
-    // We do not use MoneyField.isTouched() as we want to ensure both fields have been touched.
-    // This avoids showing an error when the user just selected a language but didn't add
-    // an amount yet.
-    const hasAnyErrors =
-      this.props.touched &&
-      this.props.touched.amount &&
-      this.props.touched.currencyCode &&
-      hasErrors(this.props.errors);
+    // MoneyField.isTouched() ensures both fields have been touched.
+    // This avoids showing an error when the user just selected a language but
+    // didn't add an amount yet.
+    const hasError =
+      MoneyInput.isTouched(this.props.touched) && hasErrors(this.props.errors);
     return (
       <Constraints.Horizontal constraint={this.props.horizontalConstraint}>
         <Spacings.Stack scale="xs">
@@ -148,13 +138,12 @@ class MoneyField extends React.Component {
             onBlur={this.props.onBlur}
             isDisabled={this.props.isDisabled}
             onChange={this.props.onChange}
-            hasCurrencyError={hasAnyErrors}
-            hasAmountError={hasAnyErrors}
+            hasError={hasError}
             {...filterDataAttributes(this.props)}
           />
           <FieldErrors
             errors={this.props.errors}
-            isVisible={hasAnyErrors}
+            isVisible={hasError}
             renderError={this.props.renderError}
           />
         </Spacings.Stack>

--- a/src/components/fields/money-field/money-field.spec.js
+++ b/src/components/fields/money-field/money-field.spec.js
@@ -114,8 +114,7 @@ describe('rendering', () => {
       expect(moneyInput).toHaveProp('onBlur', props.onBlur);
       expect(moneyInput).toHaveProp('isDisabled', props.isDisabled);
       expect(moneyInput).toHaveProp('placeholder', props.placeholder);
-      expect(moneyInput).toHaveProp('hasAmountError', true);
-      expect(moneyInput).toHaveProp('hasCurrencyError', true);
+      expect(moneyInput).toHaveProp('hasError', true);
 
       expect(wrapper).toRender(FieldErrors);
       expect(wrapper.find(FieldErrors)).toHaveProp('errors', props.errors);
@@ -145,7 +144,7 @@ describe('rendering', () => {
       wrapper = shallow(<MoneyField {...props} />);
     });
     it('should mark the MoneyInput as erroneous', () => {
-      expect(wrapper.find(MoneyInput)).toHaveProp('hasAmountError', true);
+      expect(wrapper.find(MoneyInput)).toHaveProp('hasError', true);
     });
     it('should render the known error', () => {
       expect(wrapper).toRender(FieldErrors);
@@ -164,7 +163,7 @@ describe('rendering', () => {
       wrapper = shallow(<MoneyField {...props} />);
     });
     it('should mark the NumberInput as erroneous', () => {
-      expect(wrapper.find(MoneyInput)).toHaveProp('hasAmountError', true);
+      expect(wrapper.find(MoneyInput)).toHaveProp('hasError', true);
     });
     it('should forward the error', () => {
       expect(wrapper.find(FieldErrors)).toHaveProp('errors', props.errors);

--- a/src/components/inputs/money-input/README.md
+++ b/src/components/inputs/money-input/README.md
@@ -41,10 +41,8 @@ The amount can have an arbitrary precision. When the precision of the amount exc
 | `isDisabled`           | `bool`                                     |    -     | -                            | `false` | Indicates that the field cannot be used.                                                                                                                      |
 | `onBlur`               | `func`                                     |    -     | -                            | -       | Called when the amount field or the currency code dropdown is blurred.                                                                                        |
 | `onChange`             | `function(event)`                          |    ✳️    | -                            | -       | Called with the event of the input or dropdown when either the currency or the amount have changed. Either `onChange` or `onChangeValue` must be passed.      |
-| `hasCurrencyError`     | `bool`                                     |    -     | -                            | -       | Indicates if the currency field has an error                                                                                                                  |
-| `hasCurrencyWarning`   | `bool`                                     |    -     | -                            | -       | Indicates if the currency field has a warning                                                                                                                 |
-| `hasAmountError`       | `bool`                                     |    -     | -                            | -       | Indicates if the centAmount field has an error                                                                                                                |
-| `hasAmountWarning`     | `bool`                                     |    -     | -                            | -       | Indicates if the centAmount field has a warning                                                                                                               |
+| `hasError`             | `bool`                                     |    -     | -                            | -       | Indicates if the input has an error                                                                                                                           |
+| `hasWarning`           | `bool`                                     |    -     | -                            | -       | Indicates if the input has a warning                                                                                                                          |
 | `horizontalConstraint` | `string`                                   |    -     | `s`, `m`, `l`, `xl`, `scale` | `scale` | Horizontal size limit of the input fields.                                                                                                                    |
 
 ### Static methods
@@ -91,6 +89,19 @@ MoneyInput.isEmpty({ amount: '5', currencyCode: '' }); // -> true
 MoneyInput.isEmpty(); // -> true
 
 MoneyInput.isEmpty({ amount: '5', currencyCode: 'EUR' }); // -> false
+```
+
+#### `MoneyInput.isTouched`
+
+The `areAllTouched` function will return `true` when all input elements were touched (currency dropdown and amount input).
+
+```js
+MoneyInput.isTouched({ amount: true, currencyCode: true }); // -> true
+
+MoneyInput.isTouched({ amount: true }); // -> false
+MoneyInput.isTouched({ currencyCode: true }); // -> false
+MoneyInput.isTouched({ amount: false, currencyCode: false }); // -> false
+MoneyInput.isTouched({}); // -> false
 ```
 
 #### `MoneyInput.getCurrencyDropdownId`
@@ -209,7 +220,9 @@ return (
           onBlur={() => setFieldTouched('somePrice')}
           isDisabled={isSubmitting}
           onChange={value => setFieldValue('somePrice', value)}
-          hasAmountError={touched.somePrice && Boolean(errors.somePrice)}
+          hasError={
+            MoneyInput.isTouched(touched.somePrice) && Boolean(errors.somePrice)
+          }
           horizontalConstraint="l"
         />
         {touched.somePrice &&

--- a/src/components/inputs/money-input/README.md
+++ b/src/components/inputs/money-input/README.md
@@ -93,7 +93,7 @@ MoneyInput.isEmpty({ amount: '5', currencyCode: 'EUR' }); // -> false
 
 #### `MoneyInput.isTouched`
 
-The `areAllTouched` function will return `true` when all input elements were touched (currency dropdown and amount input).
+The `isTouched` function will return `true` when all input elements were touched (currency dropdown and amount input).
 
 ```js
 MoneyInput.isTouched({ amount: true, currencyCode: true }); // -> true

--- a/src/components/inputs/money-input/currency-dropdown.js
+++ b/src/components/inputs/money-input/currency-dropdown.js
@@ -9,21 +9,21 @@ import DropdownChevron from './dropdown-chevron';
 
 const getCurrencyDropdownSelectStyles = ({
   isDisabled,
-  hasCurrencyError,
-  hasCurrencyWarning,
+  hasError,
+  hasWarning,
   isOpen,
 }) => {
   if (isDisabled) return styles['currency-disabled'];
-  if (hasCurrencyError) return styles['currency-error'];
-  if (hasCurrencyWarning) return styles['currency-warning'];
+  if (hasError) return styles['currency-error'];
+  if (hasWarning) return styles['currency-warning'];
   if (isOpen) return styles['currency-active'];
 
   return styles['currency-default'];
 };
 
 const getCurrencyDropdownOptionsStyles = props => {
-  if (props.hasCurrencyError) return styles['options-wrapper-error'];
-  if (props.hasCurrencyWarning) return styles['options-wrapper-warning'];
+  if (props.hasError) return styles['options-wrapper-error'];
+  if (props.hasWarning) return styles['options-wrapper-warning'];
 
   return styles['options-wrapper-active'];
 };
@@ -34,8 +34,8 @@ const CurrencyDropdown = props => (
       <div
         className={getCurrencyDropdownSelectStyles({
           isDisabled: props.isDisabled,
-          hasCurrencyError: props.hasCurrencyError,
-          hasCurrencyWarning: props.hasCurrencyWarning,
+          hasError: props.hasError,
+          hasWarning: props.hasWarning,
           isOpen,
         })}
       >
@@ -45,8 +45,8 @@ const CurrencyDropdown = props => (
               id={props.id}
               isDropdown={true}
               isDisabled={props.isDisabled}
-              hasError={props.hasCurrencyError}
-              hasWarning={props.hasCurrencyWarning}
+              hasError={props.hasError}
+              hasWarning={props.hasWarning}
               currency={props.currencyCode}
             />
             {props.currencies.length > 0 && (
@@ -58,8 +58,8 @@ const CurrencyDropdown = props => (
           props.currencies.length > 0 && (
             <div
               className={getCurrencyDropdownOptionsStyles({
-                hasCurrencyError: props.hasCurrencyError,
-                hasCurrencyWarning: props.hasCurrencyWarning,
+                hasError: props.hasError,
+                hasWarning: props.hasWarning,
               })}
             >
               {props.currencies.map(currencyCode => (
@@ -90,8 +90,8 @@ CurrencyDropdown.propTypes = {
   currencies: PropTypes.arrayOf(PropTypes.string).isRequired,
   currencyCode: PropTypes.string,
   isDisabled: PropTypes.bool,
-  hasCurrencyError: PropTypes.bool,
-  hasCurrencyWarning: PropTypes.bool,
+  hasError: PropTypes.bool,
+  hasWarning: PropTypes.bool,
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
   name: PropTypes.string,

--- a/src/components/inputs/money-input/currency-dropdown.js
+++ b/src/components/inputs/money-input/currency-dropdown.js
@@ -6,6 +6,7 @@ import styles from './money-input.mod.css';
 import Currency from './currency';
 import Option from './option';
 import DropdownChevron from './dropdown-chevron';
+import filterDataAttributes from '../../../utils/filter-data-attributes';
 
 const getCurrencyDropdownSelectStyles = ({
   isDisabled,
@@ -38,6 +39,7 @@ const CurrencyDropdown = props => (
           hasWarning: props.hasWarning,
           isOpen,
         })}
+        {...filterDataAttributes(props)}
       >
         <div className={styles.languagesDropdown} onClick={toggleMenu}>
           <Spacings.Inline scale="xs" alignItems="center">

--- a/src/components/inputs/money-input/currency.spec.js
+++ b/src/components/inputs/money-input/currency.spec.js
@@ -105,9 +105,7 @@ describe('rendering', () => {
 
         describe('error', () => {
           beforeEach(() => {
-            props = createTestProps({
-              hasCurrencyError: true,
-            });
+            props = createTestProps({ hasError: true });
             downshiftProps = { isOpen: false, toggleMenu: jest.fn() };
             downshiftRenderWrapper = render(props, downshiftProps);
           });
@@ -121,9 +119,7 @@ describe('rendering', () => {
 
         describe('warning', () => {
           beforeEach(() => {
-            props = createTestProps({
-              hasCurrencyWarning: true,
-            });
+            props = createTestProps({ hasWarning: true });
             downshiftProps = { isOpen: false, toggleMenu: jest.fn() };
             downshiftRenderWrapper = render(props, downshiftProps);
           });
@@ -185,9 +181,7 @@ describe('rendering', () => {
 
       describe('error', () => {
         beforeEach(() => {
-          props = createTestProps({
-            hasAmountError: true,
-          });
+          props = createTestProps({ hasError: true });
           wrapper = shallow(<MoneyInput {...props} />);
           centAmountField = wrapper.find('input');
         });
@@ -199,9 +193,7 @@ describe('rendering', () => {
 
       describe('warning', () => {
         beforeEach(() => {
-          props = createTestProps({
-            hasAmountWarning: true,
-          });
+          props = createTestProps({ hasWarning: true });
           wrapper = shallow(<MoneyInput {...props} />);
           centAmountField = wrapper.find('input');
         });

--- a/src/components/inputs/money-input/money-input.form.story.js
+++ b/src/components/inputs/money-input/money-input.form.story.js
@@ -51,26 +51,18 @@ storiesOf('Examples|Forms/Inputs', module)
                 value={formik.values.price}
                 onChange={formik.handleChange}
                 onBlur={formik.handleBlur}
-                hasCurrencyError={Boolean(
-                  formik.touched.price &&
-                    formik.touched.price.currencyCode &&
-                    formik.errors.price
-                )}
-                hasAmountError={Boolean(
-                  formik.touched.price &&
-                    formik.touched.price.amount &&
-                    formik.errors.price
-                )}
+                hasError={
+                  MoneyInput.isTouched(formik.touched.price) &&
+                  Boolean(formik.errors.price)
+                }
                 horizontalConstraint="m"
               />
               {MoneyInput.isTouched(formik.touched.price) &&
-                formik.errors.price &&
-                formik.errors.price.missing && (
+                formik.errors.price?.missing && (
                   <ErrorMessage>Missing price</ErrorMessage>
                 )}
               {MoneyInput.isTouched(formik.touched.price) &&
-                formik.errors.price &&
-                formik.errors.price.unsupportedHighPrecision && (
+                formik.errors.price?.unsupportedHighPrecision && (
                   <ErrorMessage>
                     This value is a high precision value. High precision pricing
                     is not supported for products.

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -301,7 +301,7 @@ export default class MoneyInput extends React.Component {
     this.props.onChange(fakeEvent);
   };
 
-  formatAmount = () => {
+  handleAmountBlur = () => {
     const amount = this.props.value.amount.trim();
     // Skip formatting for empty value or when the input is used with an
     // unknown currency.
@@ -340,7 +340,10 @@ export default class MoneyInput extends React.Component {
           onBlur={event => {
             // ensures that both fields are marked as touched when one of them
             // is blurred
-            if (!this.containerRef.current.contains(event.relatedTarget)) {
+            if (
+              typeof this.props.onBlur === 'function' &&
+              !this.containerRef.current.contains(event.relatedTarget)
+            ) {
               this.props.onBlur({
                 target: {
                   id: MoneyInput.getCurrencyDropdownId(this.props.id),
@@ -391,7 +394,7 @@ export default class MoneyInput extends React.Component {
             })}
             placeholder={this.props.placeholder}
             onChange={this.handleAmountChange}
-            onBlur={this.formatAmount}
+            onBlur={this.handleAmountBlur}
             disabled={this.props.isDisabled}
             {...filterDataAttributes(this.props)}
           />

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -147,8 +147,8 @@ const getAmountAsNumberFromMoneyValue = money =>
 
 const getAmountStyles = props => {
   if (props.isDisabled) return styles['amount-disabled'];
-  if (props.hasAmountError) return styles['amount-error'];
-  if (props.hasAmountWarning) return styles['amount-warning'];
+  if (props.hasError) return styles['amount-error'];
+  if (props.hasWarning) return styles['amount-warning'];
 
   return styles['amount-default'];
 };
@@ -218,7 +218,8 @@ export default class MoneyInput extends React.Component {
     return moneyValue && moneyValue.type === 'highPrecision';
   };
 
-  static isTouched = touched => touched && Object.values(touched).some(Boolean);
+  static isTouched = touched =>
+    Boolean(touched && touched.currencyCode && touched.amount);
 
   static propTypes = {
     id: PropTypes.string,
@@ -232,10 +233,8 @@ export default class MoneyInput extends React.Component {
     onBlur: PropTypes.func,
     isDisabled: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
-    hasCurrencyError: PropTypes.bool,
-    hasCurrencyWarning: PropTypes.bool,
-    hasAmountError: PropTypes.bool,
-    hasAmountWarning: PropTypes.bool,
+    hasError: PropTypes.bool,
+    hasWarning: PropTypes.bool,
 
     horizontalConstraint: PropTypes.oneOf(['s', 'm', 'l', 'xl', 'scale']),
   };
@@ -342,8 +341,8 @@ export default class MoneyInput extends React.Component {
               onChange={this.handleCurrencyChange}
               onBlur={this.props.onBlur}
               isDisabled={this.props.isDisabled}
-              hasCurrencyError={this.props.hasCurrencyError}
-              hasCurrencyWarning={this.props.hasCurrencyWarning}
+              hasError={this.props.hasError}
+              hasWarning={this.props.hasWarning}
             />
           ) : (
             <div className={styles['currency-label']}>
@@ -363,8 +362,8 @@ export default class MoneyInput extends React.Component {
             value={this.props.value.amount}
             className={getAmountStyles({
               isDisabled: this.props.isDisabled,
-              hasAmountError: this.props.hasAmountError,
-              hasAmountWarning: this.props.hasAmountWarning,
+              hasError: this.props.hasError,
+              hasWarning: this.props.hasWarning,
             })}
             placeholder={this.props.placeholder}
             onChange={this.handleAmountChange}

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -283,6 +283,7 @@ export default class MoneyInput extends React.Component {
       }
     }
     toggleMenu();
+    this.amountInputRef.current.focus();
   };
 
   handleAmountChange = event => {
@@ -300,7 +301,7 @@ export default class MoneyInput extends React.Component {
     this.props.onChange(fakeEvent);
   };
 
-  handleBlur = event => {
+  formatAmount = () => {
     const amount = this.props.value.amount.trim();
     // Skip formatting for empty value or when the input is used with an
     // unknown currency.
@@ -325,13 +326,36 @@ export default class MoneyInput extends React.Component {
         this.props.onChange(fakeEvent);
       }
     }
-    if (this.props.onBlur) this.props.onBlur(event);
   };
+
+  containerRef = React.createRef();
+  amountInputRef = React.createRef();
 
   render() {
     return (
       <Contraints.Horizontal constraint={this.props.horizontalConstraint}>
-        <div className={styles['field-container']}>
+        <div
+          ref={this.containerRef}
+          className={styles['field-container']}
+          onBlur={event => {
+            // ensures that both fields are marked as touched when one of them
+            // is blurred
+            if (!this.containerRef.current.contains(event.relatedTarget)) {
+              this.props.onBlur({
+                target: {
+                  id: MoneyInput.getCurrencyDropdownId(this.props.id),
+                  name: getCurrencyDropdownName(this.props.name),
+                },
+              });
+              this.props.onBlur({
+                target: {
+                  id: MoneyInput.getAmountInputId(this.props.id),
+                  name: getAmountInputName(this.props.name),
+                },
+              });
+            }
+          }}
+        >
           {this.props.currencies.length > 0 ? (
             <CurrencyDropdown
               id={MoneyInput.getCurrencyDropdownId(this.props.id)}
@@ -339,7 +363,6 @@ export default class MoneyInput extends React.Component {
               currencies={this.props.currencies}
               currencyCode={this.props.value.currencyCode}
               onChange={this.handleCurrencyChange}
-              onBlur={this.props.onBlur}
               isDisabled={this.props.isDisabled}
               hasError={this.props.hasError}
               hasWarning={this.props.hasWarning}
@@ -356,6 +379,7 @@ export default class MoneyInput extends React.Component {
             </div>
           )}
           <input
+            ref={this.amountInputRef}
             id={MoneyInput.getAmountInputId(this.props.id)}
             name={getAmountInputName(this.props.name)}
             type="number"
@@ -367,7 +391,7 @@ export default class MoneyInput extends React.Component {
             })}
             placeholder={this.props.placeholder}
             onChange={this.handleAmountChange}
-            onBlur={this.handleBlur}
+            onBlur={this.formatAmount}
             disabled={this.props.isDisabled}
             {...filterDataAttributes(this.props)}
           />

--- a/src/components/inputs/money-input/money-input.spec.js
+++ b/src/components/inputs/money-input/money-input.spec.js
@@ -1,28 +1,61 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import Downshift from 'downshift';
-import AccessibleButton from '../../buttons/accessible-button';
+import PropTypes from 'prop-types';
 import MoneyInput from './money-input';
-import Currency from './currency';
-import Option from './option';
-import CurrencyDropdown from './currency-dropdown';
-import DropdownChevron from './dropdown-chevron';
-import styles from './money-input.mod.css';
+import { render, fireEvent } from '../../../test-utils';
 
-const createTestProps = customProps => ({
-  value: { currencyCode: 'EUR', amount: '' },
-  currencies: ['EUR', 'USD'],
-  onChange: jest.fn(),
-  onBlur: jest.fn(),
-  ...customProps,
-});
-
-const createCurrencyProps = customProps => ({
-  isDisabled: false,
-  onClick: jest.fn(),
-  currency: '€',
-  ...customProps,
-});
+// We use this component to simulate the whole flow of
+// changing a value and formatting on blur.
+class TestComponent extends React.Component {
+  state = {
+    value: this.props.value,
+  };
+  static propTypes = {
+    id: PropTypes.string,
+    value: PropTypes.shape({
+      amount: PropTypes.string,
+      currencyCode: PropTypes.string,
+    }),
+    onChange: PropTypes.func,
+  };
+  static defaultProps = {
+    id: 'some-id',
+    name: 'some-name',
+    value: {
+      currencyCode: 'EUR',
+      amount: '12.50',
+    },
+    currencies: ['EUR', 'USD'],
+  };
+  handleChange = event => {
+    if (event.target.name === 'some-name.amount') {
+      this.setState(prevState => ({
+        value: { ...prevState.value, amount: event.target.value },
+      }));
+    }
+    if (event.target.name === 'some-name.currencyCode') {
+      this.setState(prevState => ({
+        value: { ...prevState.value, currencyCode: event.target.value },
+      }));
+    }
+  };
+  render() {
+    return (
+      <React.Fragment>
+        <label htmlFor={MoneyInput.getAmountInputId(this.props.id)}>
+          Amount
+        </label>
+        <label htmlFor={MoneyInput.getCurrencyDropdownId(this.props.id)}>
+          Currency Code
+        </label>
+        <MoneyInput
+          {...this.props}
+          onChange={this.props.onChange || this.handleChange}
+          value={this.state.value}
+        />
+      </React.Fragment>
+    );
+  }
+}
 
 describe('MoneyInput.getCurrencyDropdownId', () => {
   describe('when an id is passed', () => {
@@ -288,356 +321,107 @@ describe('MoneyInput.isHighPrecision', () => {
 
 // -----------------------------------------------------------------------------
 
-describe('rendering', () => {
-  let wrapper;
-  let props;
-  let downshiftProps;
-  let dowshiftRenderWrapper;
+describe('MoneyInput', () => {
+  it('should forward data-attributes', () => {
+    const { getByLabelText } = render(<TestComponent data-foo="bar" />);
+    expect(getByLabelText('Amount')).toHaveAttribute('data-foo', 'bar');
+  });
 
-  describe('`Currency` component', () => {
-    const currencyProps = createCurrencyProps();
-    beforeEach(() => {
-      wrapper = shallow(<Currency {...currencyProps} />);
-    });
+  it('should render a number input', () => {
+    const { getByLabelText } = render(<TestComponent />);
+    expect(getByLabelText('Amount')).toHaveAttribute('type', 'number');
+  });
 
-    it('should render an `AccessibleButton`', () => {
-      expect(wrapper).toRender(AccessibleButton);
-    });
+  it('should have an HTML name based on the passed name', () => {
+    const { getByLabelText } = render(<TestComponent name="foo" />);
+    expect(getByLabelText('Amount')).toHaveAttribute('name', 'foo.amount');
+  });
 
-    it('should render selected currency symbol', () => {
-      expect(wrapper.find('TextDetail')).toHaveProp('children', '€');
+  it('should show the passed value', () => {
+    const { getByLabelText } = render(
+      <TestComponent value={{ amount: '20', currencyCode: 'EUR' }} />
+    );
+    expect(getByLabelText('Amount')).toHaveAttribute('value', '20');
+    expect(getByLabelText('Currency Code')).toHaveTextContent('EUR');
+  });
+
+  it('should allow changing the amount', () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = render(<TestComponent onChange={onChange} />);
+
+    const event = { target: { value: '12' } };
+    fireEvent.change(getByLabelText('Amount'), event);
+
+    // onChange should be called with the updated amount
+    expect(onChange).toHaveBeenCalledWith({
+      persist: expect.any(Function),
+      target: {
+        name: 'some-name.amount',
+        value: '12',
+      },
     });
   });
 
-  describe('currency field', () => {
-    describe('dropdown head', () => {
-      beforeEach(() => {
-        props = createTestProps();
-        wrapper = shallow(<MoneyInput {...props} />);
-        downshiftProps = { isOpen: false, toggleMenu: jest.fn() };
-        dowshiftRenderWrapper = wrapper
-          .find(CurrencyDropdown)
-          .shallow()
-          .find(Downshift)
-          .renderProp('children', downshiftProps);
-      });
+  it('should allow changing the currency', () => {
+    const onChange = jest.fn();
 
-      it('should render `Currency`', () => {
-        expect(dowshiftRenderWrapper).toRender(Currency);
-      });
+    // We add labels here to be able to find the elements by their id and to
+    // ensure the MoneyInput is usable in forms which use labels
+    const { getByLabelText } = render(<TestComponent onChange={onChange} />);
 
-      describe('when currency is selectable', () => {
-        it('should render a chevron', () => {
-          expect(dowshiftRenderWrapper).toRender(DropdownChevron);
-        });
-      });
+    // open
+    fireEvent.click(getByLabelText('Currency Code'));
 
-      describe('with states', () => {
-        describe('open', () => {
-          beforeEach(() => {
-            props = createTestProps();
-            wrapper = shallow(<MoneyInput {...props} />);
-            downshiftProps = { isOpen: true, toggleMenu: jest.fn() };
-            dowshiftRenderWrapper = wrapper
-              .find(CurrencyDropdown)
-              .shallow()
-              .find(Downshift)
-              .renderProp('children', downshiftProps);
-          });
+    // change currency to USD
+    fireEvent.click(document.querySelector('[aria-label="USD"]'));
 
-          it('should have opened styles', () => {
-            expect(dowshiftRenderWrapper).toRender({
-              className: styles['currency-active'],
-            });
-          });
-        });
-
-        describe('disabled', () => {
-          beforeEach(() => {
-            props = createTestProps({
-              isDisabled: true,
-            });
-            wrapper = shallow(<MoneyInput {...props} />);
-            downshiftProps = { isOpen: false, toggleMenu: jest.fn() };
-            dowshiftRenderWrapper = wrapper
-              .find(CurrencyDropdown)
-              .shallow()
-              .find(Downshift)
-              .renderProp('children', downshiftProps);
-          });
-
-          it('should have disabled styles', () => {
-            expect(dowshiftRenderWrapper).toRender({
-              className: styles['currency-disabled'],
-            });
-          });
-        });
-
-        describe('error', () => {
-          beforeEach(() => {
-            props = createTestProps({
-              hasError: true,
-            });
-            wrapper = shallow(<MoneyInput {...props} />);
-            downshiftProps = { isOpen: false, toggleMenu: jest.fn() };
-            dowshiftRenderWrapper = wrapper
-              .find(CurrencyDropdown)
-              .shallow()
-              .find(Downshift)
-              .renderProp('children', downshiftProps);
-          });
-
-          it('should have error styles', () => {
-            expect(dowshiftRenderWrapper).toRender({
-              className: styles['currency-error'],
-            });
-          });
-        });
-
-        describe('warning', () => {
-          beforeEach(() => {
-            props = createTestProps({
-              hasWarning: true,
-            });
-            wrapper = shallow(<MoneyInput {...props} />);
-            downshiftProps = { isOpen: false, toggleMenu: jest.fn() };
-            dowshiftRenderWrapper = wrapper
-              .find(CurrencyDropdown)
-              .shallow()
-              .find(Downshift)
-              .renderProp('children', downshiftProps);
-          });
-
-          it('should have error styles', () => {
-            expect(dowshiftRenderWrapper).toRender({
-              className: styles['currency-warning'],
-            });
-          });
-        });
-      });
+    // onChange should be called when changing the currency
+    expect(onChange).toHaveBeenCalledWith({
+      persist: expect.any(Function),
+      target: {
+        name: 'some-name.currencyCode',
+        value: 'USD',
+      },
     });
 
-    describe('dropdown options', () => {
-      let options;
-      beforeEach(() => {
-        props = createTestProps();
-        wrapper = shallow(<MoneyInput {...props} />);
-        downshiftProps = { isOpen: true, toggleMenu: jest.fn() };
-        dowshiftRenderWrapper = wrapper
-          .find(CurrencyDropdown)
-          .shallow()
-          .find(Downshift)
-          .renderProp('children', downshiftProps);
-        options = dowshiftRenderWrapper.find('Option');
-      });
-
-      it('should render options', () => {
-        expect(dowshiftRenderWrapper).toRender('.currency-active');
-      });
-
-      it('should render as many options as currencies', () => {
-        expect(options).toHaveLength(2);
-      });
-    });
+    // the amount input should have focus after changing the currency
+    expect(getByLabelText('Amount')).toHaveFocus();
   });
 
-  describe('centAmount field', () => {
-    let centAmountField;
-    beforeEach(() => {
-      props = createTestProps();
-      wrapper = shallow(<MoneyInput {...props} />);
-      centAmountField = wrapper.find('input');
-    });
+  it('should format the amount on blur', () => {
+    const { getByLabelText } = render(<TestComponent />);
 
-    it('should render a `input`', () => {
-      expect(wrapper).toRender('input');
-    });
+    // change amount
+    fireEvent.change(getByLabelText('Amount'), { target: { value: '12' } });
 
-    describe('with states', () => {
-      describe('disabled', () => {
-        beforeEach(() => {
-          props = createTestProps({
-            isDisabled: true,
-          });
-          wrapper = shallow(<MoneyInput {...props} />);
-          centAmountField = wrapper.find('input');
-        });
+    // blur amount
+    fireEvent.blur(getByLabelText('Amount'));
 
-        it('should have disabled styles', () => {
-          expect(centAmountField).toRender({
-            className: styles['amount-disabled'],
-          });
-        });
-      });
-
-      describe('error', () => {
-        beforeEach(() => {
-          props = createTestProps({
-            hasError: true,
-          });
-          wrapper = shallow(<MoneyInput {...props} />);
-          centAmountField = wrapper.find('input');
-        });
-
-        it('should have error styles', () => {
-          expect(centAmountField).toRender({
-            className: styles['amount-error'],
-          });
-        });
-      });
-
-      describe('warning', () => {
-        beforeEach(() => {
-          props = createTestProps({
-            hasWarning: true,
-          });
-          wrapper = shallow(<MoneyInput {...props} />);
-          centAmountField = wrapper.find('input');
-        });
-
-        it('should have warning styles', () => {
-          expect(centAmountField).toRender({
-            className: styles['amount-warning'],
-          });
-        });
-      });
-    });
-  });
-});
-
-describe('callbacks', () => {
-  let wrapper;
-  let props;
-  let dowshiftRenderWrapper;
-  let inputWrapper;
-  describe('currency field', () => {
-    describe('when selecting the already used currency', () => {
-      beforeEach(() => {
-        props = createTestProps();
-        wrapper = shallow(<MoneyInput {...props} />);
-
-        dowshiftRenderWrapper = wrapper
-          .find(CurrencyDropdown)
-          .dive()
-          .renderProp('children', { isOpen: true, toggleMenu: jest.fn() });
-
-        dowshiftRenderWrapper
-          .find(Option)
-          // click the currency which is already selected
-          .findWhere(item => item.prop('children') === props.value.currencyCode)
-          .prop('onClick')({ target: { value: '12' } });
-      });
-
-      it('should not call onChange', () => {
-        expect(props.onChange).not.toHaveBeenCalled();
-      });
-    });
-    describe('when changing currency', () => {
-      beforeEach(() => {
-        props = createTestProps({ name: 'foo' });
-        wrapper = shallow(<MoneyInput {...props} />);
-
-        dowshiftRenderWrapper = wrapper
-          .find(CurrencyDropdown)
-          .dive()
-          .renderProp('children', { isOpen: true, toggleMenu: jest.fn() });
-
-        dowshiftRenderWrapper
-          .find(Option)
-          // clicking the already selected one (EUR) won't trigger an action,
-          // so we click the second one (USD)
-          .findWhere(item => item.prop('children') === 'USD')
-          .prop('onClick')({ target: { value: '12' } });
-      });
-
-      it('should call onChange with an event', async () => {
-        // wait for onChange call which happens in setTimeout(fn ,0)
-        // This can be removed once the setTimeout workarounds are
-        // removed from money-input.
-        await new Promise(resolve => setTimeout(resolve, 1));
-        expect(props.onChange).toHaveBeenCalledWith(
-          expect.objectContaining({
-            persist: expect.any(Function),
-            target: expect.objectContaining({
-              name: `foo.currencyCode`,
-              value: 'USD',
-            }),
-          })
-        );
-      });
-    });
+    // input should have the formatted value after blurring
+    expect(getByLabelText('Amount')).toHaveAttribute('value', '12.00');
   });
 
-  describe('amount field', () => {
-    describe('when changing amount', () => {
-      beforeEach(() => {
-        props = createTestProps({ name: 'foo' });
-        wrapper = shallow(<MoneyInput {...props} />);
+  // The original currency (EUR) uses 2 fraction digits, whereas the
+  // next currency (KWD) uses 3 fraction digits.
+  // We expect the last fraction to get added when changing the value
+  it('should format the amount when the currency changes', async () => {
+    const { getByLabelText } = render(
+      <TestComponent
+        currencies={['EUR', 'KWD']}
+        value={{ currencyCode: 'EUR', amount: '12.50' }}
+      />
+    );
 
-        inputWrapper = wrapper.find('input');
-        inputWrapper.simulate('change', {
-          target: { name: 'foo.amount', value: '1.3' },
-        });
-      });
-      it('should call onChange', () => {
-        expect(props.onChange).toHaveBeenCalledWith(
-          expect.objectContaining({
-            persist: expect.any(Function),
-            target: expect.objectContaining({
-              name: `foo.amount`,
-              value: '1.3',
-            }),
-          })
-        );
-      });
-    });
-    describe('when input loses focus', () => {
-      describe('when value is not formatted', () => {
-        const event = {};
-        beforeEach(() => {
-          props = createTestProps({
-            name: 'foo',
-            value: { currencyCode: 'EUR', amount: '10.3' },
-            onBlur: jest.fn(),
-          });
-          wrapper = shallow(<MoneyInput {...props} />);
-          wrapper.find('input').prop('onBlur')(event);
-        });
+    // change currency
+    fireEvent.click(getByLabelText('Currency Code'));
 
-        it('should call onChange with the formatted value', () => {
-          expect(props.onChange).toHaveBeenCalledWith(
-            expect.objectContaining({
-              persist: expect.any(Function),
-              target: expect.objectContaining({
-                name: `foo.amount`,
-                value: '10.30',
-              }),
-            })
-          );
-        });
+    // change currency to KWD
+    fireEvent.click(document.querySelector('[aria-label="KWD"]'));
 
-        it('should call onBlur with an event', () => {
-          expect(props.onBlur).toHaveBeenCalledWith(event);
-        });
-      });
-      describe('when value is already formatted', () => {
-        const event = {};
-        beforeEach(() => {
-          props = createTestProps({
-            value: { currencyCode: 'EUR', amount: '10.15' },
-            onBlur: jest.fn(),
-          });
-          wrapper = shallow(<MoneyInput {...props} />);
-          wrapper.find('input').prop('onBlur')(event);
-        });
+    expect(getByLabelText('Currency Code')).toHaveTextContent('KWD');
 
-        it('should call onBlur with an event', () => {
-          expect(props.onBlur).toHaveBeenCalledWith(event);
-        });
-        it('should not call onChange', () => {
-          expect(props.onChange).not.toHaveBeenCalled();
-        });
-      });
-    });
+    // We can't use .toHaveAttribute('value', ' 12.500') as the attribute
+    // itself does not change in the DOM tree. Only the actual value changes.
+    expect(getByLabelText('Amount').value).toEqual('12.500');
   });
 });

--- a/src/components/inputs/money-input/money-input.spec.js
+++ b/src/components/inputs/money-input/money-input.spec.js
@@ -376,7 +376,7 @@ describe('rendering', () => {
         describe('error', () => {
           beforeEach(() => {
             props = createTestProps({
-              hasCurrencyError: true,
+              hasError: true,
             });
             wrapper = shallow(<MoneyInput {...props} />);
             downshiftProps = { isOpen: false, toggleMenu: jest.fn() };
@@ -397,7 +397,7 @@ describe('rendering', () => {
         describe('warning', () => {
           beforeEach(() => {
             props = createTestProps({
-              hasCurrencyWarning: true,
+              hasWarning: true,
             });
             wrapper = shallow(<MoneyInput {...props} />);
             downshiftProps = { isOpen: false, toggleMenu: jest.fn() };
@@ -473,7 +473,7 @@ describe('rendering', () => {
       describe('error', () => {
         beforeEach(() => {
           props = createTestProps({
-            hasAmountError: true,
+            hasError: true,
           });
           wrapper = shallow(<MoneyInput {...props} />);
           centAmountField = wrapper.find('input');
@@ -489,7 +489,7 @@ describe('rendering', () => {
       describe('warning', () => {
         beforeEach(() => {
           props = createTestProps({
-            hasAmountWarning: true,
+            hasWarning: true,
           });
           wrapper = shallow(<MoneyInput {...props} />);
           centAmountField = wrapper.find('input');

--- a/src/components/inputs/money-input/money-input.story.js
+++ b/src/components/inputs/money-input/money-input.story.js
@@ -65,10 +65,8 @@ class MoneyInputStory extends React.Component {
                 this.setState({ currencyCode: event.target.value });
               }
             }}
-            hasCurrencyError={boolean('hasCurrencyError', false)}
-            hasCurrencyWarning={boolean('hasCurrencyWarning', false)}
-            hasAmountError={boolean('hasAmountError', false)}
-            hasAmountWarning={boolean('hasAmountWarning', false)}
+            hasError={boolean('hasError', false)}
+            hasWarning={boolean('hasWarning', false)}
             horizontalConstraint={select(
               'horizontalConstraint',
               ['s', 'm', 'l', 'xl', 'scale'],


### PR DESCRIPTION
The old `MoneyInput` was capable of displaying an error either on the currency dropdown or the amount input:

| `hasCurrencyError` | `hasAmountError` |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1765075/47153443-f54ffc80-d2df-11e8-9d8e-3c0cee19daae.png) | ![image](https://user-images.githubusercontent.com/1765075/47153457-faad4700-d2df-11e8-8493-facb69476762.png) |

After talking to @filippobocik we agreed to drop the individual error states from `MoneyInput`. `MoneyInput` will now only accept `hasError` (and `hasWarning`)  instead of  `hasCurrencyError` and `hasAmountError`.

```diff
<MoneyInput
- hasAmountError={true}
- hasCurrencyError={true}
- hasAmountWarning={true}
- hasCurrencyWarning={true}
+ hasError={true}
+ hasWarning={true}
/>
```

This makes the code easier for consumers as they only need to worry about one error state and they don't need to worry about individual `touched` states anymore to display the errors in the right cases.

**Old  `MoneyInput` in a form**

![money-old](https://user-images.githubusercontent.com/1765075/47153624-70b1ae00-d2e0-11e8-8b94-22d7ca94d69d.gif)

* Notice how the error appears while the user is still interacting with the `MoneyInput`. It pops up before the user has a chance to type the amount.

**New  `MoneyInput` in a form**

![money-new](https://user-images.githubusercontent.com/1765075/47153637-79a27f80-d2e0-11e8-8e63-2e22d5fcf86b.gif)

* The error only appears when the user leaves the `MoneyInput` completely
* The amount-input gets focused automatically after selecting a currency to improve UX



Play with it [https://deploy-preview-175--mc-uikit.netlify.com/?selectedKind=Examples%7CForms%2FInputs&selectedStory=MoneyInput&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybook%2Factions%2Factions-panel](here).

