### PR TITLE
Allow tags to be flexible in height

### DIFF
--- a/src/components/tag/tag.mod.css
+++ b/src/components/tag/tag.mod.css
@@ -3,9 +3,9 @@
 .contentWrapper {
   display: flex;
   align-items: center;
-  height: var(--token-size-height-tag);
+  min-height: var(--token-size-height-tag);
   border-radius: var(--token-border-radius-tag);
-  padding: 0 var(--spacing-8);
+  padding: 5px var(--spacing-8);
   cursor: default;
   font-family: inherit;
   white-space: normal;

--- a/src/components/tag/tag.percy.js
+++ b/src/components/tag/tag.percy.js
@@ -2,17 +2,37 @@ import React from 'react';
 import { Tag } from '../../../dist/ui-kit.esm';
 import { Suite, Spec, screenshot } from '../../../test/percy';
 
+const longText = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur et
+metus ultrices, interdum augue eget, consequat orci. Nam et nisi
+eleifend, fermentum nunc non, sagittis tortor. Pellentesque vulputate
+dignissim leo fermentum vehicula. Fusce efficitur est molestie augue
+ullamcorper dictum. Donec non leo a augue dictum pretium. Praesent ac
+quam pharetra, posuere mauris in, pharetra nisi.`;
+
 screenshot('Tag', () => (
   <Suite>
     <Spec label="Normal">
       <Tag type="normal">Tag</Tag>
+    </Spec>
+    <Spec label="Normal - multiple lines of text">
+      <Tag type="normal">{longText}</Tag>
     </Spec>
     <Spec label="Normal - onRemove">
       <Tag type="normal" onRemove={() => {}}>
         With remove
       </Tag>
     </Spec>
+    <Spec label="Normal - multiple lines of text - onRemove">
+      <Tag type="normal" onRemove={() => {}}>
+        {longText}
+      </Tag>
+    </Spec>
     <Spec label="Normal - horizontalConstraint - xs">
+      <Tag type="normal" horizontalConstraint="xs">
+        Tag
+      </Tag>
+    </Spec>
+    <Spec label="Normal - multiple lines of text - horizontalConstraint - xs">
       <Tag type="normal" horizontalConstraint="xs">
         Tag
       </Tag>

--- a/src/components/tag/tag.percy.js
+++ b/src/components/tag/tag.percy.js
@@ -14,25 +14,12 @@ screenshot('Tag', () => (
     <Spec label="Normal">
       <Tag type="normal">Tag</Tag>
     </Spec>
-    <Spec label="Normal - multiple lines of text">
-      <Tag type="normal">{longText}</Tag>
-    </Spec>
     <Spec label="Normal - onRemove">
       <Tag type="normal" onRemove={() => {}}>
         With remove
       </Tag>
     </Spec>
-    <Spec label="Normal - multiple lines of text - onRemove">
-      <Tag type="normal" onRemove={() => {}}>
-        {longText}
-      </Tag>
-    </Spec>
     <Spec label="Normal - horizontalConstraint - xs">
-      <Tag type="normal" horizontalConstraint="xs">
-        Tag
-      </Tag>
-    </Spec>
-    <Spec label="Normal - multiple lines of text - horizontalConstraint - xs">
       <Tag type="normal" horizontalConstraint="xs">
         Tag
       </Tag>
@@ -64,6 +51,14 @@ screenshot('Tag', () => (
     <Spec label="Warning - disabled">
       <Tag type="warning" isDisabled={true}>
         Warning but disabled
+      </Tag>
+    </Spec>
+    <Spec label="Normal - multiple lines of text">
+      <Tag type="normal">{longText}</Tag>
+    </Spec>
+    <Spec label="Normal - multiple lines of text - onRemove">
+      <Tag type="normal" onRemove={() => {}}>
+        {longText}
       </Tag>
     </Spec>
   </Suite>


### PR DESCRIPTION
#### Summary

Fixes #323 

* Sets min height
* Adds padding so that multiline tags have a consistent appearance with single line tags.

Check the VRT diff 