### PR TITLE
Convert AsyncSelectInput and AsyncCreatableSelectInput tests

### DIFF
--- a/src/components/inputs/async-creatable-select-input/async-creatable-select-input.spec.js
+++ b/src/components/inputs/async-creatable-select-input/async-creatable-select-input.spec.js
@@ -1,101 +1,393 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { AsyncCreatable as AsyncCreatableSelect } from 'react-select';
-import { AsyncCreatableSelectInput } from './async-creatable-select-input';
+import PropTypes from 'prop-types';
+import { render, fireEvent, waitForElement } from '../../../test-utils';
+import AsyncCreatableSelectInput from './async-creatable-select-input';
 
-const createTestProps = custom => ({
-  name: 'foo',
-  defaultOptions: [
-    { value: 'ready', label: 'Ready' },
-    { value: 'shipped', label: 'Shipped' },
-    { value: 'delivered', label: 'Delivered' },
-    { value: 'returned', label: 'Returned' },
-  ],
-  loadOptions: jest.fn(),
-  onChange: jest.fn(),
-  onBlur: jest.fn(),
-  intl: { formatMessage: jest.fn(message => message.id) },
-  ...custom,
+// We use this component to simulate the whole flow of
+// changing a value and formatting on blur.
+class TestComponent extends React.Component {
+  static displayName = 'TestComponent';
+  static propTypes = {
+    id: PropTypes.string,
+    value: (props, ...rest) =>
+      props.isMulti
+        ? PropTypes.arrayOf(
+            PropTypes.shape({ value: PropTypes.string.isRequired })
+          )(props, ...rest)
+        : PropTypes.shape({ value: PropTypes.string.isRequired })(
+            props,
+            ...rest
+          ),
+    onChange: PropTypes.func,
+  };
+  static defaultProps = {
+    id: 'some-id',
+    name: 'some-name',
+    value: { value: 'banana', label: 'Banana' },
+    loadOptions: () =>
+      Promise.resolve([
+        { value: 'banana', label: 'Banana' },
+        { value: 'mango', label: 'Mango' },
+        { value: 'raspberry', label: 'Raspberry' },
+        { value: 'lichi', label: 'Lichi' },
+      ]),
+    defaultOptions: true,
+    isSearchable: true,
+  };
+
+  state = {
+    value: this.props.value,
+  };
+
+  handleChange = event => {
+    event.persist();
+    this.setState({
+      value: event.target.value,
+    });
+    if (this.props.onChange) {
+      this.props.onChange(event);
+    }
+  };
+
+  render() {
+    return (
+      <React.Fragment>
+        <label htmlFor={this.props.id}>Fruit</label>
+        <AsyncCreatableSelectInput
+          {...this.props}
+          onChange={this.handleChange}
+          value={this.state.value}
+          loadOptions={this.props.loadOptions}
+          defaultOptions={this.props.defaultOptions}
+          isSearchable={this.props.isSearchable}
+        />
+      </React.Fragment>
+    );
+  }
+}
+
+const renderInput = (props, options) =>
+  render(<TestComponent {...props} />, options);
+
+it('should forward data-attributes', () => {
+  const { container } = renderInput({ 'data-foo': 'bar' });
+  // here we have to use container.querySelector because the data attributes are attached
+  // to the wrapper div, not to the input itself.
+  expect(container.querySelector('[data-foo="bar"]')).toBeInTheDocument();
 });
 
-describe('overwritten props', () => {
-  describe('when in single-value mode', () => {
-    let wrapper;
-    let props;
-    beforeEach(() => {
-      props = createTestProps();
-      wrapper = shallow(<AsyncCreatableSelectInput {...props} />);
+it('should have focus automatically when isAutofocussed is passed', () => {
+  const { getByLabelText } = renderInput({ isAutofocussed: true });
+  expect(getByLabelText('Fruit')).toHaveFocus();
+});
+
+it('should call onFocus when the input is focused', () => {
+  const onFocus = jest.fn();
+  const { getByLabelText } = renderInput({ onFocus });
+  const input = getByLabelText('Fruit');
+  input.focus();
+  expect(input).toHaveFocus();
+  expect(onFocus).toHaveBeenCalled();
+});
+
+it('should call onBlur when input loses focus', () => {
+  const onBlur = jest.fn();
+  const { getByLabelText } = renderInput({ onBlur });
+  const input = getByLabelText('Fruit');
+  input.focus();
+  expect(input).toHaveFocus();
+  input.blur();
+  expect(input).not.toHaveFocus();
+  expect(onBlur).toHaveBeenCalled();
+});
+
+describe('in single mode', () => {
+  describe('when no value is specified', () => {
+    it('should render a select input', () => {
+      const { getByLabelText } = renderInput();
+      const input = getByLabelText('Fruit');
+      expect(input).toBeInTheDocument();
     });
-    describe('when value is changed', () => {
-      const info = {};
-      beforeEach(() => {
-        wrapper.find(AsyncCreatableSelect).prop('onChange')(
-          props.defaultOptions[1],
-          info
-        );
+  });
+  describe('when a value is specified', () => {
+    it('should render a select input with preselected value', () => {
+      const { getByLabelText, getByText } = renderInput({
+        value: { value: 'banana', label: 'Banana' },
       });
-      it('should call onChange with an event', () => {
-        expect(props.onChange).toHaveBeenCalledWith(
-          {
-            persist: expect.any(Function),
-            target: {
-              name: 'foo',
-              value: { value: 'shipped', label: 'Shipped' },
-            },
-          },
-          info
-        );
+      const input = getByLabelText('Fruit');
+      expect(input).toBeInTheDocument();
+      expect(getByText('Banana')).toBeInTheDocument();
+    });
+  });
+  describe('interacting', () => {
+    it('should open the list and all options should be visible', async () => {
+      const { getByLabelText, getByText } = renderInput();
+      const input = getByLabelText('Fruit');
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      fireEvent.keyUp(input, { key: 'ArrowDown' });
+      await waitForElement(() => getByText('Mango'));
+      expect(getByText('Mango')).toBeInTheDocument();
+      expect(getByText('Lichi')).toBeInTheDocument();
+      expect(getByText('Raspberry')).toBeInTheDocument();
+    });
+    it('should be able to select an option', async () => {
+      const { getByLabelText, getByText, queryByText } = renderInput();
+      const input = getByLabelText('Fruit');
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      await waitForElement(() => getByText('Mango'));
+      getByText('Mango').click();
+      // new selected value should be Mango
+      expect(getByText('Mango')).toBeInTheDocument();
+      // list should closed and not visible
+      expect(queryByText('Banana')).not.toBeInTheDocument();
+    });
+    it('should call onChange when value selected', async () => {
+      const onChange = jest.fn();
+      const { getByLabelText, getByText } = renderInput({
+        onChange,
+      });
+      const input = getByLabelText('Fruit');
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      await waitForElement(() => getByText('Mango'));
+      getByText('Mango').click();
+      expect(onChange).toHaveBeenCalledWith({
+        persist: expect.any(Function),
+        target: {
+          name: 'some-name',
+          value: { value: 'mango', label: 'Mango' },
+        },
       });
     });
-    describe('when field is blurred', () => {
-      beforeEach(() => {
-        wrapper.find(AsyncCreatableSelect).prop('onBlur')();
+    it('should be able to create an option', () => {
+      const { getByLabelText, getByText } = renderInput();
+      const input = getByLabelText('Fruit');
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      const event = { target: { value: 'Orange', label: 'Orange' } };
+      fireEvent.change(input, event);
+      fireEvent.keyDown(input, { key: 'Enter' });
+      fireEvent.keyUp(input, { key: 'Enter' });
+      expect(getByText('Orange')).toBeInTheDocument();
+    });
+    it('should call onChange with the created option', async () => {
+      const onChange = jest.fn();
+      const { getByLabelText, getByText } = renderInput({
+        onChange,
+        value: null,
       });
-      it('should call onBlur with an event', () => {
-        expect(props.onBlur).toHaveBeenCalledWith({
-          persist: expect.any(Function),
-          target: { name: 'foo' },
-        });
+      const input = getByLabelText('Fruit');
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: 'Orange', label: 'Orange' } });
+      await waitForElement(() => getByText('Create "Orange"'));
+      getByText('Create "Orange"').click();
+      expect(onChange).toHaveBeenCalledWith({
+        persist: expect.any(Function),
+        target: {
+          name: 'some-name',
+          value: expect.objectContaining({ value: 'Orange', label: 'Orange' }),
+        },
       });
     });
   });
-  describe('when in multi-value mode', () => {
-    let wrapper;
-    let props;
-    beforeEach(() => {
-      props = createTestProps({ isMulti: true, value: [] });
-      wrapper = shallow(<AsyncCreatableSelectInput {...props} />);
+});
+
+describe('in multi mode', () => {
+  describe('when no value is specified', () => {
+    it('should render a select input', () => {
+      const { getByLabelText } = renderInput({
+        isMulti: true,
+        value: [],
+      });
+      const input = getByLabelText('Fruit');
+      expect(input).toBeInTheDocument();
     });
-    describe('when value is changed', () => {
-      const info = {};
-      let selectedOptions;
-      beforeEach(() => {
-        selectedOptions = props.defaultOptions.slice(0, 2);
-        wrapper.find(AsyncCreatableSelect).prop('onChange')(
-          selectedOptions,
-          info
-        );
-      });
-      it('should call onChange with an event', () => {
-        expect(props.onChange).toHaveBeenCalledWith(
-          {
-            persist: expect.any(Function),
-            target: { name: 'foo', value: selectedOptions },
-          },
-          info
-        );
-      });
-    });
-    describe('when field is blurred', () => {
-      beforeEach(() => {
-        wrapper.find(AsyncCreatableSelect).prop('onBlur')();
-      });
-      it('should call onBlur with an event', () => {
-        expect(props.onBlur).toHaveBeenCalledWith({
-          persist: expect.any(Function),
-          target: { name: 'foo.0' },
+    describe('when values are specified', () => {
+      it('should render a select input with preselected values', () => {
+        const { getByLabelText, getByText } = renderInput({
+          isMulti: true,
+          value: [
+            { value: 'mango', label: 'Mango' },
+            { value: 'raspberry', label: 'Raspberry' },
+          ],
         });
+        const input = getByLabelText('Fruit');
+        expect(input).toBeInTheDocument();
+        expect(getByText('Mango')).toBeInTheDocument();
+        expect(getByText('Raspberry')).toBeInTheDocument();
       });
     });
+  });
+  describe('interacting', () => {
+    it('should open the list and all options should be visible', async () => {
+      const { getByLabelText, getByText } = renderInput({
+        isMulti: true,
+        value: [],
+      });
+      const input = getByLabelText('Fruit');
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      fireEvent.keyUp(input, { key: 'ArrowDown' });
+      await waitForElement(() => getByText('Mango'));
+      expect(getByText('Mango')).toBeInTheDocument();
+      expect(getByText('Lichi')).toBeInTheDocument();
+      expect(getByText('Raspberry')).toBeInTheDocument();
+    });
+    it('should be able to select two option', async () => {
+      const { getByLabelText, getByText, queryByText } = renderInput({
+        isMulti: true,
+        value: [],
+      });
+      const input = getByLabelText('Fruit');
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      await waitForElement(() => getByText('Mango'));
+      getByText('Mango').click();
+      // new selected value should be Mango
+      expect(getByText('Mango')).toBeInTheDocument();
+      // list should closed and not visible
+      expect(queryByText('Banana')).not.toBeInTheDocument();
+      // open list again
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      await waitForElement(() => getByText('Banana'));
+      getByText('Banana').click();
+      // new values should be Banana and Mango
+      expect(getByText('Banana')).toBeInTheDocument();
+      expect(getByText('Mango')).toBeInTheDocument();
+      // list should closed and not visible
+      expect(queryByText('Raspberry')).not.toBeInTheDocument();
+    });
+    it('should call onChange when two values selected', async () => {
+      const onChange = jest.fn();
+      const { getByLabelText, getByText } = renderInput({
+        onChange,
+        isMulti: true,
+        value: [],
+      });
+      const input = getByLabelText('Fruit');
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      await waitForElement(() => getByText('Mango'));
+      getByText('Mango').click();
+      expect(onChange).toHaveBeenCalledWith({
+        persist: expect.any(Function),
+        target: {
+          name: 'some-name',
+          value: [expect.objectContaining({ value: 'mango', label: 'Mango' })],
+        },
+      });
+      // open list again
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      await waitForElement(() => getByText('Raspberry'));
+      getByText('Raspberry').click();
+
+      expect(onChange).toHaveBeenCalledWith({
+        persist: expect.any(Function),
+        target: {
+          name: 'some-name',
+          value: [
+            expect.objectContaining(
+              { value: 'mango', label: 'Mango' },
+              { value: 'raspberry', label: 'Raspberry' }
+            ),
+          ],
+        },
+      });
+    });
+    it('should be able to create two options', async () => {
+      const { getByLabelText, getByText } = renderInput({
+        isMulti: true,
+        value: [],
+      });
+      const input = getByLabelText('Fruit');
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      const event = { target: { value: 'Orange', label: 'Orange' } };
+      fireEvent.change(input, event);
+      await waitForElement(() => getByText('Create "Orange"'));
+      getByText('Create "Orange"').click();
+      // open again
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      const appleEvent = { target: { value: 'Apple', label: 'Apple' } };
+      fireEvent.change(input, appleEvent);
+      await waitForElement(() => getByText('Create "Apple"'));
+      getByText('Create "Apple"').click();
+
+      expect(getByText('Orange')).toBeInTheDocument();
+      expect(getByText('Apple')).toBeInTheDocument();
+    });
+    it('should call onChange when two created values', async () => {
+      const onChange = jest.fn();
+      const { getByLabelText, getByText } = renderInput({
+        onChange,
+        isMulti: true,
+        value: [],
+      });
+      const input = getByLabelText('Fruit');
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      fireEvent.change(input, { target: { value: 'Orange', label: 'Orange' } });
+      await waitForElement(() => getByText('Create "Orange"'));
+      getByText('Create "Orange"').click();
+      expect(onChange).toHaveBeenCalledWith({
+        persist: expect.any(Function),
+        target: {
+          name: 'some-name',
+          value: [
+            expect.objectContaining({ value: 'Orange', label: 'Orange' }),
+          ],
+        },
+      });
+
+      // open list again
+      fireEvent.change(input, { target: { value: 'Apple', label: 'Apple' } });
+      await waitForElement(() => getByText('Create "Apple"'));
+      getByText('Create "Apple"').click();
+
+      expect(onChange).toHaveBeenCalledWith({
+        persist: expect.any(Function),
+        target: {
+          name: 'some-name',
+          value: [
+            expect.objectContaining({ value: 'Orange', label: 'Orange' }),
+            expect.objectContaining({ value: 'Apple', label: 'Apple' }),
+          ],
+        },
+      });
+    });
+  });
+});
+
+describe('when used with option groups', () => {
+  const colourOptions = [
+    { value: 'purple', label: 'Purple', color: '#5243AA' },
+    { value: 'orange', label: 'Orange', color: '#FF8B00' },
+    { value: 'yellow', label: 'Yellow', color: '#FFC400' },
+  ];
+
+  const flavourOptions = [
+    { value: 'vanilla', label: 'Vanilla', rating: 'safe' },
+    { value: 'chocolate', label: 'Chocolate', rating: 'good' },
+  ];
+  const groupedOptions = [
+    { label: 'Colours', options: colourOptions },
+    { label: 'Flavours', options: flavourOptions },
+  ];
+
+  const yellowOption = colourOptions[2];
+
+  it('should render a select input with preselected values', () => {
+    const { getByLabelText, getByText } = renderInput({
+      value: yellowOption,
+      loadOptions: () => Promise.resolve(groupedOptions),
+    });
+    const input = getByLabelText('Fruit');
+    expect(input).toBeInTheDocument();
+    expect(getByText(yellowOption.label)).toBeInTheDocument();
   });
 });

--- a/src/components/inputs/async-select-input/async-select-input.spec.js
+++ b/src/components/inputs/async-select-input/async-select-input.spec.js
@@ -1,98 +1,292 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { Async as AsynSelect } from 'react-select';
-import { AsyncSelectInput } from './async-select-input';
+import PropTypes from 'prop-types';
+import { render, fireEvent, waitForElement } from '../../../test-utils';
+import AsyncSelectInput from './async-select-input';
 
-const createTestProps = custom => ({
-  name: 'foo',
-  defaultOptions: [
-    { value: 'ready', label: 'Ready' },
-    { value: 'shipped', label: 'Shipped' },
-    { value: 'delivered', label: 'Delivered' },
-    { value: 'returned', label: 'Returned' },
-  ],
-  loadOptions: jest.fn(),
-  onChange: jest.fn(),
-  onBlur: jest.fn(),
-  intl: { formatMessage: jest.fn(message => message.id) },
-  ...custom,
+// We use this component to simulate the whole flow of
+// changing a value and formatting on blur.
+class TestComponent extends React.Component {
+  static displayName = 'TestComponent';
+  static propTypes = {
+    id: PropTypes.string,
+    value: (props, ...rest) =>
+      props.isMulti
+        ? PropTypes.arrayOf(PropTypes.object).isRequired(props, ...rest)
+        : PropTypes.object(props, ...rest),
+    onChange: PropTypes.func,
+  };
+  static defaultProps = {
+    id: 'some-id',
+    name: 'some-name',
+    value: { value: 'banana', label: 'Banana' },
+    defaultOptions: true,
+    loadOptions: () =>
+      Promise.resolve([
+        { value: 'banana', label: 'Banana' },
+        { value: 'mango', label: 'Mango' },
+        { value: 'raspberry', label: 'Raspberry' },
+        { value: 'lichi', label: 'Lichi' },
+      ]),
+  };
+
+  state = {
+    value: this.props.value,
+  };
+
+  handleChange = event => {
+    event.persist();
+    this.setState({
+      value: event.target.value,
+    });
+    if (this.props.onChange) {
+      this.props.onChange(event);
+    }
+  };
+
+  render() {
+    return (
+      <React.Fragment>
+        <label htmlFor={this.props.id}>Fruit</label>
+        <AsyncSelectInput
+          {...this.props}
+          onChange={this.handleChange}
+          value={this.state.value}
+          loadOptions={this.props.loadOptions}
+          defaultOptions={this.props.defaultOptions}
+        />
+      </React.Fragment>
+    );
+  }
+}
+
+const renderInput = (props, options) =>
+  render(<TestComponent {...props} />, options);
+
+it('should forward data-attributes', () => {
+  const { container } = renderInput({ 'data-foo': 'bar' });
+  // here we have to use container.querySelector because the data attributes are attached
+  // to the wrapper div, not to the input itself.
+  expect(container.querySelector('[data-foo="bar"]')).toBeInTheDocument();
 });
 
-describe('overwritten props', () => {
-  describe('when in single-value mode', () => {
-    let wrapper;
-    let props;
-    beforeEach(() => {
-      props = createTestProps();
-      wrapper = shallow(<AsyncSelectInput {...props} />);
+it('should have focus automatically when isAutofocussed is passed', () => {
+  const { getByLabelText } = renderInput({ isAutofocussed: true });
+  expect(getByLabelText('Fruit')).toHaveFocus();
+});
+
+it('should call onFocus when the input is focused', () => {
+  const onFocus = jest.fn();
+  const { getByLabelText } = renderInput({ onFocus });
+  const input = getByLabelText('Fruit');
+  input.focus();
+  expect(input).toHaveFocus();
+  expect(onFocus).toHaveBeenCalled();
+});
+
+it('should call onBlur when input loses focus', () => {
+  const onBlur = jest.fn();
+  const { getByLabelText } = renderInput({ onBlur });
+  const input = getByLabelText('Fruit');
+  input.focus();
+  expect(input).toHaveFocus();
+  input.blur();
+  expect(input).not.toHaveFocus();
+  expect(onBlur).toHaveBeenCalled();
+});
+
+describe('in single mode', () => {
+  describe('when no value is specified', () => {
+    it('should render a select input', () => {
+      const { getByLabelText } = renderInput();
+      const input = getByLabelText('Fruit');
+      expect(input).toBeInTheDocument();
     });
-    describe('when value is changed', () => {
-      const info = {};
-      beforeEach(() => {
-        wrapper.find(AsynSelect).prop('onChange')(
-          props.defaultOptions[1],
-          info
-        );
+  });
+  describe('when a value is specified', () => {
+    it('should render a select input with preselected value', () => {
+      const { getByLabelText, getByText } = renderInput({
+        value: { value: 'banana', label: 'Banana' },
       });
-      it('should call onChange with an event', () => {
-        expect(props.onChange).toHaveBeenCalledWith(
-          {
-            persist: expect.any(Function),
-            target: {
-              name: 'foo',
-              value: { value: 'shipped', label: 'Shipped' },
-            },
-          },
-          info
-        );
-      });
+      const input = getByLabelText('Fruit');
+      expect(input).toBeInTheDocument();
+      expect(getByText('Banana')).toBeInTheDocument();
     });
-    describe('when field is blurred', () => {
-      beforeEach(() => {
-        wrapper.find(AsynSelect).prop('onBlur')();
+  });
+  describe('interacting', () => {
+    it('should open the list and all options should be visible', async () => {
+      const { getByLabelText, getByText } = renderInput();
+      const input = getByLabelText('Fruit');
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      fireEvent.keyUp(input, { key: 'ArrowDown' });
+      await waitForElement(() => getByText('Mango'));
+      expect(getByText('Mango')).toBeInTheDocument();
+      expect(getByText('Lichi')).toBeInTheDocument();
+      expect(getByText('Raspberry')).toBeInTheDocument();
+    });
+    it('should be able to select an option', async () => {
+      const { getByLabelText, getByText, queryByText } = renderInput();
+      const input = getByLabelText('Fruit');
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      await waitForElement(() => getByText('Mango'));
+      getByText('Mango').click();
+      // new selected value should be Mango
+      expect(getByText('Mango')).toBeInTheDocument();
+      // list should closed and not visible
+      expect(queryByText('Banana')).not.toBeInTheDocument();
+    });
+    it('should call onChange when value selected', async () => {
+      const onChange = jest.fn();
+      const { getByLabelText, getByText } = renderInput({
+        onChange,
       });
-      it('should call onBlur with an event', () => {
-        expect(props.onBlur).toHaveBeenCalledWith({
-          persist: expect.any(Function),
-          target: { name: 'foo' },
-        });
+      const input = getByLabelText('Fruit');
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      await waitForElement(() => getByText('Mango'));
+      getByText('Mango').click();
+      expect(onChange).toHaveBeenCalledWith({
+        persist: expect.any(Function),
+        target: {
+          name: 'some-name',
+          value: { value: 'mango', label: 'Mango' },
+        },
       });
     });
   });
-  describe('when in multi-value mode', () => {
-    let wrapper;
-    let props;
-    beforeEach(() => {
-      props = createTestProps({ isMulti: true, value: [] });
-      wrapper = shallow(<AsyncSelectInput {...props} />);
+});
+
+describe('in multi mode', () => {
+  describe('when no value is specified', () => {
+    it('should render a select input', () => {
+      const { getByLabelText } = renderInput({
+        isMulti: true,
+        value: [],
+      });
+      const input = getByLabelText('Fruit');
+      expect(input).toBeInTheDocument();
     });
-    describe('when value is changed', () => {
-      const info = {};
-      let selectedOptions;
-      beforeEach(() => {
-        selectedOptions = props.defaultOptions.slice(0, 2);
-        wrapper.find(AsynSelect).prop('onChange')(selectedOptions, info);
-      });
-      it('should call onChange with an event', () => {
-        expect(props.onChange).toHaveBeenCalledWith(
-          {
-            persist: expect.any(Function),
-            target: { name: 'foo', value: selectedOptions },
-          },
-          info
-        );
-      });
-    });
-    describe('when field is blurred', () => {
-      beforeEach(() => {
-        wrapper.find(AsynSelect).prop('onBlur')();
-      });
-      it('should call onBlur with an event', () => {
-        expect(props.onBlur).toHaveBeenCalledWith({
-          persist: expect.any(Function),
-          target: { name: 'foo.0' },
+    describe('when values are specified', () => {
+      it('should render a select input with preselected values', () => {
+        const { getByLabelText, getByText } = renderInput({
+          isMulti: true,
+          value: [
+            { value: 'mango', label: 'Mango' },
+            { value: 'raspberry', label: 'Raspberry' },
+          ],
         });
+        const input = getByLabelText('Fruit');
+        expect(input).toBeInTheDocument();
+        expect(getByText('Mango')).toBeInTheDocument();
+        expect(getByText('Raspberry')).toBeInTheDocument();
       });
     });
+  });
+  describe('interacting', () => {
+    it('should open the list and all options should be visible', async () => {
+      const { getByLabelText, getByText } = renderInput({
+        isMulti: true,
+        value: [],
+      });
+      const input = getByLabelText('Fruit');
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      fireEvent.keyUp(input, { key: 'ArrowDown' });
+      await waitForElement(() => getByText('Mango'));
+      expect(getByText('Mango')).toBeInTheDocument();
+      expect(getByText('Lichi')).toBeInTheDocument();
+      expect(getByText('Raspberry')).toBeInTheDocument();
+    });
+    it('should be able to select two option', async () => {
+      const { getByLabelText, getByText, queryByText } = renderInput({
+        isMulti: true,
+        value: [],
+      });
+      const input = getByLabelText('Fruit');
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      await waitForElement(() => getByText('Mango'));
+      getByText('Mango').click();
+      // new selected value should be Mango
+      expect(getByText('Mango')).toBeInTheDocument();
+      // list should closed and not visible
+      expect(queryByText('Banana')).not.toBeInTheDocument();
+      // open list again
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      getByText('Banana').click();
+      // new values should be Banana and Mango
+      expect(getByText('Banana')).toBeInTheDocument();
+      expect(getByText('Mango')).toBeInTheDocument();
+      // list should closed and not visible
+      expect(queryByText('Raspberry')).not.toBeInTheDocument();
+    });
+    it('should call onChange when two values selected', async () => {
+      const onChange = jest.fn();
+      const { getByLabelText, getByText } = renderInput({
+        onChange,
+        isMulti: true,
+        value: [],
+      });
+      const input = getByLabelText('Fruit');
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      await waitForElement(() => getByText('Mango'));
+      getByText('Mango').click();
+      expect(onChange).toHaveBeenCalledWith({
+        persist: expect.any(Function),
+        target: {
+          name: 'some-name',
+          value: [{ value: 'mango', label: 'Mango' }],
+        },
+      });
+      // open list again
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+      await waitForElement(() => getByText('Raspberry'));
+      getByText('Raspberry').click();
+
+      expect(onChange).toHaveBeenCalledWith({
+        persist: expect.any(Function),
+        target: {
+          name: 'some-name',
+          value: [
+            { value: 'mango', label: 'Mango' },
+            { value: 'raspberry', label: 'Raspberry' },
+          ],
+        },
+      });
+    });
+  });
+});
+
+describe('when used with option groups', () => {
+  const colourOptions = [
+    { value: 'purple', label: 'Purple', color: '#5243AA' },
+    { value: 'orange', label: 'Orange', color: '#FF8B00' },
+    { value: 'yellow', label: 'Yellow', color: '#FFC400' },
+  ];
+
+  const flavourOptions = [
+    { value: 'vanilla', label: 'Vanilla', rating: 'safe' },
+    { value: 'chocolate', label: 'Chocolate', rating: 'good' },
+  ];
+  const groupedOptions = [
+    { label: 'Colours', options: colourOptions },
+    { label: 'Flavours', options: flavourOptions },
+  ];
+
+  const yellowOption = colourOptions[2];
+
+  it('should render a select input with preselected values', () => {
+    const { getByLabelText, getByText } = renderInput({
+      value: yellowOption,
+      loadOptions: () => Promise.resolve(groupedOptions),
+    });
+    const input = getByLabelText('Fruit');
+    expect(input).toBeInTheDocument();
+    expect(getByText(yellowOption.label)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Convert `AsyncSelectInput` and `AsyncCreatableSelectInput` to `react-testing-library`.

I copied the tests of `SelectInput` and `CreatableSelectInput` and converted them to work with async values. It was pretty straightforward. The biggest "gotcha" was that I had to add a `defaultOptions={true}` to make `react-select` load the default options without having to type anything first.