### PR TITLE
Temporarily disable percy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,12 @@ script:
   - "! test -f fail-tests-because-there-was-an-unhandled-rejection.lock"
   # skip percy builds when this is not a pull request or when it's not master to save precious snaps
   # also skip when PR is opened by `renovate`
-  - bash ./scripts/run-percy.sh
+  #
+  # Percy is disabled for now as we ran over the budget for this month.
+  # It should be reenabled once we are moved to the bigger plan, which we
+  # already requested from Percy, or as soon as the new month starts.
+  #- bash ./scripts/run-percy.sh
+  #
   # back to default in case internal travis scripts return non zero response codes.
   - set +e
 


### PR DESCRIPTION
We ran over the limit now

> $ react-percy
> Compiling...
> Uploading 48 snapshots to Percy
> Error: This organization has exceeded the limits of the (unactivated) plan. Administrators can upgrade here: https://percy.io/organizations/commercetools-GmbH/billing

We can't upgrade using their UI as we are one a custom plan at the moment (since we signed up through GitHub). I already reached out to their support and requested to be moved to a different plan. We will reenable Percy once the bigger plan is activated or when the next month starts and the budget is reset in case we were not upgraded in the meantime.

cc @montezume FYI