### PR TITLE
fix: typo in rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -65,7 +65,7 @@ const plugins = [
   // so that they do not end up in the bundle.
   // See also https://medium.com/@kelin2025/so-you-wanna-use-es6-modules-714f48b3a953
   peerDepsExternal({
-    dependencies: true,
+    includeDependencies: true,
   }),
   // Transpile sources using our custom babel preset.
   babel({


### PR DESCRIPTION
#### Summary

At some point between v3.0.0 and v4.0.2, we moved some deps from peer deps to regular deps. We assumed all of our deps were being externalized, since we had included `dependencies: true` in our rollup config of [rollup-plugin-peer-deps-external](https://www.npmjs.com/package/rollup-plugin-peer-deps-external). However, this was a typo because it should be `includeDependencies: true`.

Please don't git blame this because I'm 100% sure I'm guilty of introducing this 🙈 

#### Approach

Fix typo.