### PR TITLE
Add DateField component

### DIFF
--- a/src/components/fields/date-field/README.md
+++ b/src/components/fields/date-field/README.md
@@ -1,0 +1,59 @@
+# DateField
+
+#### Description
+
+A controlled date input component for single date.
+
+## Usage
+
+```js
+import { DateField } from '@commercetools-frontend/ui-kit';
+
+<DateField
+  title="Release Date"
+  value="2018-10-30"
+  onChange={event => alert(event.target.value)}
+/>;
+```
+
+#### Properties
+
+| Props                  | Type               | Required | Values                             | Default | Description                                                                                                                                                                                                                                                           |
+| ---------------------- | ------------------ | :------: | ---------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                   | `string`           |    -     | -                                  | -       | Used as HTML `id` property. An `id` is auto-generated when it is not specified.                                                                                                                                                                                       |
+| `horizontalConstraint` | `object`           |          | `xs`, `s`, `m`, `l`, `xl`, `scale` | `scale` | Horizontal size limit of the input fields.                                                                                                                                                                                                                            |
+| `errors`               | `object`           |    -     | -                                  | -       | A map of errors. Error messages for known errors are rendered automatically. Unknown errors will be forwarded to `renderError`.                                                                                                                                       |
+| `renderError`          | `function`         |    -     | -                                  | -       | Called with custom errors, as `renderError(key, error)`. This function can return a message which will be wrapped in an `ErrorMessage`. It can also return `null` to show no error.                                                                                   |
+| `isRequired`           | `bool`             |    -     | -                                  | `false` | Indicates if the value is required. Shows an the "required asterisk" if so.                                                                                                                                                                                           |
+| `touched`              | `bool`             |    -     | -                                  | `false` | Indicates whether the field was touched. Errors will only be shown when the field was touched.                                                                                                                                                                        |
+| `name`                 | `string`           |    -     | -                                  | -       | Used as HTML `name` of the input component. property                                                                                                                                                                                                                  |
+| `value`                | `string`           |    ✅    | -                                  | -       | Value of the input component.                                                                                                                                                                                                                                         |
+| `onChange`             | `func`             |    ✅    | -                                  | -       | Called with an event containing the new value. This is always called with either an empty string or a valid date in the format of `YYYY-MM-DD`. Parent should pass it back as `value`.                                                                                |
+| `onBlur`               | `func`             |    -     | -                                  | -       | Called when input is blurred                                                                                                                                                                                                                                          |
+| `onFocus`              | `func`             |    -     | -                                  | -       | Called when input is focused                                                                                                                                                                                                                                          |
+| `isDisabled`           | `bool`             |    -     | -                                  | `false` | Indicates that the input cannot be modified (e.g not authorised, or changes currently saving).                                                                                                                                                                        |
+| `placeholder`          | `string`           |    -     | -                                  | -       | Placeholder text for the input                                                                                                                                                                                                                                        |
+| `title`                | `string` or `node` |    ✅    | -                                  | -       | Title of the label                                                                                                                                                                                                                                                    |
+| `onInfoButtonClick`    | `function`         |    -     | -                                  | -       | Function called when info button is pressed. Info button will only be visible when this prop is passed.                                                                                                                                                               |
+| `hint`                 | `string` or `node` |    -     | -                                  | -       | Hint for the label. Provides a supplementary but important information regarding the behaviour of the input (e.g warn about uniqueness of a field, when it can only be set once), whereas `description` can describe it in more depth. Can also receive a `hintIcon`. |
+| `hintIcon`             | `node`             |    -     | -                                  | -       | Icon to be displayed beside the hint text. Will only get rendered when `hint` is passed as well.                                                                                                                                                                      |
+| `description`          | `string` or `node` |    -     | -                                  | -       | Provides a description for the title.                                                                                                                                                                                                                                 |
+| `badge`                | `node`             |    -     | -                                  | -       | Badge to be displayed beside the label. Might be used to display additional information about the content of the field (E.g verified email)                                                                                                                           |
+
+The component further forwards all `data-` attributes to the underlying `input` component.
+
+##### `errors`
+
+This object is a key-value map. The `renderError` prop will be called for each entry with the key and the value. The return value will be rendered inside an `ErrorMessage` component underneath the input.
+
+The `DateField` supports some errors out of the box. Return `undefined` from `renderError` for these and the default errors will be shown instead. This prevents consumers from having to reimplement the same error messages for known errors while still keeping the flexibility of showing custom error messages for them.
+
+When the `key` is known, and when the value is truthy, and when `renderError` returned `undefined` for that error entry, then the `DateField` will render an appropriate error automatically.
+
+Known error keys are:
+
+- `missing`: tells the user that this field is required
+
+### Main Functions and use cases are:
+
+- Input field for a single date

