### PR TITLE
chore: skip percy on non prs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - yarn run jest --projects jest.*.config.js --maxWorkers=4 --reporters jest-silent-reporter
   - "! test -f fail-tests-because-there-was-an-unhandled-rejection.lock"
   # skip percy builds when this is not a pull request or when it's not master to save precious snaps
-  - if [[ $TRAVIS_PULL_REQUEST != 'false' || ${TRAVIS_BRANCH} == 'master' ]] ; then yarn build; else echo 'skipping percy build'; fi
+  - if [[ $TRAVIS_PULL_REQUEST != 'false' || ${TRAVIS_BRANCH} == 'master' ]] ; then yarn percy; else echo 'skipping percy build'; fi
   # back to default in case internal travis scripts return non zero response codes.
   - set +e
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ script:
   - yarn build
   - yarn run jest --projects jest.*.config.js --maxWorkers=4 --reporters jest-silent-reporter
   - "! test -f fail-tests-because-there-was-an-unhandled-rejection.lock"
-  - yarn percy
+  # skip percy builds when this is not a pull request or when it's not master to save precious snaps
+  - if [[ $TRAVIS_PULL_REQUEST != 'false' || ${TRAVIS_BRANCH} == 'master' ]] ; then yarn build; else echo 'skipping percy build'; fi
   # back to default in case internal travis scripts return non zero response codes.
   - set +e
 


### PR DESCRIPTION
#### Summary

Snapshots are precious. If we run `yarn percy` on every CI build, we will run out of snapshots. 😢 

#### Approach

Skip percy on non PRs.