### PR TITLE
Export FieldErrors component

### DIFF
--- a/src/components/field-errors/README.md
+++ b/src/components/field-errors/README.md
@@ -1,0 +1,58 @@
+# FieldErrors
+
+#### Description
+
+Renders errors based on configuration.
+
+## Usage
+
+```jsx
+import { FieldErrors } from '@commercetools-frontend/ui-kit';
+
+// This example shows how to handle custom errors on top of the
+// predefined errors of FieldErrors which this component and other
+// Field components use under the hood.
+<FieldErrors
+  errors={{
+    [FieldErrors.errors.MISSING]: true,
+    duplicate: true,
+    minLength: true,
+  }}
+  isVisible={isTouched}
+  renderError={key => {
+    switch (key) {
+      case 'duplicate':
+        return 'This thing is already in use. It must be unique.';
+      default:
+        // When null is returned then the default error handling from
+        // renderDefaultError will kick in for that error.
+        return null;
+    }
+  }}
+  renderDefaultError={key => {
+    switch (key) {
+      case 'minLength':
+        return 'This thing is too short.';
+      default:
+        // When null is returned then the error handling defined in
+        // FieldError itself will kick in
+        return null;
+    }
+  }}
+/>;
+```
+
+#### Properties
+
+| Props                | Type     | Required | Values | Default | Description                                                                                                                                                                                                                               |
+| -------------------- | -------- | :------: | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `errors`             | `object` |    -     | -      | -       | List of errors. Only entries with truthy values will count as active errors.                                                                                                                                                              |
+| `isVisible`          | `bool`   |    -     | -      | -       | `true` when the error messages should be rendered. Usually you'd pass in a `touched` state of fields.                                                                                                                                     |
+| `renderError`        | `func`   |    -     | -      | -       | Function which gets called with each error key (from the `errors` prop) and may render an error message or return `null` to hand the error handling off to `renderDefaultError`.                                                          |
+| `renderDefaultError` | `func`   |    -     | -      | -       | Function which gets called with each error key (from the `errors` prop) for which `renderError` returned `null`. It may render an error message or return `null` to hand the error handling off to `FieldError`s built-in error handling. |
+
+### Static properties
+
+#### `FieldErrors.errorTypes`
+
+An enum of known errors which `FieldErrors` can handle itself. You might want to use this while constructing the error object you're passing as the `errors` prop.

--- a/src/components/field-errors/field-errors.js
+++ b/src/components/field-errors/field-errors.js
@@ -36,19 +36,19 @@ const FieldErrors = props => {
             return <ErrorMessage key={key}>{defaultErrorElement}</ErrorMessage>;
 
           // Try to see if we know this error and render that error instead then
-          if (key === 'missing')
+          if (key === FieldErrors.errorTypes.MISSING)
             return (
               <ErrorMessage key={key}>
                 <FormattedMessage {...messages.missingRequiredField} />
               </ErrorMessage>
             );
-          if (key === 'negative')
+          if (key === FieldErrors.errorTypes.NEGATIVE)
             return (
               <ErrorMessage key={key}>
                 <FormattedMessage {...messages.invalidNegativeNumber} />
               </ErrorMessage>
             );
-          if (key === 'fractions')
+          if (key === FieldErrors.errorTypes.FRACTIONS)
             return (
               <ErrorMessage key={key}>
                 <FormattedMessage {...messages.invalidFractionalNumber} />
@@ -71,6 +71,12 @@ FieldErrors.propTypes = {
   isVisible: PropTypes.bool,
   renderError: PropTypes.func,
   renderDefaultError: PropTypes.func,
+};
+
+FieldErrors.errorTypes = {
+  MISSING: 'missing',
+  NEGATIVE: 'negative',
+  FRACTIONS: 'fractions',
 };
 
 export default FieldErrors;

--- a/src/components/field-errors/field-errors.js
+++ b/src/components/field-errors/field-errors.js
@@ -56,8 +56,6 @@ const FieldErrors = props => {
             );
           // Render nothing in case the error is not known and no custom error
           // was returned
-          // The input element will still have the red border to indicate an
-          // error in this case.
           return null;
         })}
     </React.Fragment>

