### PR TITLE
chore: fix storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "jest-silent-reporter": "0.1.1",
     "jest-validate": "23.6.0",
     "jest-watch-master": "1.0.0",
+    "json-loader": "0.5.7",
     "lint-staged": "8.1.0",
     "lodash.camelcase": "4.3.0",
     "lodash.pick": "4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8949,6 +8949,11 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
+json-loader@^0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
+  integrity sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==
+
 json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"


### PR DESCRIPTION
😆 
In #373 we removed `@react/percy`, which had a dev dependency on webpack 3, which has `json-loader`, so  `json-loader` was removed as well.. Storybook couldn't be built because of this. Here I readded json-loader.