### PR TITLE
Add bundle tests setup

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -58,16 +58,20 @@ rules:
           'componentDidUpdate',
         ]
     'function-paren-newline': 0
+    # ui-kit is a mapped module in bundle tests, so it will not be found
+    # settting ignorePackages will disable the extension warning for it.
     'import/extensions': [
       'error',
-      'always',
+      'ignorePackages',
       {
         js: 'never',
       },
     ]
     'import/no-extraneous-dependencies': 0
     'import/no-named-as-default': 0
-    'import/no-unresolved': 0
+    # ui-kit is a mapped module in bundle tests, so it will not be found
+    # We exclude it from the checks
+    'import/no-unresolved': [2, { ignore: ['^ui-kit$'] }]
     'import/first': 0
     'import/order': 2
     'no-restricted-globals': ['error', 'find', 'name', 'location']

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ cache:
     - node_modules
 
 script:
+  # the jest.bundle.config.js tests run on the bundle,
+  # so we need to build it first
+  - yarn build
   - yarn run jest --projects jest.*.config.js --maxWorkers=4 --reporters jest-silent-reporter
   - "! test -f fail-tests-because-there-was-an-unhandled-rejection.lock"
 

--- a/jest.bundle.config.js
+++ b/jest.bundle.config.js
@@ -1,5 +1,32 @@
 // Resolve the absolute path of the caller location.
 const rootPath = process.cwd();
