### PR TITLE
Multiple smaller fixes for date related inputs

### DIFF
--- a/src/components/inputs/date-input/date-input.form.story.js
+++ b/src/components/inputs/date-input/date-input.form.story.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Formik } from 'formik';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withKnobs } from '@storybook/addon-knobs';
+import withReadme from 'storybook-readme/with-readme';
+import Section from '../../../../.storybook/decorators/section';
+import FormikBox from '../../../../.storybook/decorators/formik-box';
+import PrimaryButton from '../../buttons/primary-button';
+import SecondaryButton from '../../buttons/secondary-button';
+import Spacings from '../../spacings';
+import Readme from './README.md';
+import DateInput from './date-input';
+
+storiesOf('Examples|Forms/Inputs', module)
+  .addDecorator(withKnobs)
+  .addDecorator(withReadme(Readme))
+  .add('DateInput', () => (
+    <Section>
+      <Formik
+        initialValues={{
+          startDate: '2018-09-20',
+          endDate: '',
+        }}
+        onSubmit={(values, formik, ...rest) => {
+          action('onSubmit')(values, formik, ...rest);
+          formik.resetForm(values);
+        }}
+        render={formik => (
+          <Spacings.Stack scale="l">
+            <DateInput
+              name="startDate"
+              value={formik.values.startDate}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+              horizontalConstraint="m"
+            />
+            <DateInput
+              name="endDate"
+              value={formik.values.endDate}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+              horizontalConstraint="m"
+            />
+            <Spacings.Inline>
+              <SecondaryButton
+                onClick={formik.handleReset}
+                isDisabled={formik.isSubmitting}
+                label="Reset"
+              />
+              <PrimaryButton
+                onClick={formik.handleSubmit}
+                isDisabled={formik.isSubmitting || !formik.dirty}
+                label="Submit"
+              />
+            </Spacings.Inline>
+            <hr />
+            <FormikBox formik={formik} />
+          </Spacings.Stack>
+        )}
+      />
+    </Section>
+  ));

--- a/src/components/inputs/date-input/date-input.js
+++ b/src/components/inputs/date-input/date-input.js
@@ -73,6 +73,15 @@ class DateCalendar extends React.Component {
       () => this.inputRef.current.focus()
     );
   };
