### PR TITLE
Fail Fast on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,17 @@ cache:
     - node_modules
 
 script:
+  # fail fast - in case there is an error building, quit immediately.
+  # instruct bash to quit if there is a non zero response code (error)
+  # https://github.com/commercetools/ui-kit/pull/284
+  - set -e
   # the jest.bundle.config.js tests run on the bundle,
   # so we need to build it first
-  - set -e
   - yarn build
   - yarn run jest --projects jest.*.config.js --maxWorkers=4 --reporters jest-silent-reporter
   - yarn percy
   - "! test -f fail-tests-because-there-was-an-unhandled-rejection.lock"
+  # back to default in case internal travis scripts return non zero response codes.
   - set +e
 
 before_deploy: yarn build

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,12 @@ cache:
 script:
   # the jest.bundle.config.js tests run on the bundle,
   # so we need to build it first
+  - set -e
   - yarn build
   - yarn run jest --projects jest.*.config.js --maxWorkers=4 --reporters jest-silent-reporter
   - yarn percy
   - "! test -f fail-tests-because-there-was-an-unhandled-rejection.lock"
+  - set +e
 
 before_deploy: yarn build
 


### PR DESCRIPTION
#### Summary

If the tests fail on CI, the apps still build. See [here](https://travis-ci.org/commercetools/ui-kit/builds/462944149) for an example.

#### Approach

Add `set -e` to the beginning of our scripts (instructs bash to quit if there is an error), and add `set +e` to unset the flag at the end of our scripts, as travis can sometimes have internal scripts that exit with a non zero code that we wouldn't result in our build failing.

#### Example

Check [here](https://travis-ci.org/commercetools/ui-kit/builds/463355886) for an example of this PR resulting in a fail fast.

#### Help / docs

[https://github.com/travis-ci/travis-ci/issues/1066](https://github.com/travis-ci/travis-ci/issues/1066)
