### PR TITLE
fix: allow scrolling in icon story

### DIFF
--- a/materials/internals/reset.mod.css
+++ b/materials/internals/reset.mod.css
@@ -14,7 +14,6 @@ body {
   margin: 0;
   padding: 0;
   height: 100vh;
-  overflow: hidden;
 }
 
 html {


### PR DESCRIPTION
#### Summary

Before #186 , we had

```
import '../materials/internals/reset.mod.css';	
import './main.mod.css';	
```

This meant that the `overflow: auto` took precedence over `overflow: hidden` in `reset.mod.css`. 

By importing `reset.mod.css` in `index.js`, this order of precedence changed.

#### Approach

Remove overflow: hidden in `reset.mod.css` because this shouldn't be in UI-Kit anyways.

**Release notes** Consumers which were relying on `overflow: hidden` on `body` now need to define this themselves.