--- a/src/components/fields/date-field/date-field.js
+++ b/src/components/fields/date-field/date-field.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import requiredIf from 'react-required-if';
+import Constraints from '../../constraints';
+import Spacings from '../../spacings';
+import FieldLabel from '../../field-label';
+import DateInput from '../../inputs/date-input';
+import createSequentialId from '../../../utils/create-sequential-id';
+import FieldErrors from '../../field-errors';
+import filterDataAttributes from '../../../utils/filter-data-attributes';
+
+const sequentialId = createSequentialId('date-field-');
+
+const hasErrors = errors => errors && Object.values(errors).some(Boolean);
+
+class DateField extends React.Component {
+  static displayName = 'DateField';
+
+  static propTypes = {
+    // DateField
+    id: PropTypes.string,
+    horizontalConstraint: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl', 'scale']),
+    errors: PropTypes.shape({
+      missing: PropTypes.bool,
+    }),
+    renderError: PropTypes.func,
+    isRequired: PropTypes.bool,
+    touched: PropTypes.bool,
+
+    // DateInput
+    name: PropTypes.string,
+    value: PropTypes.string.isRequired,
+    onChange: requiredIf(PropTypes.func, props => !props.isReadOnly),
+    onBlur: PropTypes.func,
+    onFocus: PropTypes.func,
+    isDisabled: PropTypes.bool,
+    placeholder: PropTypes.string,
+
+    // LabelField
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+    hint: requiredIf(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+      props => props.hintIcon
+    ),
+    description: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    onInfoButtonClick: PropTypes.func,
+    hintIcon: PropTypes.node,
+    badge: PropTypes.node,
+  };
+
+  static defaultProps = {
+    horizontalConstraint: 'scale',
+  };
+
+  state = {
+    // We generate an id in case no id is provided by the parent to attach the
+    // label to the input component.
+    id: this.props.id,
+  };
+
+  static getDerivedStateFromProps = (props, state) => ({
+    id: do {
+      if (props.id) props.id;
+      else if (state.id) state.id;
+      else sequentialId();
+    },
+  });
+
+  render() {
+    const hasError = this.props.touched && hasErrors(this.props.errors);
+    return (
+      <Constraints.Horizontal constraint={this.props.horizontalConstraint}>
+        <Spacings.Stack scale="xs">
+          <FieldLabel
+            title={this.props.title}
+            hint={this.props.hint}
+            description={this.props.description}
+            onInfoButtonClick={this.props.onInfoButtonClick}
+            hintIcon={this.props.hintIcon}
+            badge={this.props.badge}
+            hasRequiredIndicator={this.props.isRequired}
+            htmlFor={this.state.id}
+          />
+          <DateInput
+            id={this.state.id}
+            name={this.props.name}
+            value={this.props.value}
+            onChange={this.props.onChange}
+            onFocus={this.props.onFocus}
+            onBlur={this.props.onBlur}
+            isDisabled={this.props.isDisabled}
+            hasError={hasError}
+            placeholder={this.props.placeholder}
+            horizontalConstraint="scale"
+            {...filterDataAttributes(this.props)}
+          />
+          <FieldErrors
+            errors={this.props.errors}
+            isVisible={hasError}
+            renderError={this.props.renderError}
+          />
+        </Spacings.Stack>
+      </Constraints.Horizontal>
+    );
+  }
+}
+
+export default DateField;