+  handleBlur = () => {
+    if (this.props.onBlur)
+      this.props.onBlur({
+        target: {
+          id: this.props.id,
+          name: this.props.name,
+        },
+      });
+  };
   handleChange = date => {
     this.inputRef.current.setSelectionRange(0, 100);
     this.emit(date);
@@ -174,7 +183,7 @@ class DateCalendar extends React.Component {
             const today = getToday();
 
             return (
-              <div onFocus={this.props.onFocus} onBlur={this.props.onBlur}>
+              <div onFocus={this.props.onFocus} onBlur={this.handleBlur}>
                 <CalendarBody
                   inputRef={this.inputRef}
                   inputProps={getInputProps({

--- a/src/components/inputs/date-input/date-input.js
+++ b/src/components/inputs/date-input/date-input.js
@@ -44,8 +44,7 @@ class DateCalendar extends React.Component {
   };
   inputRef = React.createRef();
   state = {
-    calendarDate:
-      this.props.value.length === 2 ? this.props.value[0] : getToday(),
+    calendarDate: this.props.value || getToday(),
     suggestedItems: [],
     highlightedIndex:
       this.props.value === '' ? null : getDateInMonth(this.props.value) - 1,

--- a/src/components/inputs/date-time-input/date-time-input.form.story.js
+++ b/src/components/inputs/date-time-input/date-time-input.form.story.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Formik } from 'formik';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withKnobs } from '@storybook/addon-knobs';
+import withReadme from 'storybook-readme/with-readme';
+import Section from '../../../../.storybook/decorators/section';
+import FormikBox from '../../../../.storybook/decorators/formik-box';
+import PrimaryButton from '../../buttons/primary-button';
+import SecondaryButton from '../../buttons/secondary-button';
+import Spacings from '../../spacings';
+import Readme from './README.md';
+import DateTimeInput from './date-time-input';
+
+storiesOf('Examples|Forms/Inputs', module)
+  .addDecorator(withKnobs)
+  .addDecorator(withReadme(Readme))
+  .add('DateTimeInput', () => (
+    <Section>
+      <Formik
+        initialValues={{
+          startDate: '2018-12-10T12:07:11.112Z',
+          endDate: '',
+        }}
+        onSubmit={(values, formik, ...rest) => {
+          action('onSubmit')(values, formik, ...rest);
+          formik.resetForm(values);
+        }}
+        render={formik => (
+          <Spacings.Stack scale="l">
+            <DateTimeInput
+              name="startDate"
+              value={formik.values.startDate}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+              timeZone="Europe/Berlin"
+              horizontalConstraint="m"
+            />
+            <DateTimeInput
+              name="endDate"
+              value={formik.values.endDate}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+              timeZone="Europe/Berlin"
+              horizontalConstraint="m"
+            />
+            <Spacings.Inline>
+              <SecondaryButton
+                onClick={formik.handleReset}
+                isDisabled={formik.isSubmitting}
+                label="Reset"
+              />
+              <PrimaryButton
+                onClick={formik.handleSubmit}
+                isDisabled={formik.isSubmitting || !formik.dirty}
+                label="Submit"
+              />
+            </Spacings.Inline>
+            <hr />
+            <FormikBox formik={formik} />
+          </Spacings.Stack>
+        )}
+      />
+    </Section>
+  ));

--- a/src/components/inputs/date-time-input/date-time-input.js
+++ b/src/components/inputs/date-time-input/date-time-input.js
@@ -103,8 +103,14 @@ class DateTimeInput extends React.Component {
       () => this.inputRef.current.focus()
     );
   };
-  handleChange = date => {
-    this.emit(date);
+  handleBlur = () => {
+    if (this.props.onBlur)
+      this.props.onBlur({
+        target: {
+          id: this.props.id,
+          name: this.props.name,
+        },
+      });
   };
   handleTimeChange = event => {
     const parsedTime = parseTime(event.target.value);
@@ -147,7 +153,7 @@ class DateTimeInput extends React.Component {
           )}
           selectedItem={this.props.value === '' ? null : this.props.value}
           highlightedIndex={this.state.highlightedIndex}
-          onChange={this.handleChange}
+          onChange={this.emit}
           stateReducer={(state, changes) => {
             if (activationTypes.includes(changes.type)) {
               return { ...changes, isOpen: true };
@@ -262,7 +268,7 @@ class DateTimeInput extends React.Component {
               Boolean(this.props.value) && this.props.value !== '';
 
             return (
-              <div onFocus={this.props.onFocus} onBlur={this.props.onBlur}>
+              <div onFocus={this.props.onFocus} onBlur={this.handleBlur}>
                 <CalendarBody
                   inputRef={this.inputRef}
                   inputProps={getInputProps({

--- a/src/components/inputs/time-input/time-input.form.story.js
+++ b/src/components/inputs/time-input/time-input.form.story.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Formik } from 'formik';
+import { injectIntl } from 'react-intl';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs } from '@storybook/addon-knobs';
@@ -12,49 +13,59 @@ import Spacings from '../../spacings';
 import Readme from './README.md';
 import TimeInput from './time-input';
 
+const Story = injectIntl(props => (
+  <Section>
+    <Formik
+      initialValues={{
+        startTime: TimeInput.toLocaleTime('10:00', props.intl.locale),
+        endTime: '',
+      }}
+      onSubmit={(values, formik, ...rest) => {
+        action('onSubmit')(values, formik, ...rest);
+        // eslint-disable-next-line no-console
+        console.log({
+          startTime: TimeInput.to24h(values.startTime),
+          endTime: TimeInput.to24h(values.endTime),
+        });
+        formik.resetForm(values);
+      }}
+      render={formik => (
+        <Spacings.Stack scale="l">
+          <TimeInput
+            name="startTime"
+            value={formik.values.startTime}
+            onChange={formik.handleChange}
+            onBlur={formik.handleBlur}
+            horizontalConstraint="m"
+          />
+          <TimeInput
+            name="endTime"
+            value={formik.values.endTime}
+            onChange={formik.handleChange}
+            onBlur={formik.handleBlur}
+            horizontalConstraint="m"
+          />
+          <Spacings.Inline>
+            <SecondaryButton
+              onClick={formik.handleReset}
+              isDisabled={formik.isSubmitting}
+              label="Reset"
+            />
+            <PrimaryButton
+              onClick={formik.handleSubmit}
+              isDisabled={formik.isSubmitting || !formik.dirty}
+              label="Submit"
+            />
+          </Spacings.Inline>
+          <hr />
+          <FormikBox formik={formik} />
+        </Spacings.Stack>
+      )}
+    />
+  </Section>
+));
+
 storiesOf('Examples|Forms/Inputs', module)
   .addDecorator(withKnobs)
   .addDecorator(withReadme(Readme))
-  .add('TimeInput', () => (
-    <Section>
-      <Formik
-        initialValues={{ startTime: TimeInput.to24h('10:00'), endTime: '' }}
-        onSubmit={(values, formik, ...rest) => {
-          action('onSubmit')(values, formik, ...rest);
-          formik.resetForm(values);
-        }}
-        render={formik => (
-          <Spacings.Stack scale="l">
-            <TimeInput
-              name="startTime"
-              value={formik.values.startTime}
-              onChange={formik.handleChange}
-              onBlur={formik.handleBlur}
-              horizontalConstraint="m"
-            />
-            <TimeInput
-              name="endTime"
-              value={formik.values.endTime}
-              onChange={formik.handleChange}
-              onBlur={formik.handleBlur}
-              horizontalConstraint="m"
-            />
-            <Spacings.Inline>
-              <SecondaryButton
-                onClick={formik.handleReset}
-                isDisabled={formik.isSubmitting}
-                label="Reset"
-              />
-              <PrimaryButton
-                onClick={formik.handleSubmit}
-                isDisabled={formik.isSubmitting || !formik.dirty}
-                label="Submit"
-              />
-            </Spacings.Inline>
-            <hr />
-            <FormikBox formik={formik} />
-          </Spacings.Stack>
-        )}
-      />
-    </Section>
-  ));
+  .add('TimeInput', () => <Story />);

--- a/src/components/inputs/time-input/time-input.form.story.js
+++ b/src/components/inputs/time-input/time-input.form.story.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Formik } from 'formik';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withKnobs } from '@storybook/addon-knobs';
+import withReadme from 'storybook-readme/with-readme';
+import Section from '../../../../.storybook/decorators/section';
+import FormikBox from '../../../../.storybook/decorators/formik-box';
+import PrimaryButton from '../../buttons/primary-button';
+import SecondaryButton from '../../buttons/secondary-button';
+import Spacings from '../../spacings';
+import Readme from './README.md';
+import TimeInput from './time-input';
+
+storiesOf('Examples|Forms/Inputs', module)
+  .addDecorator(withKnobs)
+  .addDecorator(withReadme(Readme))
+  .add('TimeInput', () => (
+    <Section>
+      <Formik
+        initialValues={{ startTime: TimeInput.to24h('10:00'), endTime: '' }}
+        onSubmit={(values, formik, ...rest) => {
+          action('onSubmit')(values, formik, ...rest);
+          formik.resetForm(values);
+        }}
+        render={formik => (
+          <Spacings.Stack scale="l">
+            <TimeInput
+              name="startTime"
+              value={formik.values.startTime}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+              horizontalConstraint="m"
+            />
+            <TimeInput
+              name="endTime"
+              value={formik.values.endTime}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+              horizontalConstraint="m"
+            />
+            <Spacings.Inline>
+              <SecondaryButton
+                onClick={formik.handleReset}
+                isDisabled={formik.isSubmitting}
+                label="Reset"
+              />
+              <PrimaryButton
+                onClick={formik.handleSubmit}
+                isDisabled={formik.isSubmitting || !formik.dirty}
+                label="Submit"
+              />
+            </Spacings.Inline>
+            <hr />
+            <FormikBox formik={formik} />
+          </Spacings.Stack>
+        )}
+      />
+    </Section>
+  ));

--- a/src/components/internals/calendar-menu/calendar-menu.mod.css
+++ b/src/components/internals/calendar-menu/calendar-menu.mod.css
@@ -6,6 +6,7 @@
   position: absolute;
   width: 100%;
   background-color: var(--color-white);
+  z-index: 1;
 }
 
 .menuBase.warning {


### PR DESCRIPTION
## Fixes

### Ensure layering 6402f41

| Before | After |
| ------- | ----- |
| ![image](https://user-images.githubusercontent.com/1765075/49732280-5f50a680-fc7e-11e8-9183-1c4b30cce8d2.png) | ![image](https://user-images.githubusercontent.com/1765075/49732301-6c6d9580-fc7e-11e8-9cbb-99b1d98a81dc.png) |


###  add `toLocaleTime` acfa406

Previously it wasn't possible to format the initial value of `TimeInput`. The `toLocaleTime` function was moved to a static method to allow using it in `docToForm`.

### Ensure calendar opens on date of value 22ddbcb

There as a problem where the calendar would open on the current date instead of the date of the currently selected value. This was caused as we were using the logic of the date-range-input by accident. I removed it now.

### Set name and id on blur event 6305f3e 1db3122b85b8b63e2cae3f2ab2ba9c4c90b98f07

When the `DateInput` / `DateTimeInput` was blurred, the blur event did not contain `target.id` or `target.name` which result in Formik printing a warning message. This has now been fixed by faking the event properly.

### Stories

Stories for all date-related inputs were added as well.


FEATURE: added static `toLocaleTime` to `TimeInput`.
