### PR TITLE
fix(storybook): set title (remove semi colon error)

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,1 +1,1 @@
-<script>document.title = "UI Kit";</script>;
+<script>document.title = "UI Kit";</script>


### PR DESCRIPTION
#261 introduced a syntax error to the document head. I wanted to fix it in https://github.com/commercetools/ui-kit/commit/f0e333e805ae05c5f6db398e0f81ecc785de18f4 which I pushed directly onto `master` (by accident).

I now set up branch protection rules so this doesn't happen again. For some reason prettier automatically added the final semi-colon which this PR removes. It might be a bug in prettier when used with an html file.

This PR removes the semi colon.