--- a/src/components/fields/date-field/date-field.percy.js
+++ b/src/components/fields/date-field/date-field.percy.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { DateField } from '../../../../dist/ui-kit.esm';
+import { Suite, Spec, screenshot } from '../../../../test/percy';
+
+const value = '2018-09-20';
+
+screenshot('DateField', () => (
+  <Suite>
+    <Spec label="minimal">
+      <DateField
+        title="Release Date"
+        horizontalConstraint="m"
+        value={value}
+        onChange={() => {}}
+      />
+    </Spec>
+    <Spec label="when disabled">
+      <DateField
+        title="Release Date"
+        horizontalConstraint="m"
+        value={value}
+        onChange={() => {}}
+        isDisabled={true}
+      />
+    </Spec>
+    <Spec label="when required">
+      <DateField
+        title="Release Date"
+        horizontalConstraint="m"
+        value={value}
+        onChange={() => {}}
+        isRequired={true}
+      />
+    </Spec>
+    <Spec label="with description">
+      <DateField
+        title="Release Date"
+        description="When will the product be avialable?"
+        horizontalConstraint="m"
+        value={value}
+        onChange={() => {}}
+      />
+    </Spec>
+    <Spec label="with placeholder">
+      <DateField
+        title="Release Date"
+        horizontalConstraint="m"
+        value=""
+        onChange={() => {}}
+        placeholder="Select release date"
+      />
+    </Spec>
+    <Spec label="with error when not touched">
+      <DateField
+        title="Release Date"
+        horizontalConstraint="m"
+        value=""
+        onChange={() => {}}
+        errors={{ missing: true }}
+      />
+    </Spec>
+    <Spec label="with error when touched">
+      <DateField
+        title="Release Date"
+        horizontalConstraint="m"
+        value=""
+        onChange={() => {}}
+        errors={{ missing: true }}
+        touched={true}
+      />
+    </Spec>
+  </Suite>
+));

