### PR TITLE
chore: self contain styles intermediate solution

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -5,7 +5,6 @@ import IntlDecorator from './decorators/intl';
 
 // setAddon(infoAddon);
 
-import '../materials/internals/reset.mod.css';
 import './main.mod.css';
 
 setOptions({

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 /* This is the entry point of the public package interface */
 
+import '../materials/internals/grid.mod.css';
+import '../materials/internals/reset.mod.css';
+
 /* eslint-disable max-len,prettier/prettier */
 import * as i18n from '../i18n'
 import * as Icons from './components/icons';


### PR DESCRIPTION
#### Summary

To fulfill the **intermediate suggestion** of #185, we propose importing the global css (`reset.mod.css` and `grid.mod.css`) in the `index.js` file.

Then, we can move on to a more permanent solution.

This way regression testing can be introduced before the permanent solution.

**Release notes** Consumers of ui-kit no longer need to `import '../materials/internals/reset.mod.css';` and `import '../materials/internals/grid.mod.css';`.