### PR TITLE
Fix for Checkbox and Radio hovered, disabled states

### DIFF
--- a/src/components/switches/checkbox/checkbox.mod.css
+++ b/src/components/switches/checkbox/checkbox.mod.css
@@ -11,11 +11,11 @@
   align-items: center;
 }
 
-.checkboxWrapper svg [id='borderAndContent'] > [id='border'] {
+.checkboxWrapper svg [id$='borderAndContent'] > [id$='border'] {
   stroke: 1px var(--token-border-color-input-pristine) solid;
 }
 
-.checkboxWrapper svg [id='borderAndContent'] > [id='content'] {
+.checkboxWrapper svg [id$='borderAndContent'] > [id$='content'] {
   fill: var(--token-border-color-input-focus);
 }
 
@@ -37,21 +37,21 @@
 
 /* hasError */
 
-.hasError svg [id='borderAndContent'] > [id='content'] {
+.hasError svg [id$='borderAndContent'] > [id$='content'] {
   fill: var(--token-border-color-input-error);
 }
 
-.hasError svg [id='borderAndContent'] > [id='border'] {
+.hasError svg [id$='borderAndContent'] > [id$='border'] {
   stroke: var(--token-font-color-error);
 }
 
 /* isDisabled */
 
-.isDisabled svg [id='borderAndContent'] > [id='content'] {
+.isDisabled svg [id$='borderAndContent'] > [id$='content'] {
   fill: var(--token-font-color-disabled);
 }
 
-.isDisabled svg [id='borderAndContent'] > [id='border'] {
+.isDisabled svg [id$='borderAndContent'] > [id$='border'] {
   stroke: var(--token-border-color-input-disabled);
 }
 
@@ -59,11 +59,11 @@
 
 .labelWrapper:not(.labelWrapperDisabled, .labelWrapperError):hover
   svg
-  [id='borderAndContent']
-  > [id='border'] {
+  [id$='borderAndContent']
+  > [id$='border'] {
   stroke: var(--token-border-color-input-focus);
 }
 
-.isHovered svg [id='borderAndContent'] > [id='border'] {
+.isHovered svg [id$='borderAndContent'] > [id$='border'] {
   stroke: var(--token-border-color-input-focus);
 }

--- a/src/components/switches/checkbox/checkbox.percy.js
+++ b/src/components/switches/checkbox/checkbox.percy.js
@@ -1,0 +1,98 @@
+import React from 'react';
+import { Checkbox } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+screenshot('Checkbox', () => (
+  <Suite>
+    <Spec label="when default">
+      <Checkbox onChange={() => {}} value="value">
+        I want kale
+      </Checkbox>
+    </Spec>
+    <Spec label="when checked">
+      <Checkbox onChange={() => {}} value="value" isChecked={true}>
+        I want pizza
+      </Checkbox>
+    </Spec>
+    <Spec label="when indetermiate">
+      <Checkbox onChange={() => {}} value="value" isIndeterminate={true}>
+        I want kale pizza
+      </Checkbox>
+    </Spec>
+    <Spec label="when hovered">
+      <Checkbox onChange={() => {}} value="value" isHovered={true}>
+        I want pasta
+      </Checkbox>
+    </Spec>
+    <Spec label="when checked and hovered">
+      <Checkbox
+        onChange={() => {}}
+        value="value"
+        isHovered={true}
+        isChecked={true}
+      >
+        I want to watch hockey
+      </Checkbox>
+    </Spec>
+    <Spec label="when indeterminate and hovered">
+      <Checkbox
+        onChange={() => {}}
+        value="value"
+        isIndeterminate={true}
+        isHovered={true}
+      >
+        I want kale
+      </Checkbox>
+    </Spec>
+    <Spec label="when with error">
+      <Checkbox onChange={() => {}} value="value" hasError={true}>
+        I want ice cream pizza
+      </Checkbox>
+    </Spec>
+    <Spec label="when checked and with error">
+      <Checkbox
+        onChange={() => {}}
+        isChecked={true}
+        value="value"
+        hasError={true}
+      >
+        I want pizza but not frozen pizza
+      </Checkbox>
+    </Spec>
+    <Spec label="when indeterminate and with error">
+      <Checkbox
+        onChange={() => {}}
+        isIndeterminate={true}
+        value="value"
+        hasError={true}
+      >
+        I want frozen beer
+      </Checkbox>
+    </Spec>
+    <Spec label="when disabled">
+      <Checkbox onChange={() => {}} value="value" isDisabled={true}>
+        I want tequila
+      </Checkbox>
+    </Spec>
+    <Spec label="when checked and disabled">
+      <Checkbox
+        onChange={() => {}}
+        value="value"
+        isDisabled={true}
+        isChecked={true}
+      >
+        I want mezcal
+      </Checkbox>
+    </Spec>
+    <Spec label="when indeterminate and disabled">
+      <Checkbox
+        onChange={() => {}}
+        value="value"
+        isDisabled={true}
+        isIndeterminate={true}
+      >
+        I want mezcal with a worm
+      </Checkbox>
+    </Spec>
+  </Suite>
+));

--- a/src/components/switches/radio/radio-option.mod.css
+++ b/src/components/switches/radio/radio-option.mod.css
@@ -11,21 +11,21 @@
   align-items: center;
 }
 
-.radioWrapper svg [id='borderAndContent'] > [id='border'] {
+.radioWrapper svg [id$='borderAndContent'] > [id$='border'] {
   stroke: 1px var(--token-border-color-input-pristine) solid;
 }
 
-.radioWrapper svg [id='borderAndContent'] > [id='content'] {
+.radioWrapper svg [id$='borderAndContent'] > [id$='content'] {
   fill: var(--token-border-color-input-focus);
 }
 
 /* isDisabled */
 
-.isDisabled svg [id='borderAndContent'] > [id='content'] {
+.isDisabled svg [id$='borderAndContent'] > [id$='content'] {
   fill: var(--token-font-color-disabled);
 }
 
-.isDisabled svg [id='borderAndContent'] > [id='border'] {
+.isDisabled svg [id$='borderAndContent'] > [id$='border'] {
   stroke: var(--token-border-color-input-disabled);
 }
 
@@ -33,12 +33,12 @@
 
 .labelWrapper:not(.labelWrapperDisabled):hover
   svg
-  [id='borderAndContent']
-  > [id='border'] {
+  [id$='borderAndContent']
+  > [id$='border'] {
   stroke: var(--token-border-color-input-focus);
 }
 
-.isHovered svg [id='borderAndContent'] > [id='border'] {
+.isHovered svg [id$='borderAndContent'] > [id$='border'] {
   stroke: var(--token-border-color-input-focus);
 }
 

--- a/src/components/switches/radio/radio.percy.js
+++ b/src/components/switches/radio/radio.percy.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Radio } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+screenshot('Radio', () => (
+  <Suite>
+    <Spec label="when direction is stack">
+      <Radio.Group
+        name="uikit-group"
+        value={'apples'}
+        onChange={() => {}}
+        direction={'stack'}
+      >
+        <Radio.Option value="apples">Apples</Radio.Option>
+        <Radio.Option isChecked={true} value="oranges">
+          Oranges
+        </Radio.Option>
+        <Radio.Option isDisabled={true} value="kiwis">
+          Kiwis (disabled)
+        </Radio.Option>
+        <Radio.Option isHovered={true} value="plums">
+          Plums (hovered)
+        </Radio.Option>
+      </Radio.Group>
+    </Spec>
+    <Spec label="when direction is inline">
+      <Radio.Group
+        name="uikit-group"
+        value={'oranges'}
+        onChange={() => {}}
+        direction={'inline'}
+      >
+        <Radio.Option value="apples">Apples</Radio.Option>
+        <Radio.Option isChecked={true} value="oranges">
+          Oranges
+        </Radio.Option>
+      </Radio.Group>
+    </Spec>
+  </Suite>
+));


### PR DESCRIPTION
#### Summary

We were using SVG ids to apply css styling to some of our svgs in the components `checkbox` and `radio`. However, at some point in the last period of time since we last checked to see if this worked, SVGO moved to making SVG id's unique, by prepending them with the file name.

We give id="borderAndContent", and SVGO outputs id="radio-option-default_react_svg__borderAndContent". 

#### Approach

Use regex to target the id. [ref](https://stackoverflow.com/questions/8903313/using-regular-expression-in-css)

Add VRT tests for the two components.

![screen shot 2018-12-07 at 2 31 04 pm](https://user-images.githubusercontent.com/2425013/49650787-b57adb00-fa2d-11e8-9c80-0884ef3173cf.png)