--- a/src/components/fields/date-field/date-field.spec.js
+++ b/src/components/fields/date-field/date-field.spec.js
@@ -1,0 +1,169 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import DateField from './date-field';
+import FieldLabel from '../../field-label';
+import DateInput from '../../inputs/date-input';
+import FieldErrors from '../../field-errors';
+import { AddBoldIcon } from '../../icons';
+
+const createTestProps = customProps => ({
+  title: 'Username',
+  value: '',
+  onChange: () => jest.fn(),
+  ...customProps,
+});
+
+describe('DateField.isEmpty', () => {
+  describe('when called with an empty value', () => {
+    it('should return true', () => {
+      expect(DateField.isEmpty('')).toBe(true);
+    });
+  });
+  describe('when called with a filled value', () => {
+    it('should return false', () => {
+      expect(DateField.isEmpty('2018-10-30')).toBe(false);
+    });
+  });
+});
+
+describe('rendering', () => {
+  describe('data attributes', () => {
+    let textInput;
+    beforeEach(() => {
+      const props = createTestProps({
+        'data-foo': 'bar',
+        'data-test': 'baz',
+      });
+      const wrapper = shallow(<DateField {...props} />);
+      textInput = wrapper.find(DateInput);
+    });
+    it('should forward the attributes to the DateInput', () => {
+      expect(textInput).toHaveProp('data-foo', 'bar');
+      expect(textInput).toHaveProp('data-test', 'baz');
+    });
+  });
+  describe('when no id is provided', () => {
+    let props;
+    let wrapper;
+    beforeEach(() => {
+      props = createTestProps({ id: undefined });
+      wrapper = shallow(<DateField {...props} />);
+    });
+    it('should add a default id attribute', () => {
+      expect(wrapper.find(DateInput)).toHaveProp(
+        'id',
+        expect.stringMatching(/.+/)
+      );
+    });
+    it('should add a default htmlFor attribute', () => {
+      expect(wrapper.find(FieldLabel)).toHaveProp('htmlFor');
+    });
+    it('should use the same value for the id and htmlFor attribute', () => {
+      expect(wrapper.find(DateInput).prop('id')).toEqual(
+        wrapper.find(FieldLabel).prop('htmlFor')
+      );
+    });
+  });
+  describe('when touched', () => {
+    let props;
+    let wrapper;
+    beforeEach(() => {
+      props = createTestProps({
+        // DateField
+        id: 'foo',
+        // FieldLabel
+        title: 'Release Date',
+        hint: 'Date of publication',
+        hintIcon: <AddBoldIcon />,
+        description: 'A description',
+        onInfoButtonClick: jest.fn(),
+        badge: <div>Some badge</div>,
+
+        // DateField
+        name: 'field1',
+        value: '2018-10-30',
+        onChange: jest.fn(),
+        onBlur: jest.fn(),
+        onFocus: jest.fn(),
+        isDisabled: false,
+        placeholder: 'Some placeholder',
+        errors: { missing: true },
+        touched: true,
+      });
+      wrapper = shallow(<DateField {...props} />);
+    });
+
+    it('should forward the props for to the related components', () => {
+      const fieldLabel = wrapper.find(FieldLabel);
+      expect(fieldLabel).toHaveProp('title', props.title);
+      expect(fieldLabel).toHaveProp('hint', props.hint);
+      expect(fieldLabel).toHaveProp('hintIcon', props.hintIcon);
+      expect(fieldLabel).toHaveProp('description', props.description);
+      expect(fieldLabel).toHaveProp(
+        'onInfoButtonClick',
+        props.onInfoButtonClick
+      );
+      expect(fieldLabel).toHaveProp('badge', props.badge);
+      expect(fieldLabel).toHaveProp('htmlFor', props.id);
+
+      const textInput = wrapper.find(DateInput);
+      expect(textInput).toHaveProp('name', props.name);
+      expect(textInput).toHaveProp('value', props.value);
+      expect(textInput).toHaveProp('onChange', props.onChange);
+      expect(textInput).toHaveProp('onBlur', props.onBlur);
+      expect(textInput).toHaveProp('onFocus', props.onFocus);
+      expect(textInput).toHaveProp('isDisabled', props.isDisabled);
+      expect(textInput).toHaveProp('placeholder', props.placeholder);
+      expect(textInput).toHaveProp('hasError', true);
+
+      expect(wrapper).toRender(FieldErrors);
+      expect(wrapper.find(FieldErrors)).toHaveProp('errors', props.errors);
+    });
+  });
+
+  describe('when disabled', () => {
+    let props;
+    let wrapper;
+    beforeEach(() => {
+      props = createTestProps({ isDisabled: true });
+      wrapper = shallow(<DateField {...props} />);
+    });
+    it('should disable the DateInput', () => {
+      expect(wrapper.find(DateInput)).toHaveProp('isDisabled', true);
+    });
+  });
+
+  describe('when there are known errors', () => {
+    let props;
+    let wrapper;
+    beforeEach(() => {
+      props = createTestProps({ touched: true, errors: { missing: true } });
+      wrapper = shallow(<DateField {...props} />);
+    });
+    it('should mark the DateInput as erroneous', () => {
+      expect(wrapper.find(DateInput)).toHaveProp('hasError', true);
+    });
+    it('should render the known error', () => {
+      expect(wrapper).toRender(FieldErrors);
+    });
+  });
+
+  describe('when there are unknown errors', () => {
+    let props;
+    let wrapper;
+    beforeEach(() => {
+      props = createTestProps({
+        touched: true,
+        renderError: jest.fn(key => key),
+        errors: { customError: 5 },
+      });
+      wrapper = shallow(<DateField {...props} />);
+    });
+    it('should mark the NumberInput as erroneous', () => {
+      expect(wrapper.find(DateInput)).toHaveProp('hasError', true);
+    });
+    it('should forward the error', () => {
+      expect(wrapper.find(FieldErrors)).toHaveProp('errors', props.errors);
+    });
+  });
+});

