### PR TITLE
fix: remove root from media queries

### DIFF
--- a/materials/media-queries.mod.css
+++ b/materials/media-queries.mod.css
@@ -1,15 +1,13 @@
-:root {
-  /* MAX-WIDTH */
-  @custom-media --screen-max-mobile (width < 768px); /* xsm */
-  @custom-media --screen-max-desktop (width < 1024px); /* sm */
-  @custom-media --screen-max-biggerdesktop (width < 1280px); /* md */
-  @custom-media --screen-max-giantdesktop (width < 1680px); /* lg */
-  @custom-media --screen-max-jumbodesktop (width < 1920px); /* xlg */
+/* MAX-WIDTH */
+@custom-media --screen-max-mobile (width < 768px); /* xsm */
+@custom-media --screen-max-desktop (width < 1024px); /* sm */
+@custom-media --screen-max-biggerdesktop (width < 1280px); /* md */
+@custom-media --screen-max-giantdesktop (width < 1680px); /* lg */
+@custom-media --screen-max-jumbodesktop (width < 1920px); /* xlg */
 
-  /* MIN-WIDTH */
-  @custom-media --screen-min-mobile (width >= 768px); /* xsm */
-  @custom-media --screen-min-desktop (width >= 1024px); /* sm */
-  @custom-media --screen-min-biggerdesktop (width >= 1280px); /* md */
-  @custom-media --screen-min-giantdesktop (width >= 1680px); /* lg */
-  @custom-media --screen-min-jumbodesktop (width >= 1920px); /* xlg */
-}
+/* MIN-WIDTH */
+@custom-media --screen-min-mobile (width >= 768px); /* xsm */
+@custom-media --screen-min-desktop (width >= 1024px); /* sm */
+@custom-media --screen-min-biggerdesktop (width >= 1280px); /* md */
+@custom-media --screen-min-giantdesktop (width >= 1680px); /* lg */
+@custom-media --screen-min-jumbodesktop (width >= 1920px); /* xlg */


### PR DESCRIPTION
To make our media queries compatible with version 7 of postcss-custom-media.

After this is merged and released, we will update our webpack-config in `merchant-center-application-kit` to 

```js
postcssCustomMediaQueries({
  preserve: false,
  importFrom: [
    require.resolve(
      '@commercetools-frontend/ui-kit/materials/media-queries.mod.css'
    ),
  ],
}),
```

and update `postcss-custom-media` to version 7.0.6 (important), and remove the resolution for version 6 in the MC.

and then we can remove all of the @import's of media queries in the MC.