### PR TITLE
feat(typography): add `title` prop to all typography components

### DIFF
--- a/src/components/typography/text/README.md
+++ b/src/components/typography/text/README.md
@@ -24,6 +24,7 @@ Wraps the given text in the given HTML header `size`.
 | ------------- | ---------------- | :------: | -------------------- | ------- | -------------------------------------------------------------- |
 | `elementType` | `String`         |    ✅    | `['h1', 'h2', 'h3']` | -       | -                                                              |
 | `children`    | `PropTypes.node` |    ✅    | -                    | -       | -                                                              |
+| `title`       | `String`         |    -     | -                    | -       | Text to show in a tooltip on hover over the element            |
 | `truncate`    | `Bool`           |    -     | -                    | `false` | Option for truncate content in case the screen has small width |
 
 #### Where to use
@@ -47,6 +48,7 @@ Wraps the given text in the given HTML header `size`.
 | `elementType` | `String`         |    ✅    | `['h4', 'h5']` | -       |
 | `isBold`      | `Boolean`        |    -     | -              | `false` |
 | `children`    | `PropTypes.node` |    ✅    | -              | -       |
+| `title`       | `String`         |    -     | -              | -       |
 | `truncate`    | `Bool`           |    -     | -              | `false` |
 
 #### Where to use
@@ -85,6 +87,7 @@ Wraps the given text in a `<p>` element, for normal content.
 | `isItalic` | `Boolean`        |    -     | -                                                  | `false` |
 | `tone`     | `String`         |    -     | `['primary', 'secondary', 'positive', 'negative']` | -       |
 | `children` | `PropTypes.node` |    ✅    | -                                                  | -       |
+| `title`    | `String`         |    -     | -                                                  | -       |
 | `truncate` | `Bool`           |    -     | -                                                  | `false` |
 
 #### Where to use
@@ -111,6 +114,7 @@ properly style the text.
 | `isItalic` | `Boolean`        |    -     | -                                                                          | `false` |
 | `tone`     | `String`         |    -     | `['primary', 'secondary', 'positive', 'negative', 'inverted', 'warning'']` | -       |
 | `children` | `PropTypes.node` |    ✅    | -                                                                          | -       |
+| `title`    | `String`         |    -     | -                                                                          | -       |
 | `truncate` | `Bool`           |    -     | -                                                                          | `false` |
 
 #### Where to use

--- a/src/components/typography/text/text.js
+++ b/src/components/typography/text/text.js
@@ -3,6 +3,15 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import styles from './text.mod.css';
 
+const nonEmptyString = (props, propName, componentName) => {
+  const value = props[propName];
+  if (typeof value === 'string' && !value)
+    return new Error(
+      `Invalid prop '${propName}' supplied to '${componentName}'. Expected it to be nonempty string, but it was empty.`
+    );
+  return null;
+};
+
 const Headline = props => {
   const HeadlineElement = props.elementType;
   return (
@@ -20,7 +29,7 @@ Headline.displayName = 'TextHeadline';
 Headline.propTypes = {
   elementType: PropTypes.oneOf(['h1', 'h2', 'h3']).isRequired,
   children: PropTypes.node.isRequired,
-  title: PropTypes.string,
+  title: nonEmptyString,
   truncate: PropTypes.bool,
 };
 
@@ -51,7 +60,7 @@ Subheadline.propTypes = {
     'negative',
   ]),
   children: PropTypes.node.isRequired,
-  title: PropTypes.string,
+  title: nonEmptyString,
   truncate: PropTypes.bool,
 };
 
@@ -63,7 +72,7 @@ const Wrap = props => (
 Wrap.displayName = 'TextWrap';
 Wrap.propTypes = {
   children: PropTypes.node.isRequired,
-  title: PropTypes.string,
+  title: nonEmptyString,
 };
 
 const Body = props =>
@@ -106,7 +115,7 @@ Body.propTypes = {
     'inverted',
   ]),
   children: PropTypes.node.isRequired,
-  title: PropTypes.string,
+  title: nonEmptyString,
   truncate: PropTypes.bool,
 };
 
@@ -138,7 +147,7 @@ Detail.propTypes = {
     'warning',
   ]),
   children: PropTypes.node.isRequired,
-  title: PropTypes.string,
+  title: nonEmptyString,
   truncate: PropTypes.bool,
 };
 

--- a/src/components/typography/text/text.js
+++ b/src/components/typography/text/text.js
@@ -10,6 +10,7 @@ const Headline = props => {
       className={classnames({
         [styles.truncate]: props.truncate,
       })}
+      title={props.title}
     >
       {props.children}
     </HeadlineElement>
@@ -19,6 +20,7 @@ Headline.displayName = 'TextHeadline';
 Headline.propTypes = {
   elementType: PropTypes.oneOf(['h1', 'h2', 'h3']).isRequired,
   children: PropTypes.node.isRequired,
+  title: PropTypes.string,
   truncate: PropTypes.bool,
 };
 
@@ -31,6 +33,7 @@ const Subheadline = props => {
         [styles[`${props.tone}`]]: props.tone,
         [styles.truncate]: props.truncate,
       })}
