### PR TITLE
Release v3.0.0 & establish release practices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
+  tag: next
 
 # Keep it disabled until this issue is clarified
 # https://twitter.com/emmenko/status/1040544486101856256

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-<a name="2.0.0-rc.12"></a>
+<a name="3.0.0"></a>
 
-# [2.0.0-rc.12](https://github.com/commercetools/ui-kit/compare/2.0.0-rc.11...2.0.0) (2018-11-23)
+# [3.0.0](https://github.com/commercetools/ui-kit/compare/2.0.0-rc.11...3.0.0) (2018-11-23)
 
 ## BREAKING CHANGES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 - `MoneyInput`: `isTouched` only returns true when both fields were touched from now on. ([9e00148](https://github.com/commercetools/ui-kit/commit/9e00148)), closes [#175](https://github.com/commercetools/ui-kit/issues/175)
 - `media-queries`: need to be imported differently now [#218](https://github.com/commercetools/ui-kit/pull/218)
 
-* You need to explicitly add [our peer deep deps](https://github.com/commercetools/ui-kit/blob/20a9315/package.json#L210-L220) ([#156](https://github.com/commercetools/ui-kit/issues/156)) ([ae59216](https://github.com/commercetools/ui-kit/commit/ae59216))
-* We dropped some images which were hosted in ui-kit but didn't belong here ([#230](https://github.com/commercetools/ui-kit/issues/230)) ([3f3dadf](https://github.com/commercetools/ui-kit/commit/3f3dadf))
+* You need to explicitly add [our peer dependencies](https://github.com/commercetools/ui-kit/blob/20a9315/package.json#L210-L220) ([#156](https://github.com/commercetools/ui-kit/issues/156)) ([ae59216](https://github.com/commercetools/ui-kit/commit/ae59216))
+* We dropped some images which were hosted in ui-kit but didn't belong here ([#230](https://github.com/commercetools/ui-kit/issues/230)) ([3f3dadf](https://github.com/commercetools/ui-kit/commit/3f3dadf)) and moved them into another package [`@commercetools-frontend/assets`](https://www.npmjs.com/package/@commercetools-frontend/assets)
 * Consumers of ui-kit no longer need to `import '../materials/internals/reset.mod.css';` and `import '../materials/internals/grid.mod.css';` ([#186](https://github.com/commercetools/ui-kit/issues/186)) ([7a9e27b](https://github.com/commercetools/ui-kit/commit/7a9e27b))
 
 ## Bug Fixes
@@ -25,12 +25,12 @@
 
 ## Features
 
-- `ConnectorIcon`: added `ConnectorIcon`([#243](https://github.com/commercetools/ui-kit/issues/243)) ([36ef073](https://github.com/commercetools/ui-kit/commit/36ef073))
 - **Media Queries** are now exported as custom properties ([#220](https://github.com/commercetools/ui-kit/issues/220)) ([5073d2a](https://github.com/commercetools/ui-kit/commit/5073d2a))
 - `MoneyInput`: added thousand-separators ([#221](https://github.com/commercetools/ui-kit/issues/221)) ([6f58ca8](https://github.com/commercetools/ui-kit/commit/6f58ca8))
 - Our design tokens are now exported as css variables (custom properties) and as a json file (`materials/custom-properties.css` and `materials/custom-properties.json`) ([#181](https://github.com/commercetools/ui-kit/issues/181)) ([b7c4e85](https://github.com/commercetools/ui-kit/commit/b7c4e85))
 - `FieldLabel`: it's now possible to pass a `theme` for the `hintIcon` ([#231](https://github.com/commercetools/ui-kit/issues/231)) ([5ea305e](https://github.com/commercetools/ui-kit/commit/5ea305e))
-- **icons:** add several new icons ([#247](https://github.com/commercetools/ui-kit/issues/247)) ([67d1810](https://github.com/commercetools/ui-kit/commit/67d1810))
+- **icons:** add several new icons ([#247](https://github.com/commercetools/ui-kit/issues/247)) ([67d1810](https://github.com/commercetools/ui-kit/commit/67d1810)) ([#251](https://github.com/commercetools/ui-kit/pull/251))
+  - `ConnectedTriangleIcon`, `ConnectedSquareIcon`, `HeartIcon`, `PaperclipIcon`, `PluginIcon`, `RocketIcon`, `StarIcon`
 - `ContentNotification`: add new notification type ([#232](https://github.com/commercetools/ui-kit/issues/232)) ([46fb887](https://github.com/commercetools/ui-kit/commit/46fb887))
 - **typography:** add `title` prop to all typography components ([#191](https://github.com/commercetools/ui-kit/issues/191)) ([acb4e78](https://github.com/commercetools/ui-kit/commit/acb4e78))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-<a name="2.0.0"></a>
+<a name="2.0.0-rc.12"></a>
 
-# [2.0.0](https://github.com/commercetools/ui-kit/compare/2.0.0-rc.11...2.0.0) (2018-11-23)
+# [2.0.0-rc.12](https://github.com/commercetools/ui-kit/compare/2.0.0-rc.11...2.0.0) (2018-11-23)
 
 ## BREAKING CHANGES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+<a name="2.0.0"></a>
+
+# [2.0.0](https://github.com/commercetools/ui-kit/compare/2.0.0-rc.11...2.0.0) (2018-11-23)
+
+## BREAKING CHANGES
+
+- `MoneyInput`: dropped support for `hasAmountError`, `hasAmountWarning`, `hasCurrencyError` and `hasCurrencyWarning`. Use `hasError` and `hasWarning` instead. ([9e00148](https://github.com/commercetools/ui-kit/commit/9e00148)), closes [#175](https://github.com/commercetools/ui-kit/issues/175)
+- `MoneyInput`: `isTouched` only returns true when both fields were touched from now on. ([9e00148](https://github.com/commercetools/ui-kit/commit/9e00148)), closes [#175](https://github.com/commercetools/ui-kit/issues/175)
+- `media-queries`: need to be imported differently now [#218](https://github.com/commercetools/ui-kit/pull/218)
+
+* You need to explicitly add [our peer deep deps](https://github.com/commercetools/ui-kit/blob/20a9315/package.json#L210-L220) ([#156](https://github.com/commercetools/ui-kit/issues/156)) ([ae59216](https://github.com/commercetools/ui-kit/commit/ae59216))
+* We dropped some images which were hosted in ui-kit but didn't belong here ([#230](https://github.com/commercetools/ui-kit/issues/230)) ([3f3dadf](https://github.com/commercetools/ui-kit/commit/3f3dadf))
+* Consumers of ui-kit no longer need to `import '../materials/internals/reset.mod.css';` and `import '../materials/internals/grid.mod.css';` ([#186](https://github.com/commercetools/ui-kit/issues/186)) ([7a9e27b](https://github.com/commercetools/ui-kit/commit/7a9e27b))
+
+## Bug Fixes
+
+- `SelectInput`, `CreatableSelectInput`, `AsyncSelectInput`, `AsyncCreatableSelectInput`: align indicator icons properly ([#190](https://github.com/commercetools/ui-kit/issues/190)) ([b2f0141](https://github.com/commercetools/ui-kit/commit/b2f0141))
+- `MoneyInput`: Avoid rounding errors ([#229](https://github.com/commercetools/ui-kit/issues/229)) ([b92ede4](https://github.com/commercetools/ui-kit/commit/b92ede4))
+
+* `MoneyInput`: fix group style ([#188](https://github.com/commercetools/ui-kit/issues/188)) ([68430ab](https://github.com/commercetools/ui-kit/commit/68430ab))
+
+- `LocalizedTextField`: expose `LocalizedTextField` form main exports ([#233](https://github.com/commercetools/ui-kit/issues/233)) ([f04256d](https://github.com/commercetools/ui-kit/commit/f04256d))
+- styles: Remove `overflow: hidden` from body style ([#189](https://github.com/commercetools/ui-kit/issues/189)) ([a6b4b3b](https://github.com/commercetools/ui-kit/commit/a6b4b3b))
+- replace styled-components with react-emotion ([#184](https://github.com/commercetools/ui-kit/issues/184)) ([869a036](https://github.com/commercetools/ui-kit/commit/869a036))
+
+## Features
+
+- `ConnectorIcon`: added `ConnectorIcon`([#243](https://github.com/commercetools/ui-kit/issues/243)) ([36ef073](https://github.com/commercetools/ui-kit/commit/36ef073))
+- **Media Queries** are now exported as custom properties ([#220](https://github.com/commercetools/ui-kit/issues/220)) ([5073d2a](https://github.com/commercetools/ui-kit/commit/5073d2a))
+- `MoneyInput`: added thousand-separators ([#221](https://github.com/commercetools/ui-kit/issues/221)) ([6f58ca8](https://github.com/commercetools/ui-kit/commit/6f58ca8))
+- Our design tokens are now exported as css variables (custom properties) and as a json file (`materials/custom-properties.css` and `materials/custom-properties.json`) ([#181](https://github.com/commercetools/ui-kit/issues/181)) ([b7c4e85](https://github.com/commercetools/ui-kit/commit/b7c4e85))
+- `FieldLabel`: it's now possible to pass a `theme` for the `hintIcon` ([#231](https://github.com/commercetools/ui-kit/issues/231)) ([5ea305e](https://github.com/commercetools/ui-kit/commit/5ea305e))
+- **icons:** add several new icons ([#247](https://github.com/commercetools/ui-kit/issues/247)) ([67d1810](https://github.com/commercetools/ui-kit/commit/67d1810))
+- `ContentNotification`: add new notification type ([#232](https://github.com/commercetools/ui-kit/issues/232)) ([46fb887](https://github.com/commercetools/ui-kit/commit/46fb887))
+- **typography:** add `title` prop to all typography components ([#191](https://github.com/commercetools/ui-kit/issues/191)) ([acb4e78](https://github.com/commercetools/ui-kit/commit/acb4e78))
+
 <a name="2.0.0-rc.11"></a>
 
 # [2.0.0-rc.11](https://github.com/commercetools/ui-kit/compare/v2.0.0-rc.10...v2.0.0-rc.11) (2018-10-09)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ const green = customProperties['--color-green'];
 
 Available at https://uikit.commercetools.com.
 
-## Release
+## Releasing
 
 The release process is _semi-automated_: you only need to **manually** trigger it and [Travis][travis] will take care of the rest. All automated releases go the the `next` distribution channel. This gives us a chance to test releases out before making them offical by moving the `latest` dist-tag along.
 
@@ -113,13 +113,17 @@ The release process is _semi-automated_: you only need to **manually** trigger i
   - the tag name is the `version` string in the `package.json` plus the prefix `v`
 - push the tag: `git push --tags`
 
-From now on, [Travis][travis] will take over the release: build the bundles, publish to `npm` and update branch for the documentation website (see below).
+From that point, [Travis][travis] will take over the release: build the bundles, publish to `npm` and update branch for the documentation website (see below).
 
 ### Moving the `latest` dist-tag to a release:
 
-After testing the `next` release by upgrading an application, it's time to move the `latest` tag to make the release official. Use `npm dist-tag add @commercetools-frontend/ui-kit@<version> latest` to move the `latest` dist-tag onto that release.
+After testing the `next` release on a production project, it's time to move to the `latest` dist-tag to make the release official.
 
-## About release-candidates & alpha / beta versions
+```bash
+$ npm dist-tag add @commercetools-frontend/ui-kit@<version> latest
+```
+
+### About release-candidates & alpha / beta versions
 
 Having release candidates is not necesssary when using semantic releases:
 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ Available at https://uikit.commercetools.com.
 
 ## Release
 
-The release process is _semi-automated_: you only need to **manually** trigger it and [Travis][travis] will take care of the rest.
+The release process is _semi-automated_: you only need to **manually** trigger it and [Travis][travis] will take care of the rest. All automated releases go the the `next` distribution channel. This gives us a chance to test releases out before making them offical by moving the `latest` dist-tag along.
 
-The steps to prepare and trigger a release are as follows:
+### The steps to prepare and trigger a release to `next` are as follows:
 
 - ensure you are on the latest `master` branch
 - update the `CHANGELOG.md`
@@ -114,6 +114,18 @@ The steps to prepare and trigger a release are as follows:
 - push the tag: `git push --tags`
 
 From now on, [Travis][travis] will take over the release: build the bundles, publish to `npm` and update branch for the documentation website (see below).
+
+### Moving the `latest` dist-tag to a release:
+
+After testing the `next` release by upgrading an application, it's time to move the `latest` tag to make the release official. Use `npm dist-tag add @commercetools-frontend/ui-kit@<version> latest` to move the `latest` dist-tag onto that release.
+
+## About release-candidates & alpha / beta versions
+
+Having release candidates is not necesssary when using semantic releases:
+
+> "With semantic-release it’s discouraged to put information about stability into the version number (i.e. 1.0.0-beta or 2.0.0-rc1) because it’s mixing things up. The tool you can use to comunicate stability are npm’s dist-tags. The last paragraph of this section should give you some hints: https://github.com/semantic-release/semantic-release#how-does-it-work"
+>
+> boennemann, [source](https://gitter.im/semantic-release/semantic-release/archives/2015/08/26)
 
 ## Publishing documentation website
 

--- a/materials/internals/tokens/README.md
+++ b/materials/internals/tokens/README.md
@@ -4,7 +4,7 @@
 
 Design Tokens are an abstraction for everything impacting the visual design of an app/platform. They are the visual design atoms of the design system — specifically, they are named entities that store visual design attributes.
 
-> A system’s strength comes from knowing how to apply options (like $color-neutral-20) to contexts (like a conventional dark background color). This grounds the option as a decision.
+> A system’s strength comes from knowing how to apply options (like \$color-neutral-20) to contexts (like a conventional dark background color). This grounds the option as a decision.
 
 ```
 $background-color-dark = $color-neutral-20;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-frontend/ui-kit",
-  "version": "2.0.0",
+  "version": "2.0.0-rc.12",
   "description": "UI component library based on our Design System",
   "homepage": "https://uikit.commercetools.com/",
   "bugs": "https://github.com/commercetools/ui-kit/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-frontend/ui-kit",
-  "version": "2.0.0-rc.11",
+  "version": "2.0.0",
   "description": "UI component library based on our Design System",
   "homepage": "https://uikit.commercetools.com/",
   "bugs": "https://github.com/commercetools/ui-kit/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-frontend/ui-kit",
-  "version": "2.0.0-rc.12",
+  "version": "3.0.0",
   "description": "UI component library based on our Design System",
   "homepage": "https://uikit.commercetools.com/",
   "bugs": "https://github.com/commercetools/ui-kit/issues",

--- a/src/components/inputs/money-input/README.md
+++ b/src/components/inputs/money-input/README.md
@@ -225,11 +225,9 @@ return (
           }
           horizontalConstraint="l"
         />
-        {touched.somePrice &&
-          errors.somePrice &&
-          errors.somePrice.missing && (
-            <ErrorMessage>This field is required!</ErrorMessage>
-          )}
+        {touched.somePrice && errors.somePrice && errors.somePrice.missing && (
+          <ErrorMessage>This field is required!</ErrorMessage>
+        )}
         {touched.somePrice &&
           errors.somePrice &&
           errors.somePrice.highPrecision && (


### PR DESCRIPTION
So far our releases were not following semver and it was cumbersome to test new releases. This PR changes that by releasing to `next` from CI. Check the changed documentation in this PR to find out more.