### PR TITLE
fix(money-input): avoid rounding errors

### DIFF
--- a/src/components/inputs/money-input/money-input.spec.js
+++ b/src/components/inputs/money-input/money-input.spec.js
@@ -152,6 +152,33 @@ describe('MoneyInput.convertToMoneyValue', () => {
     });
   });
 
+  describe('when called with a centPrecision price with weird JS rounding', () => {
+    it('should treat it as a decimal separator', () => {
+      expect(
+        MoneyInput.convertToMoneyValue({ currencyCode: 'EUR', amount: '2.49' })
+      ).toEqual({
+        type: 'centPrecision',
+        currencyCode: 'EUR',
+        centAmount: 249,
+        fractionDigits: 2,
+      });
+
+      // This test ensures that rounding is used instead of just cutting the
+      // number of. Cutting it of would result in an incorrect 239998.
+      expect(
+        MoneyInput.convertToMoneyValue({
+          currencyCode: 'EUR',
+          amount: '2399.99',
+        })
+      ).toEqual({
+        type: 'centPrecision',
+        currencyCode: 'EUR',
+        centAmount: 239999,
+        fractionDigits: 2,
+      });
+    });
+  });
+
   describe('when called with a high precision price', () => {
     it('should return a money value of type "highPrecision"', () => {
       expect(


### PR DESCRIPTION
When users selected the currency EUR (or any other with 2 fraction digits) and typed certain numbers like `2.49`, the `MoneyInput.convertToMoneyValue` would determine an incorrect `centAmount` due to rounding errors as @adnasa hinted at in https://github.com/commercetools/ui-kit/pull/221#issuecomment-437869330.

![screenshot showing rounding error](https://user-images.githubusercontent.com/462507/48348692-54582580-e682-11e8-8efc-550a0af2b3f0.png)

This PR fixes that by ensuring `centAmount` is an integer.