### PR TITLE
feat(fields): remove reexport of static methods

### DIFF
--- a/examples/form-fields.story.js
+++ b/examples/form-fields.story.js
@@ -11,9 +11,13 @@ import { FormikBox, Section } from '../.storybook/decorators';
 import {
   Text,
   TextField,
+  TextInput,
   MultilineTextField,
+  MultilineTextInput,
   NumberField,
+  NumberInput,
   MoneyField,
+  MoneyInput,
   PrimaryButton,
   SecondaryButton,
   Spacings,
@@ -105,12 +109,12 @@ const docToForm = (doc, locale) => ({
   // could be undefined, in which case toFormValue will set it to an empty
   // string. This eases validation later on, as we don't have to deal with
   // undefined anymore.
-  inventory: NumberField.toFormValue(doc.inventory),
+  inventory: NumberInput.toFormValue(doc.inventory),
   // parseMoneyValue will ensure that the price field will have currencyCode and
   // amount filled out or set to empty strings. This reduces the cases we
   // need to deal with (amount, currencyCode or the whole object being
   // undefined).
-  price: MoneyField.parseMoneyValue(doc.price, locale),
+  price: MoneyInput.parseMoneyValue(doc.price, locale),
   status: doc.status,
 });
 
@@ -126,7 +130,7 @@ const formToDoc = formValues => ({
   key: formValues.key,
   description: formValues.description,
   inventory: formValues.inventory,
-  price: MoneyField.convertToMoneyValue(formValues.price),
+  price: MoneyInput.convertToMoneyValue(formValues.price),
   status: formValues.status,
 });
 
@@ -151,26 +155,26 @@ const validate = formValues => {
   // validate key
   // Input elements usually provide a way to check whether it's value is empty
   // This is useful to determine whether a required value was not filled out.
-  if (TextField.isEmpty(formValues.key)) errors.key.missing = true;
+  if (TextInput.isEmpty(formValues.key)) errors.key.missing = true;
 
   // validate description
-  if (MultilineTextField.isEmpty(formValues.description))
+  if (MultilineTextInput.isEmpty(formValues.description))
     errors.description.missing = true;
 
   // validate inventory
-  if (NumberField.isEmpty(formValues.inventory)) {
+  if (NumberInput.isEmpty(formValues.inventory)) {
     errors.inventory.missing = true;
   } else {
     // When the value is not empty, we can assume that it is a number
     if (formValues.inventory < 0) errors.inventory.negative = true;
-    if (NumberField.hasFractionDigits(formValues.inventory))
+    if (NumberInput.hasFractionDigits(formValues.inventory))
       errors.inventory.fractions = true;
   }
 
   // validate price
-  if (MoneyField.isEmpty(formValues.price)) {
+  if (MoneyInput.isEmpty(formValues.price)) {
     errors.price.missing = true;
-  } else if (MoneyField.isHighPrecision(formValues.price)) {
+  } else if (MoneyInput.isHighPrecision(formValues.price)) {
     errors.price.unsupportedHighPrecision = true;
   }
 

--- a/src/components/fields/async-creatable-select-field/README.md
+++ b/src/components/fields/async-creatable-select-field/README.md
@@ -84,7 +84,3 @@ When the `key` is known, and when the value is truthy, and when `renderError` re
 Known error keys are:
 
 - `missing`: tells the user that this field is required
-
-### Static methods
-
-`AsyncCreatableSelectField` supports the same static methods as `AsyncCreatableSelectInput`. See `AsyncCreatableSelectInput` for the description.

--- a/src/components/fields/async-creatable-select-field/async-creatable-select-field.js
+++ b/src/components/fields/async-creatable-select-field/async-creatable-select-field.js
@@ -16,32 +16,6 @@ const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 export default class SelectField extends React.Component {
   static displayName = 'SelectField';
 
-  static isTouched = AsyncCreatableSelectInput.isTouched;
-
-  // customizable components
-  static ClearIndicator = AsyncCreatableSelectInput.ClearIndicator;
-  static Control = AsyncCreatableSelectInput.Control;
-  static DropdownIndicator = AsyncCreatableSelectInput.DropdownIndicator;
-  static Group = AsyncCreatableSelectInput.Group;
-  static GroupHeading = AsyncCreatableSelectInput.GroupHeading;
-  static IndicatorsContainer = AsyncCreatableSelectInput.IndicatorsContainer;
-  static IndicatorSeparator = AsyncCreatableSelectInput.IndicatorSeparator;
-  static Input = AsyncCreatableSelectInput.Input;
-  static LoadingIndicator = AsyncCreatableSelectInput.LoadingIndicator;
-  static Menu = AsyncCreatableSelectInput.Menu;
-  static MenuList = AsyncCreatableSelectInput.MenuList;
-  static LoadingMessage = AsyncCreatableSelectInput.LoadingMessage;
-  static NoOptionsMessage = AsyncCreatableSelectInput.NoOptionsMessage;
-  static MultiValue = AsyncCreatableSelectInput.MultiValue;
-  static MultiValueContainer = AsyncCreatableSelectInput.MultiValueContainer;
-  static MultiValueLabel = AsyncCreatableSelectInput.MultiValueLabel;
-  static MultiValueRemove = AsyncCreatableSelectInput.MultiValueRemove;
-  static Option = AsyncCreatableSelectInput.Option;
-  static Placeholder = AsyncCreatableSelectInput.Placeholder;
-  static SelectContainer = AsyncCreatableSelectInput.SelectContainer;
-  static SingleValue = AsyncCreatableSelectInput.SingleValue;
-  static ValueContainer = AsyncCreatableSelectInput.ValueContainer;
-
   static propTypes = {
     // SelectField
     id: PropTypes.string,

--- a/src/components/fields/async-select-field/README.md
+++ b/src/components/fields/async-select-field/README.md
@@ -74,7 +74,3 @@ When the `key` is known, and when the value is truthy, and when `renderError` re
 Known error keys are:
 
 - `missing`: tells the user that this field is required
-
-### Static methods
-
-`AsyncSelectField` supports the same static methods as `AsyncSelectInput`. See `AsyncSelectInput` for the description.

--- a/src/components/fields/async-select-field/async-select-field.js
+++ b/src/components/fields/async-select-field/async-select-field.js
@@ -16,32 +16,6 @@ const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 export default class AsyncSelectField extends React.Component {
   static displayName = 'AsyncSelectField';
 
-  static isTouched = AsyncSelectInput.isTouched;
-
-  // customizable components
-  static ClearIndicator = AsyncSelectInput.ClearIndicator;
-  static Control = AsyncSelectInput.Control;
-  static DropdownIndicator = AsyncSelectInput.DropdownIndicator;
-  static Group = AsyncSelectInput.Group;
-  static GroupHeading = AsyncSelectInput.GroupHeading;
-  static IndicatorsContainer = AsyncSelectInput.IndicatorsContainer;
-  static IndicatorSeparator = AsyncSelectInput.IndicatorSeparator;
-  static Input = AsyncSelectInput.Input;
-  static LoadingIndicator = AsyncSelectInput.LoadingIndicator;
-  static Menu = AsyncSelectInput.Menu;
-  static MenuList = AsyncSelectInput.MenuList;
-  static LoadingMessage = AsyncSelectInput.LoadingMessage;
-  static NoOptionsMessage = AsyncSelectInput.NoOptionsMessage;
-  static MultiValue = AsyncSelectInput.MultiValue;
-  static MultiValueContainer = AsyncSelectInput.MultiValueContainer;
-  static MultiValueLabel = AsyncSelectInput.MultiValueLabel;
-  static MultiValueRemove = AsyncSelectInput.MultiValueRemove;
-  static Option = AsyncSelectInput.Option;
-  static Placeholder = AsyncSelectInput.Placeholder;
-  static SelectContainer = AsyncSelectInput.SelectContainer;
-  static SingleValue = AsyncSelectInput.SingleValue;
-  static ValueContainer = AsyncSelectInput.ValueContainer;
-
   static propTypes = {
     // AsyncSelectField
     id: PropTypes.string,

--- a/src/components/fields/creatable-select-field/README.md
+++ b/src/components/fields/creatable-select-field/README.md
@@ -83,7 +83,3 @@ When the `key` is known, and when the value is truthy, and when `renderError` re
 Known error keys are:
 
 - `missing`: tells the user that this field is required
-
-### Static methods
-
-`CreatableSelectField` supports the same static methods as `CreatableSelectInput`. See `CreatableSelectInput` for the description.

--- a/src/components/fields/creatable-select-field/creatable-select-field.js
+++ b/src/components/fields/creatable-select-field/creatable-select-field.js
@@ -16,32 +16,6 @@ const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 export default class SelectField extends React.Component {
   static displayName = 'SelectField';
 
-  static isTouched = CreatableSelectInput.isTouched;
-
-  // customizable components
-  static ClearIndicator = CreatableSelectInput.ClearIndicator;
-  static Control = CreatableSelectInput.Control;
-  static DropdownIndicator = CreatableSelectInput.DropdownIndicator;
-  static Group = CreatableSelectInput.Group;
-  static GroupHeading = CreatableSelectInput.GroupHeading;
-  static IndicatorsContainer = CreatableSelectInput.IndicatorsContainer;
-  static IndicatorSeparator = CreatableSelectInput.IndicatorSeparator;
-  static Input = CreatableSelectInput.Input;
-  static LoadingIndicator = CreatableSelectInput.LoadingIndicator;
-  static Menu = CreatableSelectInput.Menu;
-  static MenuList = CreatableSelectInput.MenuList;
-  static LoadingMessage = CreatableSelectInput.LoadingMessage;
-  static NoOptionsMessage = CreatableSelectInput.NoOptionsMessage;
-  static MultiValue = CreatableSelectInput.MultiValue;
-  static MultiValueContainer = CreatableSelectInput.MultiValueContainer;
-  static MultiValueLabel = CreatableSelectInput.MultiValueLabel;
-  static MultiValueRemove = CreatableSelectInput.MultiValueRemove;
-  static Option = CreatableSelectInput.Option;
-  static Placeholder = CreatableSelectInput.Placeholder;
-  static SelectContainer = CreatableSelectInput.SelectContainer;
-  static SingleValue = CreatableSelectInput.SingleValue;
-  static ValueContainer = CreatableSelectInput.ValueContainer;
-
   static propTypes = {
     // SelectField
     id: PropTypes.string,

--- a/src/components/fields/localized-multiline-text-field/README.md
+++ b/src/components/fields/localized-multiline-text-field/README.md
@@ -64,7 +64,3 @@ When the `key` is known, and when the value is truthy, and when `renderError` re
 Known error keys are:
 
 - `missing`: tells the user that this field is required
-
-### Static methods
-
-This component supports the same static methods as `LocalizedMultilineTextInput`. See `LocalizedMultilineTextInput` for details.

--- a/src/components/fields/localized-multiline-text-field/localized-multiline-text-field.js
+++ b/src/components/fields/localized-multiline-text-field/localized-multiline-text-field.js
@@ -17,20 +17,6 @@ const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 class LocalizedMultilineTextField extends React.Component {
   static displayName = 'LocalizedMultilineTextField';
 
-  static getId = LocalizedMultilineTextInput.getId;
-
-  static getName = LocalizedMultilineTextInput.getName;
-
-  static createLocalizedString =
-    LocalizedMultilineTextInput.createLocalizedString;
-
-  static isEmpty = LocalizedMultilineTextInput.isEmpty;
-
-  static omitEmptyTranslations =
-    LocalizedMultilineTextInput.omitEmptyTranslations;
-
-  static isTouched = LocalizedMultilineTextInput.isTouched;
-
   static propTypes = {
     // LocalizedMultilineTextField
     id: PropTypes.string,

--- a/src/components/fields/localized-text-field/README.md
+++ b/src/components/fields/localized-text-field/README.md
@@ -64,7 +64,3 @@ When the `key` is known, and when the value is truthy, and when `renderError` re
 Known error keys are:
 
 - `missing`: tells the user that this field is required
-
-### Static methods
-
-This component supports the same static methods as `LocalizedTextInput`. See `LocalizedTextInput` for details.

--- a/src/components/fields/localized-text-field/localized-text-field.js
+++ b/src/components/fields/localized-text-field/localized-text-field.js
@@ -17,18 +17,6 @@ const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 class LocalizedMultilineTextField extends React.Component {
   static displayName = 'LocalizedMultilineTextField';
 
-  static getId = LocalizedTextInput.getId;
-
-  static getName = LocalizedTextInput.getName;
-
-  static createLocalizedString = LocalizedTextInput.createLocalizedString;
-
-  static isEmpty = LocalizedTextInput.isEmpty;
-
-  static omitEmptyTranslations = LocalizedTextInput.omitEmptyTranslations;
-
-  static isTouched = LocalizedTextInput.isTouched;
-
   static propTypes = {
     // LocalizedMultilineTextField
     id: PropTypes.string,

--- a/src/components/fields/money-field/README.md
+++ b/src/components/fields/money-field/README.md
@@ -67,10 +67,6 @@ Known error keys are:
 
 - `missing`: tells the user that this field is required but no value was provided
 
-### Static methods
-
-Supports the same static methods as `MoneyInput`.
-
 ### Main Functions and use cases are:
 
 - Getting monetary value input with a currency from users (with cent precision or high precision)

--- a/src/components/fields/money-field/money-field.form.story.js
+++ b/src/components/fields/money-field/money-field.form.story.js
@@ -12,11 +12,12 @@ import SecondaryButton from '../../buttons/secondary-button';
 import Spacings from '../../spacings';
 import Readme from './README.md';
 import MoneyField from './money-field';
+import MoneyInput from '../../inputs/money-input';
 
 const formToDoc = values => ({
-  price: MoneyField.convertToMoneyValue(values.price),
-  pricePerTon: MoneyField.convertToMoneyValue(values.pricePerTon),
-  discountedPrice: MoneyField.convertToMoneyValue(values.discountedPrice),
+  price: MoneyInput.convertToMoneyValue(values.price),
+  pricePerTon: MoneyInput.convertToMoneyValue(values.pricePerTon),
+  discountedPrice: MoneyInput.convertToMoneyValue(values.discountedPrice),
 });
 
 storiesOf('Examples|Forms/Fields', module)
@@ -33,17 +34,17 @@ storiesOf('Examples|Forms/Fields', module)
       <Section>
         <Formik
           initialValues={{
-            price: MoneyField.parseMoneyValue(),
-            pricePerTon: MoneyField.parseMoneyValue(),
-            discountedPrice: MoneyField.parseMoneyValue(),
+            price: MoneyInput.parseMoneyValue(),
+            pricePerTon: MoneyInput.parseMoneyValue(),
+            discountedPrice: MoneyInput.parseMoneyValue(),
           }}
           validate={values => {
             const errors = { price: {}, pricePerTon: {}, discountedPrice: {} };
-            if (MoneyField.isEmpty(values.price)) errors.price.missing = true;
-            else if (MoneyField.isHighPrecision(values.price))
+            if (MoneyInput.isEmpty(values.price)) errors.price.missing = true;
+            else if (MoneyInput.isHighPrecision(values.price))
               errors.price.unsupportedHighPrecision = true;
 
-            if (MoneyField.isEmpty(values.pricePerTon))
+            if (MoneyInput.isEmpty(values.pricePerTon))
               errors.pricePerTon.missing = true;
 
             // Shows how to validate optional `MoneyField`s. Notice that
@@ -54,8 +55,8 @@ storiesOf('Examples|Forms/Fields', module)
             // UX could want to show an error in this case, but then we'd also
             // need a way to unset the currency, which is not possible now.
             if (
-              !MoneyField.isEmpty(values.discountedPrice) &&
-              MoneyField.isHighPrecision(values.discountedPrice)
+              !MoneyInput.isEmpty(values.discountedPrice) &&
+              MoneyInput.isHighPrecision(values.discountedPrice)
             )
               errors.discountedPrice.unsupportedHighPrecision = true;
 

--- a/src/components/fields/money-field/money-field.js
+++ b/src/components/fields/money-field/money-field.js
@@ -21,14 +21,6 @@ const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 class MoneyField extends React.Component {
   static displayName = 'MoneyField';
 
-  static getAmountInputId = MoneyInput.getAmountInputId;
-  static getCurrencyDropdownId = MoneyInput.getCurrencyDropdownId;
-  static convertToMoneyValue = MoneyInput.convertToMoneyValue;
-  static parseMoneyValue = MoneyInput.parseMoneyValue;
-  static isEmpty = MoneyInput.isEmpty;
-  static isHighPrecision = MoneyInput.isHighPrecision;
-  static isTouched = MoneyInput.isTouched;
-
   static propTypes = {
     // MoneyField
     id: PropTypes.string,
@@ -98,7 +90,7 @@ class MoneyField extends React.Component {
   });
 
   render() {
-    // MoneyField.isTouched() ensures both fields have been touched.
+    // MoneyInput.isTouched() ensures both fields have been touched.
     // This avoids showing an error when the user just selected a language but
     // didn't add an amount yet.
     const hasError =

--- a/src/components/fields/money-field/money-field.spec.js
+++ b/src/components/fields/money-field/money-field.spec.js
@@ -14,18 +14,6 @@ const createTestProps = customProps => ({
   ...customProps,
 });
 
-describe('static methods', () => {
-  it('should reexport the static methods of MoneyInput', () => {
-    expect(typeof MoneyField.getAmountInputId).toBe('function');
-    expect(typeof MoneyField.getCurrencyDropdownId).toBe('function');
-    expect(typeof MoneyField.convertToMoneyValue).toBe('function');
-    expect(typeof MoneyField.parseMoneyValue).toBe('function');
-    expect(typeof MoneyField.isEmpty).toBe('function');
-    expect(typeof MoneyField.isHighPrecision).toBe('function');
-    expect(typeof MoneyField.isTouched).toBe('function');
-  });
-});
-
 describe('rendering', () => {
   describe('data attributes', () => {
     let moneyInput;

--- a/src/components/fields/money-field/money-field.story.js
+++ b/src/components/fields/money-field/money-field.story.js
@@ -13,6 +13,7 @@ import Section from '../../../../.storybook/decorators/section';
 import MoneyFieldReadme from './README.md';
 import * as icons from '../../icons';
 import MoneyField from './money-field';
+import MoneyInput from '../../inputs/money-input';
 
 // This uses a dedicated story component to keep track of state instead of
 // react-value. The reason is that MoneyInput can call twice onChange before
@@ -35,7 +36,7 @@ class MoneyFieldStory extends React.Component {
       // eslint-disable-next-line no-console
       console.log(
         'parsed',
-        MoneyField.convertToMoneyValue({
+        MoneyInput.convertToMoneyValue({
           amount: this.state.amount,
           currencyCode: this.state.currencyCode,
         })

--- a/src/components/fields/multiline-text-field/README.md
+++ b/src/components/fields/multiline-text-field/README.md
@@ -58,10 +58,6 @@ Known error keys are:
 
 - `missing`: tells the user that this field is required
 
-### Static methods
-
-This component reexports the static methods of `MultilineTextInput`. See that for more information.
-
 ### Main Functions and use cases are:
 
 - Input field for multi-line strings

--- a/src/components/fields/multiline-text-field/multiline-text-field.form.story.js
+++ b/src/components/fields/multiline-text-field/multiline-text-field.form.story.js
@@ -12,6 +12,7 @@ import SecondaryButton from '../../buttons/secondary-button';
 import Spacings from '../../spacings';
 import Readme from './README.md';
 import MultilineTextField from './multiline-text-field';
+import MultilineTextInput from '../../inputs/multiline-text-input';
 
 storiesOf('Examples|Forms/Fields', module)
   .addDecorator(withKnobs)
@@ -22,7 +23,7 @@ storiesOf('Examples|Forms/Fields', module)
         initialValues={{ description: '' }}
         validate={values => {
           const errors = { description: {} };
-          if (MultilineTextField.isEmpty(values.description))
+          if (MultilineTextInput.isEmpty(values.description))
             errors.description.missing = true;
           if (values.description.trim().length > 160)
             errors.description.exceedsMaxLength = true;

--- a/src/components/fields/multiline-text-field/multiline-text-field.js
+++ b/src/components/fields/multiline-text-field/multiline-text-field.js
@@ -16,8 +16,6 @@ const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 class MultilineTextField extends React.Component {
   static displayName = 'MultilineTextField';
 
-  static isEmpty = MultilineTextInput.isEmpty;
-
   static propTypes = {
     // MultilineTextField
     id: PropTypes.string,

--- a/src/components/fields/multiline-text-field/multiline-text-field.spec.js
+++ b/src/components/fields/multiline-text-field/multiline-text-field.spec.js
@@ -13,21 +13,6 @@ const createTestProps = customProps => ({
   ...customProps,
 });
 
-describe('MultilineTextField.isEmpty', () => {
-  describe('when called with an empty value', () => {
-    it('should return true', () => {
-      expect(MultilineTextField.isEmpty('')).toBe(true);
-      expect(MultilineTextField.isEmpty(' ')).toBe(true);
-    });
-  });
-  describe('when called with a filled value', () => {
-    it('should return false', () => {
-      expect(MultilineTextField.isEmpty('a')).toBe(false);
-      expect(MultilineTextField.isEmpty(' a ')).toBe(false);
-    });
-  });
-});
-
 describe('rendering', () => {
   describe('data attributes', () => {
     let textInput;

--- a/src/components/fields/number-field/README.md
+++ b/src/components/fields/number-field/README.md
@@ -62,7 +62,3 @@ When the `key` is known, and when the value is truthy, and when `renderError` re
 Known error keys are:
 
 - `missing`: tells the user that this field is required
-
-### Static methods
-
-This input has the same static methods as the `NumberInput`. See its README for their documentation.

--- a/src/components/fields/number-field/number-field.form.story.js
+++ b/src/components/fields/number-field/number-field.form.story.js
@@ -12,6 +12,7 @@ import SecondaryButton from '../../buttons/secondary-button';
 import Spacings from '../../spacings';
 import Readme from './README.md';
 import NumberField from './number-field';
+import NumberInput from '../../inputs/number-input';
 
 // Cool stuff to try in this story:
 //  - Click the "Age" label and see how the input is focused automatically
@@ -28,7 +29,7 @@ storiesOf('Examples|Forms/Fields', module)
         initialValues={{ age: '' }}
         validate={values => {
           const errors = { age: {} };
-          if (NumberField.isEmpty(values.age)) errors.age.missing = true;
+          if (NumberInput.isEmpty(values.age)) errors.age.missing = true;
           else if (values.age < 0) errors.age.negative = true;
           return omitEmpty(errors);
         }}

--- a/src/components/fields/number-field/number-field.js
+++ b/src/components/fields/number-field/number-field.js
@@ -16,8 +16,6 @@ const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 class NumberField extends React.Component {
   static displayName = 'NumberField';
 
-  static isEmpty = NumberInput.isEmpty;
-
   static propTypes = {
     // NumberField
     id: PropTypes.string,
@@ -117,7 +115,4 @@ class NumberField extends React.Component {
   }
 }
 
-NumberField.hasFractionDigits = NumberInput.hasFractionDigits;
-NumberField.isEmpty = NumberInput.isEmpty;
-NumberField.toFormValue = NumberInput.toFormValue;
 export default NumberField;

--- a/src/components/fields/number-field/number-field.spec.js
+++ b/src/components/fields/number-field/number-field.spec.js
@@ -13,21 +13,6 @@ const createTestProps = customProps => ({
   ...customProps,
 });
 
-describe('NumberField.isEmpty', () => {
-  describe('when called with an empty value', () => {
-    it('should return true', () => {
-      expect(NumberField.isEmpty('')).toBe(true);
-      expect(NumberField.isEmpty(' ')).toBe(true);
-    });
-  });
-  describe('when called with a filled value', () => {
-    it('should return false', () => {
-      expect(NumberField.isEmpty('a')).toBe(false);
-      expect(NumberField.isEmpty(' a ')).toBe(false);
-    });
-  });
-});
-
 describe('rendering', () => {
   describe('data attributes', () => {
     let textInput;

--- a/src/components/fields/select-field/README.md
+++ b/src/components/fields/select-field/README.md
@@ -77,7 +77,3 @@ When the `key` is known, and when the value is truthy, and when `renderError` re
 Known error keys are:
 
 - `missing`: tells the user that this field is required
-
-### Static methods
-
-`SelectField` supports the same static methods as `SelectInput`. See `SelectInput` for the description.

--- a/src/components/fields/select-field/select-field.js
+++ b/src/components/fields/select-field/select-field.js
@@ -16,32 +16,6 @@ const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 export default class SelectField extends React.Component {
   static displayName = 'SelectField';
 
-  static isTouched = SelectInput.isTouched;
-
-  // customizable components
-  static ClearIndicator = SelectInput.ClearIndicator;
-  static Control = SelectInput.Control;
-  static DropdownIndicator = SelectInput.DropdownIndicator;
-  static Group = SelectInput.Group;
-  static GroupHeading = SelectInput.GroupHeading;
-  static IndicatorsContainer = SelectInput.IndicatorsContainer;
-  static IndicatorSeparator = SelectInput.IndicatorSeparator;
-  static Input = SelectInput.Input;
-  static LoadingIndicator = SelectInput.LoadingIndicator;
-  static Menu = SelectInput.Menu;
-  static MenuList = SelectInput.MenuList;
-  static LoadingMessage = SelectInput.LoadingMessage;
-  static NoOptionsMessage = SelectInput.NoOptionsMessage;
-  static MultiValue = SelectInput.MultiValue;
-  static MultiValueContainer = SelectInput.MultiValueContainer;
-  static MultiValueLabel = SelectInput.MultiValueLabel;
-  static MultiValueRemove = SelectInput.MultiValueRemove;
-  static Option = SelectInput.Option;
-  static Placeholder = SelectInput.Placeholder;
-  static SelectContainer = SelectInput.SelectContainer;
-  static SingleValue = SelectInput.SingleValue;
-  static ValueContainer = SelectInput.ValueContainer;
-
   static propTypes = {
     // SelectField
     id: PropTypes.string,

--- a/src/components/fields/text-field/README.md
+++ b/src/components/fields/text-field/README.md
@@ -57,18 +57,6 @@ Known error keys are:
 
 - `missing`: tells the user that this field is required
 
-### Static methods
-
-#### `TextField.isEmpty`
-
-Returns `true` when the value is considered empty, which is when the value is empty or consists of spaces only.
-
-```js
-TextField.isEmpty(''); // -> true
-TextField.isEmpty(' '); // -> true
-TextField.isEmpty('tree'); // -> false
-```
-
 ### Main Functions and use cases are:
 
 - Input field for single-line strings

--- a/src/components/fields/text-field/text-field.form.story.js
+++ b/src/components/fields/text-field/text-field.form.story.js
@@ -12,6 +12,7 @@ import SecondaryButton from '../../buttons/secondary-button';
 import Spacings from '../../spacings';
 import Readme from './README.md';
 import TextField from './text-field';
+import TextInput from '../../inputs/text-input';
 
 // Cool stuff to try in this story:
 //  - Click the "Username" label and see how the input is focused automatically
@@ -29,7 +30,7 @@ storiesOf('Examples|Forms/Fields', module)
         initialValues={{ userName: '' }}
         validate={values => {
           const errors = { userName: {} };
-          if (TextField.isEmpty(values.userName))
+          if (TextInput.isEmpty(values.userName))
             errors.userName.missing = true;
           if (values.userName.trim().indexOf(' ') !== -1)
             errors.userName.usesSpaces = true;

--- a/src/components/fields/text-field/text-field.js
+++ b/src/components/fields/text-field/text-field.js
@@ -16,8 +16,6 @@ const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 class TextField extends React.Component {
   static displayName = 'TextField';
 
-  static isEmpty = TextInput.isEmpty;
-
   static propTypes = {
     // TextField
     id: PropTypes.string,

--- a/src/components/fields/text-field/text-field.spec.js
+++ b/src/components/fields/text-field/text-field.spec.js
@@ -13,21 +13,6 @@ const createTestProps = customProps => ({
   ...customProps,
 });
 
-describe('TextField.isEmpty', () => {
-  describe('when called with an empty value', () => {
-    it('should return true', () => {
-      expect(TextField.isEmpty('')).toBe(true);
-      expect(TextField.isEmpty(' ')).toBe(true);
-    });
-  });
-  describe('when called with a filled value', () => {
-    it('should return false', () => {
-      expect(TextField.isEmpty('a')).toBe(false);
-      expect(TextField.isEmpty(' a ')).toBe(false);
-    });
-  });
-});
-
 describe('rendering', () => {
   describe('data attributes', () => {
     let textInput;


### PR DESCRIPTION
We were reexporting the static methods of input elements on field elements for convenience. This caused more confusion and overhead than just forcing consumers to use the statics of the input elements instead.

BREAKING: Removes reexported static methods from fields. Use the static methods of the respective inputs instead.

Closes #315