### PR TITLE
Drop styled-components peerDep (Redo CollapsibleMotion)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "classnames": "2.2.6",
     "common-tags": "1.8.0",
     "dom-helpers": "3.3.1",
-    "downshift": "2.2.3",
+    "downshift": "3.1.1",
     "is-touch-device": "1.0.1",
     "lodash.flatmap": "4.5.0",
     "lodash.has": "4.5.2",
@@ -185,14 +185,14 @@
     "rollup-plugin-replace": "2.1.0",
     "rollup-plugin-url": "2.0.1",
     "shelljs": "0.8.2",
-    "storybook-readme": "4.0.0-beta1",
+    "storybook-readme": "4.0.2",
     "style-loader": "0.23.1",
-    "styled-components": "3.4.10",
+    "styled-components": "4.0.2",
     "stylelint": "9.6.0",
     "stylelint-config-standard": "18.2.0",
     "stylelint-order": "1.0.0",
     "url-loader": "1.1.2",
-    "webpack": "4.20.2"
+    "webpack": "4.21.0"
   },
   "peerDependencies": {
     "flatpickr": ">4.5.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "test:watch": "jest --config jest.test.config.js --watch"
   },
   "dependencies": {
-    "@sindresorhus/string-hash": "1.0.0",
     "classnames": "2.2.6",
     "common-tags": "1.8.0",
     "dom-helpers": "3.3.1",
@@ -70,7 +69,6 @@
     "prop-types": "15.6.2",
     "react-required-if": "1.0.3",
     "recompose": "0.30.0",
-    "style-inject": "0.3.0",
     "tiny-invariant": "1.0.1",
     "warning": "4.0.2"
   },
@@ -99,6 +97,7 @@
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",
     "babel-loader": "8.0.4",
+    "babel-plugin-emotion": "9.2.11",
     "babel-plugin-react-intl": "3.0.1",
     "babel-plugin-transform-dynamic-import": "2.1.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.19",
@@ -110,6 +109,7 @@
     "cross-env": "5.2.0",
     "css": "2.2.4",
     "css-loader": "1.0.0",
+    "emotion": "9.2.12",
     "enzyme": "3.7.0",
     "enzyme-adapter-react-16": "1.6.0",
     "enzyme-to-json": "3.3.4",
@@ -195,6 +195,7 @@
     "webpack": "4.21.0"
   },
   "peerDependencies": {
+    "emotion": "^9.1.2",
     "flatpickr": ">4.5.0",
     "moment": ">2.2",
     "moment-timezone": "^0.5",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test:watch": "jest --config jest.test.config.js --watch"
   },
   "dependencies": {
+    "@sindresorhus/string-hash": "1.0.0",
     "classnames": "2.2.6",
     "common-tags": "1.8.0",
     "dom-helpers": "3.3.1",
@@ -69,6 +70,7 @@
     "prop-types": "15.6.2",
     "react-required-if": "1.0.3",
     "recompose": "0.30.0",
+    "style-inject": "0.3.0",
     "tiny-invariant": "1.0.1",
     "warning": "4.0.2"
   },
@@ -202,8 +204,7 @@
     "react-router-dom": ">=4",
     "react-select": ">2.1.0",
     "react-textarea-autosize": ">7.0.0",