--- a/src/components/field-errors/field-errors.spec.js
+++ b/src/components/field-errors/field-errors.spec.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import FieldErrors from './field-errors';
+import { render } from '../../test-utils';
+
+describe('errorTypes', () => {
+  it('should export errorTypes', () => {
+    expect(FieldErrors.errorTypes.MISSING).toBe('missing');
+    expect(FieldErrors.errorTypes.NEGATIVE).toBe('negative');
+    expect(FieldErrors.errorTypes.FRACTIONS).toBe('fractions');
+  });
+
+  it('should render the "missing" error', () => {
+    const { container } = render(
+      <FieldErrors
+        errors={{ [FieldErrors.errorTypes.MISSING]: true }}
+        isVisible={true}
+      />
+    );
+    expect(container).toHaveTextContent(/field is required/i);
+  });
+
+  it('should render the "negative" error', () => {
+    const { container } = render(
+      <FieldErrors
+        errors={{ [FieldErrors.errorTypes.NEGATIVE]: true }}
+        isVisible={true}
+      />
+    );
+    expect(container).toHaveTextContent(/negative/i);
+  });
+
+  it('should render the "fractions" error', () => {
+    const { container } = render(
+      <FieldErrors
+        errors={{ [FieldErrors.errorTypes.FRACTIONS]: true }}
+        isVisible={true}
+      />
+    );
+    expect(container).toHaveTextContent(/whole number/i);
+  });
+});
+
+describe('when not visible', () => {
+  it('should render no errors', () => {
+    const { container } = render(
+      <FieldErrors
+        errors={{ [FieldErrors.errorTypes.MISSING]: true }}
+        isVisible={false}
+      />
+    );
+    expect(container).toBeEmpty();
+  });
+});
+
+describe('error renderers', () => {
+  it('should give highest importance to renderError', () => {
+    const { container } = render(
+      <FieldErrors
+        errors={{ [FieldErrors.errorTypes.MISSING]: true }}
+        isVisible={true}
+        renderError={key =>
+          key === FieldErrors.errorTypes.MISSING ? 'RENDER_ERROR' : null
+        }
+        renderDefaultError={key =>
+          key === FieldErrors.errorTypes.MISSING ? 'RENDER_DEFAULT_ERROR' : null
+        }
+      />
+    );
+    expect(container).toHaveTextContent('RENDER_ERROR');
+  });
+
+  it('should give second highest importance to renderDefaultError', () => {
+    const { container } = render(
+      <FieldErrors
+        errors={{ [FieldErrors.errorTypes.MISSING]: true }}
+        isVisible={true}
+        renderError={() => null}
+        renderDefaultError={key =>
+          key === FieldErrors.errorTypes.MISSING ? 'RENDER_DEFAULT_ERROR' : null
+        }
+      />
+    );
+    expect(container).toHaveTextContent('RENDER_DEFAULT_ERROR');
+  });
+
+  it('should fall back to internal error handling', () => {
+    const { container } = render(
+      <FieldErrors
+        errors={{ [FieldErrors.errorTypes.MISSING]: true }}
+        isVisible={true}
+        renderError={() => null}
+        renderDefaultError={() => null}
+      />
+    );
+    expect(container).toHaveTextContent(/required/i);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ export {
 } from './components/dropdowns/primary-action-dropdown';
 
 export { default as FieldLabel } from './components/field-label';
+export { default as FieldErrors } from './components/field-errors';
 
 export { default as TextField } from './components/fields/text-field';
 export { default as DateField } from './components/fields/date-field';


### PR DESCRIPTION
- exports the `FieldErrors` component
- adds `FieldErrors.errorTypes` constants which aim to make code of consumers easier to follow by avoiding "magic" keys like `missing` in the errors object by showing the constants instead (non-breaking change)
- adds `react-testing-library` tests for the public API
- adds `README`

I didn't add a story as this component doesn't have any visuals itself (apart from rendering `ErrorMessage` which is already tested separately).

Closes #246 