+const fs = require('fs');
+
+// Ensure UI Kit build (ui-kit.esm.js) exists
+// and warn in case it is old.
+const info = (() => {
+  try {
+    return fs.statSync('./dist/ui-kit.esm.js');
+  } catch (e) {
+    return null;
+  }
+})();
+const twoMinutesAgo = Date.now() - 2 * 60 * 1000;
+if (!info) {
+  // We can only test ui-kit when it was built first
+  // eslint-disable-next-line no-console
+  console.info(
+    '\x1b[33m%s\x1b[0m', // log in yellow
+    '⚠️  You need to run "yarn build" or "yarn build:watch" before starting the bundle tests!'
+  );
+  process.exit(1);
+} else if (info.mtime < twoMinutesAgo) {
+  // eslint-disable-next-line no-console
+  console.info(
+    '\x1b[33m%s\x1b[0m', // log in yellow
+    "⏳  The ui-kit build is more than two minutes old! Are you sure you're testing the latest version?"
+  );
+}
 
 module.exports = {
   displayName: 'bundle',

--- a/jest.bundle.config.js
+++ b/jest.bundle.config.js
@@ -1,0 +1,27 @@
+// Resolve the absolute path of the caller location.
+const rootPath = process.cwd();
+
+module.exports = {
+  displayName: 'bundle',
+  globals: { 'process.env': { NODE_ENV: 'test' } },
+  moduleDirectories: ['src', 'node_modules'],
+  moduleNameMapper: {
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+      '<rootDir>/test/transform-file.js',
+    '\\.css$': 'identity-obj-proxy',
+  },
+  rootDir: rootPath,
+  setupFiles: [
+    'raf/polyfill',
+    '<rootDir>/test/setup-tests.js',
+    'jest-localstorage-mock',
+  ],
+  testEnvironment: 'jsdom',
+  testURL: 'https://mc.commercetools.com/',
+  testPathIgnorePatterns: ['node_modules'],
+  testRegex: '\\.bundlespec\\.js$',
+  transform: {
+    '^.+\\.js$': '<rootDir>/test/transform-babel-jest.js',
+  },
+  watchPlugins: ['jest-plugin-filename', 'jest-watch-master'],
+};

--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
     "format:css": "prettier --write --parser css '**/*.css'",
     "format:md": "prettier --write --parser markdown '**/*.md'",
     "test": "jest --config jest.test.config.js",
-    "test:watch": "jest --config jest.test.config.js --watch"
+    "test:watch": "jest --config jest.test.config.js --watch",
+    "test:bundle": "jest --config jest.bundle.config.js",
+    "test:bundle:watch": "jest --config jest.bundle.config.js --watch"
   },
   "dependencies": {
     "classnames": "2.2.6",
@@ -106,6 +108,7 @@
     "babel-jest": "23.6.0",
     "babel-loader": "8.0.4",
     "babel-plugin-emotion": "9.2.11",
+    "babel-plugin-module-rewrite": "0.2.0",
     "babel-plugin-react-intl": "3.0.1",
     "babel-plugin-transform-dynamic-import": "2.1.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.19",

--- a/src/index.bundlespec.js
+++ b/src/index.bundlespec.js
@@ -4,7 +4,16 @@ describe('exports', () => {
   it('should export i18n for three languages', () => {
     expect(Object.keys(i18n)).toEqual(['en', 'de', 'es']);
   });
+
   it('should export custom-properties', () => {
     expect(customProperties).toBeTruthy();
+  });
+
+  it('should have the translations', () => {
+    // This test ensures some translations exist, assuming the others would
+    // work as well then
+    expect(i18n.en['UIKit.DateInput.labelRange']).toEqual('to');
+    expect(i18n.de['UIKit.DateInput.labelRange']).toEqual('bis');
+    expect(i18n.es['UIKit.DateInput.labelRange']).toEqual('hasta');
   });
 });

--- a/src/index.bundlespec.js
+++ b/src/index.bundlespec.js
@@ -1,5 +1,4 @@
 import { i18n, customProperties } from 'ui-kit';
-// import { i18n, customProperties } from '..';
 
 describe('exports', () => {
   it('should export i18n for three languages', () => {

--- a/src/index.bundlespec.js
+++ b/src/index.bundlespec.js
@@ -1,0 +1,11 @@
+import { i18n, customProperties } from 'ui-kit';
+// import { i18n, customProperties } from '..';
+
+describe('exports', () => {
+  it('should export i18n for three languages', () => {
+    expect(Object.keys(i18n)).toEqual(['en', 'de', 'es']);
+  });
+  it('should export custom-properties', () => {
+    expect(customProperties).toBeTruthy();
+  });
+});

--- a/test/replace-module-paths.js
+++ b/test/replace-module-paths.js
@@ -1,6 +1,12 @@
 const path = require('path');
 
 module.exports = function replaceImport(originalPath, callingFileName) {
+  // This replacement rewrites imports of ui-kit to an import using a relative
+  // path pointing at the root folder.
+  // This allows to import from the bundled ui-kit using
+  //   import { PrimaryButton } from 'ui-kit'
+  // instead of
+  //   import { PrimaryButton } from '../../..'
   if (originalPath === 'ui-kit' && callingFileName.endsWith('.bundlespec.js')) {
     const fromPath = path.dirname(callingFileName);
     const toPath = process.cwd();

--- a/test/replace-module-paths.js
+++ b/test/replace-module-paths.js
@@ -1,0 +1,11 @@
+const path = require('path');
+
+module.exports = function replaceImport(originalPath, callingFileName) {
+  if (originalPath === 'ui-kit' && callingFileName.endsWith('.bundlespec.js')) {
+    const fromPath = path.dirname(callingFileName);
+    const toPath = process.cwd();
+    const relativePath = path.relative(fromPath, toPath);
+    return relativePath;
+  }
+  return originalPath;
+};

--- a/test/transform-babel-jest.js
+++ b/test/transform-babel-jest.js
@@ -5,7 +5,11 @@ const mcAppBabelConfig = getBabelPreset();
 
 const jestBabelConfig = {
   ...mcAppBabelConfig,
-  plugins: [...mcAppBabelConfig.plugins, ...jestBabelPreset.plugins],
+  plugins: [
+    ...mcAppBabelConfig.plugins,
+    ...jestBabelPreset.plugins,
+    ['module-rewrite', { replaceFunc: './test/replace-module-paths.js' }],
+  ],
 };
 
 module.exports = require('babel-jest').createTransformer(jestBabelConfig);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2570,6 +2570,11 @@ babel-plugin-minify-type-constructors@^0.4.3:
   dependencies:
     babel-helper-is-void-0 "^0.4.3"
 
+babel-plugin-module-rewrite@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-rewrite/-/babel-plugin-module-rewrite-0.2.0.tgz#5d7e6c31e3bad6ce3a0ef723983af245b96fdc84"
+  integrity sha1-XX5sMeO61s46DvcjmDryRblv3IQ=
+
 babel-plugin-react-docgen@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-docgen/-/babel-plugin-react-docgen-2.0.0.tgz#039d90f5a1a37131c8cc3015017eecafa8d78882"


### PR DESCRIPTION
So far it was not possible to test the produced ui-kit bundle. This left us blind when errors happened within the bundling process (e.g. when updating the rollup config).

This PR adds a way to test the produced `dist/ui-kit.esm.js` bundle.

There are now two types of tests, which can both be placed anywhere in the code-base:
- `*.spec.js`: The regular tests for the sources
- `*.bundlespec.js`: Tests for the produced bundle

### `*.spec.js`

- These tests use Jest to transpile the source code of the file-under-test
- It is possible to mock other source files in these tests
- These tests can not catch errors in the build process
- These tests can not test the final bundle

### `*.bundlespec.js`

- These tests use the produced final bundle (they don't need transpilation on modern envs)
- It is **not** possible to mock parts of ui-kit
- These tests can catch errors in the build process
- These tests can only test the final bundle
- These tests **may not** import source files

### Future

This is the basic setup for testing the produced bundle. I'll open a PR which adds Visual Regression Testing (VRT) on top of this setup soon. VRT will also run on top of the produced bundle.

Relates to #187 