+      title={props.title}
     >
       {props.children}
     </SubheadlineElement>
@@ -48,13 +51,19 @@ Subheadline.propTypes = {
     'negative',
   ]),
   children: PropTypes.node.isRequired,
+  title: PropTypes.string,
   truncate: PropTypes.bool,
 };
 
-const Wrap = props => <div className={styles.wrap}>{props.children}</div>;
+const Wrap = props => (
+  <div className={styles.wrap} title={props.title}>
+    {props.children}
+  </div>
+);
 Wrap.displayName = 'TextWrap';
 Wrap.propTypes = {
   children: PropTypes.node.isRequired,
+  title: PropTypes.string,
 };
 
 const Body = props =>
@@ -66,6 +75,7 @@ const Body = props =>
         [styles[`${props.tone}`]]: props.tone,
         [styles.truncate]: props.truncate,
       })}
+      title={props.title}
     >
       {props.children}
     </span>
@@ -77,6 +87,7 @@ const Body = props =>
         [styles[`${props.tone}`]]: props.tone,
         [styles.truncate]: props.truncate,
       })}
+      title={props.title}
     >
       {props.children}
     </p>
@@ -95,6 +106,7 @@ Body.propTypes = {
     'inverted',
   ]),
   children: PropTypes.node.isRequired,
+  title: PropTypes.string,
   truncate: PropTypes.bool,
 };
 
@@ -107,6 +119,7 @@ const Detail = props => (
       [styles[`${props.tone}`]]: props.tone,
       [styles.truncate]: props.truncate,
     })}
+    title={props.title}
   >
     {props.children}
   </small>
@@ -125,6 +138,7 @@ Detail.propTypes = {
     'warning',
   ]),
   children: PropTypes.node.isRequired,
+  title: PropTypes.string,
   truncate: PropTypes.bool,
 };
 

--- a/src/components/typography/text/text.spec.js
+++ b/src/components/typography/text/text.spec.js
@@ -43,7 +43,7 @@ describe('<Headline>', () => {
     expect(wrapper.text()).toMatch('Title');
   });
   it('should has `title` prop', () => {
-    expect(wrapper.prop('title')).toBe('tooltip text');
+    expect(wrapper).toHaveProp('title', 'tooltip text');
   });
 
   describe('with truncated text', () => {
@@ -120,7 +120,7 @@ describe('<Subheadline>', () => {
       expect(wrapper).toContainClass(styles.primary);
     });
     it('should has `title` prop', () => {
-      expect(wrapper.prop('title')).toBe('tooltip text');
+      expect(wrapper).toHaveProp('title', 'tooltip text');
     });
   });
   describe('with truncated text', () => {
@@ -154,7 +154,7 @@ describe('<Wrap>', () => {
     expect(wrapper.text()).toMatch('Title');
   });
   it('should has `title` prop', () => {
-    expect(wrapper.prop('title')).toBe('tooltip text');
+    expect(wrapper).toHaveProp('title', 'tooltip text');
   });
 });
 
@@ -222,7 +222,7 @@ describe('<Body>', () => {
         );
       });
       it('should has `title` prop', () => {
-        expect(wrapper.prop('title')).toBe('tooltip text');
+        expect(wrapper).toHaveProp('title', 'tooltip text');
       });
     });
     describe('with truncated text', () => {
@@ -424,7 +424,7 @@ describe('<Detail>', () => {
         );
       });
       it('should has `title` prop', () => {
-        expect(wrapper.prop('title')).toBe('tooltip text');
+        expect(wrapper).toHaveProp('title', 'tooltip text');
       });
     });
 

