### PR TITLE
Money Input Fixes

### DIFF
--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -338,14 +338,16 @@ export default class MoneyInput extends React.Component {
     // value to a number, as we want to keep a string!
     // The fake event does not contain the input type information, so Formik
     // will not convert the value to a number.
-    const fakeEvent = {
-      persist: () => {},
-      target: {
-        name: event.target.name,
-        value: event.target.value,
-      },
-    };
-    this.props.onChange(fakeEvent);
+    if (isNumberish(event.target.value)) {
+      const fakeEvent = {
+        persist: () => {},
+        target: {
+          name: event.target.name,
+          value: event.target.value,
+        },
+      };
+      this.props.onChange(fakeEvent);
+    }
   };
 
   handleAmountBlur = () => {
@@ -429,7 +431,7 @@ export default class MoneyInput extends React.Component {
             ref={this.amountInputRef}
             id={MoneyInput.getAmountInputId(this.props.id)}
             name={getAmountInputName(this.props.name)}
-            type="number"
+            type="text"
             value={this.props.value.amount}
             className={getAmountStyles({
               isDisabled: this.props.isDisabled,

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -356,19 +356,8 @@ export default class MoneyInput extends React.Component {
   };
 
   handleAmountChange = event => {
-    // We need to emit a fake event to stop Formik from auto-converting the
-    // value to a number, as we want to keep a string!
-    // The fake event does not contain the input type information, so Formik
-    // will not convert the value to a number.
     if (isNumberish(event.target.value)) {
-      const fakeEvent = {
-        persist: () => {},
-        target: {
-          name: event.target.name,
-          value: event.target.value,
-        },
-      };
-      this.props.onChange(fakeEvent);
+      this.props.onChange(event);
     }
   };
 

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -377,8 +377,7 @@ export default class MoneyInput extends React.Component {
       // When the user entered a value with centPrecision, we can format
       // the resulting value to that currency, e.g. 20.1 to 20.10
       if (String(formattedAmount) !== amount) {
-        // We need to emit a fake event to stop Formik from auto-converting the
-        // value to a number, as we want to keep a string!
+        // We need to emit an event with the now formatted value
         const fakeEvent = {
           persist: () => {},
           target: {

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -19,7 +19,7 @@ const createCurrencySelectStyles = ({
   hasError,
   hasNoCurrencies,
   isDisabled,
-  inputHasFocus,
+  hasFocus,
 }) => {
   const selectStyles = createSelectStyles({ hasWarning, hasError });
   return {
@@ -34,14 +34,14 @@ const createCurrencySelectStyles = ({
         if (isDisabled) vars['--token-border-color-input-disabled'];
         else if (hasError) vars['--token-border-color-input-error'];
         else if (hasWarning) vars['--token-border-color-input-warning'];
-        else if (inputHasFocus) vars['--token-border-color-input-focus'];
+        else if (hasFocus) vars['--token-border-color-input-focus'];
         else vars['--token-border-color-input-pristine'];
       },
       '&:hover': do {
         if (isDisabled) vars['--token-border-color-input-disabled'];
         else if (hasError) vars['--token-border-color-input-error'];
         else if (hasWarning) vars['--token-border-color-input-warning'];
-        else if (inputHasFocus) vars['--token-border-color-input-focus'];
+        else if (hasFocus) vars['--token-border-color-input-focus'];
         else vars['--token-border-color-input-pristine'];
       },
     }),
@@ -360,9 +360,7 @@ export default class MoneyInput extends React.Component {
 
   handleAmountBlur = () => {
     const amount = this.props.value.amount.trim();
-    this.setState({
-      amountHasFocus: false,
-    });
+    this.setState({ amountHasFocus: false });
     // Skip formatting for empty value or when the input is used with an
     // unknown currency.
     if (amount.length > 0 && currencies[this.props.value.currencyCode]) {
@@ -392,15 +390,14 @@ export default class MoneyInput extends React.Component {
   render() {
     const hasNoCurrencies = this.props.currencies.length === 0;
     const hasWarning = this.props.hasCurrencyWarning;
-    const inputHasFocus =
-      this.state.currencyHasFocus || this.state.amountHasFocus;
+    const hasFocus = this.state.currencyHasFocus || this.state.amountHasFocus;
 
     const currencySelectStyles = createCurrencySelectStyles({
       hasWarning,
       hasError: this.props.hasCurrencyError || this.props.hasError,
       hasNoCurrencies,
       isDisabled: this.props.isDisabled || hasNoCurrencies,
-      inputHasFocus,
+      hasFocus,
     });
     const options = this.props.currencies.map(currencyCode => ({
       label: currencyCode,
@@ -454,7 +451,7 @@ export default class MoneyInput extends React.Component {
               isDisabled: this.props.isDisabled,
               hasError: this.props.hasError,
               hasWarning: this.props.hasWarning,
-              hasFocus: inputHasFocus,
+              hasFocus,
             })}
             placeholder={this.props.placeholder}
             onChange={this.handleAmountChange}

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -13,7 +13,6 @@ import currencies from './currencies.json';
 import createSelectStyles from '../../internals/create-select-styles';
 import vars from '../../../../materials/custom-properties.json';
 
-console.log('token-font-color-error', vars['--token-font-color-error']);
 // overwrite styles of createSelectStyles
 const createCurrencySelectStyles = ({
   hasWarning,

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -13,6 +13,7 @@ import currencies from './currencies.json';
 import createSelectStyles from '../../internals/create-select-styles';
 import vars from '../../../../materials/custom-properties.json';
 
+console.log('token-font-color-error', vars['--token-font-color-error']);
 // overwrite styles of createSelectStyles
 const createCurrencySelectStyles = ({
   hasWarning,
@@ -31,6 +32,11 @@ const createCurrencySelectStyles = ({
     }),
     singleValue: base => ({
       ...base,
+      marginLeft: '0',
+      marginRight: '0',
+      maxWidth: '100%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)',
       color: do {
         if (hasError) vars['--token-font-color-error'];
         else if (hasWarning) vars['--token-font-color-warning'];

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -29,7 +29,7 @@ const createCurrencySelectStyles = ({
       borderTopRightRadius: '0',
       borderBottomRightRadius: '0',
       borderRight: '0',
-      width: '72px',
+      minWidth: '72px',
       borderColor: do {
         if (isDisabled) vars['--token-border-color-input-disabled'];
         else if (hasError) vars['--token-border-color-input-error'];
@@ -47,11 +47,8 @@ const createCurrencySelectStyles = ({
     }),
     singleValue: base => ({
       ...base,
-      marginLeft: '0',
-      marginRight: '0',
-      maxWidth: '100%',
-      left: '50%',
-      transform: 'translate(-50%, -50%)',
+      marginLeft: 0,
+      maxWidth: 'initial',
       color: do {
         if (hasError) vars['--token-font-color-error'];
         else if (hasWarning) vars['--token-font-color-warning'];

--- a/src/components/inputs/money-input/money-input.mod.css
+++ b/src/components/inputs/money-input/money-input.mod.css
@@ -23,6 +23,7 @@
   outline: none;
   box-shadow: none;
   appearance: none;
+  margin-left: 0;
 }
 
 .amountInput::placeholder {

--- a/src/components/inputs/money-input/money-input.mod.css
+++ b/src/components/inputs/money-input/money-input.mod.css
@@ -59,6 +59,13 @@
   border-color: var(--token-border-color-input-error);
 }
 
+.amount-focus {
+  composes: amountInput;
+  border-color: var(--token-border-color-input-focus);
+  background: var(--token-background-color-input-pristine);
+  color: var(--token-font-color-default);
+}
+
 .amount-default:active,
 .amount-default:focus {
   border-color: var(--token-border-color-input-focus);

--- a/src/components/inputs/money-input/money-input.spec.js
+++ b/src/components/inputs/money-input/money-input.spec.js
@@ -327,11 +327,6 @@ describe('MoneyInput', () => {
     expect(getByLabelText('Amount')).toHaveAttribute('data-foo', 'bar');
   });
 
-  it('should render a text input', () => {
-    const { getByLabelText } = render(<TestComponent />);
-    expect(getByLabelText('Amount')).toHaveAttribute('type', 'text');
-  });
-
   it('should have an HTML name based on the passed name', () => {
     const { getByLabelText } = render(<TestComponent name="foo" />);
     expect(getByLabelText('Amount')).toHaveAttribute('name', 'foo.amount');

--- a/src/components/inputs/money-input/money-input.spec.js
+++ b/src/components/inputs/money-input/money-input.spec.js
@@ -327,9 +327,9 @@ describe('MoneyInput', () => {
     expect(getByLabelText('Amount')).toHaveAttribute('data-foo', 'bar');
   });
 
-  it('should render a number input', () => {
+  it('should render a text input', () => {
     const { getByLabelText } = render(<TestComponent />);
-    expect(getByLabelText('Amount')).toHaveAttribute('type', 'number');
+    expect(getByLabelText('Amount')).toHaveAttribute('type', 'text');
   });
 
   it('should have an HTML name based on the passed name', () => {


### PR DESCRIPTION
#### Approach
A few CSS fixes to fix the problems `ellipses are shown for the currency code even for short currencies like EUR` and `inputs look different in Safari`.

However, due to Firefox limitations, it's not possible to have a correct format on blur functionality on firefox, as firefox number inputs don't allow extra zeros. So the input has been changed to type "text"

* Fixes #205 
* Fixes focus so that the input acts as one input with regards to focus and error states.