### PR TITLE
fix(*-select-input): align indicator icons of clearable select-inputs

### DIFF
--- a/src/components/internals/clear-indicator/clear-indicator.js
+++ b/src/components/internals/clear-indicator/clear-indicator.js
@@ -2,12 +2,23 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { CloseIcon } from '../../icons';
 
-const ClearIndicator = props => (
-  <div className="react-select__clear-indicator" {...props.innerProps}>
-    {/* FIXME: add proper tone when tones are refactored */}
-    <CloseIcon theme={props.isDisabled && 'grey'} size="medium" />
-  </div>
-);
+const ClearIndicator = props => {
+  const {
+    getStyles,
+    innerProps: { ref, ...restInnerProps },
+  } = props;
+  return (
+    <div
+      {...restInnerProps}
+      ref={ref}
+      style={getStyles('clearIndicator', props)}
+    >
+      <div>
+        <CloseIcon theme={props.isDisabled && 'grey'} size="medium" />
+      </div>
+    </div>
+  );
+};
 
 ClearIndicator.displayName = 'ClearIndicator';
 

--- a/src/components/internals/create-select-styles.js
+++ b/src/components/internals/create-select-styles.js
@@ -72,7 +72,6 @@ const indicatorSeparatorStyles = () => base => ({
 const dropdownIndicatorStyles = () => base => ({
   ...base,
   color: vars['--token-font-color-default'],
-  marginRight: vars['--spacing-8'],
   margin: '0',
   padding: '0',
   marginLeft: vars['--spacing-4'],
@@ -81,6 +80,7 @@ const dropdownIndicatorStyles = () => base => ({
 const clearIndicatorStyles = () => base => ({
   ...base,
   display: 'flex',
+  padding: 0,
 });
 
 const menuListStyles = () => base => ({
@@ -192,6 +192,8 @@ const containerStyles = () => (base, state) => ({
 
 const indicatorsContainerStyles = () => () => ({
   background: 'none',
+  display: 'flex',
+  alignItems: 'baseline',
 });
 
 export default props => ({

--- a/src/components/internals/dropdown-indicator/dropdown-indicator.js
+++ b/src/components/internals/dropdown-indicator/dropdown-indicator.js
@@ -6,7 +6,7 @@ import { CaretDownIcon } from '../../icons';
 const DropdownIndicator = props => (
   <components.DropdownIndicator {...props}>
     {/* FIXME: add proper tone when tones are refactored */}
-    <CaretDownIcon theme={props.isDisabled && 'grey'} size="small" />
+    <CaretDownIcon theme={props.isDisabled && 'grey'} size="medium" />
   </components.DropdownIndicator>
 );
 


### PR DESCRIPTION
Fixes alignment of indicator icons in `SelectInput`, `CreatableSelectInput`, `AsyncSelectInput` & `AsyncCreatableSelectInput`  after it broke in #182.

Before
![bildschirmfoto 2018-10-26 um 15 11 50](https://user-images.githubusercontent.com/1765075/47568680-06c58400-d932-11e8-8129-9fe0b431faa0.png)

After
![bildschirmfoto 2018-10-26 um 15 12 44](https://user-images.githubusercontent.com/1765075/47568683-09c07480-d932-11e8-89ff-40d4677581d1.png)

I also changed both icons to have size `medium`. Previously one was `small` and the other was `medium`.