--- a/src/components/typography/text/text.spec.js
+++ b/src/components/typography/text/text.spec.js
@@ -28,7 +28,9 @@ describe('<Headline>', () => {
   let wrapper;
   beforeEach(() => {
     wrapper = shallow(
-      <Text.Headline elementType="h1">{'Title'}</Text.Headline>
+      <Text.Headline elementType="h1" title="tooltip text">
+        {'Title'}
+      </Text.Headline>
     );
   });
   it('should render element tag h1', () => {
@@ -39,6 +41,9 @@ describe('<Headline>', () => {
   });
   it('should render given text', () => {
     expect(wrapper.text()).toMatch('Title');
+  });
+  it('should has `title` prop', () => {
+    expect(wrapper.prop('title')).toBe('tooltip text');
   });
 
   describe('with truncated text', () => {
@@ -92,7 +97,12 @@ describe('<Subheadline>', () => {
   describe('with tone', () => {
     beforeEach(() => {
       wrapper = shallow(
-        <Text.Subheadline elementType="h4" isBold={true} tone="primary">
+        <Text.Subheadline
+          elementType="h4"
+          isBold={true}
+          tone="primary"
+          title="tooltip text"
+        >
           {'Subtitle'}
         </Text.Subheadline>
       );
@@ -108,6 +118,9 @@ describe('<Subheadline>', () => {
     });
     it('should have "primary" class', () => {
       expect(wrapper).toContainClass(styles.primary);
+    });
+    it('should has `title` prop', () => {
+      expect(wrapper.prop('title')).toBe('tooltip text');
     });
   });
   describe('with truncated text', () => {
@@ -132,13 +145,16 @@ describe('<Subheadline>', () => {
 describe('<Wrap>', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = shallow(<Text.Wrap>{'Title'}</Text.Wrap>);
+    wrapper = shallow(<Text.Wrap title={'tooltip text'}>{'Title'}</Text.Wrap>);
   });
   it('should have "wrap" class', () => {
     expect(wrapper).toContainClass(styles.wrap);
   });
   it('should render given text', () => {
     expect(wrapper.text()).toMatch('Title');
+  });
+  it('should has `title` prop', () => {
+    expect(wrapper.prop('title')).toBe('tooltip text');
   });
 });
 
@@ -197,6 +213,16 @@ describe('<Body>', () => {
       });
       it('should render given text', () => {
         expect(wrapper).toHaveText('Detail');
+      });
+    });
+    describe('with title', () => {
+      beforeEach(() => {
+        wrapper = shallow(
+          <Text.Body title="tooltip text">{'Detail'}</Text.Body>
+        );
+      });
+      it('should has `title` prop', () => {
+        expect(wrapper.prop('title')).toBe('tooltip text');
       });
     });
     describe('with truncated text', () => {
@@ -386,6 +412,19 @@ describe('<Detail>', () => {
       });
       it('should render given text', () => {
         expect(wrapper).toHaveText('Detail');
+      });
+    });
+
+    describe('with title', () => {
+      beforeEach(() => {
+        wrapper = shallow(
+          <Text.Detail isInline={true} title="tooltip text">
+            {'Detail'}
+          </Text.Detail>
+        );
+      });
+      it('should has `title` prop', () => {
+        expect(wrapper.prop('title')).toBe('tooltip text');
       });
     });
 

--- a/src/components/typography/typography.story.js
+++ b/src/components/typography/typography.story.js
@@ -19,6 +19,7 @@ storiesOf('Typography/Text', module)
     <Section>
       <Text.Headline
         elementType={select('Element type', ['h1', 'h2', 'h3'], 'h1')}
+        title={text('title', 'Text to be shown as tooltip on hover')}
         truncate={boolean('truncate', false)}
       >
         {text('Text', 'Sample text Headline')}
@@ -38,6 +39,7 @@ storiesOf('Typography/Text', module)
           'positive',
           'negative',
         ])}
+        title={text('title', 'Text to be shown as tooltip on hover')}
         truncate={boolean('truncate', false)}
       >
         {text('Text', 'Sample text Subheadline')}
@@ -47,7 +49,9 @@ storiesOf('Typography/Text', module)
   .add('Wrap', () => (
     <Section>
       <InlineColorWrapper width={'200px'}>
-        <Text.Wrap>
+        <Text.Wrap
+          title={text('title', 'Text to be shown as tooltip on hover')}
+        >
           {text(
             'Text',
             'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
@@ -71,6 +75,7 @@ storiesOf('Typography/Text', module)
           'negative',
           'inverted',
         ])}
+        title={text('title', 'Text to be shown as tooltip on hover')}
         truncate={boolean('truncate', false)}
       >
         {text('Text', 'Sample text Body')}
@@ -92,6 +97,7 @@ storiesOf('Typography/Text', module)
           'negative',
           'warning',
         ])}
+        title={text('title', 'Text to be shown as tooltip on hover')}
         truncate={boolean('truncate', false)}
       >
         {text('Text', 'Sample text Detail')}


### PR DESCRIPTION

![tooltip](https://user-images.githubusercontent.com/1228431/47569216-5d7f8d80-d933-11e8-9a42-054e95c4c327.gif)


`Text.*` components provides a way to truncate long texts by setting `truncate` prop to true. And when using this feature it's a very common scenario to show full version of truncated text in a tooltip on hover. Which leads to code like this all around the place:

```js
<div titile={longText}>
  <Text.Detail truncate>{longText}</Text.Detail>
</div>
```

I suggest to add `tooltip` prop to all the `Text` component to prevent adding unnecessary markup elements. So that example above would look like:

```js
<Text.Detail truncate title={longText}>{longText}</Text.Detail>
```

The only thing I am not sure about is whether it worth adding `title` prop to `Text.Wrap` component, as it not provide truncation behaviour. But I added it to make API across all the `Text.*` components consistent. 