### PR TITLE
Typography (Text): adding data test prop to text components

### DIFF
--- a/src/components/typography/text/README.md
+++ b/src/components/typography/text/README.md
@@ -26,6 +26,7 @@ Wraps the given text in the given HTML header `size`.
 | `children`    | `PropTypes.node` |    ✅    | -                    | -       | -                                                              |
 | `title`       | `String`         |    -     | -                    | -       | Text to show in a tooltip on hover over the element            |
 | `truncate`    | `Bool`           |    -     | -                    | `false` | Option for truncate content in case the screen has small width |
+| `dataTest`    | `String`         |    -     | -                    | -       | Prop for E2E testing                                           |
 
 #### Where to use
 
@@ -51,6 +52,7 @@ Wraps the given text in the given HTML header `size`.
 | `children`    | `PropTypes.node` |    ✅    | -                                                                 | -       |
 | `title`       | `String`         |    -     | -                                                                 | -       |
 | `truncate`    | `Bool`           |    -     | -                                                                 | `false` |
+| `dataTest`    | `String`         |    -     | -                                                                 | -       | Prop for E2E testing |
 
 #### Where to use
 
@@ -90,6 +92,7 @@ Wraps the given text in a `<p>` element, for normal content.
 | `children` | `PropTypes.node` |    ✅    | -                                                                             | -       |
 | `title`    | `String`         |    -     | -                                                                             | -       |
 | `truncate` | `Bool`           |    -     | -                                                                             | `false` |
+| `dataTest` | `String`         |    -     | -                                                                             | -       |
 
 #### Where to use
 
@@ -117,6 +120,7 @@ properly style the text.
 | `children` | `PropTypes.node` |    ✅    | -                                                                             | -       |
 | `title`    | `String`         |    -     | -                                                                             | -       |
 | `truncate` | `Bool`           |    -     | -                                                                             | `false` |
+| `dataTest` | `String`         |    -     | -                                                                             | -       |
 
 #### Where to use
 

--- a/src/components/typography/text/README.md
+++ b/src/components/typography/text/README.md
@@ -26,7 +26,8 @@ Wraps the given text in the given HTML header `size`.
 | `children`    | `PropTypes.node` |    ✅    | -                    | -       | -                                                              |
 | `title`       | `String`         |    -     | -                    | -       | Text to show in a tooltip on hover over the element            |
 | `truncate`    | `Bool`           |    -     | -                    | `false` | Option for truncate content in case the screen has small width |
-| `dataTest`    | `String`         |    -     | -                    | -       | Prop for E2E testing                                           |
+
+The component further forwards all `data-` attributes to the underlying component.
 
 #### Where to use
 
@@ -52,7 +53,8 @@ Wraps the given text in the given HTML header `size`.
 | `children`    | `PropTypes.node` |    ✅    | -                                                                 | -       |
 | `title`       | `String`         |    -     | -                                                                 | -       |
 | `truncate`    | `Bool`           |    -     | -                                                                 | `false` |
-| `dataTest`    | `String`         |    -     | -                                                                 | -       | Prop for E2E testing |
+
+The component further forwards all `data-` attributes to the underlying component.
 
 #### Where to use
 
@@ -92,7 +94,8 @@ Wraps the given text in a `<p>` element, for normal content.
 | `children` | `PropTypes.node` |    ✅    | -                                                                             | -       |
 | `title`    | `String`         |    -     | -                                                                             | -       |
 | `truncate` | `Bool`           |    -     | -                                                                             | `false` |
-| `dataTest` | `String`         |    -     | -                                                                             | -       |
+
+The component further forwards all `data-` attributes to the underlying component.
 
 #### Where to use
 
@@ -120,7 +123,8 @@ properly style the text.
 | `children` | `PropTypes.node` |    ✅    | -                                                                             | -       |
 | `title`    | `String`         |    -     | -                                                                             | -       |
 | `truncate` | `Bool`           |    -     | -                                                                             | `false` |
