### PR TITLE
chore: refactor multiline-text-input to use rtl

### DIFF
--- a/src/components/inputs/multiline-text-input/multiline-text-input.spec.js
+++ b/src/components/inputs/multiline-text-input/multiline-text-input.spec.js
@@ -1,42 +1,57 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import TextareaAutosize from 'react-textarea-autosize';
-import FlatButton from '../../buttons/flat-button';
-import Collapsible from '../../collapsible';
-import { MultilineTextInput } from './multiline-text-input';
+import PropTypes from 'prop-types';
+import { render, fireEvent } from '../../../test-utils';
+import MultilineTextInput from './multiline-text-input';
 
-const createTestProps = customProps => ({
-  value: '',
-  intl: {
-    formatMessage: jest.fn(message => message.id),
-  },
-  onChange: jest.fn(),
-  ...customProps,
-});
+class TestComponent extends React.Component {
+  static displayName = 'TestComponent';
+  static propTypes = {
+    id: PropTypes.string,
+    value: PropTypes.string.isRequired,
+    onChange: PropTypes.func,
+  };
+  static defaultProps = {
+    id: 'some-test-id',
+    name: 'some-name',
+    value: '',
+    intl: {
+      formatMessage: jest.fn(message => message.id),
+    },
+  };
 
-const getWrapper = (
-  customProps,
-  customRenderProps = { isOpen: true, toggle: jest.fn() }
-) => {
-  const props = createTestProps(customProps);
-  return shallow(<MultilineTextInput {...props} />)
-    .find(Collapsible)
-    .renderProp('children', customRenderProps);
-};
+  state = {
+    value: this.props.value || '',
+  };
 
-const getOpenWrapper = customProps =>
-  getWrapper(customProps, { isOpen: true, toggle: jest.fn() });
-const getClosedWrapper = customProps =>
-  getWrapper(customProps, { isOpen: false, toggle: jest.fn() });
+  handleChange = event => {
+    event.persist();
+    this.setState({
+      value: event.target.value,
+    });
+  };
+
+  render() {
+    return (
+      <React.Fragment>
+        <label htmlFor={this.props.id}>Description</label>
+        <MultilineTextInput
+          {...this.props}
+          value={this.state.value}
+          onChange={this.props.onChange || this.handleChange}
+        />
+      </React.Fragment>
+    );
+  }
+}
 
 describe('MultilineTextInput.isEmpty', () => {
   describe('when called with an empty value', () => {
     it('should return true', () => {
       expect(MultilineTextInput.isEmpty('')).toBe(true);
       expect(MultilineTextInput.isEmpty(' ')).toBe(true);
-      expect(MultilineTextInput.isEmpty('\n')).toBe(true);
     });
   });
+
   describe('when called with a filled value', () => {
     it('should return false', () => {
       expect(MultilineTextInput.isEmpty('a')).toBe(false);
@@ -45,278 +60,97 @@ describe('MultilineTextInput.isEmpty', () => {
   });
 });
 
-describe('rendering', () => {
-  describe('data attributes', () => {
-    let wrapper;
-    beforeEach(() => {
-      wrapper = getOpenWrapper({ name: 'text-field1', 'data-foo': 'bar' });
-    });
-    it('should forward the attributes', () => {
-      expect(wrapper.find(TextareaAutosize)).toHaveProp('data-foo', 'bar');
-    });
+describe('MultilineTextInput', () => {
+  it('should forward data-attributes', () => {
+    const { getByLabelText } = render(<TestComponent data-foo="bar" />);
+    expect(getByLabelText('Description')).toHaveAttribute('data-foo', 'bar');
   });
-  describe('component by default', () => {
-    let textarea;
-    let wrapper;
-    beforeEach(() => {
-      wrapper = getOpenWrapper({ name: 'field1', value: 'foo' });
-      textarea = wrapper.find(TextareaAutosize);
-    });
 
-    it('should have class for default styles', () => {
-      expect(textarea).toHaveClassName('pristine');
-    });
-
-    it('should have ARIA role', () => {
-      expect(textarea).toHaveProp('role', 'textbox');
-    });
-
-    it('should have ARIA multiline set as true', () => {
-      expect(textarea).toHaveProp('aria-multiline', 'true');
-    });
-
-    it('textarea have a HTML name', () => {
-      expect(textarea).toHaveProp('name', 'field1');
-    });
-
-    it('should render textarea', () => {
-      expect(wrapper).toRender('TextareaAutosize');
-    });
+  it('should have role `textbox`', () => {
+    const { getByLabelText } = render(<TestComponent />);
+    expect(getByLabelText('Description')).toHaveAttribute('role', 'textbox');
   });
-  describe('with validation', () => {
-    describe('has warning', () => {
-      let textarea;
-      beforeEach(() => {
-        const wrapper = getOpenWrapper({ hasWarning: true });
-        textarea = wrapper.find(TextareaAutosize);
-      });
-      it('should have warning styles', () => {
-        expect(textarea).toHaveClassName('warning');
-      });
-    });
-    describe('error', () => {
-      let textarea;
-      beforeEach(() => {
-        const wrapper = getOpenWrapper({ hasError: true });
-        textarea = wrapper.find(TextareaAutosize);
-      });
 
-      it('should have error styles', () => {
-        expect(textarea).toHaveClassName('error');
-      });
-    });
-    describe('disabled', () => {
-      let textarea;
-      beforeEach(() => {
-        const wrapper = getClosedWrapper({ isDisabled: true });
-        textarea = wrapper.find(TextareaAutosize);
-      });
-
-      it('should MultilineTextInput have class for the disabled state', () => {
-        expect(textarea).toHaveClassName('disabled');
-      });
-    });
-    describe('readonly', () => {
-      let textarea;
-      beforeEach(() => {
-        const wrapper = getOpenWrapper({ isReadOnly: true });
-        textarea = wrapper.find(TextareaAutosize);
-      });
-
-      it('should have class for the readonly state', () => {
-        expect(textarea).toHaveClassName('readonly');
-      });
-
-      it('should have ARIA properties for the readonly state', () => {
-        expect(textarea).toHaveProp('aria-readonly', true);
-      });
-    });
+  it('should have role aria-multiline set to `true`', () => {
+    const { getByLabelText } = render(<TestComponent />);
+    expect(getByLabelText('Description')).toHaveAttribute(
+      'aria-multiline',
+      'true'
+    );
   });
-  describe('`isDefaultClosed`', () => {
-    describe('when false', () => {
-      describe('<MultilineTextInput />', () => {
-        describe('has 1 row', () => {
-          let textAreaWrapper;
-          let wrapper;
-          beforeEach(() => {
-            const props = createTestProps({
-              name: 'field1',
-              value: 'foo',
-            });
-            wrapper = shallow(<MultilineTextInput {...props} />);
-            wrapper.setState({ contentRowCount: 1 });
-            textAreaWrapper = wrapper.find(Collapsible).renderProp('children', {
-              isOpen: true,
-              toggle: jest.fn(),
-            });
-          });
-          it('should not render FlatButton', () => {
-            expect(textAreaWrapper).not.toRender(FlatButton);
-          });
-        });
-        describe('has more than 1 row', () => {
-          let flatbutton;
-          let textAreaWrapper;
-          let wrapper;
-          beforeEach(() => {
-            const props = createTestProps({
-              name: 'field2',
-              value: 'foo2',
-            });
-            wrapper = shallow(<MultilineTextInput {...props} />);
-            wrapper.setState({ contentRowCount: 10 });
-            textAreaWrapper = wrapper.find(Collapsible).renderProp('children', {
-              isOpen: true,
-              toggle: jest.fn(),
-            });
-            flatbutton = textAreaWrapper.find(FlatButton);
-          });
-          it('should render FlatButton', () => {
-            expect(textAreaWrapper).toRender(FlatButton);
-          });
-          it('should have `Collapse` message', () => {
-            expect(flatbutton).toHaveProp(
-              'label',
-              'UIKit.MultilineTextInput.collapse'
-            );
-          });
-        });
-      });
-    });
-    describe('when true', () => {
-      describe('<MultilineTextInput />', () => {
-        describe('has 1 row', () => {
-          let textAreaWrapper;
-          let wrapper;
-          beforeEach(() => {
-            const props = createTestProps({
-              name: 'field2',
-              value: 'The quick brown fox jumps over the lazy dog',
-              isDefaultClosed: true,
-            });
-            wrapper = shallow(<MultilineTextInput {...props} />);
-            wrapper.setState({ contentRowCount: 1 });
-            textAreaWrapper = wrapper.find(Collapsible).renderProp('children', {
-              isOpen: false,
-              toggle: jest.fn(),
-            });
-          });
-          it('should not render FlatButton', () => {
-            expect(textAreaWrapper).not.toRender(FlatButton);
-          });
-        });
-        describe('has more than 1 row', () => {
-          let flatbutton;
-          let textAreaWrapper;
-          let wrapper;
-          beforeEach(() => {
-            const props = createTestProps({
-              name: 'field2',
-              value:
-                'The quick brown fox jumps over the lazy dog, The quick brown fox jumps over the lazy dog, The quick brown fox jumps over the lazy dog',
-              isDefaultClosed: true,
-            });
-            wrapper = shallow(<MultilineTextInput {...props} />);
-            wrapper.setState({ contentRowCount: 10 });
-            textAreaWrapper = wrapper.find(Collapsible).renderProp('children', {
-              isOpen: false,
-              toggle: jest.fn(),
-            });
-            flatbutton = textAreaWrapper.find(FlatButton);
-            textAreaWrapper.find(FlatButton).simulate('click');
-          });
-          it('should render FlatButton', () => {
-            expect(textAreaWrapper).toRender(FlatButton);
-          });
-          it('should FlatButton have `Expand` message', () => {
-            expect(flatbutton).toHaveProp(
-              'label',
-              'UIKit.MultilineTextInput.expand'
-            );
-          });
-        });
-      });
-    });
+
+  it('should forward html name', () => {
+    const { getByLabelText } = render(<TestComponent name="field1" />);
+    expect(getByLabelText('Description')).toHaveAttribute('name', 'field1');
   });
-});
 
-describe('callbacks', () => {
-  describe('`onChange`', () => {
-    let props;
-    const event = { target: { value: 'bar' } };
-    beforeEach(() => {
-      props = createTestProps({
-        value: 'foo',
-        onChange: jest.fn(),
-      });
-      const wrapper = getOpenWrapper(props);
-      const textarea = wrapper.find(TextareaAutosize);
-      textarea.simulate('change', event);
-    });
-
-    it('should call onChange', () => {
-      expect(props.onChange).toHaveBeenCalled();
-    });
-
-    it('should update with new value', () => {
-      expect(props.onChange).toHaveBeenCalledWith(event);
-    });
+  it('should render a textarea', () => {
+    const { getByLabelText } = render(<TestComponent />);
+    expect(getByLabelText('Description').tagName.toLowerCase()).toEqual(
+      'textarea'
+    );
   });
-  describe('`onFocus`', () => {
-    let props;
-    let textarea;
-    beforeEach(() => {
-      props = createTestProps({
-        value: 'foo',
-        onFocus: jest.fn(),
-      });
-      const wrapper = getOpenWrapper(props);
-      textarea = wrapper.find(TextareaAutosize);
-      textarea.simulate('focus');
-    });
 
-    it('should call onFocus', () => {
-      expect(props.onFocus).toHaveBeenCalled();
-    });
-
-    it('should keep the same value', () => {
-      expect(textarea).toHaveProp('value', 'foo');
-    });
+  it('should forward the passed value', () => {
+    const { getByLabelText } = render(<TestComponent value="foo" />);
+    expect(getByLabelText('Description').value).toEqual('foo');
   });
-  describe('`onBlur`', () => {
-    let props;
-    let textarea;
-    beforeEach(() => {
-      props = createTestProps({
-        value: 'foo',
-        onBlur: jest.fn(),
-      });
-      const wrapper = getOpenWrapper(props);
-      textarea = wrapper.find(TextareaAutosize);
-      textarea.simulate('blur');
-    });
 
-    it('should call onBlur', () => {
-      expect(props.onBlur).toHaveBeenCalled();
-    });
-
-    it('should keep the same value', () => {
-      expect(textarea).toHaveProp('value', 'foo');
-    });
+  it('should forward the placeholder', () => {
+    const { getByLabelText } = render(
+      <TestComponent placeholder="Enter a description" />
+    );
+    expect(getByLabelText('Description')).toHaveAttribute(
+      'placeholder',
+      'Enter a description'
+    );
   });
-  describe('`isAutofocussed`', () => {
-    let textarea;
-    beforeEach(() => {
-      const props = createTestProps({
-        isAutofocussed: true,
-        onFocus: jest.fn(),
-      });
-      const wrapper = getOpenWrapper(props);
-      textarea = wrapper.find(TextareaAutosize);
-    });
 
-    it('should autofocus prop be true', () => {
-      expect(textarea).toHaveProp('autoFocus', true);
-    });
+  it('should have focus automatically when isAutofocussed is passed', () => {
+    const { getByLabelText } = render(<TestComponent isAutofocussed={true} />);
+    expect(getByLabelText('Description')).toHaveFocus();
+  });
+
+  it('should have ARIA properties for the readonly state', () => {
+    const { getByLabelText } = render(<TestComponent isReadOnly={true} />);
+    expect(getByLabelText('Description')).toHaveAttribute(
+      'aria-readonly',
+      'true'
+    );
+  });
+
+  it('should forward disabled attribute when disabled', () => {
+    const { getByLabelText } = render(<TestComponent isDisabled={true} />);
+    expect(getByLabelText('Description')).toHaveAttribute('disabled');
+  });
+
+  it('should call onFocus when the input is focused', () => {
+    const onFocus = jest.fn();
+    const { getByLabelText } = render(<TestComponent onFocus={onFocus} />);
+    const textArea = getByLabelText('Description');
+    textArea.focus();
+    expect(textArea).toHaveFocus();
+    expect(onFocus).toHaveBeenCalled();
+  });
+
+  it('should call onBlur when the input is loses focus', () => {
+    const onBlur = jest.fn();
+    const { getByLabelText } = render(<TestComponent onBlur={onBlur} />);
+    const textArea = getByLabelText('Description');
+    textArea.focus();
+    expect(textArea).toHaveFocus();
+    textArea.blur();
+    expect(onBlur).toHaveBeenCalled();
+  });
+
+  it('should allow changing value of the textarea', () => {
+    const { getByLabelText } = render(<TestComponent />);
+    const event = { target: { value: 'I want chicken' } };
+    const textArea = getByLabelText('Description');
+    fireEvent.focus(textArea);
+    fireEvent.change(textArea, event);
+    fireEvent.keyDown(textArea, { key: 'Enter' });
+    fireEvent.keyUp(textArea, { key: 'Enter' });
+    expect(textArea.value).toEqual('I want chicken');
   });
 });

--- a/src/components/inputs/text-input/text-input.spec.js
+++ b/src/components/inputs/text-input/text-input.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '../../../test-utils';
-import { TextInput } from '../../../index';
+import TextInput from './text-input';
 
 const baseProps = { value: '', onChange: () => {} };
 


### PR DESCRIPTION
#### Summary

Refactors `multiline-text-input` to use `react-testing-library`.

#### Limitations

I couldn't figure out how to work out how to test the open / closed states of the component, mostly due to `react-textarea-autosized` not being able to calculate the nodeHeight in the js-dom environment. Do you have any ideas @pa3 ?