### PR TITLE
Add accepting `theme` in FieldLabel's  hintIcon

### DIFF
--- a/src/components/field-label/README.md
+++ b/src/components/field-label/README.md
@@ -30,6 +30,23 @@ import { FieldLabel } from '@commercetools-frontend/ui-kit';
 />
 ```
 
+The `hintIcon` also accepts a custom `theme` while defaulting to `orange` in the case above.
+
+```diff
+<FieldLabel
+  title={<FormattedMessage {...messages.title} />}
+  hasRequiredIndicator={true}
+  onInfoButtonClick={() => {}} />}
+  hint={<FormattedMessage {...messages.hint} />}
+- hintIcon={<WarningIcon />}
++ hintIcon={<WarningIcon theme="green" />}
+  description={<FormattedMessage {...messages.description} />}
+  badge={<FlatButton tone="primary" label="show" />}
+  htmlFor="sampleInput"
+  horizontalConstraint="m"
+/>
+```
+
 #### Properties
 
 | Props                  | Type               | Required | Values                             | Default | Description                                                                                                                                                                                                                                                           |

--- a/src/components/field-label/field-label.js
+++ b/src/components/field-label/field-label.js
@@ -41,7 +41,7 @@ export const FieldLabel = props => (
               {// FIXME: add proper tone when tones are refactored
               React.cloneElement(props.hintIcon, {
                 size: 'medium',
-                theme: 'orange',
+                theme: props.hintIcon.props.theme || 'orange',
               })}
             </span>
           )}

--- a/src/components/field-label/field-label.spec.js
+++ b/src/components/field-label/field-label.spec.js
@@ -114,6 +114,21 @@ describe('rendering', () => {
       it('should set the icon size', () => {
         expect(hintIconWrapper).toHaveProp('size', 'medium');
       });
+
+      describe('with custom theme', () => {
+        beforeEach(() => {
+          props = createTestProps({
+            hint: 'foo',
+            hintIcon: <WarningIcon theme="green" />,
+          });
+          wrapper = shallow(<FieldLabel {...props} />);
+          hintIconWrapper = wrapper.find(WarningIcon);
+        });
+
+        it('should set the icon theme', () => {
+          expect(hintIconWrapper).toHaveProp('theme', 'green');
+        });
+      });
     });
 
     describe('when hintIcon is not given', () => {


### PR DESCRIPTION
#### Summary

The `<FieldLabel />` used by all fields currently defaults/overwrites the `theme` to be orange in any case. We recently received designs requiring a custom theme (according to the icon's available themes). 

#### Description

Refactors the `<FieldLabel>` so that a custom `theme` can be passed without being overwritten.

```js
hintIcon={<WarningIcon theme="black" />}
```

will be accepted after this PR. We already have application level code passing (mostly black) which will just work after upgrading to this in the next version of UIKit.