-| `dataTest` | `String`         |    -     | -                                                                             | -       |
+
+The component further forwards all `data-` attributes to the underlying component.
 
 #### Where to use
 

--- a/src/components/typography/text/README.md
+++ b/src/components/typography/text/README.md
@@ -26,7 +26,8 @@ Wraps the given text in the given HTML header `size`.
 | `children`    | `PropTypes.node` |    ✅    | -                    | -       | -                                                              |
 | `title`       | `String`         |    -     | -                    | -       | Text to show in a tooltip on hover over the element            |
 | `truncate`    | `Bool`           |    -     | -                    | `false` | Option for truncate content in case the screen has small width |
-| `dataTest`    | `String`         |    -     | -                    | -       | Prop for E2E testing                                           |
+
+The component further forwards all `data-` attributes to the underlying component.
 
 The component further forwards all `data-` attributes to the underlying component.
 
@@ -54,7 +55,8 @@ Wraps the given text in the given HTML header `size`.
 | `children`    | `PropTypes.node` |    ✅    | -                                                                 | -       |
 | `title`       | `String`         |    -     | -                                                                 | -       |
 | `truncate`    | `Bool`           |    -     | -                                                                 | `false` |
-| `dataTest`    | `String`         |    -     | -                                                                 | -       | Prop for E2E testing |
+
+The component further forwards all `data-` attributes to the underlying component.
 
 The component further forwards all `data-` attributes to the underlying component.
 
@@ -96,7 +98,8 @@ Wraps the given text in a `<p>` element, for normal content.
 | `children` | `PropTypes.node` |    ✅    | -                                                                             | -       |
 | `title`    | `String`         |    -     | -                                                                             | -       |
 | `truncate` | `Bool`           |    -     | -                                                                             | `false` |
-| `dataTest` | `String`         |    -     | -                                                                             | -       |
+
+The component further forwards all `data-` attributes to the underlying component.
 
 The component further forwards all `data-` attributes to the underlying component.
 
@@ -126,7 +129,8 @@ properly style the text.
 | `children` | `PropTypes.node` |    ✅    | -                                                                             | -       |
 | `title`    | `String`         |    -     | -                                                                             | -       |
 | `truncate` | `Bool`           |    -     | -                                                                             | `false` |
-| `dataTest` | `String`         |    -     | -                                                                             | -       |
+
+The component further forwards all `data-` attributes to the underlying component.
 
 The component further forwards all `data-` attributes to the underlying component.
 

--- a/src/components/typography/text/README.md
+++ b/src/components/typography/text/README.md
@@ -29,8 +29,6 @@ Wraps the given text in the given HTML header `size`.
 
 The component further forwards all `data-` attributes to the underlying component.
 
-The component further forwards all `data-` attributes to the underlying component.
-
 #### Where to use
 
 Title of pages.
@@ -55,8 +53,6 @@ Wraps the given text in the given HTML header `size`.
 | `children`    | `PropTypes.node` |    ✅    | -                                                                 | -       |
 | `title`       | `String`         |    -     | -                                                                 | -       |
 | `truncate`    | `Bool`           |    -     | -                                                                 | `false` |
-
-The component further forwards all `data-` attributes to the underlying component.
 
 The component further forwards all `data-` attributes to the underlying component.
 
@@ -101,8 +97,6 @@ Wraps the given text in a `<p>` element, for normal content.
 
 The component further forwards all `data-` attributes to the underlying component.
 
-The component further forwards all `data-` attributes to the underlying component.
-
 #### Where to use
 
 Content text in general.
@@ -129,8 +123,6 @@ properly style the text.
 | `children` | `PropTypes.node` |    ✅    | -                                                                             | -       |
 | `title`    | `String`         |    -     | -                                                                             | -       |
 | `truncate` | `Bool`           |    -     | -                                                                             | `false` |
-
-The component further forwards all `data-` attributes to the underlying component.
 
 The component further forwards all `data-` attributes to the underlying component.
 

