### PR TITLE
Add `isAutofocussed` and `isReadOnly` to `MoneyInput` and `MoneyField`

### DIFF
--- a/src/components/fields/money-field/money-field.js
+++ b/src/components/fields/money-field/money-field.js
@@ -57,6 +57,8 @@ class MoneyField extends React.Component {
     placeholder: PropTypes.string,
     onBlur: PropTypes.func,
     isDisabled: PropTypes.bool,
+    isReadOnly: PropTypes.bool,
+    isAutofocussed: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
 
     // LabelField
@@ -130,6 +132,8 @@ class MoneyField extends React.Component {
             onFocus={this.props.onFocus}
             onBlur={this.props.onBlur}
             isDisabled={this.props.isDisabled}
+            isAutofocussed={this.props.isAutofocussed}
+            isReadOnly={this.props.isReadOnly}
             onChange={this.props.onChange}
             hasError={hasError}
             {...filterDataAttributes(this.props)}

--- a/src/components/fields/money-field/money-field.percy.js
+++ b/src/components/fields/money-field/money-field.percy.js
@@ -106,5 +106,15 @@ screenshot('MoneyField', () => (
         touched={{ amount: true, currencyCode: true }}
       />
     </Spec>
+    <Spec label="when readonly">
+      <MoneyField
+        title="Price"
+        horizontalConstraint="m"
+        value={value}
+        onChange={() => {}}
+        currencies={currencies}
+        isReadOnly={true}
+      />
+    </Spec>
   </Suite>
 ));

--- a/src/components/fields/money-field/money-field.spec.js
+++ b/src/components/fields/money-field/money-field.spec.js
@@ -46,9 +46,6 @@ class Story extends React.Component {
         <label htmlFor={MoneyInput.getAmountInputId(this.props.id)}>
           Amount
         </label>
-        <label htmlFor={MoneyInput.getCurrencyDropdownId(this.props.id)}>
-          Currency Code
-        </label>
         <MoneyField
           {...this.props}
           value={this.state.value}
@@ -65,7 +62,7 @@ const renderMoneyField = (props, options) =>
 it('should render a money field', () => {
   const { getByLabelText } = renderMoneyField();
   expect(getByLabelText('Amount')).toBeInTheDocument();
-  expect(getByLabelText('Currency Code')).toBeInTheDocument();
+  expect(getByLabelText('EUR')).toBeInTheDocument();
 });
 
 it('should render a title', () => {
@@ -97,8 +94,8 @@ it('should call onFocus when amount input is focused', () => {
 it('should call onFocus when currency select is focused', () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderMoneyField({ onFocus });
-  getByLabelText('Currency Code').focus();
-  expect(getByLabelText('Currency Code')).toHaveFocus();
+  getByLabelText('EUR').focus();
+  expect(getByLabelText('EUR')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
 
@@ -115,10 +112,10 @@ it('should call onBlur when amount input loses focus', () => {
 it('should call onBlur when currency select loses focus', () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderMoneyField({ onBlur });
-  getByLabelText('Currency Code').focus();
-  expect(getByLabelText('Currency Code')).toHaveFocus();
-  getByLabelText('Currency Code').blur();
-  expect(getByLabelText('Currency Code')).not.toHaveFocus();
+  getByLabelText('EUR').focus();
+  expect(getByLabelText('EUR')).toHaveFocus();
+  getByLabelText('EUR').blur();
+  expect(getByLabelText('EUR')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });
 
@@ -131,8 +128,8 @@ it('should call onChange when changing the value', () => {
   });
   fireEvent.change(getByLabelText('Amount'), { target: { value: '20' } });
 
-  fireEvent.focus(getByLabelText('Currency Code'));
-  fireEvent.keyDown(getByLabelText('Currency Code'), { key: 'ArrowDown' });
+  fireEvent.focus(getByLabelText('EUR'));
+  fireEvent.keyDown(getByLabelText('EUR'), { key: 'ArrowDown' });
 
   expect(onChange).toHaveBeenCalledTimes(1);
   expect(onChange).toHaveBeenCalledWith({
@@ -145,8 +142,8 @@ it('should call onChange when changing the value', () => {
   });
 
   // change currency to USD using keyboard
-  fireEvent.keyDown(getByLabelText('Currency Code'), { key: 'ArrowDown' });
-  fireEvent.keyDown(getByLabelText('Currency Code'), { key: 'Enter' });
+  fireEvent.keyDown(getByLabelText('EUR'), { key: 'ArrowDown' });
+  fireEvent.keyDown(getByLabelText('EUR'), { key: 'Enter' });
 
   // it should change the currency
   expect(onChange).toHaveBeenCalledWith({
@@ -202,7 +199,7 @@ describe('when disabled', () => {
   it('should disable the inputs', () => {
     const { getByLabelText } = renderMoneyField({ isDisabled: true });
     expect(getByLabelText('Amount')).toHaveAttribute('disabled');
-    expect(getByLabelText('Currency Code')).toHaveAttribute('disabled');
+    expect(getByLabelText('EUR')).toHaveAttribute('disabled');
   });
 });
 

--- a/src/components/fields/money-field/money-field.spec.js
+++ b/src/components/fields/money-field/money-field.spec.js
@@ -119,6 +119,13 @@ it('should call onBlur when currency select loses focus', () => {
   expect(onBlur).toHaveBeenCalled();
 });
 
+it('should have focus the amount input automatically when isAutofocussed is passed', () => {
+  const { getByLabelText } = renderMoneyField({
+    isAutofocussed: true,
+  });
+  expect(getByLabelText('Amount')).toHaveFocus();
+});
+
 it('should call onChange when changing the value', () => {
   const onChange = jest.fn();
   const { getByLabelText } = renderMoneyField({
@@ -199,6 +206,15 @@ describe('when disabled', () => {
   it('should disable the inputs', () => {
     const { getByLabelText } = renderMoneyField({ isDisabled: true });
     expect(getByLabelText('Amount')).toHaveAttribute('disabled');
+    expect(getByLabelText('EUR')).toHaveAttribute('disabled');
+  });
+});
+
+describe('when readOnly', () => {
+  it('should make the inputs readonly', () => {
+    const { getByLabelText } = renderMoneyField({ isReadOnly: true });
+    expect(getByLabelText('Amount')).toHaveAttribute('readonly');
+    // currency select should be disabled
     expect(getByLabelText('EUR')).toHaveAttribute('disabled');
   });
 });

--- a/src/components/fields/money-field/money-field.spec.js
+++ b/src/components/fields/money-field/money-field.spec.js
@@ -119,7 +119,7 @@ it('should call onBlur when currency select loses focus', () => {
   expect(onBlur).toHaveBeenCalled();
 });
 
-it('should have focus the amount input automatically when isAutofocussed is passed', () => {
+it('should focus the amount input automatically when isAutofocussed is passed', () => {
   const { getByLabelText } = renderMoneyField({
     isAutofocussed: true,
   });

--- a/src/components/fields/money-field/money-field.story.js
+++ b/src/components/fields/money-field/money-field.story.js
@@ -88,6 +88,8 @@ class MoneyFieldStory extends React.Component {
           placeholder={text('placeholder', 'Placeholder')}
           onBlur={action('onBlur')}
           isDisabled={boolean('isDisabled', false)}
+          isReadOnly={boolean('isReadOnly', false)}
+          isAutofocussed={boolean('isAutofocussed', false)}
           onChange={event => {
             action('onChange')(event);
 

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -44,7 +44,6 @@ SingleValue.propTypes = {
 const createCurrencySelectStyles = ({
   hasWarning,
   hasError,
-  hasNoCurrencies,
   isDisabled,
   isReadOnly,
   hasFocus,
@@ -88,10 +87,6 @@ const createCurrencySelectStyles = ({
         else if (hasWarning) vars['--token-font-color-warning'];
         else base.color;
       },
-    }),
-    dropdownIndicator: (base, state) => ({
-      ...selectStyles.dropdownIndicator(base, state),
-      visibility: hasNoCurrencies ? 'hidden' : undefined,
     }),
   };
 };
@@ -485,8 +480,7 @@ class MoneyInput extends React.Component {
     const currencySelectStyles = createCurrencySelectStyles({
       hasWarning,
       hasError: this.props.hasCurrencyError || this.props.hasError,
-      hasNoCurrencies,
-      isDisabled: this.props.isDisabled || hasNoCurrencies,
+      isDisabled: this.props.isDisabled,
       isReadOnly: this.props.isReadOnly,
       hasFocus,
     });
@@ -539,8 +533,11 @@ class MoneyInput extends React.Component {
             }
           }}
         >
-          {this.props.isCurrencySelectionDisabled ? (
-            <CurrencyLabel id={MoneyInput.getAmountInputId(this.props.id)}>
+          {hasNoCurrencies ? (
+            <CurrencyLabel
+              id={MoneyInput.getAmountInputId(this.props.id)}
+              isDisabled={this.props.isDisabled}
+            >
               {option && option.label}
             </CurrencyLabel>
           ) : (
@@ -548,11 +545,7 @@ class MoneyInput extends React.Component {
               inputId={id}
               name={getCurrencyDropdownName(this.props.name)}
               value={option}
-              isDisabled={
-                this.props.isDisabled ||
-                hasNoCurrencies ||
-                this.props.isReadOnly
-              }
+              isDisabled={this.props.isDisabled || this.props.isReadOnly}
               isSearchable={false}
               components={{
                 SingleValue: props => <SingleValue {...props} id={id} />,

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -15,6 +15,19 @@ import currencies from './currencies.json';
 import createSelectStyles from '../../internals/create-select-styles';
 import vars from '../../../../materials/custom-properties.json';
 
+const CurrencyLabel = props => (
+  <label htmlFor={props.id} className={styles['currency-label']}>
+    {props.children}
+  </label>
+);
+
+CurrencyLabel.displayName = 'CurrencyLabel';
+
+CurrencyLabel.propTypes = {
+  id: PropTypes.string,
+  children: PropTypes.node,
+};
+
 const SingleValue = ({ id, ...props }) => (
   <components.SingleValue {...props}>
     <label htmlFor={id}>{props.children}</label>
@@ -526,36 +539,44 @@ class MoneyInput extends React.Component {
             }
           }}
         >
-          <Select
-            inputId={id}
-            name={getCurrencyDropdownName(this.props.name)}
-            value={option}
-            isDisabled={
-              this.props.isDisabled || hasNoCurrencies || this.props.isReadOnly
-            }
-            isSearchable={false}
-            components={{
-              SingleValue: props => <SingleValue {...props} id={id} />,
-              DropdownIndicator,
-              ClearIndicator,
-            }}
-            options={options}
-            placeholder=""
-            styles={currencySelectStyles}
-            onFocus={() => {
-              if (this.props.onFocus)
-                this.props.onFocus({
-                  target: {
-                    id: MoneyInput.getCurrencyDropdownId(this.props.id),
-                    name: getCurrencyDropdownName(this.props.name),
-                  },
-                });
-              this.setState({ currencyHasFocus: true });
-            }}
-            onBlur={() => this.setState({ currencyHasFocus: false })}
-            onChange={this.handleCurrencyChange}
-            data-testid="currency-dropdown"
-          />
+          {this.props.isCurrencySelectionDisabled ? (
+            <CurrencyLabel id={MoneyInput.getAmountInputId(this.props.id)}>
+              {option && option.label}
+            </CurrencyLabel>
+          ) : (
+            <Select
+              inputId={id}
+              name={getCurrencyDropdownName(this.props.name)}
+              value={option}
+              isDisabled={
+                this.props.isDisabled ||
+                hasNoCurrencies ||
+                this.props.isReadOnly
+              }
+              isSearchable={false}
+              components={{
+                SingleValue: props => <SingleValue {...props} id={id} />,
+                DropdownIndicator,
+                ClearIndicator,
+              }}
+              options={options}
+              placeholder=""
+              styles={currencySelectStyles}
+              onFocus={() => {
+                if (this.props.onFocus)
+                  this.props.onFocus({
+                    target: {
+                      id: MoneyInput.getCurrencyDropdownId(this.props.id),
+                      name: getCurrencyDropdownName(this.props.name),
+                    },
+                  });
+                this.setState({ currencyHasFocus: true });
+              }}
+              onBlur={() => this.setState({ currencyHasFocus: false })}
+              onChange={this.handleCurrencyChange}
+              data-testid="currency-dropdown"
+            />
+          )}
           <input
             ref={this.amountInputRef}
             id={MoneyInput.getAmountInputId(this.props.id)}

--- a/src/components/inputs/money-input/money-input.mod.css
+++ b/src/components/inputs/money-input/money-input.mod.css
@@ -1,5 +1,13 @@
-:root {
-  --width-currency-label: 60px;
+.currency-label {
+  position: relative;
+  display: flex;
+  border-top-left-radius: var(--token-border-radius-input);
+  border-bottom-left-radius: var(--token-border-radius-input);
+  border: 1px var(--token-border-color-input-pristine) solid;
+  border-right: 0;
+  padding: 0 var(--spacing-8);
+  align-items: center;
+  min-width: 72px;
 }
 
 .field-container {

--- a/src/components/inputs/money-input/money-input.mod.css
+++ b/src/components/inputs/money-input/money-input.mod.css
@@ -47,6 +47,13 @@
   opacity: 1; /* fix for mobile safari */
 }
 
+.amount-readonly {
+  composes: amountInput;
+  border-color: var(--token-border-color-input-readonly);
+  color: var(--token-font-color-readonly);
+  cursor: default;
+}
+
 .amount-warning {
   composes: amountInput;
   color: var(--token-font-color-warning);

--- a/src/components/inputs/money-input/money-input.mod.css
+++ b/src/components/inputs/money-input/money-input.mod.css
@@ -1,9 +1,10 @@
 .currency-label {
-  position: relative;
   display: flex;
+  color: var(--token-font-color-disabled);
+  background-color: var(--token-background-color-input-disabled);
   border-top-left-radius: var(--token-border-radius-input);
   border-bottom-left-radius: var(--token-border-radius-input);
-  border: 1px var(--token-border-color-input-pristine) solid;
+  border: 1px var(--token-border-color-input-disabled) solid;
   border-right: 0;
   padding: 0 var(--spacing-8);
   align-items: center;

--- a/src/components/inputs/money-input/money-input.percy.js
+++ b/src/components/inputs/money-input/money-input.percy.js
@@ -96,5 +96,31 @@ screenshot('MoneyInput', () => (
         isReadOnly={true}
       />
     </Spec>
+    <Spec label="without currencies">
+      <MoneyInput
+        horizontalConstraint="m"
+        value={value}
+        onChange={() => {}}
+        currencies={[]}
+      />
+    </Spec>
+    <Spec label="without currencies - when readOnly">
+      <MoneyInput
+        horizontalConstraint="m"
+        value={value}
+        onChange={() => {}}
+        currencies={[]}
+        isReadOnly={true}
+      />
+    </Spec>
+    <Spec label="without currencies - when disabled">
+      <MoneyInput
+        horizontalConstraint="m"
+        value={value}
+        onChange={() => {}}
+        currencies={[]}
+        isDisabled={true}
+      />
+    </Spec>
   </Suite>
 ));

--- a/src/components/inputs/money-input/money-input.percy.js
+++ b/src/components/inputs/money-input/money-input.percy.js
@@ -90,8 +90,9 @@ screenshot('MoneyInput', () => (
     <Spec label="when readOnly">
       <MoneyInput
         horizontalConstraint="m"
-        value={emptyValue}
+        value={value}
         onChange={() => {}}
+        currencies={currencies}
         isReadOnly={true}
       />
     </Spec>

--- a/src/components/inputs/money-input/money-input.percy.js
+++ b/src/components/inputs/money-input/money-input.percy.js
@@ -87,5 +87,13 @@ screenshot('MoneyInput', () => (
         hasWarning={true}
       />
     </Spec>
+    <Spec label="when readOnly">
+      <MoneyInput
+        horizontalConstraint="m"
+        value={emptyValue}
+        onChange={() => {}}
+        isReadOnly={true}
+      />
+    </Spec>
   </Suite>
 ));

--- a/src/components/inputs/money-input/money-input.spec.js
+++ b/src/components/inputs/money-input/money-input.spec.js
@@ -670,7 +670,7 @@ describe('MoneyInput', () => {
     });
   });
 
-  it('should have focus the amount input automatically when isAutofocussed is passed', () => {
+  it('should focus the amount input automatically when isAutofocussed is passed', () => {
     const { getByLabelText } = render(<TestComponent isAutofocussed={true} />);
     expect(getByLabelText('Amount')).toHaveFocus();
   });

--- a/src/components/inputs/money-input/money-input.spec.js
+++ b/src/components/inputs/money-input/money-input.spec.js
@@ -670,6 +670,11 @@ describe('MoneyInput', () => {
     });
   });
 
+  it('should have focus the amount input automatically when isAutofocussed is passed', () => {
+    const { getByLabelText } = render(<TestComponent isAutofocussed={true} />);
+    expect(getByLabelText('Amount')).toHaveFocus();
+  });
+
   it('should render a readonly input when readonly', () => {
     const { getByLabelText } = render(<TestComponent isReadOnly={true} />);
     expect(getByLabelText('Amount')).toHaveAttribute('readonly');

--- a/src/components/inputs/money-input/money-input.spec.js
+++ b/src/components/inputs/money-input/money-input.spec.js
@@ -45,9 +45,6 @@ class TestComponent extends React.Component {
         <label htmlFor={MoneyInput.getAmountInputId(this.props.id)}>
           Amount
         </label>
-        <label htmlFor={MoneyInput.getCurrencyDropdownId(this.props.id)}>
-          Currency Code
-        </label>
         <MoneyInput
           {...this.props}
           onChange={this.props.onChange || this.handleChange}
@@ -416,8 +413,8 @@ describe('MoneyInput', () => {
         onFocus={onFocus}
       />
     );
-    getByLabelText('Currency Code').focus();
-    expect(getByLabelText('Currency Code')).toHaveFocus();
+    getByLabelText('EUR').focus();
+    expect(getByLabelText('EUR')).toHaveFocus();
     expect(onFocus).toHaveBeenCalledWith({
       target: { id: 'some-id.currencyCode', name: 'some-name.currencyCode' },
     });
@@ -455,10 +452,10 @@ describe('MoneyInput', () => {
         onBlur={onBlur}
       />
     );
-    getByLabelText('Currency Code').focus();
-    expect(getByLabelText('Currency Code')).toHaveFocus();
-    getByLabelText('Currency Code').blur();
-    expect(getByLabelText('Currency Code')).not.toHaveFocus();
+    getByLabelText('EUR').focus();
+    expect(getByLabelText('EUR')).toHaveFocus();
+    getByLabelText('EUR').blur();
+    expect(getByLabelText('EUR')).not.toHaveFocus();
 
     // onBlur should be called twice as we want to mark both,
     // currency dropdown and amount input as touched when the element
@@ -479,11 +476,11 @@ describe('MoneyInput', () => {
         onBlur={onBlur}
       />
     );
-    getByLabelText('Currency Code').focus();
-    expect(getByLabelText('Currency Code')).toHaveFocus();
+    getByLabelText('EUR').focus();
+    expect(getByLabelText('EUR')).toHaveFocus();
 
     getByLabelText('Amount').focus();
-    expect(getByLabelText('Currency Code')).not.toHaveFocus();
+    expect(getByLabelText('EUR')).not.toHaveFocus();
     expect(getByLabelText('Amount')).toHaveFocus();
 
     expect(onBlur).not.toHaveBeenCalled();
@@ -501,8 +498,8 @@ describe('MoneyInput', () => {
     getByLabelText('Amount').focus();
     expect(getByLabelText('Amount')).toHaveFocus();
 
-    getByLabelText('Currency Code').focus();
-    expect(getByLabelText('Currency Code')).toHaveFocus();
+    getByLabelText('EUR').focus();
+    expect(getByLabelText('EUR')).toHaveFocus();
     expect(getByLabelText('Amount')).not.toHaveFocus();
 
     expect(onBlur).not.toHaveBeenCalled();
@@ -553,12 +550,12 @@ describe('MoneyInput', () => {
     const { getByLabelText } = render(<TestComponent onChange={onChange} />);
 
     // open using keyboard
-    fireEvent.focus(getByLabelText('Currency Code'));
-    fireEvent.keyDown(getByLabelText('Currency Code'), { key: 'ArrowDown' });
+    fireEvent.focus(getByLabelText('EUR'));
+    fireEvent.keyDown(getByLabelText('EUR'), { key: 'ArrowDown' });
 
     // change currency to USD using keyboard
-    fireEvent.keyDown(getByLabelText('Currency Code'), { key: 'ArrowDown' });
-    fireEvent.keyDown(getByLabelText('Currency Code'), { key: 'Enter' });
+    fireEvent.keyDown(getByLabelText('EUR'), { key: 'ArrowDown' });
+    fireEvent.keyDown(getByLabelText('EUR'), { key: 'Enter' });
 
     // onChange should be called when changing the currency
     expect(onChange).toHaveBeenCalledWith({
@@ -601,12 +598,12 @@ describe('MoneyInput', () => {
     );
 
     // open currency dropdown using keyboard
-    fireEvent.focus(getByLabelText('Currency Code'));
-    fireEvent.keyDown(getByLabelText('Currency Code'), { key: 'ArrowDown' });
+    fireEvent.focus(getByLabelText('EUR'));
+    fireEvent.keyDown(getByLabelText('EUR'), { key: 'ArrowDown' });
 
     // change currency to KWD using keyboard
-    fireEvent.keyDown(getByLabelText('Currency Code'), { key: 'ArrowDown' });
-    fireEvent.keyDown(getByLabelText('Currency Code'), { key: 'Enter' });
+    fireEvent.keyDown(getByLabelText('EUR'), { key: 'ArrowDown' });
+    fireEvent.keyDown(getByLabelText('EUR'), { key: 'Enter' });
 
     // We can't use .toHaveAttribute('value', ' 12.500') as the attribute
     // itself does not change in the DOM tree. Only the actual value changes.
@@ -662,7 +659,6 @@ describe('MoneyInput', () => {
         { locale: 'de' }
       );
 
-      //
       getByLabelText('Amount').focus();
       fireEvent.blur(getByLabelText('Amount'));
 
@@ -672,5 +668,14 @@ describe('MoneyInput', () => {
         '(12.5).toLocaleString(de, {"minimumFractionDigits":2})'
       );
     });
+  });
+
+  it('should render a readonly input when readonly', () => {
+    const { getByLabelText } = render(<TestComponent isReadOnly={true} />);
+    expect(getByLabelText('Amount')).toHaveAttribute('readonly');
+  });
+  it('should render a disabled currency select when readonly', () => {
+    const { getByLabelText } = render(<TestComponent isReadOnly={true} />);
+    expect(getByLabelText('EUR')).toHaveAttribute('disabled');
   });
 });

--- a/src/components/inputs/money-input/money-input.spec.js
+++ b/src/components/inputs/money-input/money-input.spec.js
@@ -683,4 +683,23 @@ describe('MoneyInput', () => {
     const { getByLabelText } = render(<TestComponent isReadOnly={true} />);
     expect(getByLabelText('EUR')).toHaveAttribute('disabled');
   });
+
+  describe('when there are no currencies', () => {
+    it('should call onFocus when the input is focused', () => {
+      const onFocus = jest.fn();
+      const { getByLabelText } = render(
+        <TestComponent
+          currencies={[]}
+          onFocus={onFocus}
+          value={{ currencyCode: 'EUR', amount: '12.33' }}
+        />
+      );
+      const input = getByLabelText('EUR');
+      input.focus();
+      expect(input).toHaveFocus();
+      expect(onFocus).toHaveBeenCalledWith({
+        target: { id: 'some-id.amount', name: 'some-name.amount' },
+      });
+    });
+  });
 });

--- a/src/components/inputs/money-input/money-input.story.js
+++ b/src/components/inputs/money-input/money-input.story.js
@@ -43,6 +43,7 @@ class MoneyInputStory extends React.Component {
   }
 
   render() {
+    const currencies = array('currencies', ['EUR', 'USD', 'AED', 'KWD']);
     const name = text('name', '') || 'default-name';
     const value = {
       amount: this.state.amount,
@@ -55,16 +56,12 @@ class MoneyInputStory extends React.Component {
             id={text('id', '')}
             name={name}
             value={value}
-            currencies={array('currencies', ['EUR', 'USD', 'AED', 'KWD'])}
+            currencies={boolean('dropdown', true) ? currencies : undefined}
             placeholder={text('placeholder', 'Placeholder')}
             onFocus={action('onFocus')}
             onBlur={action('onBlur')}
             isDisabled={boolean('isDisabled', false)}
             isReadOnly={boolean('isReadOnly', false)}
-            isCurrencySelectionDisabled={boolean(
-              'isCurrencySelectionDisabled',
-              false
-            )}
             isAutofocussed={boolean('isAutofocussed', false)}
             onChange={event => {
               action('onChange')(event);

--- a/src/components/inputs/money-input/money-input.story.js
+++ b/src/components/inputs/money-input/money-input.story.js
@@ -43,7 +43,6 @@ class MoneyInputStory extends React.Component {
   }
 
   render() {
-    const currencies = array('currencies', ['EUR', 'USD', 'AED', 'KWD']);
     const name = text('name', '') || 'default-name';
     const value = {
       amount: this.state.amount,
@@ -56,12 +55,16 @@ class MoneyInputStory extends React.Component {
             id={text('id', '')}
             name={name}
             value={value}
-            currencies={boolean('dropdown', true) ? currencies : undefined}
+            currencies={array('currencies', ['EUR', 'USD', 'AED', 'KWD'])}
             placeholder={text('placeholder', 'Placeholder')}
             onFocus={action('onFocus')}
             onBlur={action('onBlur')}
             isDisabled={boolean('isDisabled', false)}
             isReadOnly={boolean('isReadOnly', false)}
+            isCurrencySelectionDisabled={boolean(
+              'isCurrencySelectionDisabled',
+              false
+            )}
             isAutofocussed={boolean('isAutofocussed', false)}
             onChange={event => {
               action('onChange')(event);

--- a/src/components/inputs/money-input/money-input.story.js
+++ b/src/components/inputs/money-input/money-input.story.js
@@ -1,7 +1,13 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, text, select } from '@storybook/addon-knobs';
+import {
+  withKnobs,
+  array,
+  boolean,
+  text,
+  select,
+} from '@storybook/addon-knobs';
 import withReadme from 'storybook-readme/with-readme';
 import Section from '../../../../.storybook/decorators/section';
 import MoneyInputReadme from './README.md';
@@ -37,7 +43,7 @@ class MoneyInputStory extends React.Component {
   }
 
   render() {
-    const currencies = ['EUR', 'USD', 'AED', 'KWD'];
+    const currencies = array('currencies', ['EUR', 'USD', 'AED', 'KWD']);
     const name = text('name', '') || 'default-name';
     const value = {
       amount: this.state.amount,

--- a/src/components/inputs/money-input/money-input.story.js
+++ b/src/components/inputs/money-input/money-input.story.js
@@ -55,6 +55,8 @@ class MoneyInputStory extends React.Component {
             onFocus={action('onFocus')}
             onBlur={action('onBlur')}
             isDisabled={boolean('isDisabled', false)}
+            isReadOnly={boolean('isReadOnly', false)}
+            isAutofocussed={boolean('isAutofocussed', false)}
             onChange={event => {
               action('onChange')(event);
 


### PR DESCRIPTION
Closes #330 

#### Summary

* Adds `isAutofocussed` prop to `<MoneyInput>` and `<MoneyField>`
* Adds `isReadOnly` prop  to `<MoneyInput>` and `<MoneyField>`
* `<MoneyInput>`: Wraps `SingleValue` of react-select with a label pointing at the currencyCode input, so that it can be targeted using RTL.