### PR TITLE
feat: add MoneyInput value formatting

### DIFF
--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -1,15 +1,25 @@
 import React from 'react';
 import { render } from 'react-testing-library';
-import { IntlProvider } from 'react-intl';
+import { IntlProvider, addLocaleData } from 'react-intl';
+import en from 'react-intl/locale-data/en';
+import de from 'react-intl/locale-data/de';
+import es from 'react-intl/locale-data/es';
 import messages from '../i18n/core.json';
 
-const customRender = (node, ...options) =>
-  render(
-    <IntlProvider locale="en" messages={messages}>
+addLocaleData(en);
+addLocaleData(de);
+addLocaleData(es);
+
+const customRender = (node, opts = {}) => {
+  const { locale = 'en', ...options } = opts;
+
+  return render(
+    <IntlProvider locale={locale} messages={messages}>
       {node}
     </IntlProvider>,
-    ...options
+    options
   );
+};
 
 // re-export everything
 export * from 'react-testing-library';


### PR DESCRIPTION
Adds thousand-separator formatting to `MoneyInput`.

![money-format](https://user-images.githubusercontent.com/1765075/48277740-d579a780-e44b-11e8-9bd9-f3fca0b833c3.gif)

This is still missing tests and coordination with UX.

Makes it easier to read big amounts by adding thousand-separators.

Parsing
- Since most users are not careful about how they enter values, we will parse both `.` and `,`
- When a value is `1.000,00` we parse it as `1000`
- When a value is `1,000.00` we also parse it as `1000`
- This means the highest amount always wins
- We do this by checking comparing the last position of `.` and `,`. Whatever is later is used as the decimal separator

**Breaking change** The `MoneyInput.parseMoneyValue` now requires callers to pass a `locale` as the second argument, so that the value can be formatted according to the users locale initially.

Closes #215 