### PR TITLE
Fix form stories example (pass locale to parseMoneyValue)

### DIFF
--- a/examples/form-fields.story.js
+++ b/examples/form-fields.story.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
 import { Formik } from 'formik';
+import { injectIntl } from 'react-intl';
 import { action } from '@storybook/addon-actions';
 import omitEmpty from 'omit-empty';
 import withReadme from 'storybook-readme/with-readme';
@@ -74,7 +75,7 @@ class FakeConnector extends React.Component {
 // When the form needs to display additional information which is not
 // editable in the form, it has so far proven better to keep this information
 // out of the form values.
-const docToForm = doc => ({
+const docToForm = (doc, locale) => ({
   // Keeping the id in the form values ensures data is not mixed accidentally
   id: doc.id,
   // Why the version should be part of the form values:
@@ -109,7 +110,7 @@ const docToForm = doc => ({
   // amount filled out or set to empty strings. This reduces the cases we
   // need to deal with (amount, currencyCode or the whole object being
   // undefined).
-  price: MoneyField.parseMoneyValue(doc.price),
+  price: MoneyField.parseMoneyValue(doc.price, locale),
   status: doc.status,
 });
 
@@ -343,66 +344,68 @@ class ProductForm extends React.Component {
   }
 }
 
+const Story = injectIntl(props => (
+  <Section>
+    <FakeConnector>
+      {({ product, updateProduct }) => (
+        <Formik
+          initialValues={docToForm(product, props.intl.locale)}
+          validate={validate}
+          onSubmit={(formValues, formik) => {
+            action('values of form submission')(formValues);
+            const nextProduct = formToDoc(formValues);
+            // Usually, we would compute update actions here by comparing
+            // nextProduct to the product from FakeConnector.
+            // We would then use formValues.id and formValues.version
+            // to send the update action to the server through the connector
+            return updateProduct({
+              // As explained in the beginning of this document, sending
+              // the id and version from formValues along prevents
+              // accidental concurrent modifications and ensures the user
+              // will run into the ConcurrentModificationError int those
+              // cases
+              id: formValues.id,
+              version: formValues.version,
+              product: nextProduct,
+            }).then(
+              updatedProduct => {
+                // Calling resetForm with the updated product will
+                // update the form values and reset the submission state,
+                // touched keys and so on.
+                formik.resetForm(docToForm(updatedProduct, props.intl.locale));
+              },
+              error => {
+                // This is an example where we have to rely on the API
+                // on submission time to ensure correct form values.
+                // The example shows how to map API errors back onto
+                // specific fields within the form.
+                if (error.code === 'DuplicateKeyError') {
+                  formik.setErrors({ key: { duplicate: true } });
+                }
+                // Since we might do things like retrying a request in case
+                // there was an error with it, we are responsible for
+                // resetting the submission state.
+                formik.setSubmitting(false);
+              }
+            );
+          }}
+          render={formik => (
+            <Spacings.Stack scale="l">
+              <Text.Headline elementType="h2">The form</Text.Headline>
+              <div>
+                <ProductForm formik={formik} />
+              </div>
+              <hr />
+              <FormikBox formik={formik} />
+            </Spacings.Stack>
+          )}
+        />
+      )}
+    </FakeConnector>
+  </Section>
+));
+
 storiesOf('Examples|Forms/Fields', module)
   .addDecorator(withKnobs)
   .addDecorator(withReadme(Forms))
-  .add('Basic Formik Example', () => (
-    <Section>
-      <FakeConnector>
-        {({ product, updateProduct }) => (
-          <Formik
-            initialValues={docToForm(product)}
-            validate={validate}
-            onSubmit={(formValues, formik) => {
-              action('values of form submission')(formValues);
-              const nextProduct = formToDoc(formValues);
-              // Usually, we would compute update actions here by comparing
-              // nextProduct to the product from FakeConnector.
-              // We would then use formValues.id and formValues.version
-              // to send the update action to the server through the connector
-              return updateProduct({
-                // As explained in the beginning of this document, sending
-                // the id and version from formValues along prevents
-                // accidental concurrent modifications and ensures the user
-                // will run into the ConcurrentModificationError int those
-                // cases
-                id: formValues.id,
-                version: formValues.version,
-                product: nextProduct,
-              }).then(
-                updatedProduct => {
-                  // Calling resetForm with the updated product will
-                  // update the form values and reset the submission state,
-                  // touched keys and so on.
-                  formik.resetForm(docToForm(updatedProduct));
-                },
-                error => {
-                  // This is an example where we have to rely on the API
-                  // on submission time to ensure correct form values.
-                  // The example shows how to map API errors back onto
-                  // specific fields within the form.
-                  if (error.code === 'DuplicateKeyError') {
-                    formik.setErrors({ key: { duplicate: true } });
-                  }
-                  // Since we might do things like retrying a request in case
-                  // there was an error with it, we are responsible for
-                  // resetting the submission state.
-                  formik.setSubmitting(false);
-                }
-              );
-            }}
-            render={formik => (
-              <Spacings.Stack scale="l">
-                <Text.Headline elementType="h2">The form</Text.Headline>
-                <div>
-                  <ProductForm formik={formik} />
-                </div>
-                <hr />
-                <FormikBox formik={formik} />
-              </Spacings.Stack>
-            )}
-          />
-        )}
-      </FakeConnector>
-    </Section>
-  ));
+  .add('Basic Formik Example', () => <Story />);


### PR DESCRIPTION
We didn't pass `locale` to `parseMoneyValue` after adding it as a required param to `MoneyInput`.

Closes #234 