### PR TITLE
feat: add breakpoints to custom properties

### DIFF
--- a/materials/custom-properties.css
+++ b/materials/custom-properties.css
@@ -117,4 +117,9 @@
   --transition-linear-80ms: 80ms linear;
   --transition-easeinout-150ms: 150ms ease-in-out;
   --transition-standard: all 0.2s ease;
+  --break-point-mobile: 768px;
+  --break-point-desktop: 1024px;
+  --break-point-biggerdesktop: 1280px;
+  --break-point-giantdesktop: 1680px;
+  --break-point-jumbodesktop: 1920px;
 }

--- a/materials/custom-properties.json
+++ b/materials/custom-properties.json
@@ -105,5 +105,10 @@
   "--token-size-height-tag": "26px",
   "--transition-linear-80ms": "80ms linear",
   "--transition-easeinout-150ms": "150ms ease-in-out",
-  "--transition-standard": "all 0.2s ease"
+  "--transition-standard": "all 0.2s ease",
+  "--break-point-mobile": "768px",
+  "--break-point-desktop": "1024px",
+  "--break-point-biggerdesktop": "1280px",
+  "--break-point-giantdesktop": "1680px",
+  "--break-point-jumbodesktop": "1920px"
 }

--- a/materials/internals/breakpoints.mod.css
+++ b/materials/internals/breakpoints.mod.css
@@ -1,0 +1,7 @@
+:root {
+  --break-point-mobile: 768px;
+  --break-point-desktop: 1024px;
+  --break-point-biggerdesktop: 1280px;
+  --break-point-giantdesktop: 1680px;
+  --break-point-jumbodesktop: 1920px;
+}

--- a/materials/internals/index.css
+++ b/materials/internals/index.css
@@ -5,3 +5,4 @@
 @import './spacings.mod.css';
 @import './tokens/tokens.mod.css';
 @import './transitions.mod.css';
+@import './breakpoints.mod.css';


### PR DESCRIPTION
Expose __breakpoints__ in our custom properties, so consumers can use them to construct media queries.