-    "react-virtualized": ">9.0.0",
-    "styled-components": ">3.4.0"
+    "react-virtualized": ">9.0.0"
   },
   "husky": {
     "hooks": {

--- a/scripts/get-babel-preset.js
+++ b/scripts/get-babel-preset.js
@@ -65,6 +65,8 @@ module.exports = function getBabelPresets() {
       // Experimental macros support. Will be documented after it's had some time
       // in the wild.
       require('babel-plugin-macros').default,
+      // https://github.com/emotion-js/emotion/tree/master/packages/babel-plugin-emotion
+      require('babel-plugin-emotion').default,
       // export { default } from './foo'
       require('@babel/plugin-proposal-export-default-from').default,
       // export * from './foo'

--- a/src/components/collapsible-motion/README.md
+++ b/src/components/collapsible-motion/README.md
@@ -1,0 +1,14 @@
+# CollapsibleMotion
+
+#### Description
+
+A component which allows building collapsible elements with an arbitrary height.
+
+#### Details
+
+Animating a div from `height: 0` to `height: auto` is something the browser will refuse to do out of the box, because calculations of this animation would be expensive.
+There are [many existing workaround](https://css-tricks.com/using-css-transitions-auto-dimensions/) which all have their different tradeoffs.
+
+`CollapsibleMotion` uses a nice workaround which allows the browser to run this animation. `CollapsibleMotion` measures the resulting since and then animates between `height: 0` and the resulting size (at 99% of the animation). At the end of the animation, it sets the `height` back to `auto`.
+
+Technically, we need to dynamically create the keyframes for this animation.

--- a/src/components/collapsible-motion/collapsible-motion.js
+++ b/src/components/collapsible-motion/collapsible-motion.js
@@ -1,26 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import invariant from 'tiny-invariant';
-import stringHash from '@sindresorhus/string-hash';
-import styleInject from 'style-inject';
+import { keyframes } from 'emotion';
 import Collapsible from '../collapsible';
-
-// allows setting global css, basically a cheap version of styled-components
-const injectedKeyframes = new Map();
-const keyframes = frames => {
-  // check if this already exists
-  const hash = stringHash(frames);
-  const hashedName = injectedKeyframes.get(hash);
-  if (hashedName) return hashedName;
-
-  const identifier = `keyframes-${hash}`;
-  injectedKeyframes.set(hash, identifier);
-  const css = `@keyframes ${identifier} { ${frames} }`;
-
-  styleInject(css);
-
-  return identifier;
-};
 
 const createOpeningAnimation = height =>
   keyframes(`

--- a/src/components/collapsible-motion/collapsible-motion.js
+++ b/src/components/collapsible-motion/collapsible-motion.js
@@ -49,12 +49,15 @@ export class ToggleAnimation extends React.Component {
       : createClosingAnimation(state.fullHeight);
     const animation = `${animationName} 200ms forwards`;
 
-    let containerStyles = {};
+    let containerStyles = props.isOpen
+      ? { height: 'auto' }
+      : { height: 0, overflow: 'hidden' };
 
     if (props.isOpen !== state.isOpen) {
-      containerStyles = props.isOpen
-        ? { height: 'auto', animation }
-        : { height: 0, overflow: 'hidden', animation };
+      containerStyles = {
+        ...containerStyles,
+        animation,
+      };
     }
 
     return {

--- a/src/components/collapsible-motion/collapsible-motion.js
+++ b/src/components/collapsible-motion/collapsible-motion.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import warning from 'warning';
+import invariant from 'tiny-invariant';
 import stringHash from '@sindresorhus/string-hash';
 import styleInject from 'style-inject';
 import Collapsible from '../collapsible';
@@ -42,70 +42,59 @@ export class ToggleAnimation extends React.Component {
     toggle: PropTypes.func.isRequired,
     children: PropTypes.func.isRequired,
   };
-  animation = '';
-  fullHeight = null;
 
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillMount() {
-    this.calcAnimation(this.props);
+  static getDerivedStateFromProps(props, state) {
+    const animationName = props.isOpen
+      ? createOpeningAnimation(state.fullHeight)
+      : createClosingAnimation(state.fullHeight);
+    return {
+      animation: `${animationName} 200ms forwards`,
+    };
   }
 
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (nextProps.isOpen !== this.props.isOpen) {
-      this.calcAnimation(nextProps);
-    } else {
-      this.animation = '';
+  nodeRef = React.createRef();
+
+  state = { fullHeight: null, animation: '' };
+
+  componentDidMount() {
+    invariant(
+      this.nodeRef.current,
+      'You need to call `registerContentNode` in order to use this component'
+    );
+
+    // Sets the full height to the content's height.
+    // We can't set this when initializing the state as the element in nodeRef
+    // would not have mounted yet.
+    if (this.props.isOpen) {
+      this.setState({
+        fullHeight: this.nodeRef.current.clientHeight,
+      });
     }
   }
 
-  calcAnimation = props => {
-    const animationName = this.getAnimationName({
-      isOpen: props.isOpen,
-      height: this.fullHeight,
-    });
-    this.animation = `${animationName} 200ms forwards`;
-  };
-
-  getAnimationName = props => {
-    // in case the render callback was called without the isOpen value actually
-    // having changed we need to avoid to replay the last animation.
-    if (props.isOpen === this.prevIsOpen) return '';
-    this.prevIsOpen = props.isOpen;
-    return props.isOpen
-      ? createOpeningAnimation(props.height)
-      : createClosingAnimation(props.height);
-  };
-
   handleToggle = () => {
-    warning(
-      this.node,
+    invariant(
+      this.nodeRef.current,
       'You need to call `registerContentNode` in order to use this component'
     );
+
     // set panel height to the height of the content,
     // so we can animate between the height and 0
-    this.fullHeight = this.calcFullHeight();
-    this.props.toggle();
-  };
-
-  calcFullHeight = () =>
-    this.fullHeight === this.node.clientHeight
-      ? this.fullHeight
-      : this.node.clientHeight;
-
-  registerContentNode = node => {
-    if (!node) return;
-    this.node = node;
+    this.setState(
+      {
+        fullHeight: this.nodeRef.current.clientHeight,
+      },
+      this.props.toggle
+    );
   };
 
   render() {
     return this.props.children({
-      animation: this.animation,
       containerStyles: this.props.isOpen
-        ? { height: 'auto' }
-        : { height: 0, overflow: 'hidden' },
+        ? { height: 'auto', animation: this.state.animation }
+        : { height: 0, overflow: 'hidden', animation: this.state.animation },
       toggle: this.handleToggle,
-      registerContentNode: this.registerContentNode,
+      registerContentNode: this.nodeRef,
     });
   }
 }
@@ -129,7 +118,6 @@ class CollapsibleMotion extends React.PureComponent {
         {({ isOpen, toggle }) => (
           <ToggleAnimation isOpen={isOpen} toggle={toggle}>
             {({
-              animation,
               containerStyles,
               toggle: animationToggle,
               registerContentNode,
@@ -137,10 +125,7 @@ class CollapsibleMotion extends React.PureComponent {
               this.props.children({
                 isOpen,
                 toggle: animationToggle,
-                containerStyles: {
-                  animation,
-                  ...containerStyles,
-                },
+                containerStyles,
                 registerContentNode,
               })
             }

--- a/src/components/collapsible-motion/collapsible-motion.js
+++ b/src/components/collapsible-motion/collapsible-motion.js
@@ -47,14 +47,22 @@ export class ToggleAnimation extends React.Component {
     const animationName = props.isOpen
       ? createOpeningAnimation(state.fullHeight)
       : createClosingAnimation(state.fullHeight);
+    const animation = `${animationName} 200ms forwards`;
     return {
-      animation: `${animationName} 200ms forwards`,
+      containerStyles: props.isOpen
+        ? { height: 'auto', animation }
+        : { height: 0, overflow: 'hidden', animation },
     };
   }
 
   nodeRef = React.createRef();
 
-  state = { fullHeight: null, animation: '' };
+  state = {
+    fullHeight: null,
+    containerStyles: this.props.isOpen
+      ? { height: 'auto' }
+      : { height: 0, overflow: 'hidden' },
+  };
 
   componentDidMount() {
     invariant(
@@ -90,9 +98,7 @@ export class ToggleAnimation extends React.Component {
 
   render() {
     return this.props.children({
-      containerStyles: this.props.isOpen
-        ? { height: 'auto', animation: this.state.animation }
-        : { height: 0, overflow: 'hidden', animation: this.state.animation },
+      containerStyles: this.state.containerStyles,
       toggle: this.handleToggle,
       registerContentNode: this.nodeRef,
     });

--- a/src/components/collapsible-motion/collapsible-motion.js
+++ b/src/components/collapsible-motion/collapsible-motion.js
@@ -48,16 +48,25 @@ export class ToggleAnimation extends React.Component {
       ? createOpeningAnimation(state.fullHeight)
       : createClosingAnimation(state.fullHeight);
     const animation = `${animationName} 200ms forwards`;
-    return {
-      containerStyles: props.isOpen
+
+    let containerStyles = {};
+
+    if (props.isOpen !== state.isOpen) {
+      containerStyles = props.isOpen
         ? { height: 'auto', animation }
-        : { height: 0, overflow: 'hidden', animation },
+        : { height: 0, overflow: 'hidden', animation };
+    }
+
+    return {
+      isOpen: props.isOpen,
+      containerStyles,
     };
   }
 
   nodeRef = React.createRef();
 
   state = {
+    isOpen: this.props.isOpen,
     fullHeight: null,
     containerStyles: this.props.isOpen
       ? { height: 'auto' }

--- a/src/components/collapsible-motion/collapsible-motion.js
+++ b/src/components/collapsible-motion/collapsible-motion.js
@@ -1,34 +1,39 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import warning from 'warning';
-import { keyframes } from 'styled-components';
+import stringHash from '@sindresorhus/string-hash';
+import styleInject from 'style-inject';
 import Collapsible from '../collapsible';
 
-const createOpeningAnimation = height => keyframes`
-  0% {
-    height: 0;
-    overflow: hidden;
-  }
+// allows setting global css, basically a cheap version of styled-components
+const injectedKeyframes = new Map();
+const keyframes = frames => {
+  // check if this already exists
+  const hash = stringHash(frames);
+  const hashedName = injectedKeyframes.get(hash);
+  if (hashedName) return hashedName;
 
-  99% {
-    height: ${height}px;
-    overflow: hidden;
-  }
-  100% {
-    height: auto;
-    overflow: visible;
-  }
-`;
-const createClosingAnimation = height => keyframes`
-  from {
-    height: ${height}px;
-  }
+  const identifier = `keyframes-${hash}`;
+  injectedKeyframes.set(hash, identifier);
+  const css = `@keyframes ${identifier} { ${frames} }`;
 
-  to {
-    height: 0;
-    overflow: hidden;
-  }
-`;
+  styleInject(css);
+
+  return identifier;
+};
+
+const createOpeningAnimation = height =>
+  keyframes(`
+    0% { height: 0; overflow: hidden; }
+    99% { height: ${height}px; overflow: hidden; }
+    100% { height: auto; overflow: visible; }
+  `);
+
+const createClosingAnimation = height =>
+  keyframes(`
+    from { height: ${height}px; }
+    to { height: 0; overflow: hidden; }
+  `);
 
 export class ToggleAnimation extends React.Component {
   static displayName = 'ToggleAnimation';

--- a/src/components/collapsible-motion/collapsible-motion.spec.js
+++ b/src/components/collapsible-motion/collapsible-motion.spec.js
@@ -28,10 +28,8 @@ describe('uncontrolled mode', () => {
     expect(renderProp).toHaveBeenLastCalledWith(
       expect.objectContaining({
         isOpen: true,
-        containerStyles: {
-          height: 'auto',
-          animation: 'keyframes-3501345875 200ms forwards',
-        },
+        // no animation here because the panel is already expanded
+        containerStyles: { height: 'auto' },
       })
     );
 
@@ -43,7 +41,9 @@ describe('uncontrolled mode', () => {
       expect.objectContaining({
         isOpen: false,
         containerStyles: {
-          animation: 'keyframes-1785486315 200ms forwards',
+          animation: expect.stringMatching(
+            /^animation-[a-z0-9]+ 200ms forwards$/
+          ),
           height: 0,
           overflow: 'hidden',
         },
@@ -59,7 +59,9 @@ describe('uncontrolled mode', () => {
         isOpen: true,
         containerStyles: {
           height: 'auto',
-          animation: 'keyframes-3501345875 200ms forwards',
+          animation: expect.stringMatching(
+            /^animation-[a-z0-9]+ 200ms forwards$/
+          ),
         },
       })
     );
@@ -108,10 +110,8 @@ describe('controlled mode', () => {
     expect(renderProp).toHaveBeenLastCalledWith(
       expect.objectContaining({
         isOpen: true,
-        containerStyles: {
-          height: 'auto',
-          animation: 'keyframes-3501345875 200ms forwards',
-        },
+        // no animation here because the panel is already expanded
+        containerStyles: { height: 'auto' },
       })
     );
 
@@ -123,7 +123,9 @@ describe('controlled mode', () => {
       expect.objectContaining({
         isOpen: false,
         containerStyles: {
-          animation: 'keyframes-1785486315 200ms forwards',
+          animation: expect.stringMatching(
+            /^animation-[a-z0-9]+ 200ms forwards$/
+          ),
           height: 0,
           overflow: 'hidden',
         },
@@ -139,7 +141,9 @@ describe('controlled mode', () => {
         isOpen: true,
         containerStyles: {
           height: 'auto',
-          animation: 'keyframes-3501345875 200ms forwards',
+          animation: expect.stringMatching(
+            /^animation-[a-z0-9]+ 200ms forwards$/
+          ),
         },
       })
     );

--- a/src/components/collapsible-motion/collapsible-motion.spec.js
+++ b/src/components/collapsible-motion/collapsible-motion.spec.js
@@ -1,140 +1,147 @@
 /* eslint-disable no-shadow */
 import React from 'react';
-import { shallow } from 'enzyme';
-import CollapsibleMotion, { ToggleAnimation } from './collapsible-motion';
+import { render, fireEvent } from '../../test-utils';
+import CollapsibleMotion from './collapsible-motion';
 
-const createMockNode = custom => ({
-  clientHeight: 200,
-  addEventListener: () => {},
-  removeEventListener: () => {},
-  ...custom,
-});
-
-describe('rendering', () => {
-  let wrapper;
-  let renderCallback;
-  let toggle;
-  let toggleAnimationWrapper;
-  beforeEach(() => {
-    renderCallback = jest.fn(() => <div />);
-    wrapper = shallow(<CollapsibleMotion>{renderCallback}</CollapsibleMotion>);
-    toggle = jest.fn();
-    toggleAnimationWrapper = shallow(
-      <div>
-        {wrapper.find('Collapsible').prop('children')({
-          isOpen: true,
-          toggle,
-        })}
-      </div>
+describe('uncontrolled mode', () => {
+  it('should toggle when clicked', async () => {
+    const renderProp = jest.fn(
+      ({ isOpen, toggle, containerStyles, registerContentNode }) => (
+        <div>
+          <button data-testid="button" onClick={toggle}>
+            {isOpen ? 'Close' : 'Open'}
+          </button>
+          <div data-testid="container-node" style={containerStyles}>
+            <div data-testid="content-node" ref={registerContentNode}>
+              Content
+            </div>
+          </div>
+        </div>
+      )
     );
-    shallow(
-      <div>
-        {toggleAnimationWrapper.find('ToggleAnimation').prop('children')({
-          isOpen: true,
-          toggle,
-          registerContentNode: jest.fn(),
-        })}
-      </div>
+
+    const { getByTestId } = render(
+      <CollapsibleMotion>{renderProp}</CollapsibleMotion>
     );
-  });
 
-  it('should render a Collapsible component', () => {
-    expect(wrapper).toRender('Collapsible');
-  });
+    expect(getByTestId('content-node')).toBeVisible();
+    expect(renderProp).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        containerStyles: {
+          height: 'auto',
+          animation: 'keyframes-3501345875 200ms forwards',
+        },
+      })
+    );
 
-  describe('Collapsible render callback', () => {
-    it('should render a ToggleAnimation component', () => {
-      expect(toggleAnimationWrapper).toRender('ToggleAnimation');
-    });
-  });
+    // hide the content
+    fireEvent.click(getByTestId('button'));
 
-  describe('ToggleAnimation render callback', () => {
-    it('should call the render callback', () => {
-      expect(renderCallback).toHaveBeenCalled();
-    });
+    // ensure the container gets hidden
+    expect(renderProp).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: false,
+        containerStyles: {
+          animation: 'keyframes-1785486315 200ms forwards',
+          height: 0,
+          overflow: 'hidden',
+        },
+      })
+    );
 
-    it('should propagate the isOpen state', () => {
-      expect(renderCallback.mock.calls[0][0].isOpen).toBe(true);
-    });
+    // show the content
+    fireEvent.click(getByTestId('button'));
 
-    it('should provide a callback to register the content node', () => {
-      expect(typeof renderCallback.mock.calls[0][0].registerContentNode).toBe(
-        'function'
-      );
-    });
-
-    it('should provide the container styles', () => {
-      expect(typeof renderCallback.mock.calls[0][0].containerStyles).toBe(
-        'object'
-      );
-    });
+    // ensure the container gets shown again
+    expect(renderProp).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        containerStyles: {
+          height: 'auto',
+          animation: 'keyframes-3501345875 200ms forwards',
+        },
+      })
+    );
   });
 });
 
-describe('ToggleAnimation', () => {
-  let renderCallback;
-  let props;
-  let wrapper;
-  const createTestProps = custom => ({
-    toggle: jest.fn(),
-    isOpen: true,
-    ...custom,
-  });
-  beforeEach(() => {
-    renderCallback = jest.fn();
-    props = createTestProps();
-    wrapper = shallow(
-      <ToggleAnimation {...props}>{renderCallback}</ToggleAnimation>
-    );
-  });
-  describe('when toggled', () => {
-    beforeEach(() => {
-      renderCallback.mock.calls[0][0].registerContentNode(createMockNode());
-      wrapper.instance().handleToggle();
-    });
-    it('should propagate the toggle callback', () => {
-      expect(props.toggle).toHaveBeenCalled();
-    });
+describe('controlled mode', () => {
+  it('should toggle when clicked', async () => {
+    const renderProp = jest.fn(({ containerStyles, registerContentNode }) => (
+      <div data-testid="container-node" style={containerStyles}>
+        <div data-testid="content-node" ref={registerContentNode}>
+          Content
+        </div>
+      </div>
+    ));
 
-    describe('is open', () => {
-      it('should set the full height', () => {
-        expect(wrapper.instance().fullHeight).toBe(200);
-      });
-    });
-
-    describe('is not open', () => {
-      beforeEach(() => {
-        renderCallback = jest.fn();
-        props = createTestProps({ isOpen: false });
-        wrapper = shallow(
-          <ToggleAnimation {...props}>{renderCallback}</ToggleAnimation>
+    class TestComponent extends React.Component {
+      state = {
+        isClosed: false,
+      };
+      render() {
+        return (
+          <div>
+            <button
+              data-testid="button"
+              onClick={() =>
+                this.setState(prevState => ({ isClosed: !prevState.isClosed }))
+              }
+            >
+              Toggle
+            </button>
+            <CollapsibleMotion
+              isClosed={this.state.isClosed}
+              onToggle={() => {}}
+            >
+              {renderProp}
+            </CollapsibleMotion>
+          </div>
         );
-        renderCallback.mock.calls[0][0].registerContentNode(createMockNode());
-        wrapper.instance().handleToggle();
-      });
+      }
+    }
 
-      it('should set the full height to 200', () => {
-        expect(wrapper.instance().fullHeight).toBe(200);
-      });
-    });
-  });
+    const { getByTestId } = render(<TestComponent />);
 
-  describe('componentWillReceiveProps', () => {
-    describe("when isOpen wasn't changed", () => {
-      beforeEach(() => {
-        wrapper.setProps({ foo: 'bar' });
-      });
-      it('should set no animation', () => {
-        expect(wrapper.instance().animation).toBe('');
-      });
-    });
-    describe('when isOpen was changed', () => {
-      beforeEach(() => {
-        wrapper.setProps({ isOpen: false });
-      });
-      it('should set no animation', () => {
-        expect(wrapper.instance().animation).not.toBe('');
-      });
-    });
+    expect(getByTestId('content-node')).toBeVisible();
+    expect(renderProp).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        containerStyles: {
+          height: 'auto',
+          animation: 'keyframes-3501345875 200ms forwards',
+        },
+      })
+    );
+
+    // hide the content
+    fireEvent.click(getByTestId('button'));
+
+    // ensure the container gets hidden
+    expect(renderProp).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: false,
+        containerStyles: {
+          animation: 'keyframes-1785486315 200ms forwards',
+          height: 0,
+          overflow: 'hidden',
+        },
+      })
+    );
+
+    // show the content
+    fireEvent.click(getByTestId('button'));
+
+    // ensure the container gets shown again
+    expect(renderProp).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        containerStyles: {
+          height: 'auto',
+          animation: 'keyframes-3501345875 200ms forwards',
+        },
+      })
+    );
   });
 });

--- a/src/components/collapsible-motion/collapsible-motion.story.js
+++ b/src/components/collapsible-motion/collapsible-motion.story.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { storiesOf } from '@storybook/react';
+// import { action } from '@storybook/addon-actions';
+import { withKnobs, number } from '@storybook/addon-knobs';
+// import withReadme from 'storybook-readme/with-readme';
+import CollapsibleMotion from './collapsible-motion';
+
+export const CollapsibleMotionStoryBody = props => (
+  <div>
+    <div>
+      <button label={props.isOpen ? 'Close' : 'Open'} onClick={props.onToggle}>
+        {props.isOpen ? 'Close' : 'Open'}
+      </button>
+    </div>
+    <div style={props.style}>
+      <div ref={props.registerContentNode}>{props.children}</div>
+    </div>
+  </div>
+);
+
+CollapsibleMotionStoryBody.displayName = 'CollapsibleMotionStoryBody';
+CollapsibleMotionStoryBody.propTypes = {
+  children: PropTypes.node.isRequired,
+  style: PropTypes.object,
+  isOpen: PropTypes.bool.isRequired,
+  onToggle: PropTypes.func.isRequired,
+  registerContentNode: PropTypes.any,
+};
+
+export const CollapsibleMotionStory = () => (
+  <div>
+    <div>Some content before</div>
+    <CollapsibleMotion>
+      {({ isOpen, toggle, containerStyles, registerContentNode }) => (
+        <CollapsibleMotionStoryBody
+          registerContentNode={registerContentNode}
+          style={containerStyles}
+          isOpen={isOpen}
+          onToggle={toggle}
+        >
+          <div
+            style={{
+              backgroundColor: 'red',
+              width: '200px',
+              height: `${number('height', 250, {
+                range: true,
+                min: 10,
+                max: 5000,
+                step: 50,
+              })}px`,
+            }}
+          >
+            hello
+          </div>
+        </CollapsibleMotionStoryBody>
+      )}
+    </CollapsibleMotion>
+    <div>Some content afterwards</div>
+  </div>
+);
+CollapsibleMotionStory.displayName = 'CollapsibleMotionStory';
+
+storiesOf('Panels', module)
+  .addDecorator(withKnobs)
+  // .addDecorator(withReadme(Readme))
+  .add('CollapsibleMotion', () => <CollapsibleMotionStory />);

--- a/src/components/collapsible-motion/collapsible-motion.story.js
+++ b/src/components/collapsible-motion/collapsible-motion.story.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-// import { action } from '@storybook/addon-actions';
 import { withKnobs, number, boolean } from '@storybook/addon-knobs';
-// import withReadme from 'storybook-readme/with-readme';
+import withReadme from 'storybook-readme/with-readme';
 import CollapsibleMotion from './collapsible-motion';
 import Spacings from '../spacings';
+import Readme from './README.md';
 
 class CollapsibleMotionStory extends React.Component {
   static displayName = 'CollapsibleMotionStory';
@@ -103,15 +103,5 @@ class CollapsibleMotionStory extends React.Component {
 
 storiesOf('Panels', module)
   .addDecorator(withKnobs)
-  // .addDecorator(withReadme(Readme))
-  .add('CollapsibleMotion', () => {
-    // this prop is passed to rerender the whole story, which simulates a
-    // parent rerendering
-    const num = number('rerender', 0, {
-      range: true,
-      min: 0,
-      max: 5000,
-      step: 1,
-    });
-    return <CollapsibleMotionStory num={num} />;
-  });
+  .addDecorator(withReadme(Readme))
+  .add('CollapsibleMotion', () => <CollapsibleMotionStory />);

--- a/src/components/collapsible-motion/collapsible-motion.story.js
+++ b/src/components/collapsible-motion/collapsible-motion.story.js
@@ -1,67 +1,117 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
 // import { action } from '@storybook/addon-actions';
-import { withKnobs, number } from '@storybook/addon-knobs';
+import { withKnobs, number, boolean } from '@storybook/addon-knobs';
 // import withReadme from 'storybook-readme/with-readme';
 import CollapsibleMotion from './collapsible-motion';
+import Spacings from '../spacings';
 
-export const CollapsibleMotionStoryBody = props => (
-  <div>
-    <div>
-      <button label={props.isOpen ? 'Close' : 'Open'} onClick={props.onToggle}>
-        {props.isOpen ? 'Close' : 'Open'}
-      </button>
-    </div>
-    <div style={props.style}>
-      <div ref={props.registerContentNode}>{props.children}</div>
-    </div>
-  </div>
-);
-
-CollapsibleMotionStoryBody.displayName = 'CollapsibleMotionStoryBody';
-CollapsibleMotionStoryBody.propTypes = {
-  children: PropTypes.node.isRequired,
-  style: PropTypes.object,
-  isOpen: PropTypes.bool.isRequired,
-  onToggle: PropTypes.func.isRequired,
-  registerContentNode: PropTypes.any,
-};
-
-export const CollapsibleMotionStory = () => (
-  <div>
-    <div>Some content before</div>
-    <CollapsibleMotion>
-      {({ isOpen, toggle, containerStyles, registerContentNode }) => (
-        <CollapsibleMotionStoryBody
-          registerContentNode={registerContentNode}
-          style={containerStyles}
-          isOpen={isOpen}
-          onToggle={toggle}
-        >
-          <div
-            style={{
-              backgroundColor: 'red',
-              width: '200px',
-              height: `${number('height', 250, {
-                range: true,
-                min: 10,
-                max: 5000,
-                step: 50,
-              })}px`,
-            }}
-          >
-            hello
+class CollapsibleMotionStory extends React.Component {
+  static displayName = 'CollapsibleMotionStory';
+  state = {
+    isClosed: false,
+  };
+  handleToggle = () =>
+    this.setState(prevState => ({ isClosed: !prevState.isClosed }));
+  render() {
+    const isDefaultClosed = boolean('isDefaultClosed', false);
+    return (
+      <Spacings.Inline>
+        <div>
+          <h2>Uncontrolled example</h2>
+          <div key={isDefaultClosed}>
+            <div>Some content before</div>
+            <CollapsibleMotion isDefaultClosed={isDefaultClosed}>
+              {({ isOpen, toggle, containerStyles, registerContentNode }) => (
+                <div>
+                  <div>
+                    <button onClick={toggle}>
+                      {isOpen ? 'Close' : 'Open'}
+                    </button>
+                  </div>
+                  <div style={containerStyles}>
+                    <div ref={registerContentNode}>
+                      <div
+                        style={{
+                          backgroundColor: 'red',
+                          width: '200px',
+                          height: `${number('height (uncontrolled)', 250, {
+                            range: true,
+                            min: 20,
+                            max: 5000,
+                            step: 50,
+                          })}px`,
+                        }}
+                      >
+                        hello
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </CollapsibleMotion>
+            <div>Some content afterwards</div>
           </div>
-        </CollapsibleMotionStoryBody>
-      )}
-    </CollapsibleMotion>
-    <div>Some content afterwards</div>
-  </div>
-);
-CollapsibleMotionStory.displayName = 'CollapsibleMotionStory';
+        </div>
+        <div>
+          <h2>Controlled example</h2>
+          <button onClick={() => this.setState({ isClosed: false })}>
+            Open
+          </button>
+          <button onClick={() => this.setState({ isClosed: true })}>
+            Close
+          </button>
+          <div>
+            <div>Some content before</div>
+            <CollapsibleMotion
+              isClosed={this.state.isClosed}
+              onToggle={this.handleToggle}
+            >
+              {({ toggle, containerStyles, registerContentNode }) => (
+                <div>
+                  <div>
+                    <button onClick={toggle}>Toggle</button>
+                  </div>
+                  <div style={containerStyles}>
+                    <div ref={registerContentNode}>
+                      <div
+                        style={{
+                          backgroundColor: 'red',
+                          width: '200px',
+                          height: `${number('height (controlled)', 250, {
+                            range: true,
+                            min: 20,
+                            max: 5000,
+                            step: 50,
+                          })}px`,
+                        }}
+                      >
+                        hello
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </CollapsibleMotion>
+            <div>Some content afterwards</div>
+          </div>
+        </div>
+      </Spacings.Inline>
+    );
+  }
+}
 
 storiesOf('Panels', module)
   .addDecorator(withKnobs)
   // .addDecorator(withReadme(Readme))
-  .add('CollapsibleMotion', () => <CollapsibleMotionStory />);
+  .add('CollapsibleMotion', () => {
+    // this prop is passed to rerender the whole story, which simulates a
+    // parent rerendering
+    const num = number('rerender', 0, {
+      range: true,
+      min: 0,
+      max: 5000,
+      step: 1,
+    });
+    return <CollapsibleMotionStory num={num} />;
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1223,6 +1223,18 @@
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
   integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
 
+"@sindresorhus/fnv1a@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/fnv1a/-/fnv1a-1.0.0.tgz#d419dd111b4d7fc3b87f97d86849bc23316149de"
+  integrity sha512-n+7NAD9vCDb2PaCRFIGrT2UF8WPIfMgGvCiVsYKY1/eBTrZU80N9erKhX9UTdxyvWhNuxQxwZGzdOIOlt8WqsA==
+
+"@sindresorhus/string-hash@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/string-hash/-/string-hash-1.0.0.tgz#ec26f7de627ec88b5737c6e5102516de42d25a4a"
+  integrity sha512-f+MXwrsBBcicamPLVcvfoc1SBXLRRwRGe0atZlJFRypb6CKoODYwElIQLFuilFoD+7YWdjX42Lfx6mC0ClMKgw==
+  dependencies:
+    "@sindresorhus/fnv1a" "^1.0.0"
+
 "@storybook/addon-actions@4.0.0-alpha.20":
   version "4.0.0-alpha.20"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-4.0.0-alpha.20.tgz#0faf0a8bf958b703a1dd46d4aa6904957d0d506b"
@@ -12836,7 +12848,7 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-style-inject@^0.3.0:
+style-inject@0.3.0, style-inject@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/style-inject/-/style-inject-0.3.0.tgz#d21c477affec91811cc82355832a700d22bf8dd3"
   integrity sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1223,18 +1223,6 @@
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
   integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
 
-"@sindresorhus/fnv1a@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/fnv1a/-/fnv1a-1.0.0.tgz#d419dd111b4d7fc3b87f97d86849bc23316149de"
-  integrity sha512-n+7NAD9vCDb2PaCRFIGrT2UF8WPIfMgGvCiVsYKY1/eBTrZU80N9erKhX9UTdxyvWhNuxQxwZGzdOIOlt8WqsA==
-
-"@sindresorhus/string-hash@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/string-hash/-/string-hash-1.0.0.tgz#ec26f7de627ec88b5737c6e5102516de42d25a4a"
-  integrity sha512-f+MXwrsBBcicamPLVcvfoc1SBXLRRwRGe0atZlJFRypb6CKoODYwElIQLFuilFoD+7YWdjX42Lfx6mC0ClMKgw==
-  dependencies:
-    "@sindresorhus/fnv1a" "^1.0.0"
-
 "@storybook/addon-actions@4.0.0-alpha.20":
   version "4.0.0-alpha.20"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-4.0.0-alpha.20.tgz#0faf0a8bf958b703a1dd46d4aa6904957d0d506b"
@@ -2384,7 +2372,7 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-emotion@^9.2.11:
+babel-plugin-emotion@9.2.11, babel-plugin-emotion@^9.2.11:
   version "9.2.11"
   resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-9.2.11.tgz#319c005a9ee1d15bb447f59fe504c35fd5807728"
   integrity sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==
@@ -4731,7 +4719,7 @@ emojis-list@^2.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
   integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
 
-emotion@^9.1.2, emotion@^9.2.6, emotion@^9.2.8:
+emotion@9.2.12, emotion@^9.1.2, emotion@^9.2.6, emotion@^9.2.8:
   version "9.2.12"
   resolved "https://registry.yarnpkg.com/emotion/-/emotion-9.2.12.tgz#53925aaa005614e65c6e43db8243c843574d1ea9"
   integrity sha512-hcx7jppaI8VoXxIWEhxpDW7I+B4kq9RNzQLmsrF6LY8BGKqe2N+gFAQr0EfuFucFlPs2A9HM4+xNj4NeqEWIOQ==
@@ -12849,7 +12837,7 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-style-inject@0.3.0, style-inject@^0.3.0:
+style-inject@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/style-inject/-/style-inject-0.3.0.tgz#d21c477affec91811cc82355832a700d22bf8dd3"
   integrity sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -806,7 +806,7 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
-"@babel/runtime@^7.0.0":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.2.tgz#81c89935f4647706fc54541145e6b4ecfef4b8e3"
   integrity sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==
@@ -2525,6 +2525,14 @@ babel-plugin-react-intl@3.0.1:
     intl-messageformat-parser "^1.2.0"
     mkdirp "^0.5.1"
 
+"babel-plugin-styled-components@>= 1":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.8.0.tgz#9dd054c8e86825203449a852a5746f29f2dab857"
+  integrity sha512-PcrdbXFO/9Plo9JURIj8G0Dsz+Ct8r+NvjoLh6qPt8Y/3EIAj1gHGW1ocPY1IkQbXZLBEZZSRBAxJem1KFdBXg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    lodash "^4.17.10"
+
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
@@ -3003,14 +3011,6 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
-
-buffer@^5.0.3:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.1.tgz#dd57fa0f109ac59c602479044dca7b8b3d0b71d6"
-  integrity sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -3576,7 +3576,7 @@ component-emitter@^1.2.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
   integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
 
-compute-scroll-into-view@^1.0.2:
+compute-scroll-into-view@^1.0.9:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.11.tgz#7ff0a57f9aeda6314132d8994cce7aeca794fecf"
   integrity sha512-uUnglJowSe0IPmWOdDtrlHXof5CTIJitfJEyITHBW6zDVOGu9Pjk5puaLM73SLcwak0L4hEjO7Td88/a6P5i7A==
@@ -4119,7 +4119,7 @@ css-selector-tokenizer@^0.7.0:
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
 
-css-to-react-native@^2.0.3:
+css-to-react-native@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.2.2.tgz#c077d0f7bf3e6c915a539e7325821c9dd01f9965"
   integrity sha512-w99Fzop1FO8XKm0VpbQp3y5mnTnaS+rtCvS+ylSEOK76YXO5zoHQx/QMB1N54Cp+Ya9jB9922EHrh14ld4xmmw==
@@ -4656,12 +4656,13 @@ dotenv@^6.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.1.0.tgz#9853b6ca98292acb7dec67a95018fa40bccff42c"
   integrity sha512-/veDn2ztgRlB7gKmE3i9f6CmDIyXAy6d5nBq+whO9SLX+Zs1sXEgFLPi+aSuWqUuusMfbi84fT8j34fs1HaYUw==
 
-downshift@2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-2.2.3.tgz#85187568455134e72025fbddd40bb9cf96c55eed"
-  integrity sha512-SXFgGq5QYT9mxbaSsYdp4Ng0tP87F5z33PD+tZ2kyK0qIBYd1rcPe90+ykCOYqsWHsb/gcrjaAav2Jpa6qNbQg==
+downshift@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-3.1.1.tgz#91e14d45d6ee3e239023cdfcc06248c7f5a1b2b2"
+  integrity sha512-teJ4ACfySJPC1+nOg6XqSMtCwjQkdXLfM2FlObr5FQAIR2r9TTFFDbXUTvzRA7mSJVf3FQZ/cx9i67Ox0iEy1Q==
   dependencies:
-    compute-scroll-into-view "^1.0.2"
+    "@babel/runtime" "^7.1.2"
+    compute-scroll-into-view "^1.0.9"
     prop-types "^15.6.0"
 
 duplexer@^0.1.1:
@@ -5487,7 +5488,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.9:
+fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -8446,6 +8447,11 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
+lodash.toarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
+  integrity sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
+
 lodash.topairs@4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.topairs/-/lodash.topairs-4.3.0.tgz#3b6deaa37d60fb116713c46c5f17ea190ec48d64"
@@ -8599,21 +8605,13 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.2.tgz#e639cbde7b99c841c0bacc8a07982873b46d2122"
   integrity sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA==
 
-markdown-loader@4.0.0:
+markdown-loader@4.0.0, markdown-loader@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/markdown-loader/-/markdown-loader-4.0.0.tgz#502eb94f5db1673beb1721bed82dac9e1d333b9a"
   integrity sha512-9BCm8iyLF4AVYtjtybOTg8cTcpWYKsDGWWhsc7XaJlXQiddo3ztbZxLPJ28pmCxFI1BlMkT1wDVav1chPjTpdA==
   dependencies:
     loader-utils "^1.1.0"
     marked "^0.5.0"
-
-markdown-loader@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/markdown-loader/-/markdown-loader-3.0.0.tgz#a36b65f66c9b4a22731b7d4824202ef972f23f11"
-  integrity sha512-ENNCYU7iINBYpCDeYFlaxKhxmjrsWzw/duhFoj7+VVoHBdla78Pqo6r5/txNH6m1lduMsjrq13EddBdGM+gSVg==
-  dependencies:
-    loader-utils "^1.1.0"
-    marked "^0.4.0"
 
 markdown-table@^1.1.0:
   version "1.1.2"
@@ -8624,11 +8622,6 @@ marked@^0.3.12:
   version "0.3.19"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
   integrity sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==
-
-marked@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.4.0.tgz#9ad2c2a7a1791f10a852e0112f77b571dce10c66"
-  integrity sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==
 
 marked@^0.5.0:
   version "0.5.1"
@@ -9134,6 +9127,13 @@ node-dir@^0.1.10:
   integrity sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=
   dependencies:
     minimatch "^3.0.2"
+
+node-emoji@1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.8.1.tgz#6eec6bfb07421e2148c75c6bba72421f8530a826"
+  integrity sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==
+  dependencies:
+    lodash.toarray "^4.4.0"
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -12637,15 +12637,16 @@ stealthy-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
-storybook-readme@4.0.0-beta1:
-  version "4.0.0-beta1"
-  resolved "https://registry.yarnpkg.com/storybook-readme/-/storybook-readme-4.0.0-beta1.tgz#0f5bbd5a6d01be86aec16cb7b02b2614d4f5c8f1"
-  integrity sha512-s6RlAgf6tlGNv/iOQoUbQElFz+tzP+cmH5NJQgHV2OPHfVNyDoEHHkCD81f8dQKDIl60n07N0sYH3JOtmOdJ0g==
+storybook-readme@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/storybook-readme/-/storybook-readme-4.0.2.tgz#35304e7dad1157ecb8dc9b678400db812337202c"
+  integrity sha512-Kms7I7IVpxlRHMr67hL8fFdLVfD6H0XYWoDa3xp99wR1Y1zAwt2TXz0lFX/WEF807w65SpluVqH1uK8rjuVMAg==
   dependencies:
     html-loader "^0.5.5"
     lodash "^4.17.4"
-    markdown-loader "^3.0.0"
-    marked "^0.4.0"
+    markdown-loader "^4.0.0"
+    marked "^0.5.0"
+    node-emoji "1.8.1"
     prismjs "^1.9.0"
     string-raw "^1.0.1"
 
@@ -12866,20 +12867,19 @@ style-search@^0.1.0:
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=
 
-styled-components@3.4.10:
-  version "3.4.10"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.4.10.tgz#9a654c50ea2b516c36ade57ddcfa296bf85c96e1"
-  integrity sha512-TA8ip8LoILgmSAFd3r326pKtXytUUGu5YWuqZcOQVwVVwB6XqUMn4MHW2IuYJ/HAD81jLrdQed8YWfLSG1LX4Q==
+styled-components@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.0.2.tgz#7d4409ada019cdd34c25ba68c4577ea95dbcf0c5"
+  integrity sha512-VTNCmBLNx0OS2GRaYk0yRAnQVDBCGnnxGkR6+BCmkKVv9VgICO7bEn3UDjlnwCw8hgIyecMzVLOPl+p1zqUxog==
   dependencies:
-    buffer "^5.0.3"
-    css-to-react-native "^2.0.3"
-    fbjs "^0.8.16"
-    hoist-non-react-statics "^2.5.0"
+    "@emotion/is-prop-valid" "^0.6.8"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^2.2.2"
+    memoize-one "^4.0.0"
     prop-types "^15.5.4"
     react-is "^16.3.1"
     stylis "^3.5.0"
     stylis-rule-sheet "^0.0.10"
-    supports-color "^3.2.3"
 
 stylelint-config-recommended@^2.1.0:
   version "2.1.0"
@@ -13854,7 +13854,37 @@ webpack-sources@^1.1.0, webpack-sources@^1.3.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@4.20.2, webpack@^4.17.1:
+webpack@4.21.0:
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.21.0.tgz#bd03605c0f48c0d4aaaef78ead2769485e5afd92"
+  integrity sha512-CGBeop4AYR0dcmk9Afl33qQULwTHQCXQPAIBTHMJoy9DpY8FPUDna/NUlAGTr5o5y9QC901Ww3wCY4wNo1X9Lw==
+  dependencies:
+    "@webassemblyjs/ast" "1.7.8"
+    "@webassemblyjs/helper-module-context" "1.7.8"
+    "@webassemblyjs/wasm-edit" "1.7.8"
+    "@webassemblyjs/wasm-parser" "1.7.8"
+    acorn "^5.6.2"
+    acorn-dynamic-import "^3.0.0"
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    chrome-trace-event "^1.0.0"
+    enhanced-resolve "^4.1.0"
+    eslint-scope "^4.0.0"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^2.3.0"
+    loader-utils "^1.1.0"
+    memory-fs "~0.4.1"
+    micromatch "^3.1.8"
+    mkdirp "~0.5.0"
+    neo-async "^2.5.0"
+    node-libs-browser "^2.0.0"
+    schema-utils "^0.4.4"
+    tapable "^1.1.0"
+    uglifyjs-webpack-plugin "^1.2.4"
+    watchpack "^1.5.0"
+    webpack-sources "^1.3.0"
+
+webpack@^4.17.1:
   version "4.20.2"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.20.2.tgz#89f6486b6bb276a91b0823453d377501fc625b5a"
   integrity sha512-75WFUMblcWYcocjSLlXCb71QuGyH7egdBZu50FtBGl2Nso8CK3Ej+J7bTZz2FPFq5l6fzCisD9modB7t30ikuA==


### PR DESCRIPTION
As described in #21 we were including all of  `styled-components` and making it a peer dependency just for the sake of one single component called `CollapsibleMotion`.

The task of `CollapsibleMotion` is not an easy one, as it needs to animate a components height from `0` to `auto` and vice versa. This is a really difficult animation, as browsers don't allow to animate to `auto` - because it is really expensive. There is [one long article](https://css-tricks.com/using-css-transitions-auto-dimensions/) which goes into detail of different approach to this problem and their downsides. None of them are pretty.

`CollapsibleMotion` solves this problem in a clever way as it dynamically injects keyframes to be able to animate. It also sets the height to the measured height and then, only on the last frame of the animation sets it back to `auto`. It thereby simulates the browser animating between `0` and `auto`.

We were using `styled-components` to dynamically inject the generated keyframes into the DOM. Including `styled-components` for this single animation is overkill as styled-components [weighs in at 16.2kb minified+gzipped](https://bundlephobia.com/result?p=styled-components@3.4.10).

This PR
- drops `styled-components` and recreates the dynamic keyframes injection ~~manually~~ *using `emotion`*
- drops `styled-components` as a peer dependency 🔥 
- refactors `CollapsibleMotion` to the new lifecycle and generally simplifies it
- refactors `registerContentNode` to the use `React.createRef` (no breaking change though)
- adds a story for `CollapsibleMotion`
- rewrites the tests in `react-testing-library`

Closes #21