--- a/src/components/typography/text/README.md
+++ b/src/components/typography/text/README.md
@@ -26,6 +26,7 @@ Wraps the given text in the given HTML header `size`.
 | `children`    | `PropTypes.node` |    ✅    | -                    | -       | -                                                              |
 | `title`       | `String`         |    -     | -                    | -       | Text to show in a tooltip on hover over the element            |
 | `truncate`    | `Bool`           |    -     | -                    | `false` | Option for truncate content in case the screen has small width |
+| `dataTest`    | `String`         |    -     | -                    | -       | Prop for E2E testing                                           |
 
 The component further forwards all `data-` attributes to the underlying component.
 
@@ -53,6 +54,7 @@ Wraps the given text in the given HTML header `size`.
 | `children`    | `PropTypes.node` |    ✅    | -                                                                 | -       |
 | `title`       | `String`         |    -     | -                                                                 | -       |
 | `truncate`    | `Bool`           |    -     | -                                                                 | `false` |
+| `dataTest`    | `String`         |    -     | -                                                                 | -       | Prop for E2E testing |
 
 The component further forwards all `data-` attributes to the underlying component.
 
@@ -94,6 +96,7 @@ Wraps the given text in a `<p>` element, for normal content.
 | `children` | `PropTypes.node` |    ✅    | -                                                                             | -       |
 | `title`    | `String`         |    -     | -                                                                             | -       |
 | `truncate` | `Bool`           |    -     | -                                                                             | `false` |
+| `dataTest` | `String`         |    -     | -                                                                             | -       |
 
 The component further forwards all `data-` attributes to the underlying component.
 
@@ -123,6 +126,7 @@ properly style the text.
 | `children` | `PropTypes.node` |    ✅    | -                                                                             | -       |
 | `title`    | `String`         |    -     | -                                                                             | -       |
 | `truncate` | `Bool`           |    -     | -                                                                             | `false` |
+| `dataTest` | `String`         |    -     | -                                                                             | -       |
 
 The component further forwards all `data-` attributes to the underlying component.
 

--- a/src/components/typography/text/text.js
+++ b/src/components/typography/text/text.js
@@ -20,6 +20,7 @@ const Headline = props => {
         [styles.truncate]: props.truncate,
       })}
       title={props.title}
+      data-test={props.dataTest}
     >
       {props.children}
     </HeadlineElement>
@@ -31,6 +32,7 @@ Headline.propTypes = {
   children: PropTypes.node.isRequired,
   title: nonEmptyString,
   truncate: PropTypes.bool,
+  dataTest: PropTypes.string,
 };
 
 const Subheadline = props => {
@@ -43,6 +45,7 @@ const Subheadline = props => {
         [styles.truncate]: props.truncate,
       })}
       title={props.title}
+      data-test={props.dataTest}
     >
       {props.children}
     </SubheadlineElement>
@@ -62,6 +65,7 @@ Subheadline.propTypes = {
   children: PropTypes.node.isRequired,
   title: nonEmptyString,
   truncate: PropTypes.bool,
+  dataTest: PropTypes.string,
 };
 
 const Wrap = props => (
@@ -85,6 +89,7 @@ const Body = props =>
         [styles.truncate]: props.truncate,
       })}
       title={props.title}
+      data-test={props.dataTest}
     >
       {props.children}
     </span>
@@ -97,6 +102,7 @@ const Body = props =>
         [styles.truncate]: props.truncate,
       })}
       title={props.title}
+      data-test={props.dataTest}
     >
       {props.children}
     </p>
@@ -117,6 +123,7 @@ Body.propTypes = {
   children: PropTypes.node.isRequired,
   title: nonEmptyString,
   truncate: PropTypes.bool,
+  dataTest: PropTypes.string,
 };
 
 const Detail = props => (
@@ -129,6 +136,7 @@ const Detail = props => (
       [styles.truncate]: props.truncate,
     })}
     title={props.title}
+    data-test={props.dataTest}
   >
     {props.children}
   </small>