--- a/src/components/fields/date-field/date-field.spec.js
+++ b/src/components/fields/date-field/date-field.spec.js
@@ -13,19 +13,6 @@ const createTestProps = customProps => ({
   ...customProps,
 });
 
-describe('DateField.isEmpty', () => {
-  describe('when called with an empty value', () => {
-    it('should return true', () => {
-      expect(DateField.isEmpty('')).toBe(true);
-    });
-  });
-  describe('when called with a filled value', () => {
-    it('should return false', () => {
-      expect(DateField.isEmpty('2018-10-30')).toBe(false);
-    });
-  });
-});
-
 describe('rendering', () => {
   describe('data attributes', () => {
     let textInput;

--- a/src/components/fields/date-field/date-field.story.js
+++ b/src/components/fields/date-field/date-field.story.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { Value } from 'react-value';
+import {
+  withKnobs,
+  boolean,
+  text,
+  select,
+  object,
+} from '@storybook/addon-knobs';
+import withReadme from 'storybook-readme/with-readme';
+import Section from '../../../../.storybook/decorators/section';
+import DateFieldReadme from './README.md';
+import * as icons from '../../icons';
+import DateField from './date-field';
+
+storiesOf('Fields', module)
+  .addDecorator(withKnobs)
+  .addDecorator(withReadme(DateFieldReadme))
+  .add('DateField', () => (
+    <Section>
+      <Value
+        defaultValue=""
+        render={(value, onChange) => {
+          const name = text('name', '');
+          const hint = text('hint', 'Select the date of publication');
+
+          // hintIcon will only render when hint exists
+          const iconNames = Object.keys(icons);
+          const icon = select('hintIcon', ['', ...iconNames], '');
+          const hintIcon = icon ? React.createElement(icons[icon]) : undefined;
+          return (
+            <DateField
+              id={name.trim() === '' ? undefined : name}
+              horizontalConstraint={select(
+                'horizontalConstraint',
+                ['xs', 's', 'm', 'l', 'xl', 'scale'],
+                'm'
+              )}
+              errors={object('errors', { missing: true, customError: true })}
+              renderError={key => {
+                switch (key) {
+                  case 'customError':
+                    return 'A custom error.';
+                  default:
+                    return null;
+                }
+              }}
+              isRequired={boolean('isRequired', false)}
+              touched={boolean('touched', false)}
+              name={text('name', '')}
+              value={text('value', value)}
+              onChange={event => {
+                action('onChange')(event);
+                onChange(event.target.value);
+              }}
+              onBlur={action('onBlur')}
+              onFocus={action('onFocus')}
+              isDisabled={boolean('isDisabled', false)}
+              placeholder={text('placeholder', 'Placeholder')}
+              title={text('title', 'Release Date')}
+              hint={hint}
+              description={text('description', '')}
+              onInfoButtonClick={
+                boolean('show info button', false)
+                  ? action('onInfoButtonClick')
+                  : undefined
+              }
+              hintIcon={hintIcon}
+              badge={text('badge', '')}
+            />
+          );
+        }}
+      />
+    </Section>
+  ));

--- a/src/components/fields/date-field/index.js
+++ b/src/components/fields/date-field/index.js
@@ -1,0 +1,1 @@
+export { default } from './date-field';

--- a/src/components/inputs/date-input/README.md
+++ b/src/components/inputs/date-input/README.md
@@ -8,8 +8,7 @@ import { DateInput } from '@commercetools-frontend/ui-kit';
 
 #### Description
 
-The `DateInput` component allows the user to select a date. This component also supports
-multiple date selection. It formats the selected date depending on the current locale.
+The `DateInput` component allows the user to select a date. It formats the selected date depending on the users' locale.
 
 #### Usage
 
@@ -36,3 +35,14 @@ multiple date selection. It formats the selected date depending on the current l
 | `horizontalConstraint` | `object` |    -     | `xs`, `s`, `m`, `l`, `xl`, `scale` | `scale` | Horizontal size limit of the input field.                                                                                                 |
 | `hasWarning`           | `bool`   |    -     | -                                  | -       | Indicates the input field has a warning                                                                                                   |
 | `hasError`             | `bool`   |    -     | -                                  | -       | Indicates the input field has an error                                                                                                    |
+
+### Static methods
+
+#### `DateInput.isEmpty`
+
+Returns `true` when the value is considered empty, which is when the value is an empty string.
+
+```js
+DateInput.isEmpty(''); // -> true
+DateInput.isEmpty('2018-09-20'); // -> false
+```

--- a/src/components/inputs/date-input/date-input.js
+++ b/src/components/inputs/date-input/date-input.js
@@ -27,6 +27,9 @@ import {
 
 class DateInput extends React.Component {
   static displayName = 'DateInput';
+
+  static isEmpty = value => value === '';
+
   static propTypes = {
     intl: PropTypes.shape({
       locale: PropTypes.string.isRequired,
@@ -42,13 +45,16 @@ class DateInput extends React.Component {
     hasError: PropTypes.bool,
     hasWarning: PropTypes.bool,
   };
+
   inputRef = React.createRef();
+
   state = {
     calendarDate: this.props.value || getToday(),
     suggestedItems: [],
     highlightedIndex:
       this.props.value === '' ? null : getDateInMonth(this.props.value) - 1,
   };
+
   showPrevMonth = () => {
     this.setState(prevState => ({
       calendarDate: changeMonth(prevState.calendarDate, -1),
@@ -56,12 +62,14 @@ class DateInput extends React.Component {
       highlightedIndex: prevState.suggestedItems.length,
     }));
   };
+
   jumpMonth = amount => {
     this.setState(prevState => {
       const nextDate = changeMonth(prevState.calendarDate, amount);
       return { calendarDate: nextDate, highlightedIndex: 0 };
     });
   };
+
   showToday = () => {
     const today = getToday();
     this.setState(
@@ -73,6 +81,7 @@ class DateInput extends React.Component {
       () => this.inputRef.current.focus()
     );
   };
+
   handleBlur = () => {
     if (this.props.onBlur)
       this.props.onBlur({
@@ -82,10 +91,12 @@ class DateInput extends React.Component {
         },
       });
   };
+
   handleChange = date => {
     this.inputRef.current.setSelectionRange(0, 100);
     this.emit(date);
   };
+
   emit = value =>
     this.props.onChange({
       target: {
@@ -96,6 +107,7 @@ class DateInput extends React.Component {
         value: value || '',
       },
     });
+
   render() {
     return (
       <Constraints.Horizontal constraint={this.props.horizontalConstraint}>

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ export {
 export { default as FieldLabel } from './components/field-label';
 
 export { default as TextField } from './components/fields/text-field';
+export { default as DateField } from './components/fields/date-field';
 export {
   default as MultilineTextField,
 } from './components/fields/multiline-text-field';


### PR DESCRIPTION
#### Summary

Add `DateField` component.

*I did not add Visual Regression Tests yet as we're awaiting #293.*

#### Design

![image](https://user-images.githubusercontent.com/1765075/49807243-df980a00-fd59-11e8-966c-1fc871e7e98c.png)


#### Component Checklist

##### Technical

- Documentation

  - [x] Has `README.md` file
  - [ ] Explains use-cases
  - [x] Explains props
  - [x] Has story for Storybook

- Props

  - [x] Uses prop names consistent with existing components
  - [x] Does not use `true` for default-props
  - [x] Does not accept `classNames` prop
  - [ ] Has default props for labels (where applicable)

- Design

  - [x] Does not use hard-coded values
  - [ ] Uses design-tokens (instead of e.g. color variables)

- Testing

  - [x] Supports `data` attributes
  - [x] Uses [react-testing-library](https://github.com/kentcdodds/react-testing-library) tests
  - [ ] Has visual regression tests

- Accessibility (optional)
  - [ ] Supports `aria` attributes
