### PR TITLE
Convert select-fields and fix prop-types

### DIFF
--- a/src/components/fields/async-creatable-select-field/async-creatable-select-field.js
+++ b/src/components/fields/async-creatable-select-field/async-creatable-select-field.js
@@ -65,8 +65,13 @@ export default class SelectField extends React.Component {
     tabSelectsValue: PropTypes.bool,
     value: (props, ...rest) =>
       props.isMulti
-        ? PropTypes.arrayOf(PropTypes.string).isRequired(props, ...rest)
-        : PropTypes.string(props, ...rest),
+        ? PropTypes.arrayOf(
+            PropTypes.shape({ value: PropTypes.string.isRequired })
+          )(props, ...rest)
+        : PropTypes.shape({ value: PropTypes.string.isRequired })(
+            props,
+            ...rest
+          ),
 
     // Async props
     defaultOptions: PropTypes.oneOfType([

--- a/src/components/fields/async-select-field/async-select-field.js
+++ b/src/components/fields/async-select-field/async-select-field.js
@@ -55,8 +55,13 @@ export default class AsyncSelectField extends React.Component {
     tabSelectsValue: PropTypes.bool,
     value: (props, ...rest) =>
       props.isMulti
-        ? PropTypes.arrayOf(PropTypes.string).isRequired(props, ...rest)
-        : PropTypes.string(props, ...rest),
+        ? PropTypes.arrayOf(
+            PropTypes.shape({ value: PropTypes.string.isRequired })
+          )(props, ...rest)
+        : PropTypes.shape({ value: PropTypes.string.isRequired })(
+            props,
+            ...rest
+          ),
 
     // Async props
     defaultOptions: PropTypes.oneOfType([

--- a/src/components/fields/async-select-field/async-select-field.spec.js
+++ b/src/components/fields/async-select-field/async-select-field.spec.js
@@ -1,164 +1,193 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import PropTypes from 'prop-types';
+import { render, fireEvent, waitForElement } from '../../../test-utils';
 import AsyncSelectField from './async-select-field';
-import FieldLabel from '../../field-label';
-import AsyncSelectInput from '../../inputs/async-select-input';
-import FieldErrors from '../../field-errors';
-import { AddBoldIcon } from '../../icons';
 
-const createTestProps = customProps => ({
-  title: 'Favourite Animal',
-  defaultOptions: [
-    { value: 'ready', label: 'Ready' },
-    { value: 'shipped', label: 'Shipped' },
-    { value: 'delivered', label: 'Delivered' },
-    { value: 'returned', label: 'Returned' },
-  ],
-  loadOptions: jest.fn(),
-  onChange: () => jest.fn(),
-  ...customProps,
+// This component is used to enable easy testing.
+// It overwrites the onChange function and places a label for the
+// input component. It also ensures an id so that the label can associate
+// the input. This allows tests to use getByLabelText.
+// It also makes sure the event's value passed to onChange flows back to the
+// component so that we can test it under real conditions.
+// As a convenience, we enable accessing a mocked onChange function.
+class Story extends React.Component {
+  static displayName = 'Story';
+  static propTypes = {
+    onChange: PropTypes.func.isRequired,
+    value: PropTypes.object,
+    id: PropTypes.string,
+    loadOptions: PropTypes.func,
+    defaultOptions: PropTypes.bool,
+  };
+  static defaultProps = {
+    id: 'text-field',
+    title: 'foo',
+    onChange: () => {},
+    loadOptions: () =>
+      Promise.resolve([
+        { value: 'ready', label: 'Ready' },
+        { value: 'shipped', label: 'Shipped' },
+        { value: 'delivered', label: 'Delivered' },
+        { value: 'returned', label: 'Returned' },
+      ]),
+    defaultOptions: true,
+    value: { value: 'ready', label: 'Ready' },
+  };
+  state = {
+    value: this.props.value,
+  };
+  handleChange = event => {
+    this.props.onChange(event);
+    this.setState({ value: event.target.value });
+  };
+  render() {
+    return (
+      <div>
+        <label htmlFor={this.props.id}>AsyncSelectField</label>
+        <AsyncSelectField
+          {...this.props}
+          value={this.state.value}
+          onChange={this.handleChange}
+        />
+      </div>
+    );
+  }
+}
+
+const renderAsyncSelectField = (props, options) =>
+  render(<Story {...props} />, options);
+
+it('should render a text field', () => {
+  const { getByLabelText } = renderAsyncSelectField();
+  expect(getByLabelText('AsyncSelectField')).toBeInTheDocument();
 });
 
-describe('rendering', () => {
-  describe('data attributes', () => {
-    let selectInput;
-    beforeEach(() => {
-      const props = createTestProps({
-        'data-foo': 'bar',
-        'data-test': 'baz',
-      });
-      const wrapper = shallow(<AsyncSelectField {...props} />);
-      selectInput = wrapper.find(AsyncSelectInput);
-    });
-    it('should forward the attributes to the AsyncSelectInput', () => {
-      expect(selectInput).toHaveProp('data-foo', 'bar');
-      expect(selectInput).toHaveProp('data-test', 'baz');
-    });
-  });
-  describe('when no id is provided', () => {
-    let props;
-    let wrapper;
-    beforeEach(() => {
-      props = createTestProps({ id: undefined });
-      wrapper = shallow(<AsyncSelectField {...props} />);
-    });
-    it('should add a default id attribute', () => {
-      expect(wrapper.find(AsyncSelectInput)).toHaveProp(
-        'id',
-        expect.stringMatching(/.+/)
-      );
-    });
-    it('should add a default htmlFor attribute', () => {
-      expect(wrapper.find(FieldLabel)).toHaveProp('htmlFor');
-    });
-    it('should use the same value for the id and htmlFor attribute', () => {
-      expect(wrapper.find(AsyncSelectInput).prop('id')).toEqual(
-        wrapper.find(FieldLabel).prop('htmlFor')
-      );
-    });
-  });
-  describe('when touched', () => {
-    let props;
-    let wrapper;
-    beforeEach(() => {
-      props = createTestProps({
-        // AsyncSelectField
-        id: 'foo',
-        // FieldLabel
-        title: 'Username',
-        hint: 'Some hint',
-        hintIcon: <AddBoldIcon />,
-        description: 'A description',
-        onInfoButtonClick: jest.fn(),
-        badge: <div>Some badge</div>,
+it('should render a title', () => {
+  const { getByText } = renderAsyncSelectField({ title: 'foo title' });
+  expect(getByText('foo title')).toBeInTheDocument();
+});
 
-        // AsyncSelectField
-        name: 'field1',
-        value: 'foo',
-        onChange: jest.fn(),
-        onBlur: jest.fn(),
-        onFocus: jest.fn(),
-        isAutofocussed: true,
-        isDisabled: false,
-        placeholder: 'Some placeholder',
+it('should forward data-attributes', () => {
+  const { container } = renderAsyncSelectField({ 'data-foo': 'bar' });
+  expect(container.querySelector('[data-foo="bar"]')).toBeInTheDocument();
+});
+
+it('should have an HTML name', () => {
+  const { container } = renderAsyncSelectField({ name: 'foo' });
+  expect(container.querySelector('[name="foo"]')).toBeInTheDocument();
+});
+
+it('should call onFocus when the input is focused', () => {
+  const onFocus = jest.fn();
+  const { getByLabelText } = renderAsyncSelectField({ onFocus });
+  getByLabelText('AsyncSelectField').focus();
+  expect(getByLabelText('AsyncSelectField')).toHaveFocus();
+  expect(onFocus).toHaveBeenCalled();
+});
+
+it('should call onBlur when input loses focus', () => {
+  const onBlur = jest.fn();
+  const { getByLabelText } = renderAsyncSelectField({ onBlur });
+  getByLabelText('AsyncSelectField').focus();
+  expect(getByLabelText('AsyncSelectField')).toHaveFocus();
+  getByLabelText('AsyncSelectField').blur();
+  expect(getByLabelText('AsyncSelectField')).not.toHaveFocus();
+  expect(onBlur).toHaveBeenCalled();
+});
+
+it('should have focus automatically when isAutofocussed is passed', () => {
+  const { getByLabelText } = renderAsyncSelectField({
+    isAutofocussed: true,
+  });
+  expect(getByLabelText('AsyncSelectField')).toHaveFocus();
+});
+
+it('should call onChange when changing the value', async () => {
+  const onChange = jest.fn();
+  const { getByLabelText, getByText } = renderAsyncSelectField({
+    onChange,
+  });
+  const input = getByLabelText('AsyncSelectField');
+  fireEvent.focus(input);
+  fireEvent.keyDown(input, { key: 'ArrowDown' });
+  await waitForElement(() => getByText('Shipped'));
+  getByText('Shipped').click();
+  expect(onChange).toHaveBeenCalled();
+});
+
+describe('when `description` is passed', () => {
+  it('should render a description', () => {
+    const { getByText } = renderAsyncSelectField({
+      description: 'foo description',
+    });
+    expect(getByText('foo description')).toBeInTheDocument();
+  });
+});
+
+describe('when `hint` is passed', () => {
+  it('should render a hint', () => {
+    const { getByText } = renderAsyncSelectField({ hint: 'foo hint' });
+    expect(getByText('foo hint')).toBeInTheDocument();
+  });
+});
+
+describe('when `badge` is passed', () => {
+  it('should render a badge', () => {
+    const { getByText } = renderAsyncSelectField({ badge: 'foo badge' });
+    expect(getByText('foo badge')).toBeInTheDocument();
+  });
+});
+
+describe('when disabled', () => {
+  it('should disable the input', () => {
+    const { getByLabelText } = renderAsyncSelectField({ isDisabled: true });
+    expect(getByLabelText('AsyncSelectField')).toHaveAttribute('disabled');
+  });
+});
+
+describe('when required', () => {
+  it('should add `*` to title`', () => {
+    const { getByText } = renderAsyncSelectField({ isRequired: true });
+    expect(getByText('*')).toBeInTheDocument();
+  });
+});
+
+describe('when showing an info button', () => {
+  it('should render an info button', () => {
+    const onInfoButtonClick = jest.fn();
+    const { getByLabelText } = renderAsyncSelectField({
+      onInfoButtonClick,
+    });
+    expect(getByLabelText('More Info')).toBeInTheDocument();
+  });
+  it('should call onInfoButtonClick when button is clicked', () => {
+    const onInfoButtonClick = jest.fn();
+    const { getByLabelText } = renderAsyncSelectField({
+      onInfoButtonClick,
+    });
+    getByLabelText('More Info').click();
+    expect(onInfoButtonClick).toHaveBeenCalled();
+  });
+});
+
+describe('when field is touched and has errors', () => {
+  describe('when field empty', () => {
+    it('should render a default error', () => {
+      const { getByText } = renderAsyncSelectField({
+        touched: true,
         errors: { missing: true },
-        touched: true,
       });
-      wrapper = shallow(<AsyncSelectField {...props} />);
-    });
-
-    it('should forward the props for to the related components', () => {
-      const fieldLabel = wrapper.find(FieldLabel);
-      expect(fieldLabel).toHaveProp('title', props.title);
-      expect(fieldLabel).toHaveProp('hint', props.hint);
-      expect(fieldLabel).toHaveProp('hintIcon', props.hintIcon);
-      expect(fieldLabel).toHaveProp('description', props.description);
-      expect(fieldLabel).toHaveProp(
-        'onInfoButtonClick',
-        props.onInfoButtonClick
-      );
-      expect(fieldLabel).toHaveProp('badge', props.badge);
-      expect(fieldLabel).toHaveProp('htmlFor', props.id);
-
-      const selectInput = wrapper.find(AsyncSelectInput);
-      expect(selectInput).toHaveProp('name', props.name);
-      expect(selectInput).toHaveProp('value', props.value);
-      expect(selectInput).toHaveProp('onChange', props.onChange);
-      expect(selectInput).toHaveProp('onBlur', props.onBlur);
-      expect(selectInput).toHaveProp('onFocus', props.onFocus);
-      expect(selectInput).toHaveProp('isAutofocussed', props.isAutofocussed);
-      expect(selectInput).toHaveProp('isDisabled', props.isDisabled);
-      expect(selectInput).toHaveProp('placeholder', props.placeholder);
-      expect(selectInput).toHaveProp('hasError', true);
-
-      expect(wrapper).toRender(FieldErrors);
-      expect(wrapper.find(FieldErrors)).toHaveProp('errors', props.errors);
+      expect(getByText(/field is required/i)).toBeInTheDocument();
     });
   });
-
-  describe('when disabled', () => {
-    let props;
-    let wrapper;
-    beforeEach(() => {
-      props = createTestProps({ isDisabled: true });
-      wrapper = shallow(<AsyncSelectField {...props} />);
-    });
-    it('should disable the AsyncSelectInput', () => {
-      expect(wrapper.find(AsyncSelectInput)).toHaveProp('isDisabled', true);
-    });
-  });
-
-  describe('when there are known errors', () => {
-    let props;
-    let wrapper;
-    beforeEach(() => {
-      props = createTestProps({ touched: true, errors: { missing: true } });
-      wrapper = shallow(<AsyncSelectField {...props} />);
-    });
-    it('should mark the AsyncSelectInput as erroneous', () => {
-      expect(wrapper.find(AsyncSelectInput)).toHaveProp('hasError', true);
-    });
-    it('should render the known error', () => {
-      expect(wrapper).toRender(FieldErrors);
-    });
-  });
-
-  describe('when there are unknown errors', () => {
-    let props;
-    let wrapper;
-    beforeEach(() => {
-      props = createTestProps({
+  describe('when there is a custom error', () => {
+    it('should render the custom error message', () => {
+      const { getByText } = renderAsyncSelectField({
         touched: true,
-        renderError: jest.fn(key => key),
-        errors: { customError: 5 },
+        errors: { custom: true },
+        renderError: () => 'Custom error',
       });
-      wrapper = shallow(<AsyncSelectField {...props} />);
-    });
-    it('should mark the NumberInput as erroneous', () => {
-      expect(wrapper.find(AsyncSelectInput)).toHaveProp('hasError', true);
-    });
-    it('should forward the error', () => {
-      expect(wrapper.find(FieldErrors)).toHaveProp('errors', props.errors);
+      expect(getByText('Custom error')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/fields/creatable-select-field/creatable-select-field.js
+++ b/src/components/fields/creatable-select-field/creatable-select-field.js
@@ -65,8 +65,13 @@ export default class SelectField extends React.Component {
     tabSelectsValue: PropTypes.bool,
     value: (props, ...rest) =>
       props.isMulti
-        ? PropTypes.arrayOf(PropTypes.string)(props, ...rest)
-        : PropTypes.string(props, ...rest),
+        ? PropTypes.arrayOf(
+            PropTypes.shape({ value: PropTypes.string.isRequired })
+          )(props, ...rest)
+        : PropTypes.shape({ value: PropTypes.string.isRequired })(
+            props,
+            ...rest
+          ),
 
     // Creatable props
     allowCreateWhileLoading: PropTypes.bool,


### PR DESCRIPTION
Converts tests of `SelectField`, `AsyncSelectField`, `CreatableSelectField` & `AsyncCreatableSelectField` tests to `react-testing-library`.

Fix prop-type expectations of `AsyncSelectField`, `CreatableSelectField` & `AsyncCreatableSelectField`.