@@ -149,6 +157,7 @@ Detail.propTypes = {
   children: PropTypes.node.isRequired,
   title: nonEmptyString,
   truncate: PropTypes.bool,
+  dataTest: PropTypes.string,
 };
 
 export default {

--- a/src/components/typography/text/text.js
+++ b/src/components/typography/text/text.js
@@ -33,6 +33,7 @@ Headline.propTypes = {
   children: PropTypes.node.isRequired,
   title: nonEmptyString,
   truncate: PropTypes.bool,
+  dataTest: PropTypes.string,
 };
 
 const Subheadline = props => {
@@ -65,6 +66,7 @@ Subheadline.propTypes = {
   children: PropTypes.node.isRequired,
   title: nonEmptyString,
   truncate: PropTypes.bool,
+  dataTest: PropTypes.string,
 };
 
 const Wrap = props => (
@@ -122,6 +124,7 @@ Body.propTypes = {
   children: PropTypes.node.isRequired,
   title: nonEmptyString,
   truncate: PropTypes.bool,
+  dataTest: PropTypes.string,
 };
 
 const Detail = props => (
@@ -155,6 +158,7 @@ Detail.propTypes = {
   children: PropTypes.node.isRequired,
   title: nonEmptyString,
   truncate: PropTypes.bool,
+  dataTest: PropTypes.string,
 };
 
 export default {

--- a/src/components/typography/text/text.js
+++ b/src/components/typography/text/text.js
@@ -33,7 +33,6 @@ Headline.propTypes = {
   children: PropTypes.node.isRequired,
   title: nonEmptyString,
   truncate: PropTypes.bool,
-  dataTest: PropTypes.string,
 };
 
 const Subheadline = props => {
@@ -66,7 +65,6 @@ Subheadline.propTypes = {
   children: PropTypes.node.isRequired,
   title: nonEmptyString,
   truncate: PropTypes.bool,
-  dataTest: PropTypes.string,
 };
 
 const Wrap = props => (
@@ -124,7 +122,6 @@ Body.propTypes = {
   children: PropTypes.node.isRequired,
   title: nonEmptyString,
   truncate: PropTypes.bool,
-  dataTest: PropTypes.string,
 };
 
 const Detail = props => (
@@ -158,7 +155,6 @@ Detail.propTypes = {
   children: PropTypes.node.isRequired,
   title: nonEmptyString,
   truncate: PropTypes.bool,
-  dataTest: PropTypes.string,
 };
 
 export default {

--- a/src/components/typography/text/text.js
+++ b/src/components/typography/text/text.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import styles from './text.mod.css';
+import filterDataAttributes from '../../../utils/filter-data-attributes';
 
 const nonEmptyString = (props, propName, componentName) => {
   const value = props[propName];
@@ -20,7 +21,7 @@ const Headline = props => {
         [styles.truncate]: props.truncate,
       })}
       title={props.title}
-      data-test={props.dataTest}
+      {...filterDataAttributes(props)}
     >
       {props.children}
     </HeadlineElement>
@@ -32,7 +33,6 @@ Headline.propTypes = {
   children: PropTypes.node.isRequired,
   title: nonEmptyString,
   truncate: PropTypes.bool,
-  dataTest: PropTypes.string,
 };
 
 const Subheadline = props => {
@@ -45,7 +45,7 @@ const Subheadline = props => {
         [styles.truncate]: props.truncate,
       })}
       title={props.title}
-      data-test={props.dataTest}
+      {...filterDataAttributes(props)}
     >
       {props.children}
     </SubheadlineElement>
@@ -65,7 +65,6 @@ Subheadline.propTypes = {
   children: PropTypes.node.isRequired,
   title: nonEmptyString,
   truncate: PropTypes.bool,
-  dataTest: PropTypes.string,
 };
 
 const Wrap = props => (
@@ -89,7 +88,7 @@ const Body = props =>
         [styles.truncate]: props.truncate,
       })}
       title={props.title}
-      data-test={props.dataTest}
+      {...filterDataAttributes(props)}
     >
       {props.children}
     </span>
@@ -102,7 +101,7 @@ const Body = props =>
         [styles.truncate]: props.truncate,
       })}
       title={props.title}
-      data-test={props.dataTest}
+      {...filterDataAttributes(props)}
     >
       {props.children}
     </p>
@@ -123,7 +122,6 @@ Body.propTypes = {
   children: PropTypes.node.isRequired,
   title: nonEmptyString,
   truncate: PropTypes.bool,
-  dataTest: PropTypes.string,
 };
 
 const Detail = props => (
@@ -136,7 +134,7 @@ const Detail = props => (
       [styles.truncate]: props.truncate,
     })}
     title={props.title}
-    data-test={props.dataTest}
+    {...filterDataAttributes(props)}
   >
     {props.children}
   </small>
@@ -157,7 +155,6 @@ Detail.propTypes = {
   children: PropTypes.node.isRequired,
   title: nonEmptyString,
   truncate: PropTypes.bool,
-  dataTest: PropTypes.string,
 };
 
 export default {

--- a/src/components/typography/text/text.spec.js
+++ b/src/components/typography/text/text.spec.js
@@ -62,7 +62,7 @@ describe('<Headline>', () => {
   describe('with dataTest', () => {
     beforeEach(() => {
       wrapper = shallow(
-        <Text.Headline elementType="h1" truncate={true} dataTest="prop-test">
+        <Text.Headline elementType="h1" truncate={true} data-test="prop-test">
           {'Title'}
         </Text.Headline>
       );
@@ -163,7 +163,7 @@ describe('<Subheadline>', () => {
           isBold={true}
           tone="primary"
           title="tooltip text"
-          dataTest="prop-test"
+          data-test="prop-test"
         >
           {'Subtitle'}
         </Text.Subheadline>
@@ -324,7 +324,7 @@ describe('<Body>', () => {
   });
   describe('with dataTest', () => {
     beforeEach(() => {
-      wrapper = shallow(<Text.Body dataTest="prop-test">{'Body'}</Text.Body>);
+      wrapper = shallow(<Text.Body data-test="prop-test">{'Body'}</Text.Body>);
     });
     it('should contain `data-test` prop', () => {
       expect(wrapper).toHaveProp('data-test', 'prop-test');
@@ -482,7 +482,7 @@ describe('<Detail>', () => {
   });
   describe('with dataTest', () => {
     beforeEach(() => {
-      wrapper = shallow(<Text.Body dataTest="prop-test">{'Body'}</Text.Body>);
+      wrapper = shallow(<Text.Body data-test="prop-test">{'Body'}</Text.Body>);
     });
     it('should contain `data-test` prop', () => {
       expect(wrapper).toHaveProp('data-test', 'prop-test');

--- a/src/components/typography/text/text.spec.js
+++ b/src/components/typography/text/text.spec.js
@@ -58,6 +58,19 @@ describe('<Headline>', () => {
       expect(wrapper).toContainClass(styles.truncate);
     });
   });
+
+  describe('with dataTest', () => {
+    beforeEach(() => {
+      wrapper = shallow(
+        <Text.Headline elementType="h1" truncate={true} dataTest="prop-test">
+          {'Title'}
+        </Text.Headline>
+      );
+    });
+    it('should contain `data-test` prop', () => {
+      expect(wrapper).toHaveProp('data-test', 'prop-test');
+    });
+  });
 });
 
 describe('<Subheadline>', () => {
@@ -123,6 +136,7 @@ describe('<Subheadline>', () => {
       expect(wrapper).toHaveProp('title', 'tooltip text');
     });
   });
+
   describe('with truncated text', () => {
     beforeEach(() => {
       wrapper = shallow(
@@ -138,6 +152,25 @@ describe('<Subheadline>', () => {
     });
     it('should contain `truncate` class', () => {
       expect(wrapper).toContainClass(styles.truncate);
+    });
+  });
+
+  describe('with dataTest', () => {
+    beforeEach(() => {
+      wrapper = shallow(
+        <Text.Subheadline
+          elementType="h4"
+          isBold={true}
+          tone="primary"
+          title="tooltip text"
+          dataTest="prop-test"
+        >
+          {'Subtitle'}
+        </Text.Subheadline>
+      );
+    });
+    it('should contain `data-test` prop', () => {
+      expect(wrapper).toHaveProp('data-test', 'prop-test');
     });
   });
 });
@@ -159,8 +192,8 @@ describe('<Wrap>', () => {
 });
 
 describe('<Body>', () => {
+  let wrapper;
   describe('when used as block text', () => {
-    let wrapper;
     beforeEach(() => {
       wrapper = shallow(<Text.Body>{'Body'}</Text.Body>);
     });
@@ -240,7 +273,6 @@ describe('<Body>', () => {
   });
 
   describe('when used as inline text', () => {
-    let wrapper;
     beforeEach(() => {
       wrapper = shallow(<Text.Body isInline={true}>{'Body'}</Text.Body>);
     });
@@ -290,11 +322,19 @@ describe('<Body>', () => {
       });
     });
   });
+  describe('with dataTest', () => {
+    beforeEach(() => {
+      wrapper = shallow(<Text.Body dataTest="prop-test">{'Body'}</Text.Body>);
+    });
+    it('should contain `data-test` prop', () => {
+      expect(wrapper).toHaveProp('data-test', 'prop-test');
+    });
+  });
 });
 
 describe('<Detail>', () => {
+  let wrapper;
   describe('when used as block text', () => {
-    let wrapper;
     beforeEach(() => {
       wrapper = shallow(<Text.Detail>{'Detail'}</Text.Detail>);
     });
@@ -355,7 +395,6 @@ describe('<Detail>', () => {
     });
   });
   describe('when used as inline text', () => {
-    let wrapper;
     beforeEach(() => {
       wrapper = shallow(<Text.Detail isInline={true}>{'Detail'}</Text.Detail>);
     });
@@ -439,6 +478,14 @@ describe('<Detail>', () => {
       it('should contain `truncate` class', () => {
         expect(wrapper).toContainClass(styles.truncate);
       });
+    });
+  });
+  describe('with dataTest', () => {
+    beforeEach(() => {
+      wrapper = shallow(<Text.Body dataTest="prop-test">{'Body'}</Text.Body>);
+    });
+    it('should contain `data-test` prop', () => {
+      expect(wrapper).toHaveProp('data-test', 'prop-test');
     });
   });
 });

--- a/src/components/typography/text/text.spec.js
+++ b/src/components/typography/text/text.spec.js
@@ -272,6 +272,15 @@ describe('<Body>', () => {
     });
   });
 
+  describe('with dataTest', () => {
+    beforeEach(() => {
+      wrapper = shallow(<Text.Body data-test="prop-test">{'Body'}</Text.Body>);
+    });
+    it('should contain `data-test` prop', () => {
+      expect(wrapper).toHaveProp('data-test', 'prop-test');
+    });
+  });
+
   describe('when used as inline text', () => {
     beforeEach(() => {
       wrapper = shallow(<Text.Body isInline={true}>{'Body'}</Text.Body>);
@@ -321,13 +330,17 @@ describe('<Body>', () => {
         expect(wrapper).toHaveText('Detail');
       });
     });
-  });
-  describe('with dataTest', () => {
-    beforeEach(() => {
-      wrapper = shallow(<Text.Body data-test="prop-test">{'Body'}</Text.Body>);
-    });
-    it('should contain `data-test` prop', () => {
-      expect(wrapper).toHaveProp('data-test', 'prop-test');
+    describe('with dataTest', () => {
+      beforeEach(() => {
+        wrapper = shallow(
+          <Text.Body isInline={true} data-test="prop-test">
+            {'Body'}
+          </Text.Body>
+        );
+      });
+      it('should contain `data-test` prop', () => {
+        expect(wrapper).toHaveProp('data-test', 'prop-test');
+      });
     });
   });
 });

--- a/src/components/typography/typography.story.js
+++ b/src/components/typography/typography.story.js
@@ -21,6 +21,7 @@ storiesOf('Typography/Text', module)
         elementType={select('Element type', ['h1', 'h2', 'h3'], 'h1')}
         title={text('title', 'Text to be shown as tooltip on hover')}
         truncate={boolean('truncate', false)}
+        dataTest={text('dataTest', 'test-prop')}
       >
         {text('Text', 'Sample text Headline')}
       </Text.Headline>
@@ -41,6 +42,7 @@ storiesOf('Typography/Text', module)
         ])}
         title={text('title', 'Text to be shown as tooltip on hover')}
         truncate={boolean('truncate', false)}
+        dataTest={text('dataTest', 'test-prop')}
       >
         {text('Text', 'Sample text Subheadline')}
       </Text.Subheadline>
@@ -51,6 +53,7 @@ storiesOf('Typography/Text', module)
       <InlineColorWrapper width={'200px'}>
         <Text.Wrap
           title={text('title', 'Text to be shown as tooltip on hover')}
+          dataTest={text('dataTest', 'test-prop')}
         >
           {text(
             'Text',
@@ -77,6 +80,7 @@ storiesOf('Typography/Text', module)
         ])}
         title={text('title', 'Text to be shown as tooltip on hover')}
         truncate={boolean('truncate', false)}
+        dataTest={text('dataTest', 'test-prop')}
       >
         {text('Text', 'Sample text Body')}
       </Text.Body>
@@ -99,6 +103,7 @@ storiesOf('Typography/Text', module)
         ])}
         title={text('title', 'Text to be shown as tooltip on hover')}
         truncate={boolean('truncate', false)}
+        dataTest={text('dataTest', 'test-prop')}
       >
         {text('Text', 'Sample text Detail')}
       </Text.Detail>

--- a/src/components/typography/typography.story.js
+++ b/src/components/typography/typography.story.js
@@ -51,7 +51,6 @@ storiesOf('Typography/Text', module)
       <InlineColorWrapper width={'200px'}>
         <Text.Wrap
           title={text('title', 'Text to be shown as tooltip on hover')}
-          dataTest={text('dataTest', 'test-prop')}
         >
           {text(
             'Text',

--- a/src/components/typography/typography.story.js
+++ b/src/components/typography/typography.story.js
@@ -21,7 +21,6 @@ storiesOf('Typography/Text', module)
         elementType={select('Element type', ['h1', 'h2', 'h3'], 'h1')}
         title={text('title', 'Text to be shown as tooltip on hover')}
         truncate={boolean('truncate', false)}
-        dataTest={text('dataTest', 'test-prop')}
       >
         {text('Text', 'Sample text Headline')}
       </Text.Headline>
@@ -42,7 +41,6 @@ storiesOf('Typography/Text', module)
         ])}
         title={text('title', 'Text to be shown as tooltip on hover')}
         truncate={boolean('truncate', false)}
-        dataTest={text('dataTest', 'test-prop')}
       >
         {text('Text', 'Sample text Subheadline')}
       </Text.Subheadline>
@@ -80,7 +78,6 @@ storiesOf('Typography/Text', module)
         ])}
         title={text('title', 'Text to be shown as tooltip on hover')}
         truncate={boolean('truncate', false)}
-        dataTest={text('dataTest', 'test-prop')}
       >
         {text('Text', 'Sample text Body')}
       </Text.Body>
@@ -103,7 +100,6 @@ storiesOf('Typography/Text', module)
         ])}
         title={text('title', 'Text to be shown as tooltip on hover')}
         truncate={boolean('truncate', false)}
-        dataTest={text('dataTest', 'test-prop')}
       >
         {text('Text', 'Sample text Detail')}
       </Text.Detail>


### PR DESCRIPTION
#### Summary
Adding `data-test` prop to every `Text` component.

#### Description
Adding `data-test` prop to avoid wrapping `Text` components for E2E tests 