### PR TITLE
Add even more visual regression tests

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -33,6 +33,8 @@ overrides:
     env:
       'react-percy/globals': true
     rules:
+      # We disable the rule for dist/ui-kit imports as there is no guarantee
+      # that a bundle has been created before running the tests.
       'import/no-unresolved': [2, { ignore: ['\/dist\/ui-kit\.esm'] }]
 settings:
   import/ignore:

--- a/src/components/buttons/link-button/link-button.percy.js
+++ b/src/components/buttons/link-button/link-button.percy.js
@@ -12,7 +12,7 @@ screenshot('LinkButton', () => (
     </Spec>
 
     <Spec label="with icon left">
-      <LinkButton label="A label text" to="/" icon={<InformationIcon />} />
+      <LinkButton label="A label text" to="/" iconLeft={<InformationIcon />} />
     </Spec>
 
     <Spec label="with icon left and disabled">
@@ -20,7 +20,7 @@ screenshot('LinkButton', () => (
         label="A label text"
         to="/"
         isDisabled={true}
-        icon={<InformationIcon />}
+        iconLeft={<InformationIcon />}
       />
     </Spec>
   </Suite>

--- a/src/components/buttons/secondary-button/secondary-button.percy.js
+++ b/src/components/buttons/secondary-button/secondary-button.percy.js
@@ -78,22 +78,6 @@ screenshot('SecondaryButton', () => (
       />
     </Spec>
 
-    <Spec label='size - when "big"'>
-      <SecondaryButton label="A label text" onClick={() => {}} size="big" />
-    </Spec>
-
-    <Spec label='size - when "small"'>
-      <SecondaryButton label="A label text" onClick={() => {}} size="small" />
-    </Spec>
-
-    <Spec label='tone - when "urgent"'>
-      <SecondaryButton label="A label text" onClick={() => {}} size="urgent" />
-    </Spec>
-
-    <Spec label='tone - when "primary"'>
-      <SecondaryButton label="A label text" onClick={() => {}} size="primary" />
-    </Spec>
-
     <Spec label="when used as link">
       <SecondaryButton label="A label text" linkTo="/" />
     </Spec>

--- a/src/components/constraints/horizontal/horizontal.percy.js
+++ b/src/components/constraints/horizontal/horizontal.percy.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Constraints } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const GreenBox = styled.div`
+  width: 100%;
+  height: 20px;
+  background-color: green;
+`;
+
+screenshot('Constraints.Horizontal', () => (
+  <Suite>
+    <Spec label='when constraints is "xs"'>
+      <Constraints.Horizontal constraint="xs">
+        <GreenBox />
+      </Constraints.Horizontal>
+    </Spec>
+    <Spec label='when constraints is "s"'>
+      <Constraints.Horizontal constraint="s">
+        <GreenBox />
+      </Constraints.Horizontal>
+    </Spec>
+    <Spec label='when constraints is "m"'>
+      <Constraints.Horizontal constraint="m">
+        <GreenBox />
+      </Constraints.Horizontal>
+    </Spec>
+    <Spec label='when constraints is "l"'>
+      <Constraints.Horizontal constraint="l">
+        <GreenBox />
+      </Constraints.Horizontal>
+    </Spec>
+    <Spec label='when constraints is "xl"'>
+      <Constraints.Horizontal constraint="xl">
+        <GreenBox />
+      </Constraints.Horizontal>
+    </Spec>
+    <Spec label='when constraints is "scale"'>
+      <Constraints.Horizontal constraint="scale">
+        <GreenBox />
+      </Constraints.Horizontal>
+    </Spec>
+  </Suite>
+));

--- a/src/components/dropdowns/primary-action-dropdown/README.md
+++ b/src/components/dropdowns/primary-action-dropdown/README.md
@@ -22,13 +22,22 @@ dropdown will be disabled.
 #### Usage
 
 ```js
-import PrimaryActionDropdown, { Option } from '@commercetools-frontend/ui-kit/dropdowns/primary-action-dropdown';
+import {
+  PrimaryActionDropdown,
+  PrimaryActionDropdownOption,
+} from '@commercetools-frontend/ui-kit';
 
 <PrimaryActionDropdown>
-  <Option icon={<AddBoldIcon />} onClick={alert('primary clicked')}}>Primary option</Option>
-  <Option onClick={alert('clicked')}>Another option</Option>
-  <Option isDisabled={true} onClick={alert('clicked')}>Even another option</Option>
-</PrimaryActionDropdown>
+  <PrimaryActionDropdownOption icon={<AddBoldIcon />} onClick={() => {}}>
+    Primary option
+  </PrimaryActionDropdownOption>
+  <PrimaryActionDropdownOption onClick={() => {}}>
+    Another option
+  </PrimaryActionDropdownOption>
+  <PrimaryActionDropdownOption isDisabled={true} onClick={() => {}}>
+    Even another option
+  </PrimaryActionDropdownOption>
+</PrimaryActionDropdown>;
 ```
 
 #### Properties

--- a/src/components/dropdowns/primary-action-dropdown/primary-action-dropdown.percy.js
+++ b/src/components/dropdowns/primary-action-dropdown/primary-action-dropdown.percy.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import {
+  PrimaryActionDropdown,
+  PrimaryActionDropdownOption,
+  AddBoldIcon,
+} from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+screenshot('PrimaryActionDropdown', () => (
+  <Suite>
+    <Spec label="regular">
+      <PrimaryActionDropdown>
+        <PrimaryActionDropdownOption
+          iconLeft={<AddBoldIcon />}
+          onClick={() => {}}
+        >
+          Primary option
+        </PrimaryActionDropdownOption>
+        <PrimaryActionDropdownOption onClick={() => {}}>
+          Another option
+        </PrimaryActionDropdownOption>
+      </PrimaryActionDropdown>
+    </Spec>
+    <Spec label="when all options are disabled">
+      <PrimaryActionDropdown>
+        <PrimaryActionDropdownOption
+          isDisabled={true}
+          iconLeft={<AddBoldIcon />}
+          onClick={() => {}}
+        >
+          Primary option
+        </PrimaryActionDropdownOption>
+        <PrimaryActionDropdownOption isDisabled={true} onClick={() => {}}>
+          Another option
+        </PrimaryActionDropdownOption>
+      </PrimaryActionDropdown>
+    </Spec>
+  </Suite>
+));

--- a/src/components/field-label/field-label.percy.js
+++ b/src/components/field-label/field-label.percy.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { FieldLabel, WarningIcon, FlatButton } from '../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../test/percy';
+
+screenshot('FieldLabel', () => (
+  <Suite>
+    <Spec label="minimal">
+      <FieldLabel title="Hello" horizontalConstraint="m" />
+    </Spec>
+    <Spec label="with hint and hint icon">
+      <FieldLabel
+        title="Hello"
+        hint="a hint"
+        hintIcon={<WarningIcon />}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="with required indicator">
+      <FieldLabel
+        title="Hello"
+        hasRequiredIndicator={true}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="with all options">
+      <FieldLabel
+        title="Hello"
+        hasRequiredIndicator={true}
+        onInfoButtonClick={() => {}}
+        hint="a hint"
+        hintIcon={<WarningIcon />}
+        description="description"
+        badge={<FlatButton tone="primary" label="show" />}
+        htmlFor="sampleInput"
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="with all options and large horizontal constraint">
+      <FieldLabel
+        title="Hello"
+        hasRequiredIndicator={true}
+        onInfoButtonClick={() => {}}
+        hint="a hint"
+        hintIcon={<WarningIcon />}
+        description="description"
+        badge={<FlatButton tone="primary" label="show" />}
+        htmlFor="sampleInput"
+        horizontalConstraint="l"
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/fields/async-creatable-select-field/README.md
+++ b/src/components/fields/async-creatable-select-field/README.md
@@ -9,12 +9,15 @@ An input componentwith validation states and a label getting a selection from an
 ```js
 import { AsyncCreatableSelectField } from '@commercetools-frontend/ui-kit';
 
-<AsyncCreatableAsyncCreatableSelectInput
+<AsyncCreatableSelectField
   title="State"
   name="form-field-name"
   value={{ value: 'one', label: 'One' }}
   onChange={event => alert(event.target.value)}
-  options={[{ value: 'one', label: 'One' }, { value: 'two', label: 'Two' }]}
+  loadOptions={() => Promise.resolve([
+    { value: 'one', label: 'One' },
+    { value: 'two', label: 'Two' }
+  ])
 />;
 ```
 

--- a/src/components/fields/async-creatable-select-field/async-creatable-select-field.percy.js
+++ b/src/components/fields/async-creatable-select-field/async-creatable-select-field.percy.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { AsyncCreatableSelectField } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const loadOptions = () =>
+  Promise.resolve([
+    { value: 'one', label: 'One' },
+    { value: 'two', label: 'Two' },
+  ]);
+
+const value = { value: 'one', label: 'One' };
+
+screenshot('AsyncCreatableSelectField', () => (
+  <Suite>
+    <Spec label="minimal">
+      <AsyncCreatableSelectField
+        title="State"
+        name="form-field-name"
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when disabled">
+      <AsyncCreatableSelectField
+        title="State"
+        name="form-field-name"
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        isDisabled={true}
+      />
+    </Spec>
+    <Spec label='with "missing" error when not touched'>
+      <AsyncCreatableSelectField
+        title="State"
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        errors={{ missing: true }}
+      />
+    </Spec>
+    <Spec label='with "missing" error when touched'>
+      <AsyncCreatableSelectField
+        title="State"
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        errors={{ missing: true }}
+        touched={true}
+      />
+    </Spec>
+    <Spec label="with hint">
+      <AsyncCreatableSelectField
+        title="State"
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        hint="Select a state"
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/fields/async-select-field/async-select-field.percy.js
+++ b/src/components/fields/async-select-field/async-select-field.percy.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { AsyncSelectField } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const loadOptions = () =>
+  Promise.resolve([
+    { value: 'one', label: 'One' },
+    { value: 'two', label: 'Two' },
+  ]);
+
+const value = { value: 'one', label: 'One' };
+
+screenshot('AsyncSelectField', () => (
+  <Suite>
+    <Spec label="minimal">
+      <AsyncSelectField
+        title="State"
+        name="form-field-name"
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when disabled">
+      <AsyncSelectField
+        title="State"
+        name="form-field-name"
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        isDisabled={true}
+      />
+    </Spec>
+    <Spec label='with "missing" error when not touched'>
+      <AsyncSelectField
+        title="State"
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        errors={{ missing: true }}
+      />
+    </Spec>
+    <Spec label='with "missing" error when touched'>
+      <AsyncSelectField
+        title="State"
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        errors={{ missing: true }}
+        touched={true}
+      />
+    </Spec>
+    <Spec label="with hint">
+      <AsyncSelectField
+        title="State"
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        hint="Select a state"
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/fields/creatable-select-field/creatable-select-field.percy.js
+++ b/src/components/fields/creatable-select-field/creatable-select-field.percy.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import { CreatableSelectField } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const options = [
+  { value: 'one', label: 'One' },
+  { value: 'two', label: 'Two' },
+];
+
+const value = { value: 'one', label: 'One' };
+
+screenshot('CreatableSelectField', () => (
+  <Suite>
+    <Spec label="minimal">
+      <CreatableSelectField
+        title="State"
+        name="form-field-name"
+        value={value}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when disabled">
+      <CreatableSelectField
+        title="State"
+        name="form-field-name"
+        value={value}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        isDisabled={true}
+      />
+    </Spec>
+    <Spec label='with "missing" error when not touched'>
+      <CreatableSelectField
+        title="State"
+        value={value}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        errors={{ missing: true }}
+      />
+    </Spec>
+    <Spec label='with "missing" error when touched'>
+      <CreatableSelectField
+        title="State"
+        value={value}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        errors={{ missing: true }}
+        touched={true}
+      />
+    </Spec>
+    <Spec label="with hint">
+      <CreatableSelectField
+        title="State"
+        value={value}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        hint="Select a state"
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/fields/localized-multiline-text-field/localized-multiline-text-field.percy.js
+++ b/src/components/fields/localized-multiline-text-field/localized-multiline-text-field.percy.js
@@ -1,0 +1,126 @@
+import React from 'react';
+import { LocalizedMultilineTextField } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const value = {
+  en: 'hello\nworld',
+  de: 'hallo\nwelt',
+  es: 'hola\nmundo',
+};
+
+screenshot('LocalizedMultilineTextField', () => (
+  <Suite>
+    <Spec label="minimal">
+      <LocalizedMultilineTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+      />
+    </Spec>
+    <Spec label="when multiline text is expanded by default">
+      <LocalizedMultilineTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isMultilineDefaultExpanded={true}
+      />
+    </Spec>
+    <Spec label="when multiline text and languages are expanded by default">
+      <LocalizedMultilineTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isMultilineDefaultExpanded={true}
+        areLanguagesDefaultOpened={true}
+      />
+    </Spec>
+    <Spec label="when language controls are hidden">
+      <LocalizedMultilineTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        hideLanguageControls={true}
+      />
+    </Spec>
+    <Spec label="when languages are opened by default">
+      <LocalizedMultilineTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        areLanguagesDefaultOpened={true}
+      />
+    </Spec>
+    <Spec label="when read-only and open">
+      <LocalizedMultilineTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isReadOnly={true}
+        areLanguagesDefaultOpened={true}
+      />
+    </Spec>
+    <Spec label="when read-only and closed">
+      <LocalizedMultilineTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isReadOnly={true}
+      />
+    </Spec>
+    <Spec label="when disabled and open">
+      <LocalizedMultilineTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isDisabled={true}
+        areLanguagesDefaultOpened={true}
+      />
+    </Spec>
+    <Spec label="when disabled and closed">
+      <LocalizedMultilineTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isDisabled={true}
+      />
+    </Spec>
+    <Spec label="when there is an error and the field is not touched">
+      <LocalizedMultilineTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        errors={{ missing: true }}
+      />
+    </Spec>
+    <Spec label="when there is an error and the field is touched">
+      <LocalizedMultilineTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        errors={{ missing: true }}
+        touched={true}
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/fields/localized-text-field/localized-text-field.percy.js
+++ b/src/components/fields/localized-text-field/localized-text-field.percy.js
@@ -1,0 +1,126 @@
+import React from 'react';
+import { LocalizedTextField } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const value = {
+  en: 'hello world',
+  de: 'hallo welt',
+  es: 'hola mundo',
+};
+
+screenshot('LocalizedTextField', () => (
+  <Suite>
+    <Spec label="minimal">
+      <LocalizedTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+      />
+    </Spec>
+    <Spec label="when multiline text is expanded by default">
+      <LocalizedTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isMultilineDefaultExpanded={true}
+      />
+    </Spec>
+    <Spec label="when multiline text and languages are expanded by default">
+      <LocalizedTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isMultilineDefaultExpanded={true}
+        areLanguagesDefaultOpened={true}
+      />
+    </Spec>
+    <Spec label="when language controls are hidden">
+      <LocalizedTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        hideLanguageControls={true}
+      />
+    </Spec>
+    <Spec label="when languages are opened by default">
+      <LocalizedTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        areLanguagesDefaultOpened={true}
+      />
+    </Spec>
+    <Spec label="when read-only and open">
+      <LocalizedTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isReadOnly={true}
+        areLanguagesDefaultOpened={true}
+      />
+    </Spec>
+    <Spec label="when read-only and closed">
+      <LocalizedTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isReadOnly={true}
+      />
+    </Spec>
+    <Spec label="when disabled and open">
+      <LocalizedTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isDisabled={true}
+        areLanguagesDefaultOpened={true}
+      />
+    </Spec>
+    <Spec label="when disabled and closed">
+      <LocalizedTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isDisabled={true}
+      />
+    </Spec>
+    <Spec label="when there is an error and the field is not touched">
+      <LocalizedTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        errors={{ missing: true }}
+      />
+    </Spec>
+    <Spec label="when there is an error and the field is touched">
+      <LocalizedTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        errors={{ missing: true }}
+        touched={true}
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/fields/localized-text-field/localized-text-field.percy.js
+++ b/src/components/fields/localized-text-field/localized-text-field.percy.js
@@ -19,37 +19,6 @@ screenshot('LocalizedTextField', () => (
         horizontalConstraint="m"
       />
     </Spec>
-    <Spec label="when multiline text is expanded by default">
-      <LocalizedTextField
-        title="Welcome Text"
-        value={value}
-        onChange={() => {}}
-        selectedLanguage="en"
-        horizontalConstraint="m"
-        isMultilineDefaultExpanded={true}
-      />
-    </Spec>
-    <Spec label="when multiline text and languages are expanded by default">
-      <LocalizedTextField
-        title="Welcome Text"
-        value={value}
-        onChange={() => {}}
-        selectedLanguage="en"
-        horizontalConstraint="m"
-        isMultilineDefaultExpanded={true}
-        areLanguagesDefaultOpened={true}
-      />
-    </Spec>
-    <Spec label="when language controls are hidden">
-      <LocalizedTextField
-        title="Welcome Text"
-        value={value}
-        onChange={() => {}}
-        selectedLanguage="en"
-        horizontalConstraint="m"
-        hideLanguageControls={true}
-      />
-    </Spec>
     <Spec label="when languages are opened by default">
       <LocalizedTextField
         title="Welcome Text"
@@ -57,7 +26,17 @@ screenshot('LocalizedTextField', () => (
         onChange={() => {}}
         selectedLanguage="en"
         horizontalConstraint="m"
-        areLanguagesDefaultOpened={true}
+        isDefaultExpanded={true}
+      />
+    </Spec>
+    <Spec label="when expansion controls are hidden">
+      <LocalizedTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        hideExpansionControls={true}
       />
     </Spec>
     <Spec label="when read-only and open">
@@ -68,7 +47,7 @@ screenshot('LocalizedTextField', () => (
         selectedLanguage="en"
         horizontalConstraint="m"
         isReadOnly={true}
-        areLanguagesDefaultOpened={true}
+        isDefaultExpanded={true}
       />
     </Spec>
     <Spec label="when read-only and closed">
@@ -89,7 +68,7 @@ screenshot('LocalizedTextField', () => (
         selectedLanguage="en"
         horizontalConstraint="m"
         isDisabled={true}
-        areLanguagesDefaultOpened={true}
+        isDefaultExpanded={true}
       />
     </Spec>
     <Spec label="when disabled and closed">

--- a/src/components/fields/localized-text-field/localized-text-field.percy.js
+++ b/src/components/fields/localized-text-field/localized-text-field.percy.js
@@ -16,6 +16,7 @@ screenshot('LocalizedTextField', () => (
         value={value}
         onChange={() => {}}
         selectedLanguage="en"
+        horizontalConstraint="m"
       />
     </Spec>
     <Spec label="when multiline text is expanded by default">

--- a/src/components/fields/money-field/money-field.percy.js
+++ b/src/components/fields/money-field/money-field.percy.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import { MoneyField } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const value = {
+  amount: '13.50',
+  currencyCode: 'EUR',
+};
+
+const highPrecisionValue = {
+  amount: '13.501',
+  currencyCode: 'EUR',
+};
+
+const emptyValue = { amount: '', currencyCode: '' };
+
+const currencies = ['EUR', 'USD'];
+
+screenshot('MoneyField', () => (
+  <Suite>
+    <Spec label="minimal">
+      <MoneyField
+        title="Price"
+        horizontalConstraint="m"
+        value={value}
+        onChange={() => {}}
+        currencies={currencies}
+      />
+    </Spec>
+    <Spec label="with only one currency">
+      <MoneyField
+        title="Price"
+        horizontalConstraint="m"
+        value={value}
+        onChange={() => {}}
+        currencies={['EUR']}
+      />
+    </Spec>
+    <Spec label="when disabled">
+      <MoneyField
+        title="Price"
+        horizontalConstraint="m"
+        value={value}
+        onChange={() => {}}
+        currencies={currencies}
+        isDisabled={true}
+      />
+    </Spec>
+    <Spec label="with description">
+      <MoneyField
+        title="Price"
+        description="How much is the fish?"
+        horizontalConstraint="m"
+        value={value}
+        onChange={() => {}}
+        currencies={currencies}
+      />
+    </Spec>
+    <Spec label="with high precision badge and regular price">
+      <MoneyField
+        title="Price"
+        horizontalConstraint="m"
+        value={value}
+        onChange={() => {}}
+        currencies={currencies}
+        hasHighPrecisionBadge={true}
+      />
+    </Spec>
+    <Spec label="with high precision badge and high precision price">
+      <MoneyField
+        title="Price"
+        horizontalConstraint="m"
+        value={highPrecisionValue}
+        onChange={() => {}}
+        currencies={currencies}
+        hasHighPrecisionBadge={true}
+      />
+    </Spec>
+    <Spec label="with placeholder">
+      <MoneyField
+        title="Price"
+        horizontalConstraint="m"
+        value={emptyValue}
+        onChange={() => {}}
+        currencies={currencies}
+        placeholder="Please enter a price"
+      />
+    </Spec>
+    <Spec label="with error when not touched">
+      <MoneyField
+        title="Price"
+        horizontalConstraint="m"
+        value={emptyValue}
+        onChange={() => {}}
+        currencies={currencies}
+        errors={{ missing: true }}
+      />
+    </Spec>
+    <Spec label="with error when touched">
+      <MoneyField
+        title="Price"
+        horizontalConstraint="m"
+        value={emptyValue}
+        onChange={() => {}}
+        currencies={currencies}
+        errors={{ missing: true }}
+        touched={{ amount: true, currencyCode: true }}
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/fields/money-field/money-field.percy.js
+++ b/src/components/fields/money-field/money-field.percy.js
@@ -27,13 +27,12 @@ screenshot('MoneyField', () => (
         currencies={currencies}
       />
     </Spec>
-    <Spec label="with only one currency">
+    <Spec label="without currency selection">
       <MoneyField
         title="Price"
         horizontalConstraint="m"
         value={value}
         onChange={() => {}}
-        currencies={['EUR']}
       />
     </Spec>
     <Spec label="when disabled">

--- a/src/components/fields/multiline-text-field/multiline-text-field.percy.js
+++ b/src/components/fields/multiline-text-field/multiline-text-field.percy.js
@@ -35,6 +35,15 @@ screenshot('MultilineTextField', () => (
     <Spec label="when placeholder is visible">
       <MultilineTextField
         title="Welcome Text"
+        value=""
+        placeholder="Enter a text"
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when placeholder is visible and input is disabled">
+      <MultilineTextField
+        title="Welcome Text"
         isDisabled={true}
         value=""
         placeholder="Enter a text"

--- a/src/components/fields/multiline-text-field/multiline-text-field.percy.js
+++ b/src/components/fields/multiline-text-field/multiline-text-field.percy.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { MultilineTextField } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const value = 'hello\nworld\nhow\nare\nyou?';
+
+screenshot('MultilineTextField', () => (
+  <Suite>
+    <Spec label="minimal">
+      <MultilineTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when required">
+      <MultilineTextField
+        title="Welcome Text"
+        isRequired={true}
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when disabled">
+      <MultilineTextField
+        title="Welcome Text"
+        isDisabled={true}
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when placeholder is visible">
+      <MultilineTextField
+        title="Welcome Text"
+        isDisabled={true}
+        value=""
+        placeholder="Enter a text"
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="with error when not touched">
+      <MultilineTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        errors={{ missing: true }}
+      />
+    </Spec>
+    <Spec label="with error when touched">
+      <MultilineTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        errors={{ missing: true }}
+        touched={true}
+      />
+    </Spec>
+    <Spec label="when closed by default">
+      <MultilineTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        isDefaultClosed={true}
+      />
+    </Spec>
+    <Spec label="when disabled and closed by default">
+      <MultilineTextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        isDefaultClosed={true}
+        isDisabled={true}
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/fields/number-field/number-field.percy.js
+++ b/src/components/fields/number-field/number-field.percy.js
@@ -44,6 +44,15 @@ screenshot('NumberField', () => (
     <Spec label="when placeholder is shown">
       <NumberField
         title="Age"
+        value=""
+        placeholder="Enter a text"
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when placeholder is shown and input is disabled">
+      <NumberField
+        title="Age"
         isDisabled={true}
         value=""
         placeholder="Enter a text"

--- a/src/components/fields/number-field/number-field.percy.js
+++ b/src/components/fields/number-field/number-field.percy.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { NumberField } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const value = '12.50';
+
+screenshot('NumberField', () => (
+  <Suite>
+    <Spec label="minimal">
+      <NumberField
+        title="Age"
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when required">
+      <NumberField
+        title="Age"
+        isRequired={true}
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when disabled">
+      <NumberField
+        title="Age"
+        isDisabled={true}
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when read-only">
+      <NumberField
+        title="Age"
+        isReadOnly={true}
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when placeholder is shown">
+      <NumberField
+        title="Age"
+        isDisabled={true}
+        value=""
+        placeholder="Enter a text"
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="with error when not touched">
+      <NumberField
+        title="Age"
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        errors={{ missing: true }}
+      />
+    </Spec>
+    <Spec label="with error when touched">
+      <NumberField
+        title="Age"
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        errors={{ missing: true }}
+        touched={true}
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/fields/select-field/select-field.percy.js
+++ b/src/components/fields/select-field/select-field.percy.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import { SelectField } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const options = [
+  { value: 'one', label: 'One' },
+  { value: 'two', label: 'Two' },
+];
+
+const value = 'one';
+
+screenshot('SelectField', () => (
+  <Suite>
+    <Spec label="minimal">
+      <SelectField
+        title="State"
+        name="form-field-name"
+        value={value}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when disabled">
+      <SelectField
+        title="State"
+        name="form-field-name"
+        value={value}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        isDisabled={true}
+      />
+    </Spec>
+    <Spec label='with "missing" error when not touched'>
+      <SelectField
+        title="State"
+        value={value}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        errors={{ missing: true }}
+      />
+    </Spec>
+    <Spec label='with "missing" error when touched'>
+      <SelectField
+        title="State"
+        value={value}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        errors={{ missing: true }}
+        touched={true}
+      />
+    </Spec>
+    <Spec label="with hint">
+      <SelectField
+        title="State"
+        value={value}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        hint="Select a state"
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/fields/text-field/text-field.percy.js
+++ b/src/components/fields/text-field/text-field.percy.js
@@ -35,6 +35,15 @@ screenshot('TextField', () => (
     <Spec label="when placeholder is shown">
       <TextField
         title="Welcome Text"
+        value=""
+        placeholder="Enter a text"
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when placeholder is shown and disabled">
+      <TextField
+        title="Welcome Text"
         isDisabled={true}
         value=""
         placeholder="Enter a text"

--- a/src/components/fields/text-field/text-field.percy.js
+++ b/src/components/fields/text-field/text-field.percy.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { TextField } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const value = 'hello world, how are you?';
+
+screenshot('TextField', () => (
+  <Suite>
+    <Spec label="minimal">
+      <TextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when required">
+      <TextField
+        title="Welcome Text"
+        isRequired={true}
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when disabled">
+      <TextField
+        title="Welcome Text"
+        isDisabled={true}
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when placeholder is shown">
+      <TextField
+        title="Welcome Text"
+        isDisabled={true}
+        value=""
+        placeholder="Enter a text"
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="with error when not touched">
+      <TextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        errors={{ missing: true }}
+      />
+    </Spec>
+    <Spec label="with error when touched">
+      <TextField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        errors={{ missing: true }}
+        touched={true}
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/icons/icons.percy.js
+++ b/src/components/icons/icons.percy.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import * as UIKit from '../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../test/percy';
+
+const Inline = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+const icons = Object.keys(UIKit).filter(thing => thing.endsWith('Icon'));
+
+const sizes = ['small', 'medium', 'big', 'scale'];
+const themes = [
+  'black',
+  'grey',
+  'white',
+  'blue',
+  'green',
+  'green-light',
+  'orange',
+  'red',
+];
+
+screenshot('Icons', () => (
+  <Suite>
+    {icons.map(iconName => {
+      const Icon = UIKit[iconName];
+      return sizes.map(size => (
+        <Spec
+          key={`${iconName}-${size}`}
+          label={`${iconName} - ${size}`}
+          omitPropsList
+        >
+          <Inline>
+            {themes.map(theme => (
+              <Icon key={theme} size={size} theme={theme} />
+            ))}
+          </Inline>
+        </Spec>
+      ));
+    })}
+  </Suite>
+));

--- a/src/components/inputs/async-creatable-select-input/async-creatable-select-input.percy.js
+++ b/src/components/inputs/async-creatable-select-input/async-creatable-select-input.percy.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { AsyncCreatableSelectInput } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const loadOptions = () =>
+  Promise.resolve([
+    { value: 'one', label: 'One' },
+    { value: 'two', label: 'Two' },
+  ]);
+
+const value = { value: 'one', label: 'One' };
+
+screenshot('AsyncCreatableSelectInput', () => (
+  <Suite>
+    <Spec label="minimal">
+      <AsyncCreatableSelectInput
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when disabled">
+      <AsyncCreatableSelectInput
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        isDisabled={true}
+      />
+    </Spec>
+    <Spec label="with error">
+      <AsyncCreatableSelectInput
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        hasError={true}
+      />
+    </Spec>
+    <Spec label="with warning">
+      <AsyncCreatableSelectInput
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        hasWarning={true}
+      />
+    </Spec>
+    <Spec label="with error and warning">
+      <AsyncCreatableSelectInput
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        hasError={true}
+        hasWarning={true}
+      />
+    </Spec>
+    <Spec label="with placeholder">
+      <AsyncCreatableSelectInput
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        placeholder="Select a state"
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/inputs/async-select-input/async-select-input.percy.js
+++ b/src/components/inputs/async-select-input/async-select-input.percy.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { AsyncSelectInput } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const loadOptions = () =>
+  Promise.resolve([
+    { value: 'one', label: 'One' },
+    { value: 'two', label: 'Two' },
+  ]);
+
+const value = { value: 'one', label: 'One' };
+
+screenshot('AsyncSelectInput', () => (
+  <Suite>
+    <Spec label="minimal">
+      <AsyncSelectInput
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when disabled">
+      <AsyncSelectInput
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        isDisabled={true}
+      />
+    </Spec>
+    <Spec label="when input has an error">
+      <AsyncSelectInput
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        hasError={true}
+      />
+    </Spec>
+    <Spec label="when input has an warning">
+      <AsyncSelectInput
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        hasWarning={true}
+      />
+    </Spec>
+    <Spec label="when clearable">
+      <AsyncSelectInput
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        isClearable={true}
+      />
+    </Spec>
+    <Spec label="when input has an error and a warning">
+      <AsyncSelectInput
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        hasError={true}
+        hasWarning={true}
+      />
+    </Spec>
+    <Spec label="when placeholder is shown">
+      <AsyncSelectInput
+        value={null}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        placeholder="Select a state"
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/inputs/creatable-select-input/creatable-select-input.percy.js
+++ b/src/components/inputs/creatable-select-input/creatable-select-input.percy.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { CreatableSelectInput } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const options = [
+  { value: 'one', label: 'One' },
+  { value: 'two', label: 'Two' },
+];
+
+const value = { value: 'one', label: 'One' };
+
+screenshot('CreatableSelectInput', () => (
+  <Suite>
+    <Spec label="minimal">
+      <CreatableSelectInput
+        value={value}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when disabled">
+      <CreatableSelectInput
+        value={value}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        isDisabled={true}
+      />
+    </Spec>
+    <Spec label="when placeholder is shown">
+      <CreatableSelectInput
+        value={null}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        placeholder="Select something"
+      />
+    </Spec>
+    <Spec label="with error">
+      <CreatableSelectInput
+        value={null}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        hasError={true}
+      />
+    </Spec>
+    <Spec label="with warning">
+      <CreatableSelectInput
+        value={null}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        hasWarning={true}
+      />
+    </Spec>
+    <Spec label="with error and warning">
+      <CreatableSelectInput
+        value={null}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        hasError={true}
+        hasWarning={true}
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/inputs/date-input/date-input.js
+++ b/src/components/inputs/date-input/date-input.js
@@ -25,8 +25,8 @@ import {
   parseInputToDate,
 } from '../../../utils/calendar';
 
-class DateCalendar extends React.Component {
-  static displayName = 'DateCalendar';
+class DateInput extends React.Component {
+  static displayName = 'DateInput';
   static propTypes = {
     intl: PropTypes.shape({
       locale: PropTypes.string.isRequired,
@@ -276,4 +276,4 @@ class DateCalendar extends React.Component {
   }
 }
 
-export default injectIntl(DateCalendar);
+export default injectIntl(DateInput);

--- a/src/components/inputs/date-input/date-input.percy.js
+++ b/src/components/inputs/date-input/date-input.percy.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { DateInput } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const value = '2018-11-13';
+
+screenshot('DateInput', () => (
+  <Suite>
+    <Spec label="minimal">
+      <DateInput value={value} onChange={() => {}} horizontalConstraint="m" />
+    </Spec>
+    <Spec label="when disabled">
+      <DateInput
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        isDisabled={true}
+      />
+    </Spec>
+    <Spec label="when placeholder is shown">
+      <DateInput
+        value=""
+        onChange={() => {}}
+        horizontalConstraint="m"
+        placeholder="Select something"
+      />
+    </Spec>
+    <Spec label="with error">
+      <DateInput
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        hasError={true}
+      />
+    </Spec>
+    <Spec label="when disabled with error">
+      <DateInput
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        isDisabled={true}
+        hasError={true}
+      />
+    </Spec>
+    <Spec label="with warning">
+      <DateInput
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        hasWarning={true}
+      />
+    </Spec>
+    <Spec label="when disabled with warning">
+      <DateInput
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        isDisabled={true}
+        hasWarning={true}
+      />
+    </Spec>
+    <Spec label="with error and warning">
+      <DateInput
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        hasError={true}
+        hasWarning={true}
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/inputs/date-time-input/date-time-input.percy.js
+++ b/src/components/inputs/date-time-input/date-time-input.percy.js
@@ -1,88 +1,84 @@
 import React from 'react';
-import { TextInput } from '../../../../dist/ui-kit.esm';
+import { DateTimeInput } from '../../../../dist/ui-kit.esm';
 import { Suite, Spec, screenshot } from '../../../../test/percy';
 
-const value = 'hello world how are you?';
+const value = '2018-11-13 15:00';
 
-screenshot('TextInput', () => (
+screenshot('DateTimeInput', () => (
   <Suite>
     <Spec label="minimal">
-      <TextInput value={value} onChange={() => {}} horizontalConstraint="m" />
+      <DateTimeInput
+        value={value}
+        timeZone="UTC"
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
     </Spec>
     <Spec label="when disabled">
-      <TextInput
-        isDisabled={true}
+      <DateTimeInput
         value={value}
+        timeZone="UTC"
         onChange={() => {}}
         horizontalConstraint="m"
-      />
-    </Spec>
-    <Spec label="when read-only">
-      <TextInput
-        isReadOnly={true}
-        value={value}
-        onChange={() => {}}
-        horizontalConstraint="m"
-      />
-    </Spec>
-    <Spec label="when placeholder is visible">
-      <TextInput
         isDisabled={true}
+      />
+    </Spec>
+    <Spec label="when default placeholder is shown">
+      <DateTimeInput value="" onChange={() => {}} horizontalConstraint="m" />
+    </Spec>
+    <Spec label="when custom placeholder is shown">
+      <DateTimeInput
         value=""
-        placeholder="Enter a text"
         onChange={() => {}}
         horizontalConstraint="m"
+        placeholder="Select date and time"
       />
     </Spec>
     <Spec label="with error">
-      <TextInput
+      <DateTimeInput
         value={value}
+        timeZone="UTC"
         onChange={() => {}}
         horizontalConstraint="m"
         hasError={true}
-      />
-    </Spec>
-    <Spec label="with warning">
-      <TextInput
-        value={value}
-        onChange={() => {}}
-        horizontalConstraint="m"
-        hasWarning={true}
-      />
-    </Spec>
-    <Spec label="with error and warning">
-      <TextInput
-        value={value}
-        onChange={() => {}}
-        horizontalConstraint="m"
-        hasError={true}
-        hasWarning={true}
-      />
-    </Spec>
-    <Spec label="when disabled and closed by default">
-      <TextInput
-        value={value}
-        onChange={() => {}}
-        horizontalConstraint="m"
-        isDefaultClosed={true}
-        isDisabled={true}
       />
     </Spec>
     <Spec label="when disabled with error">
-      <TextInput
+      <DateTimeInput
         value={value}
+        timeZone="UTC"
         onChange={() => {}}
         horizontalConstraint="m"
-        isDisabled={true}
         hasError={true}
+        isDisabled={true}
+      />
+    </Spec>
+    <Spec label="with warning">
+      <DateTimeInput
+        value={value}
+        timeZone="UTC"
+        onChange={() => {}}
+        horizontalConstraint="m"
+        hasWarning={true}
       />
     </Spec>
     <Spec label="when disabled with warning">
-      <TextInput
+      <DateTimeInput
         value={value}
+        timeZone="UTC"
         onChange={() => {}}
         horizontalConstraint="m"
+        hasWarning={true}
         isDisabled={true}
+      />
+    </Spec>
+    <Spec label="with error and warning">
+      <DateTimeInput
+        value={value}
+        timeZone="UTC"
+        onChange={() => {}}
+        horizontalConstraint="m"
+        hasError={true}
         hasWarning={true}
       />
     </Spec>

--- a/src/components/inputs/localized-multiline-text-input/localized-multiline-text-input.percy.js
+++ b/src/components/inputs/localized-multiline-text-input/localized-multiline-text-input.percy.js
@@ -1,0 +1,150 @@
+import React from 'react';
+import { LocalizedMultilineTextInput } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const value = {
+  en: 'hello\nworld',
+  de: 'hallo\nwelt',
+  es: 'hola\nmundo',
+};
+
+screenshot('LocalizedMultilineTextInput', () => (
+  <Suite>
+    <Spec label="minimal">
+      <LocalizedMultilineTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+      />
+    </Spec>
+    <Spec label="when multiline text is expanded by default">
+      <LocalizedMultilineTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isMultilineDefaultExpanded={true}
+      />
+    </Spec>
+    <Spec label="when multiline text and languages are expanded by default">
+      <LocalizedMultilineTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isMultilineDefaultExpanded={true}
+        areLanguagesDefaultOpened={true}
+      />
+    </Spec>
+    <Spec label="when language controls are hidden">
+      <LocalizedMultilineTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        hideLanguageControls={true}
+      />
+    </Spec>
+    <Spec label="when languages are opened by default">
+      <LocalizedMultilineTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        areLanguagesDefaultOpened={true}
+      />
+    </Spec>
+    <Spec label="when read-only and open">
+      <LocalizedMultilineTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isReadOnly={true}
+        areLanguagesDefaultOpened={true}
+      />
+    </Spec>
+    <Spec label="when read-only and closed">
+      <LocalizedMultilineTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isReadOnly={true}
+      />
+    </Spec>
+    <Spec label="when disabled and open">
+      <LocalizedMultilineTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isDisabled={true}
+        areLanguagesDefaultOpened={true}
+      />
+    </Spec>
+    <Spec label="when disabled and closed">
+      <LocalizedMultilineTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isDisabled={true}
+      />
+    </Spec>
+    <Spec label="when there is an error for a specific language (first one)">
+      <LocalizedMultilineTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        errors={{ en: 'foo' }}
+      />
+    </Spec>
+    <Spec label="when there is an error for a specific language (second one)">
+      <LocalizedMultilineTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        errors={{ de: 'foo' }}
+      />
+    </Spec>
+    <Spec label="when there is a general error">
+      <LocalizedMultilineTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        hasError={true}
+      />
+    </Spec>
+    <Spec label="when there is a warning for a specific language (first one)">
+      <LocalizedMultilineTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        warnings={{ en: 'foo' }}
+      />
+    </Spec>
+    <Spec label="when there is a warning for a specific language (second one)">
+      <LocalizedMultilineTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        warnings={{ de: 'foo' }}
+      />
+    </Spec>
+    <Spec label="when there is a general warning">
+      <LocalizedMultilineTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        hasWarning={true}
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/inputs/localized-multiline-text-input/localized-multiline-text-input.percy.js
+++ b/src/components/inputs/localized-multiline-text-input/localized-multiline-text-input.percy.js
@@ -1,5 +1,9 @@
 import React from 'react';
-import { LocalizedMultilineTextInput } from '../../../../dist/ui-kit.esm';
+import {
+  LocalizedMultilineTextInput,
+  ErrorMessage,
+  WarningMessage,
+} from '../../../../dist/ui-kit.esm';
 import { Suite, Spec, screenshot } from '../../../../test/percy';
 
 const value = {
@@ -98,7 +102,7 @@ screenshot('LocalizedMultilineTextInput', () => (
         onChange={() => {}}
         selectedLanguage="en"
         horizontalConstraint="m"
-        errors={{ en: 'foo' }}
+        errors={{ en: <ErrorMessage>foo</ErrorMessage> }}
       />
     </Spec>
     <Spec label="when there is an error for a specific language (second one)">
@@ -107,7 +111,7 @@ screenshot('LocalizedMultilineTextInput', () => (
         onChange={() => {}}
         selectedLanguage="en"
         horizontalConstraint="m"
-        errors={{ de: 'foo' }}
+        errors={{ de: <ErrorMessage>foo</ErrorMessage> }}
       />
     </Spec>
     <Spec label="when there is a general error">
@@ -125,7 +129,7 @@ screenshot('LocalizedMultilineTextInput', () => (
         onChange={() => {}}
         selectedLanguage="en"
         horizontalConstraint="m"
-        warnings={{ en: 'foo' }}
+        warnings={{ en: <WarningMessage>foo</WarningMessage> }}
       />
     </Spec>
     <Spec label="when there is a warning for a specific language (second one)">
@@ -134,7 +138,7 @@ screenshot('LocalizedMultilineTextInput', () => (
         onChange={() => {}}
         selectedLanguage="en"
         horizontalConstraint="m"
-        warnings={{ de: 'foo' }}
+        warnings={{ de: <WarningMessage>foo</WarningMessage> }}
       />
     </Spec>
     <Spec label="when there is a general warning">

--- a/src/components/inputs/localized-text-input/localized-text-input.js
+++ b/src/components/inputs/localized-text-input/localized-text-input.js
@@ -33,7 +33,6 @@ const sequentialId = createSequentialId('localized-text-field-');
 const getStyles = props => {
   if (props.isDisabled) return styles.disabled;
   if (props.hasError) return styles.error;
-  if (props.hasWarning) return styles.warning;
   if (props.isReadOnly) return styles.readonly;
 
   return styles.pristine;
@@ -53,7 +52,6 @@ class LocalizedInput extends React.Component {
     isDisabled: PropTypes.bool,
     isReadOnly: PropTypes.bool,
     hasError: PropTypes.bool,
-    hasWarning: PropTypes.bool,
     placeholder: PropTypes.string,
   };
   handleChange = event => {
@@ -94,7 +92,6 @@ class LocalizedInput extends React.Component {
           className={getStyles({
             isDisabled: this.props.isDisabled,
             hasError: this.props.hasError,
-            hasWarning: this.props.hasWarning,
             isReadOnly: this.props.isReadOnly,
           })}
           readOnly={this.props.isReadOnly}

--- a/src/components/inputs/localized-text-input/localized-text-input.percy.js
+++ b/src/components/inputs/localized-text-input/localized-text-input.percy.js
@@ -1,0 +1,148 @@
+import React from 'react';
+import { LocalizedTextInput } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const value = {
+  en: 'hello world',
+  de: 'hallo welt',
+  es: 'hola mundo',
+};
+
+screenshot('LocalizedTextInput', () => (
+  <Suite>
+    <Spec label="minimal">
+      <LocalizedTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+      />
+    </Spec>
+    <Spec label="when multiline text is expanded by default">
+      <LocalizedTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when multiline text and languages are expanded by default">
+      <LocalizedTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        areLanguagesDefaultOpened={true}
+      />
+    </Spec>
+    <Spec label="when language controls are hidden">
+      <LocalizedTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        hideLanguageControls={true}
+      />
+    </Spec>
+    <Spec label="when languages are opened by default">
+      <LocalizedTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        areLanguagesDefaultOpened={true}
+      />
+    </Spec>
+    <Spec label="when read-only and open">
+      <LocalizedTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isReadOnly={true}
+        areLanguagesDefaultOpened={true}
+      />
+    </Spec>
+    <Spec label="when read-only and closed">
+      <LocalizedTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isReadOnly={true}
+      />
+    </Spec>
+    <Spec label="when disabled and open">
+      <LocalizedTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isDisabled={true}
+        areLanguagesDefaultOpened={true}
+      />
+    </Spec>
+    <Spec label="when disabled and closed">
+      <LocalizedTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        isDisabled={true}
+      />
+    </Spec>
+    <Spec label="when there is an error for a specific language (first one)">
+      <LocalizedTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        errors={{ en: 'foo' }}
+      />
+    </Spec>
+    <Spec label="when there is an error for a specific language (second one)">
+      <LocalizedTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        errors={{ de: 'foo' }}
+      />
+    </Spec>
+    <Spec label="when there is a general error">
+      <LocalizedTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        hasError={true}
+      />
+    </Spec>
+    <Spec label="when there is a warning for a specific language (first one)">
+      <LocalizedTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        warnings={{ en: 'foo' }}
+      />
+    </Spec>
+    <Spec label="when there is a warning for a specific language (second one)">
+      <LocalizedTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        warnings={{ de: 'foo' }}
+      />
+    </Spec>
+    <Spec label="when there is a general warning">
+      <LocalizedTextInput
+        value={value}
+        onChange={() => {}}
+        selectedLanguage="en"
+        horizontalConstraint="m"
+        hasWarning={true}
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/inputs/localized-text-input/localized-text-input.percy.js
+++ b/src/components/inputs/localized-text-input/localized-text-input.percy.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LocalizedTextInput } from '../../../../dist/ui-kit.esm';
+import { LocalizedTextInput, ErrorMessage } from '../../../../dist/ui-kit.esm';
 import { Suite, Spec, screenshot } from '../../../../test/percy';
 
 const value = {
@@ -17,39 +17,22 @@ screenshot('LocalizedTextInput', () => (
         selectedLanguage="en"
       />
     </Spec>
-    <Spec label="when multiline text is expanded by default">
+    <Spec label="when languages are expanded by default">
       <LocalizedTextInput
         value={value}
         onChange={() => {}}
         selectedLanguage="en"
         horizontalConstraint="m"
+        isDefaultExpanded={true}
       />
     </Spec>
-    <Spec label="when multiline text and languages are expanded by default">
+    <Spec label="when expansion controls are hidden">
       <LocalizedTextInput
         value={value}
         onChange={() => {}}
         selectedLanguage="en"
         horizontalConstraint="m"
-        areLanguagesDefaultOpened={true}
-      />
-    </Spec>
-    <Spec label="when language controls are hidden">
-      <LocalizedTextInput
-        value={value}
-        onChange={() => {}}
-        selectedLanguage="en"
-        horizontalConstraint="m"
-        hideLanguageControls={true}
-      />
-    </Spec>
-    <Spec label="when languages are opened by default">
-      <LocalizedTextInput
-        value={value}
-        onChange={() => {}}
-        selectedLanguage="en"
-        horizontalConstraint="m"
-        areLanguagesDefaultOpened={true}
+        hideExpansionControls={true}
       />
     </Spec>
     <Spec label="when read-only and open">
@@ -59,7 +42,7 @@ screenshot('LocalizedTextInput', () => (
         selectedLanguage="en"
         horizontalConstraint="m"
         isReadOnly={true}
-        areLanguagesDefaultOpened={true}
+        isDefaultExpanded={true}
       />
     </Spec>
     <Spec label="when read-only and closed">
@@ -78,7 +61,7 @@ screenshot('LocalizedTextInput', () => (
         selectedLanguage="en"
         horizontalConstraint="m"
         isDisabled={true}
-        areLanguagesDefaultOpened={true}
+        isDefaultExpanded={true}
       />
     </Spec>
     <Spec label="when disabled and closed">
@@ -96,7 +79,7 @@ screenshot('LocalizedTextInput', () => (
         onChange={() => {}}
         selectedLanguage="en"
         horizontalConstraint="m"
-        errors={{ en: 'foo' }}
+        errors={{ en: <ErrorMessage>foo</ErrorMessage> }}
       />
     </Spec>
     <Spec label="when there is an error for a specific language (second one)">
@@ -105,7 +88,7 @@ screenshot('LocalizedTextInput', () => (
         onChange={() => {}}
         selectedLanguage="en"
         horizontalConstraint="m"
-        errors={{ de: 'foo' }}
+        errors={{ de: <ErrorMessage>foo</ErrorMessage> }}
       />
     </Spec>
     <Spec label="when there is a general error">
@@ -115,33 +98,6 @@ screenshot('LocalizedTextInput', () => (
         selectedLanguage="en"
         horizontalConstraint="m"
         hasError={true}
-      />
-    </Spec>
-    <Spec label="when there is a warning for a specific language (first one)">
-      <LocalizedTextInput
-        value={value}
-        onChange={() => {}}
-        selectedLanguage="en"
-        horizontalConstraint="m"
-        warnings={{ en: 'foo' }}
-      />
-    </Spec>
-    <Spec label="when there is a warning for a specific language (second one)">
-      <LocalizedTextInput
-        value={value}
-        onChange={() => {}}
-        selectedLanguage="en"
-        horizontalConstraint="m"
-        warnings={{ de: 'foo' }}
-      />
-    </Spec>
-    <Spec label="when there is a general warning">
-      <LocalizedTextInput
-        value={value}
-        onChange={() => {}}
-        selectedLanguage="en"
-        horizontalConstraint="m"
-        hasWarning={true}
       />
     </Spec>
   </Suite>

--- a/src/components/inputs/money-input/money-input.percy.js
+++ b/src/components/inputs/money-input/money-input.percy.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import { MoneyInput } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const value = {
+  amount: '13.50',
+  currencyCode: 'EUR',
+};
+
+const highPrecisionValue = {
+  amount: '13.501',
+  currencyCode: 'EUR',
+};
+
+const emptyValue = { amount: '', currencyCode: '' };
+
+const currencies = ['EUR', 'USD'];
+
+screenshot('MoneyInput', () => (
+  <Suite>
+    <Spec label="minimal">
+      <MoneyInput
+        horizontalConstraint="m"
+        value={value}
+        onChange={() => {}}
+        currencies={currencies}
+      />
+    </Spec>
+    <Spec label="with only one currency">
+      <MoneyInput
+        horizontalConstraint="m"
+        value={value}
+        onChange={() => {}}
+        currencies={['EUR']}
+      />
+    </Spec>
+    <Spec label="with high precision">
+      <MoneyInput
+        horizontalConstraint="m"
+        value={highPrecisionValue}
+        onChange={() => {}}
+        currencies={currencies}
+      />
+    </Spec>
+    <Spec label="when disabled">
+      <MoneyInput
+        horizontalConstraint="m"
+        value={value}
+        onChange={() => {}}
+        currencies={currencies}
+        isDisabled={true}
+      />
+    </Spec>
+    <Spec label="with description">
+      <MoneyInput
+        description="How much is the fish?"
+        horizontalConstraint="m"
+        value={value}
+        onChange={() => {}}
+        currencies={currencies}
+      />
+    </Spec>
+    <Spec label="with placeholder">
+      <MoneyInput
+        horizontalConstraint="m"
+        value={emptyValue}
+        onChange={() => {}}
+        currencies={currencies}
+        placeholder="Please enter a price"
+      />
+    </Spec>
+    <Spec label="with error">
+      <MoneyInput
+        horizontalConstraint="m"
+        value={emptyValue}
+        onChange={() => {}}
+        currencies={currencies}
+        hasError={true}
+      />
+    </Spec>
+    <Spec label="with warning">
+      <MoneyInput
+        horizontalConstraint="m"
+        value={emptyValue}
+        onChange={() => {}}
+        currencies={currencies}
+        hasWarning={true}
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/inputs/multiline-text-input/multiline-text-input.percy.js
+++ b/src/components/inputs/multiline-text-input/multiline-text-input.percy.js
@@ -1,16 +1,20 @@
 import React from 'react';
-import { TextInput } from '../../../../dist/ui-kit.esm';
+import { MultilineTextInput } from '../../../../dist/ui-kit.esm';
 import { Suite, Spec, screenshot } from '../../../../test/percy';
 
-const value = 'hello world how are you?';
+const value = 'hello\nworld\nhow\nare\nyou?';
 
-screenshot('TextInput', () => (
+screenshot('MultilineTextInput', () => (
   <Suite>
     <Spec label="minimal">
-      <TextInput value={value} onChange={() => {}} horizontalConstraint="m" />
+      <MultilineTextInput
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
     </Spec>
     <Spec label="when disabled">
-      <TextInput
+      <MultilineTextInput
         isDisabled={true}
         value={value}
         onChange={() => {}}
@@ -18,7 +22,7 @@ screenshot('TextInput', () => (
       />
     </Spec>
     <Spec label="when read-only">
-      <TextInput
+      <MultilineTextInput
         isReadOnly={true}
         value={value}
         onChange={() => {}}
@@ -26,7 +30,7 @@ screenshot('TextInput', () => (
       />
     </Spec>
     <Spec label="when placeholder is visible">
-      <TextInput
+      <MultilineTextInput
         isDisabled={true}
         value=""
         placeholder="Enter a text"
@@ -35,7 +39,7 @@ screenshot('TextInput', () => (
       />
     </Spec>
     <Spec label="with error">
-      <TextInput
+      <MultilineTextInput
         value={value}
         onChange={() => {}}
         horizontalConstraint="m"
@@ -43,7 +47,7 @@ screenshot('TextInput', () => (
       />
     </Spec>
     <Spec label="with warning">
-      <TextInput
+      <MultilineTextInput
         value={value}
         onChange={() => {}}
         horizontalConstraint="m"
@@ -51,7 +55,7 @@ screenshot('TextInput', () => (
       />
     </Spec>
     <Spec label="with error and warning">
-      <TextInput
+      <MultilineTextInput
         value={value}
         onChange={() => {}}
         horizontalConstraint="m"
@@ -59,31 +63,21 @@ screenshot('TextInput', () => (
         hasWarning={true}
       />
     </Spec>
+    <Spec label="when closed by default">
+      <MultilineTextInput
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        isDefaultClosed={true}
+      />
+    </Spec>
     <Spec label="when disabled and closed by default">
-      <TextInput
+      <MultilineTextInput
         value={value}
         onChange={() => {}}
         horizontalConstraint="m"
         isDefaultClosed={true}
         isDisabled={true}
-      />
-    </Spec>
-    <Spec label="when disabled with error">
-      <TextInput
-        value={value}
-        onChange={() => {}}
-        horizontalConstraint="m"
-        isDisabled={true}
-        hasError={true}
-      />
-    </Spec>
-    <Spec label="when disabled with warning">
-      <TextInput
-        value={value}
-        onChange={() => {}}
-        horizontalConstraint="m"
-        isDisabled={true}
-        hasWarning={true}
       />
     </Spec>
   </Suite>

--- a/src/components/inputs/multiline-text-input/multiline-text-input.percy.js
+++ b/src/components/inputs/multiline-text-input/multiline-text-input.percy.js
@@ -31,6 +31,14 @@ screenshot('MultilineTextInput', () => (
     </Spec>
     <Spec label="when placeholder is visible">
       <MultilineTextInput
+        value=""
+        placeholder="Enter a text"
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when placeholder is visible and input is disabled">
+      <MultilineTextInput
         isDisabled={true}
         value=""
         placeholder="Enter a text"

--- a/src/components/inputs/number-input/number-input.percy.js
+++ b/src/components/inputs/number-input/number-input.percy.js
@@ -1,16 +1,16 @@
 import React from 'react';
-import { TextInput } from '../../../../dist/ui-kit.esm';
+import { NumberInput } from '../../../../dist/ui-kit.esm';
 import { Suite, Spec, screenshot } from '../../../../test/percy';
 
-const value = 'hello world how are you?';
+const value = '18';
 
-screenshot('TextInput', () => (
+screenshot('NumberInput', () => (
   <Suite>
     <Spec label="minimal">
-      <TextInput value={value} onChange={() => {}} horizontalConstraint="m" />
+      <NumberInput value={value} onChange={() => {}} horizontalConstraint="m" />
     </Spec>
     <Spec label="when disabled">
-      <TextInput
+      <NumberInput
         isDisabled={true}
         value={value}
         onChange={() => {}}
@@ -18,7 +18,7 @@ screenshot('TextInput', () => (
       />
     </Spec>
     <Spec label="when read-only">
-      <TextInput
+      <NumberInput
         isReadOnly={true}
         value={value}
         onChange={() => {}}
@@ -26,7 +26,7 @@ screenshot('TextInput', () => (
       />
     </Spec>
     <Spec label="when placeholder is visible">
-      <TextInput
+      <NumberInput
         isDisabled={true}
         value=""
         placeholder="Enter a text"
@@ -35,7 +35,7 @@ screenshot('TextInput', () => (
       />
     </Spec>
     <Spec label="with error">
-      <TextInput
+      <NumberInput
         value={value}
         onChange={() => {}}
         horizontalConstraint="m"
@@ -43,7 +43,7 @@ screenshot('TextInput', () => (
       />
     </Spec>
     <Spec label="with warning">
-      <TextInput
+      <NumberInput
         value={value}
         onChange={() => {}}
         horizontalConstraint="m"
@@ -51,7 +51,7 @@ screenshot('TextInput', () => (
       />
     </Spec>
     <Spec label="with error and warning">
-      <TextInput
+      <NumberInput
         value={value}
         onChange={() => {}}
         horizontalConstraint="m"
@@ -60,30 +60,12 @@ screenshot('TextInput', () => (
       />
     </Spec>
     <Spec label="when disabled and closed by default">
-      <TextInput
+      <NumberInput
         value={value}
         onChange={() => {}}
         horizontalConstraint="m"
         isDefaultClosed={true}
         isDisabled={true}
-      />
-    </Spec>
-    <Spec label="when disabled with error">
-      <TextInput
-        value={value}
-        onChange={() => {}}
-        horizontalConstraint="m"
-        isDisabled={true}
-        hasError={true}
-      />
-    </Spec>
-    <Spec label="when disabled with warning">
-      <TextInput
-        value={value}
-        onChange={() => {}}
-        horizontalConstraint="m"
-        isDisabled={true}
-        hasWarning={true}
       />
     </Spec>
   </Suite>

--- a/src/components/inputs/number-input/number-input.percy.js
+++ b/src/components/inputs/number-input/number-input.percy.js
@@ -27,6 +27,14 @@ screenshot('NumberInput', () => (
     </Spec>
     <Spec label="when placeholder is visible">
       <NumberInput
+        value=""
+        placeholder="Enter a text"
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when placeholder is visible and input is disabled">
+      <NumberInput
         isDisabled={true}
         value=""
         placeholder="Enter a text"

--- a/src/components/inputs/number-input/number-input.percy.js
+++ b/src/components/inputs/number-input/number-input.percy.js
@@ -67,14 +67,5 @@ screenshot('NumberInput', () => (
         hasWarning={true}
       />
     </Spec>
-    <Spec label="when disabled and closed by default">
-      <NumberInput
-        value={value}
-        onChange={() => {}}
-        horizontalConstraint="m"
-        isDefaultClosed={true}
-        isDisabled={true}
-      />
-    </Spec>
   </Suite>
 ));

--- a/src/components/inputs/password-input/password-input.percy.js
+++ b/src/components/inputs/password-input/password-input.percy.js
@@ -1,16 +1,20 @@
 import React from 'react';
-import { TextInput } from '../../../../dist/ui-kit.esm';
+import { PasswordInput } from '../../../../dist/ui-kit.esm';
 import { Suite, Spec, screenshot } from '../../../../test/percy';
 
 const value = 'hello world how are you?';
 
-screenshot('TextInput', () => (
+screenshot('PasswordInput', () => (
   <Suite>
     <Spec label="minimal">
-      <TextInput value={value} onChange={() => {}} horizontalConstraint="m" />
+      <PasswordInput
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
     </Spec>
     <Spec label="when disabled">
-      <TextInput
+      <PasswordInput
         isDisabled={true}
         value={value}
         onChange={() => {}}
@@ -18,7 +22,7 @@ screenshot('TextInput', () => (
       />
     </Spec>
     <Spec label="when read-only">
-      <TextInput
+      <PasswordInput
         isReadOnly={true}
         value={value}
         onChange={() => {}}
@@ -26,7 +30,7 @@ screenshot('TextInput', () => (
       />
     </Spec>
     <Spec label="when placeholder is visible">
-      <TextInput
+      <PasswordInput
         isDisabled={true}
         value=""
         placeholder="Enter a text"
@@ -35,7 +39,7 @@ screenshot('TextInput', () => (
       />
     </Spec>
     <Spec label="with error">
-      <TextInput
+      <PasswordInput
         value={value}
         onChange={() => {}}
         horizontalConstraint="m"
@@ -43,7 +47,7 @@ screenshot('TextInput', () => (
       />
     </Spec>
     <Spec label="with warning">
-      <TextInput
+      <PasswordInput
         value={value}
         onChange={() => {}}
         horizontalConstraint="m"
@@ -51,7 +55,7 @@ screenshot('TextInput', () => (
       />
     </Spec>
     <Spec label="with error and warning">
-      <TextInput
+      <PasswordInput
         value={value}
         onChange={() => {}}
         horizontalConstraint="m"
@@ -60,30 +64,12 @@ screenshot('TextInput', () => (
       />
     </Spec>
     <Spec label="when disabled and closed by default">
-      <TextInput
+      <PasswordInput
         value={value}
         onChange={() => {}}
         horizontalConstraint="m"
         isDefaultClosed={true}
         isDisabled={true}
-      />
-    </Spec>
-    <Spec label="when disabled with error">
-      <TextInput
-        value={value}
-        onChange={() => {}}
-        horizontalConstraint="m"
-        isDisabled={true}
-        hasError={true}
-      />
-    </Spec>
-    <Spec label="when disabled with warning">
-      <TextInput
-        value={value}
-        onChange={() => {}}
-        horizontalConstraint="m"
-        isDisabled={true}
-        hasWarning={true}
       />
     </Spec>
   </Suite>

--- a/src/components/inputs/password-input/password-input.percy.js
+++ b/src/components/inputs/password-input/password-input.percy.js
@@ -71,14 +71,5 @@ screenshot('PasswordInput', () => (
         hasWarning={true}
       />
     </Spec>
-    <Spec label="when disabled and closed by default">
-      <PasswordInput
-        value={value}
-        onChange={() => {}}
-        horizontalConstraint="m"
-        isDefaultClosed={true}
-        isDisabled={true}
-      />
-    </Spec>
   </Suite>
 ));

--- a/src/components/inputs/password-input/password-input.percy.js
+++ b/src/components/inputs/password-input/password-input.percy.js
@@ -31,6 +31,14 @@ screenshot('PasswordInput', () => (
     </Spec>
     <Spec label="when placeholder is visible">
       <PasswordInput
+        value=""
+        placeholder="Enter a text"
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when placeholder is visible and input is disabled">
+      <PasswordInput
         isDisabled={true}
         value=""
         placeholder="Enter a text"

--- a/src/components/inputs/select-input/select-input.percy.js
+++ b/src/components/inputs/select-input/select-input.percy.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { SelectInput } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const options = [
+  { value: 'one', label: 'One' },
+  { value: 'two', label: 'Two' },
+];
+
+const value = 'one';
+
+screenshot('SelectInput', () => (
+  <Suite>
+    <Spec label="minimal">
+      <SelectInput
+        value={value}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when disabled">
+      <SelectInput
+        value={value}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        isDisabled={true}
+      />
+    </Spec>
+    <Spec label="when placeholder is shown">
+      <SelectInput
+        value={null}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        placeholder="Select something"
+      />
+    </Spec>
+    <Spec label="with error">
+      <SelectInput
+        value={null}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        hasError={true}
+      />
+    </Spec>
+    <Spec label="with warning">
+      <SelectInput
+        value={null}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        hasWarning={true}
+      />
+    </Spec>
+    <Spec label="with error and warning">
+      <SelectInput
+        value={null}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        hasError={true}
+        hasWarning={true}
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/inputs/text-input/text-input.percy.js
+++ b/src/components/inputs/text-input/text-input.percy.js
@@ -67,15 +67,6 @@ screenshot('TextInput', () => (
         hasWarning={true}
       />
     </Spec>
-    <Spec label="when disabled and closed by default">
-      <TextInput
-        value={value}
-        onChange={() => {}}
-        horizontalConstraint="m"
-        isDefaultClosed={true}
-        isDisabled={true}
-      />
-    </Spec>
     <Spec label="when disabled with error">
       <TextInput
         value={value}

--- a/src/components/inputs/text-input/text-input.percy.js
+++ b/src/components/inputs/text-input/text-input.percy.js
@@ -27,6 +27,14 @@ screenshot('TextInput', () => (
     </Spec>
     <Spec label="when placeholder is visible">
       <TextInput
+        value=""
+        placeholder="Enter a text"
+        onChange={() => {}}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="when placeholder is visible and input is disabled">
+      <TextInput
         isDisabled={true}
         value=""
         placeholder="Enter a text"

--- a/src/components/inputs/time-input/time-input.percy.js
+++ b/src/components/inputs/time-input/time-input.percy.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { TimeInput } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const value = '3:00 PM';
+
+screenshot('TimeInput', () => (
+  <Suite>
+    <Spec label="minimal">
+      <TimeInput value={value} onChange={() => {}} horizontalConstraint="m" />
+    </Spec>
+    <Spec label="when disabled">
+      <TimeInput
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        isDisabled={true}
+      />
+    </Spec>
+    <Spec label="when placeholder is shown">
+      <TimeInput
+        value=""
+        onChange={() => {}}
+        horizontalConstraint="m"
+        placeholder="Select something"
+      />
+    </Spec>
+    <Spec label="with error">
+      <TimeInput
+        value={null}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        hasError={true}
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/label/label.percy.js
+++ b/src/components/label/label.percy.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Label } from '../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../test/percy';
+
+screenshot('Label', () => (
+  <Suite>
+    <Spec label="minimal">
+      <Label>Hello</Label>
+    </Spec>
+    <Spec label="when bold">
+      <Label isBold={true}>Hello</Label>
+    </Spec>
+    <Spec label="with required indicator">
+      <Label isBold={true} isRequiredIndicatorVisible={true}>
+        Hello
+      </Label>
+    </Spec>
+    <Spec label="when inverted" inverted>
+      <Label tone="inverted">Hello</Label>
+    </Spec>
+  </Suite>
+));

--- a/src/components/loading-spinner/loading-spinner.percy.js
+++ b/src/components/loading-spinner/loading-spinner.percy.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { LoadingSpinner } from '../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../test/percy';
+
+screenshot('LoadingSpinner', () => (
+  <Suite>
+    <Spec label='with scale "l" (default)'>
+      <LoadingSpinner />
+    </Spec>
+    <Spec label='with scale "s"'>
+      <LoadingSpinner scale="s" />
+    </Spec>
+    <Spec label="with children">
+      <LoadingSpinner>Loading..</LoadingSpinner>
+    </Spec>
+    <Spec label='with scale "s" and children'>
+      <LoadingSpinner scale="s">Loading..</LoadingSpinner>
+    </Spec>
+    <Spec label='with scale "l" and children'>
+      <LoadingSpinner scale="l">Loading..</LoadingSpinner>
+    </Spec>
+  </Suite>
+));

--- a/src/components/messages/messages.percy.js
+++ b/src/components/messages/messages.percy.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { ErrorMessage, WarningMessage } from '../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../test/percy';
+
+// We group error and warning messages to save a snapshot.
+screenshot('Messages', () => (
+  <Suite>
+    <Spec label="ErrorMessage">
+      <ErrorMessage>An error message</ErrorMessage>
+    </Spec>
+    <Spec label="WarningMessage">
+      <WarningMessage>A warning message</WarningMessage>
+    </Spec>
+  </Suite>
+));

--- a/src/components/notifications/content-notification/content-notification.percy.js
+++ b/src/components/notifications/content-notification/content-notification.percy.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { ContentNotification } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+screenshot('ContentNotification', () => (
+  <Suite>
+    <Spec label="when type is error">
+      <ContentNotification type="error">A Notification</ContentNotification>
+    </Spec>
+    <Spec label="when type is info">
+      <ContentNotification type="info">A Notification</ContentNotification>
+    </Spec>
+    <Spec label="when type is warning">
+      <ContentNotification type="warning">A Notification</ContentNotification>
+    </Spec>
+    <Spec label="when type is success">
+      <ContentNotification type="success">A Notification</ContentNotification>
+    </Spec>
+  </Suite>
+));

--- a/src/components/panels/collapsible-panel/collapsible-panel.percy.js
+++ b/src/components/panels/collapsible-panel/collapsible-panel.percy.js
@@ -1,0 +1,83 @@
+// These tests are disabled for now as we couldn't get CollapsiblePanel to
+// render in percy. We suspect that this happens for the same reason that we can
+// not render the table in Percy.
+// We did not get to the bottom of the problem yet, unfortunately.
+
+// import React from 'react';
+// import { CollapsiblePanel } from '../../../../dist/ui-kit.esm';
+// import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+// screenshot('CollapsiblePanel', () => (
+//   <Suite>
+//     <Spec label="condensed">
+//       <CollapsiblePanel
+//         header="Header"
+//         description="Some description"
+//         isDisabled={false}
+//         tone="primary"
+//         headerControls="headerControl"
+//         theme="dark"
+//         condensed
+//         secondaryHeader="Secondary Header"
+//       >
+//         Content
+//       </CollapsiblePanel>
+//     </Spec>
+//     <Spec label="regular (not condensed)">
+//       <CollapsiblePanel
+//         header={<CollapsiblePanel.Header>Header</CollapsiblePanel.Header>}
+//         description="Some description"
+//         isDisabled={false}
+//         tone="primary"
+//         headerControls="headerControl"
+//         theme="dark"
+//         condensed
+//         secondaryHeader="Secondary Header"
+//       >
+//         Content
+//       </CollapsiblePanel>
+//     </Spec>
+//     <Spec label="light">
+//       <CollapsiblePanel
+//         header={<CollapsiblePanel.Header>Header</CollapsiblePanel.Header>}
+//         description="Some description"
+//         isDisabled={false}
+//         tone="primary"
+//         headerControls="headerControl"
+//         theme="light"
+//         condensed
+//         secondaryHeader="Secondary Header"
+//       >
+//         Content
+//       </CollapsiblePanel>
+//     </Spec>
+//     <Spec label="urgent and light">
+//       <CollapsiblePanel
+//         header={<CollapsiblePanel.Header>Header</CollapsiblePanel.Header>}
+//         description="Some description"
+//         isDisabled={false}
+//         tone="urgent"
+//         headerControls="headerControl"
+//         theme="light"
+//         condensed
+//         secondaryHeader="Secondary Header"
+//       >
+//         Content
+//       </CollapsiblePanel>
+//     </Spec>
+//     <Spec label="urgent and dark">
+//       <CollapsiblePanel
+//         header={<CollapsiblePanel.Header>Header</CollapsiblePanel.Header>}
+//         description="Some description"
+//         isDisabled={false}
+//         tone="urgent"
+//         headerControls="headerControl"
+//         theme="dark"
+//         condensed
+//         secondaryHeader="Secondary Header"
+//       >
+//         Content
+//       </CollapsiblePanel>
+//     </Spec>
+//   </Suite>
+// ));

--- a/src/components/spacings/inline/inline.percy.js
+++ b/src/components/spacings/inline/inline.percy.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import { Spacings, Text } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const Stack = styled.div`
+  > * + * {
+    margin: 8px 0 0;
+  }
+`;
+
+const Row = styled.div`
+  display: block;
+`;
+
+const InlineColorWrapper = styled.div`
+  background-color: #e1ffdd;
+  display: inline-flex;
+  align-items: stretch;
+  height: 100px;
+`;
+
+const InlineItem = styled.div`
+  background-color: #65ff4f;
+  height: ${props =>
+    props.alignItems === 'stretch'
+      ? 'auto'
+      : `${Math.round(Math.random() * 50) + 50}px`};
+  width: 100px;
+`;
+
+const Scale = styled.div`
+  align-self: center;
+  width: 75px;
+  text-align: center;
+`;
+
+const sizes = [
+  { name: 'xs', pixels: '4px' },
+  { name: 's', pixels: '8px' },
+  { name: 'm', pixels: '16px' },
+  { name: 'l', pixels: '24px' },
+  { name: 'xl', pixels: '32px' },
+];
+
+const InlineExample = ({ alignItems }) => (
+  <Stack>
+    {sizes.map(size => (
+      <Row key={size.name}>
+        <InlineColorWrapper>
+          <Scale>
+            <Spacings.Inset scale="s" alignItems="center">
+              <Text.Subheadline elementType="h4">
+                {size.name.toUpperCase()}
+                <Text.Detail>{size.pixels}</Text.Detail>
+              </Text.Subheadline>
+            </Spacings.Inset>
+          </Scale>
+          <Spacings.Inline scale={size.name} alignItems={alignItems}>
+            <InlineItem alignItems={alignItems} />
+            <InlineItem alignItems={alignItems} />
+            <InlineItem alignItems={alignItems} />
+            <InlineItem alignItems={alignItems} />
+            <InlineItem alignItems={alignItems} />
+          </Spacings.Inline>
+        </InlineColorWrapper>
+      </Row>
+    ))}
+  </Stack>
+);
+
+InlineExample.displayName = 'InlineExample';
+InlineExample.propTypes = {
+  alignItems: PropTypes.oneOf(['stretch', 'flexStart', 'flexEnd', 'center']),
+};
+
+screenshot('Inline', () => (
+  <Suite>
+    <Spec label="when alignItems is flexStart ">
+      <InlineExample alignItems="flexStart" />
+    </Spec>
+    <Spec label="when alignItems is stretch ">
+      <InlineExample alignItems="stretch" />
+    </Spec>
+    <Spec label="when alignItems is flexEnd ">
+      <InlineExample alignItems="flexEnd" />
+    </Spec>
+    <Spec label="when alignItems is center ">
+      <InlineExample alignItems="center" />
+    </Spec>
+  </Suite>
+));

--- a/src/components/spacings/inset-squish/inset-squish.percy.js
+++ b/src/components/spacings/inset-squish/inset-squish.percy.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Spacings, Text } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const View = styled.div`
+  display: flex;
+`;
+
+const InsetColorWrapper = styled.div`
+  background-color: #ffb15c;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  border-radius: 4px;
+  > * {
+    flex-grow: 1;
+    display: flex;
+    align-items: stretch;
+  }
+`;
+
+const Button = styled.div`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: white;
+  text-align: center;
+`;
+
+const sizes = [
+  { name: 's', pixels: '4px x 8px' },
+  { name: 'm', pixels: '8px x 16px' },
+  { name: 'l', pixels: '16px x 32px' },
+];
+
+screenshot('InsetSquish', () => (
+  <Suite>
+    <Spec label="InsetSquish">
+      <View>
+        <Spacings.Inline scale="s" alignItems="center">
+          {sizes.map(size => (
+            <InsetColorWrapper key={size.name}>
+              <Spacings.InsetSquish scale={size.name}>
+                <Button>
+                  <Text.Subheadline elementType="h4">
+                    {size.name.toUpperCase()}
+                    <Text.Detail>{size.pixels}</Text.Detail>
+                  </Text.Subheadline>
+                </Button>
+              </Spacings.InsetSquish>
+            </InsetColorWrapper>
+          ))}
+        </Spacings.Inline>
+      </View>
+    </Spec>
+  </Suite>
+));

--- a/src/components/spacings/inset/inset.percy.js
+++ b/src/components/spacings/inset/inset.percy.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Spacings, Text } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const View = styled.div`
+  display: flex;
+`;
+
+const InsetColorWrapper = styled.div`
+  display: inline-block;
+  background-color: #ff5b5b;
+  height: 100px;
+  width: 100px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  > * {
+    flex-grow: 1;
+    display: flex;
+    align-items: stretch;
+  }
+`;
+
+const Square = styled.div`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: white;
+  text-align: center;
+`;
+
+const sizes = [
+  { name: 'xs', pixels: '4px' },
+  { name: 's', pixels: '8px' },
+  { name: 'm', pixels: '16px' },
+  { name: 'l', pixels: '24px' },
+  { name: 'xl', pixels: '32px' },
+];
+
+screenshot('Inset', () => (
+  <Suite>
+    <Spec label="Inset">
+      <View>
+        <Spacings.Inline scale="s">
+          {sizes.map(size => (
+            <InsetColorWrapper key={size.name}>
+              <Spacings.Inset scale={size.name}>
+                <Square>
+                  <Text.Subheadline elementType="h4">
+                    {size.name.toUpperCase()}
+                    <Text.Detail>{size.pixels}</Text.Detail>
+                  </Text.Subheadline>
+                </Square>
+              </Spacings.Inset>
+            </InsetColorWrapper>
+          ))}
+        </Spacings.Inline>
+      </View>
+    </Spec>
+  </Suite>
+));

--- a/src/components/spacings/stack/stack.percy.js
+++ b/src/components/spacings/stack/stack.percy.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import { Spacings, Text } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const StackColorWrapper = styled.div`
+  background-color: #d4e0ec;
+  width: 100px;
+  text-align: center;
+`;
+
+const StackItem = styled.div`
+  background-color: #2d68a0;
+  height: 100px;
+  width: ${props =>
+    props.alignItems === 'stretch'
+      ? 'auto'
+      : `${Math.round(Math.random() * 50) + 50}px`};
+`;
+
+const sizes = [
+  { name: 'xs', pixels: '4px' },
+  { name: 's', pixels: '8px' },
+  { name: 'm', pixels: '16px' },
+  { name: 'l', pixels: '24px' },
+  { name: 'xl', pixels: '32px' },
+];
+
+const StackExample = ({ alignItems }) => (
+  <Spacings.Inline scale="s">
+    {sizes.map(size => (
+      <StackColorWrapper key={size.name}>
+        <Spacings.Inset scale="m">
+          <Text.Subheadline elementType="h4">
+            {size.name.toUpperCase()}
+            <Text.Detail>{size.pixels}</Text.Detail>
+          </Text.Subheadline>
+        </Spacings.Inset>
+        <Spacings.Stack scale={size.name} alignItems={alignItems}>
+          <StackItem alignItems={alignItems} />
+          <StackItem alignItems={alignItems} />
+          <StackItem alignItems={alignItems} />
+          <StackItem alignItems={alignItems} />
+          <StackItem alignItems={alignItems} />
+        </Spacings.Stack>
+      </StackColorWrapper>
+    ))}
+  </Spacings.Inline>
+);
+
+StackExample.displayName = 'StackExample';
+StackExample.propTypes = {
+  alignItems: PropTypes.oneOf(['stretch', 'flexStart', 'flexEnd', 'center']),
+};
+
+screenshot('Stack', () => (
+  <Suite>
+    <Spec label="when alignItems is flexStart ">
+      <StackExample alignItems="flexStart" />
+    </Spec>
+    <Spec label="when alignItems is stretch ">
+      <StackExample alignItems="stretch" />
+    </Spec>
+    <Spec label="when alignItems is flexEnd ">
+      <StackExample alignItems="flexEnd" />
+    </Spec>
+    <Spec label="when alignItems is center ">
+      <StackExample alignItems="center" />
+    </Spec>
+  </Suite>
+));

--- a/src/components/stamp/stamp.percy.js
+++ b/src/components/stamp/stamp.percy.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Stamp } from '../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../test/percy';
+
+screenshot('Stamp', () => (
+  <Suite>
+    <Spec label="when critical">
+      <Stamp tone="critical">Critical</Stamp>
+    </Spec>
+    <Spec label="when positive">
+      <Stamp tone="positive">Positive</Stamp>
+    </Spec>
+    <Spec label="when warning">
+      <Stamp tone="warning">Warning</Stamp>
+    </Spec>
+    <Spec label="when information">
+      <Stamp tone="information">Information</Stamp>
+    </Spec>
+    <Spec label="when primary">
+      <Stamp tone="primary">Primary</Stamp>
+    </Spec>
+    <Spec label="when secondary">
+      <Stamp tone="secondary">Secondary</Stamp>
+    </Spec>
+  </Suite>
+));

--- a/src/components/switches/toggle/toggle.percy.js
+++ b/src/components/switches/toggle/toggle.percy.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Toggle } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+screenshot('Toggle', () => (
+  <Suite>
+    <Spec label="Default">
+      <Toggle />
+    </Spec>
+    <Spec label="Default - disabled">
+      <Toggle isDisabled={true} />
+    </Spec>
+    <Spec label="Default - checked">
+      <Toggle isChecked={true} />
+    </Spec>
+    <Spec label="Default - checked - disabled">
+      <Toggle isDisabled={true} isChecked={true} />
+    </Spec>
+    <Spec label="Small">
+      <Toggle size="small" />
+    </Spec>
+    <Spec label="Small - disabled">
+      <Toggle size="small" isDisabled={true} />
+    </Spec>
+    <Spec label="Small - checked">
+      <Toggle size="small" isChecked={true} />
+    </Spec>
+    <Spec label="Small - checked - disabled">
+      <Toggle size="small" isDisabled={true} isChecked={true} />
+    </Spec>
+  </Suite>
+));

--- a/src/components/tag/tag.percy.js
+++ b/src/components/tag/tag.percy.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Tag } from '../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../test/percy';
+
+screenshot('Tag', () => (
+  <Suite>
+    <Spec label="Normal">
+      <Tag type="normal">Tag</Tag>
+    </Spec>
+    <Spec label="Normal - onRemove">
+      <Tag type="normal" onRemove={() => {}}>
+        With remove
+      </Tag>
+    </Spec>
+    <Spec label="Normal - horizontalConstraint - xs">
+      <Tag type="normal" horizontalConstraint="xs">
+        Tag
+      </Tag>
+    </Spec>
+    <Spec label="Normal - horizontalConstraint - s">
+      <Tag type="normal" horizontalConstraint="s">
+        Tag
+      </Tag>
+    </Spec>
+    <Spec label="Normal - horizontalConstraint - m">
+      <Tag type="normal" horizontalConstraint="m">
+        Tag
+      </Tag>
+    </Spec>
+    <Spec label="Normal - horizontalConstraint - l">
+      <Tag type="normal" horizontalConstraint="l">
+        Tag
+      </Tag>
+    </Spec>
+    <Spec label="Normal - horizontalConstraint - xl">
+      <Tag type="normal" horizontalConstraint="xl">
+        Tag
+      </Tag>
+    </Spec>
+
+    <Spec label="Warning">
+      <Tag type="warning">Warning message</Tag>
+    </Spec>
+    <Spec label="Warning - disabled">
+      <Tag type="warning" isDisabled={true}>
+        Warning but disabled
+      </Tag>
+    </Spec>
+  </Suite>
+));

--- a/src/components/typography/text/text.percy.js
+++ b/src/components/typography/text/text.percy.js
@@ -7,23 +7,19 @@ const NarrowBox = styled.div`
   width: 200px;
 `;
 
-const InvertedBox = styled.div`
-  background-color: black;
-  color: white;
-`;
-
 screenshot('Text', () => (
   <Suite>
     <Spec label="Headline - h1">
       <Text.Headline elementType="h1">{'Title H1'}</Text.Headline>
     </Spec>
-    <Spec label="Headline - h1 - truncated">
-      <NarrowBox>
+    <NarrowBox>
+      <Spec label="Headline - h1 - truncated">
         <Text.Headline elementType="h1" truncate={true}>
           {'A longer title that should be truncated'}
         </Text.Headline>
-      </NarrowBox>
-    </Spec>
+      </Spec>
+    </NarrowBox>
+
     <Spec label="Headline - h2">
       <Text.Headline elementType="h2">{'Title H2'}</Text.Headline>
     </Spec>
@@ -35,13 +31,13 @@ screenshot('Text', () => (
         {'Bigger subheadline'}
       </Text.Subheadline>
     </Spec>
-    <Spec label="Subheadline - h4 - truncated">
-      <NarrowBox>
+    <NarrowBox>
+      <Spec label="Subheadline - h4 - truncated">
         <Text.Subheadline elementType="h4" truncate={true}>
           {'A longer subheadline that should be truncated'}
         </Text.Subheadline>
-      </NarrowBox>
-    </Spec>
+      </Spec>
+    </NarrowBox>
     <Spec label="Subheadline - h4 - bold">
       <Text.Subheadline isBold={true} elementType="h4">
         {'Bold subheadline'}
@@ -112,11 +108,9 @@ screenshot('Text', () => (
       <Text.Body tone="negative">Body text negative</Text.Body>
     </Spec>
     <NarrowBox>
-      <InvertedBox>
-        <Spec label="Body - tone - inverted">
-          <Text.Body tone="inverted">Body text inverted</Text.Body>
-        </Spec>
-      </InvertedBox>
+      <Spec inverted label="Body - tone - inverted">
+        <Text.Body tone="inverted">Body text inverted</Text.Body>
+      </Spec>
     </NarrowBox>
     <NarrowBox>
       <Spec label="Body - truncate">
@@ -125,7 +119,7 @@ screenshot('Text', () => (
         </Text.Body>
       </Spec>
     </NarrowBox>
-    <Spec label="Body - inline">
+    <Spec label="Body - inline" omitPropsList>
       <Text.Body isInline={true}>One inline body text{'. '}</Text.Body>
       <Text.Body isInline={true}>A second inline text.</Text.Body>
     </Spec>
@@ -154,11 +148,9 @@ screenshot('Text', () => (
       <Text.Detail tone="negative">Detail text negative</Text.Detail>
     </Spec>
     <NarrowBox>
-      <InvertedBox>
-        <Spec label="Detail - tone - inverted">
-          <Text.Detail tone="inverted">Detail text inverted</Text.Detail>
-        </Spec>
-      </InvertedBox>
+      <Spec inverted label="Detail - tone - inverted">
+        <Text.Detail tone="inverted">Detail text inverted</Text.Detail>
+      </Spec>
     </NarrowBox>
     <NarrowBox>
       <Spec label="Detail - truncate">
@@ -167,7 +159,7 @@ screenshot('Text', () => (
         </Text.Detail>
       </Spec>
     </NarrowBox>
-    <Spec label="Detail - inline">
+    <Spec label="Detail - inline" omitPropsList>
       <Text.Detail isInline={true}>One inline detail text{'. '}</Text.Detail>
       <Text.Detail isInline={true}>A second inline text.</Text.Detail>
     </Spec>

--- a/src/components/typography/text/text.percy.js
+++ b/src/components/typography/text/text.percy.js
@@ -1,0 +1,175 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Text } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const NarrowBox = styled.div`
+  width: 200px;
+`;
+
+const InvertedBox = styled.div`
+  background-color: black;
+  color: white;
+`;
+
+screenshot('Text', () => (
+  <Suite>
+    <Spec label="Headline - h1">
+      <Text.Headline elementType="h1">{'Title H1'}</Text.Headline>
+    </Spec>
+    <Spec label="Headline - h1 - truncated">
+      <NarrowBox>
+        <Text.Headline elementType="h1" truncate={true}>
+          {'A longer title that should be truncated'}
+        </Text.Headline>
+      </NarrowBox>
+    </Spec>
+    <Spec label="Headline - h2">
+      <Text.Headline elementType="h2">{'Title H2'}</Text.Headline>
+    </Spec>
+    <Spec label="Headline - h3">
+      <Text.Headline elementType="h3">{'Title H3'}</Text.Headline>
+    </Spec>
+    <Spec label="Subheadline - h4">
+      <Text.Subheadline elementType="h4">
+        {'Bigger subheadline'}
+      </Text.Subheadline>
+    </Spec>
+    <Spec label="Subheadline - h4 - truncated">
+      <NarrowBox>
+        <Text.Subheadline elementType="h4" truncate={true}>
+          {'A longer subheadline that should be truncated'}
+        </Text.Subheadline>
+      </NarrowBox>
+    </Spec>
+    <Spec label="Subheadline - h4 - bold">
+      <Text.Subheadline isBold={true} elementType="h4">
+        {'Bold subheadline'}
+      </Text.Subheadline>
+    </Spec>
+    <Spec label="Subheadline - tone - primary">
+      <Text.Subheadline tone="primary" elementType="h4">
+        {'Subheadline tone primary'}
+      </Text.Subheadline>
+    </Spec>
+    <Spec label="Subheadline - tone - secondary">
+      <Text.Subheadline tone="secondary" elementType="h4">
+        {'Subheadline tone secondary'}
+      </Text.Subheadline>
+    </Spec>
+    <Spec label="Subheadline - tone - information">
+      <Text.Subheadline tone="information" elementType="h4">
+        {'Subheadline tone information'}
+      </Text.Subheadline>
+    </Spec>
+    <Spec label="Subheadline - tone - positive">
+      <Text.Subheadline tone="positive" elementType="h4">
+        {'Subheadline tone positive'}
+      </Text.Subheadline>
+    </Spec>
+    <Spec label="Subheadline - tone - negative">
+      <Text.Subheadline tone="negative" elementType="h4">
+        {'Subheadline tone negative'}
+      </Text.Subheadline>
+    </Spec>
+    <Spec label="Subheadline - h5">
+      <Text.Subheadline elementType="h5">
+        {'Smaller subheadline'}
+      </Text.Subheadline>
+    </Spec>
+    <NarrowBox>
+      <Spec label="Wrap">
+        <Text.Wrap>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat.
+        </Text.Wrap>
+      </Spec>
+    </NarrowBox>
+    <Spec label="Body">
+      <Text.Body>Body text</Text.Body>
+    </Spec>
+    <Spec label="Body - bold">
+      <Text.Body isBold={true}>Body text bold</Text.Body>
+    </Spec>
+    <Spec label="Body - italic">
+      <Text.Body isItalic={true}>Body text italic</Text.Body>
+    </Spec>
+    <Spec label="Body - tone - primary">
+      <Text.Body tone="primary">Body text primary</Text.Body>
+    </Spec>
+    <Spec label="Body - tone - secondary">
+      <Text.Body tone="secondary">Body text secondary</Text.Body>
+    </Spec>
+    <Spec label="Body - tone - information">
+      <Text.Body tone="information">Body text information</Text.Body>
+    </Spec>
+    <Spec label="Body - tone - positive">
+      <Text.Body tone="positive">Body text positive</Text.Body>
+    </Spec>
+    <Spec label="Body - tone - negative">
+      <Text.Body tone="negative">Body text negative</Text.Body>
+    </Spec>
+    <NarrowBox>
+      <InvertedBox>
+        <Spec label="Body - tone - inverted">
+          <Text.Body tone="inverted">Body text inverted</Text.Body>
+        </Spec>
+      </InvertedBox>
+    </NarrowBox>
+    <NarrowBox>
+      <Spec label="Body - truncate">
+        <Text.Body truncate={true}>
+          A longer body text that needs to be truncated.
+        </Text.Body>
+      </Spec>
+    </NarrowBox>
+    <Spec label="Body - inline">
+      <Text.Body isInline={true}>One inline body text{'. '}</Text.Body>
+      <Text.Body isInline={true}>A second inline text.</Text.Body>
+    </Spec>
+    <Spec label="Detail">
+      <Text.Detail>Detail text</Text.Detail>
+    </Spec>
+    <Spec label="Detail - bold">
+      <Text.Detail isBold={true}>Detail text bold</Text.Detail>
+    </Spec>
+    <Spec label="Detail - italic">
+      <Text.Detail isItalic={true}>Detail text italic</Text.Detail>
+    </Spec>
+    <Spec label="Detail - tone - primary">
+      <Text.Detail tone="primary">Detail text primary</Text.Detail>
+    </Spec>
+    <Spec label="Detail - tone - secondary">
+      <Text.Detail tone="secondary">Detail text secondary</Text.Detail>
+    </Spec>
+    <Spec label="Detail - tone - information">
+      <Text.Detail tone="information">Detail text information</Text.Detail>
+    </Spec>
+    <Spec label="Detail - tone - positive">
+      <Text.Detail tone="positive">Detail text positive</Text.Detail>
+    </Spec>
+    <Spec label="Detail - tone - negative">
+      <Text.Detail tone="negative">Detail text negative</Text.Detail>
+    </Spec>
+    <NarrowBox>
+      <InvertedBox>
+        <Spec label="Detail - tone - inverted">
+          <Text.Detail tone="inverted">Detail text inverted</Text.Detail>
+        </Spec>
+      </InvertedBox>
+    </NarrowBox>
+    <NarrowBox>
+      <Spec label="Detail - truncate">
+        <Text.Detail truncate={true}>
+          A longer detail text that needs to be truncated.
+        </Text.Detail>
+      </Spec>
+    </NarrowBox>
+    <Spec label="Detail - inline">
+      <Text.Detail isInline={true}>One inline detail text{'. '}</Text.Detail>
+      <Text.Detail isInline={true}>A second inline text.</Text.Detail>
+    </Spec>
+  </Suite>
+));

--- a/test/percy/README.md
+++ b/test/percy/README.md
@@ -46,6 +46,8 @@ screenshot('PrimaryButton', () => (
 ));
 ```
 
+You can test this snapshot in your browser before even uploading it to Percy by running `yarn percy --debug`.
+
 ### `screenshot`
 
 Usually when writing tests for Percy you'd call `percySnapshot('label', options, () => <Foo />)`. As we want to always use the same options (the same viewport), we export a preconfigured `screenshot` function which provides the options out of the box.
@@ -65,6 +67,14 @@ A `Spec` should render your component in a specific state.
 You can use multiple specs within a `Suite`.
 
 ## Local development (rarely used)
+
+### Viewing snapshots in browser
+
+You can run `yarn percy --debug` to show your snapshots in the browser without having to upload them. This is useful when you're working on adding more snapshots or resolving bugs in existing snapshots.
+
+No snapshots will be uploaded to Percy in this case.
+
+### Uploading local snapshots
 
 Usually, you'd let Percy run for your PRs on CI. There is no need to run it locally. However, if you ever need to run Percy locally (e.g. to debug our Percy setup), you can follow the steps described [here](https://docs.percy.io/docs/local-development).
 

--- a/test/percy/spec.js
+++ b/test/percy/spec.js
@@ -2,10 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 
-const Container = styled.div`
+const SpecContainer = styled.div`
   display: flex;
   flex-direction: column;
-  background-color: ${props => (props.inverted ? '#111' : '#eee')};
+  /*
+    We don't want a change in a component's height resulting in diffs of the
+    remaining states below it, so we establish a min-height for each spec to
+    prevent that.
+  */
+  min-height: 400px;
 `;
 
 const Label = styled.div`
@@ -34,7 +39,9 @@ const PropValue = styled.span`
   padding: 0 4px;
 `;
 
-const Box = styled.div``;
+const Box = styled.div`
+  background-color: ${props => (props.inverted ? '#111' : '#eee')};
+`;
 
 const Pill = props => {
   const value = (() => {
@@ -84,11 +91,11 @@ Props.propTypes = {
 };
 
 const Spec = props => (
-  <Container inverted={props.inverted}>
+  <SpecContainer>
     <Label>{props.label}</Label>
     {!props.omitPropsList && <Props>{props.children}</Props>}
-    <Box>{props.children}</Box>
-  </Container>
+    <Box inverted={props.inverted}>{props.children}</Box>
+  </SpecContainer>
 );
 
 Spec.propTypes = {

--- a/test/percy/spec.js
+++ b/test/percy/spec.js
@@ -5,13 +5,73 @@ import styled from '@emotion/styled';
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  margin: 10px 0;
 `;
+
+const Label = styled.div`
+  font-weight: bold;
+  background-color: #774caf;
+  padding: 5px;
+  color: white;
+`;
+
+const PropList = styled.div`
+  background-color: #894ac3;
+  padding: 5px;
+  font-size: 8pt;
+  font-family: monospace;
+  color: white;
+`;
+
+const PropLabel = styled.span`
+  font-weight: bold;
+  padding: 0 4px;
+  min-width: 120px;
+  display: inline-block;
+`;
+
+const PropValue = styled.span`
+  padding: 0 4px;
+`;
+
+const Box = styled.div``;
+
+const Pill = props => (
+  <div>
+    <PropLabel>{props.label}</PropLabel>
+    <PropValue>{JSON.stringify(props.value)}</PropValue>
+  </div>
+);
+
+Pill.displayName = 'Pill';
+Pill.propTypes = {
+  label: PropTypes.string,
+  value: PropTypes.any,
+};
+
+const Props = props => {
+  const node = React.Children.only(props.children);
+  const propEntries = Object.entries(node.props);
+  return (
+    <PropList>
+      {propEntries
+        .filter(([, value]) => typeof value !== 'function')
+        .map(([key, value]) => (
+          <Pill key={key} label={key} value={value} />
+        ))}
+    </PropList>
+  );
+};
+
+Props.displayName = 'Props';
+Props.propTypes = {
+  children: PropTypes.node.isRequired,
+};
 
 const Spec = props => (
   <Container>
-    <div>{props.label}</div>
-    <div>{props.children}</div>
+    <Label>{props.label}</Label>
+    <Props>{props.children}</Props>
+    <Box>{props.children}</Box>
   </Container>
 );
 

--- a/test/percy/spec.js
+++ b/test/percy/spec.js
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 const Container = styled.div`
   display: flex;
   flex-direction: column;
+  background-color: ${props => (props.inverted ? '#111' : '#eee')};
 `;
 
 const Label = styled.div`
@@ -25,7 +26,7 @@ const PropList = styled.div`
 const PropLabel = styled.span`
   font-weight: bold;
   padding: 0 4px;
-  min-width: 120px;
+  min-width: 140px;
   display: inline-block;
 `;
 
@@ -35,12 +36,27 @@ const PropValue = styled.span`
 
 const Box = styled.div``;
 
-const Pill = props => (
-  <div>
-    <PropLabel>{props.label}</PropLabel>
-    <PropValue>{JSON.stringify(props.value)}</PropValue>
-  </div>
-);
+const Pill = props => {
+  const value = (() => {
+    if (React.isValidElement(props.value)) return 'React Element';
+    if (
+      Array.isArray(props.value) &&
+      props.value.every(element => React.isValidElement(element))
+    )
+      return '[React Element]';
+    try {
+      return JSON.stringify(props.value);
+    } catch (e) {
+      return '-';
+    }
+  })();
+  return (
+    <div>
+      <PropLabel>{props.label}</PropLabel>
+      <PropValue>{value}</PropValue>
+    </div>
+  );
+};
 
 Pill.displayName = 'Pill';
 Pill.propTypes = {
@@ -68,7 +84,7 @@ Props.propTypes = {
 };
 
 const Spec = props => (
-  <Container>
+  <Container inverted={props.inverted}>
     <Label>{props.label}</Label>
     <Props>{props.children}</Props>
     <Box>{props.children}</Box>
@@ -78,6 +94,7 @@ const Spec = props => (
 Spec.propTypes = {
   label: PropTypes.string.isRequired,
   children: PropTypes.node,
+  inverted: PropTypes.bool,
 };
 
 Spec.displayName = 'Spec';

--- a/test/percy/spec.js
+++ b/test/percy/spec.js
@@ -1,11 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: 10px 0;
+`;
 
 const Spec = props => (
-  <div>
+  <Container>
     <div>{props.label}</div>
-    {props.children}
-  </div>
+    <div>{props.children}</div>
+  </Container>
 );
 
 Spec.propTypes = {

--- a/test/percy/spec.js
+++ b/test/percy/spec.js
@@ -86,7 +86,7 @@ Props.propTypes = {
 const Spec = props => (
   <Container inverted={props.inverted}>
     <Label>{props.label}</Label>
-    <Props>{props.children}</Props>
+    {!props.omitPropsList && <Props>{props.children}</Props>}
     <Box>{props.children}</Box>
   </Container>
 );
@@ -95,6 +95,11 @@ Spec.propTypes = {
   label: PropTypes.string.isRequired,
   children: PropTypes.node,
   inverted: PropTypes.bool,
+  omitPropsList: PropTypes.bool,
+};
+
+Spec.defaultProps = {
+  omitPropsList: false,
 };
 
 Spec.displayName = 'Spec';


### PR DESCRIPTION
Adds even more visual regression tests. We are now only missing `CollapsiblePanel` and `Table` in our Visual Regression Tests.

This needs a review from designers to ensure that our baseline is correct. I can explain it in a call.