### PR TITLE
Remove `Icons.AX` export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@
 import '../materials/internals/grid.mod.css';
 import '../materials/internals/reset.mod.css';
 import * as i18n from '../i18n';
-import * as Icons from './components/icons';
 
 export {
   default as AccessibleButton,
@@ -53,8 +52,6 @@ export {
   default as AsyncCreatableSelectField,
 } from './components/fields/async-creatable-select-field';
 
-export { Icons };
-// TODO: this type of export is deprecated and should be removed in the next major release
 export * from './components/icons';
 
 export {


### PR DESCRIPTION
#### Summary

This pull request proposes to remove the `Icons.*` export.

#### Description

The export has been creating great confusion recently and I suggest to remove it for the following reasons:

1. It breaks tree shaking as all icons are imported (in case of SVG causing some unexpected bundle weight to consumers)
2. It's convenient but not really needed in most cases
   - Currently a mapping could be implemented by switching on strings and returning a specifically imported icon

Future work could entail adding a generic component to UIKit which looks like `<Icon name='circle' />` which does the mapping. However that will also break tree shaking for consumers.
