### PR TITLE
Don't run `yarn percy` when PR is opened by 🤖

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ script:
   - yarn run jest --projects jest.*.config.js --maxWorkers=4 --reporters jest-silent-reporter
   - "! test -f fail-tests-because-there-was-an-unhandled-rejection.lock"
   # skip percy builds when this is not a pull request or when it's not master to save precious snaps
-  - if [[ $TRAVIS_PULL_REQUEST != 'false' || ${TRAVIS_BRANCH} == 'master' ]] ; then yarn percy; else echo 'skipping percy build'; fi
+  # also skip when PR is opened by `renovate`
+  - bash ./scripts/run-percy.sh
   # back to default in case internal travis scripts return non zero response codes.
   - set +e
 

--- a/scripts/run-percy.sh
+++ b/scripts/run-percy.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# skip percy builds when this is not a pull request or when it's not master
+if [[ $TRAVIS_PULL_REQUEST != 'false' || ${TRAVIS_BRANCH} == 'master' ]]
+  then
+  # skip percy builds when pull request is opened by a robot
+  regexp='^renovate\/'
+  if ! [[ ${TRAVIS_PULL_REQUEST_BRANCH} =~ ${regexp} ]]
+    then
+      yarn percy
+    else
+      echo 'Skipping percy - PR opened by `renovate`'
+  fi
+else
+  echo 'Skipping percy build'
+fi

--- a/scripts/run-percy.sh
+++ b/scripts/run-percy.sh
@@ -3,7 +3,10 @@
 # skip percy builds when this is not a pull request or when it's not master
 if [[ $TRAVIS_PULL_REQUEST != 'false' || ${TRAVIS_BRANCH} == 'master' ]]
   then
-  # skip percy builds when pull request is opened by a robot
+  # skip percy builds when pull request is opened by a renovate
+  # if renovate opens an average of 6 PRs per week, that means, 24 PRs per month.
+  # 24 * ~50 snapshots = 1200, or almost 25% of our current percy snapshot allowances.
+  # if in the future, we drop more 💸 on percy, we can remove this.
   regexp='^renovate\/'
   if ! [[ ${TRAVIS_PULL_REQUEST_BRANCH} =~ ${regexp} ]]
     then


### PR DESCRIPTION
#### Summary

If `renovate` opens an average of 6 PRs per week, that means, 24 PRs per month.

24 * ~50 snapshots = 1200, or almost 25% of our current percy snapshot allowances.

These robots must be stopped.

🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