### PR TITLE
build(travis): publish canary releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   # also skip when PR is opened by `renovate`
   # back to default in case internal travis scripts return non zero response codes.
   - "! test -f fail-tests-because-there-was-an-unhandled-rejection.lock"
-  - bash ./scripts/run-percy.sh
+  - ./scripts/run-percy.sh
   - set +e
 
 before_deploy: yarn build
@@ -39,6 +39,9 @@ deploy:
   on:
     tags: true
   tag: next
+
+after_success:
+  - if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [[ ! "$TRAVIS_COMMIT_MESSAGE" =~ \[skip\ publish\] ]]; then node ./scripts/release-canary.js; fi
 
 # Keep it disabled until this issue is clarified
 # https://twitter.com/emmenko/status/1040544486101856256

--- a/package.json
+++ b/package.json
@@ -207,6 +207,7 @@
     "rollup-plugin-postcss": "1.6.3",
     "rollup-plugin-replace": "2.1.0",
     "rollup-plugin-url": "2.1.0",
+    "semver": "5.6.0",
     "shelljs": "0.8.3",
     "storybook-readme": "4.0.2",
     "style-loader": "0.23.1",

--- a/scripts/release-canary.js
+++ b/scripts/release-canary.js
@@ -1,0 +1,89 @@
+/* eslint-disable no-console */
+const shelljs = require('shelljs');
+const semver = require('semver');
+
+const constants = {
+  TRAVIS_COMMIT: 'TRAVIS_COMMIT',
+  NPM_TOKEN: 'NPM_TOKEN',
+  NPM_EMAIL: 'npmjs@commercetools.com',
+  NPM_DIST_TAG: {
+    CANARY: 'canary',
+    NEXT: 'next',
+  },
+};
+
+const exitOnError = result => {
+  if (result.code > 0) {
+    console.error(result.stderr);
+    process.exit(1);
+  }
+};
+
+const getVersionForDistTag = distTag => {
+  const infoTagResult = shelljs.exec(
+    `npm view @commercetools-frontend/ui-kit@${distTag} --json`,
+    { silent: true }
+  );
+  exitOnError(infoTagResult);
+  if (infoTagResult.stdout) {
+    const infoTag = JSON.parse(infoTagResult.stdout);
+    return infoTag.version;
+  }
+  return null;
+};
+
+const getNextCanaryVersion = () => {
+  let versionTagCanary = getVersionForDistTag(constants.NPM_DIST_TAG.CANARY);
+  if (!versionTagCanary) {
+    // In case there was no `canary` dist-tag yet, we fall back to the
+    // latest version in `next` dist-tag.
+    versionTagCanary = getVersionForDistTag(constants.NPM_DIST_TAG.NEXT);
+  }
+  const nextVersionCanary = semver.inc(
+    versionTagCanary,
+    'prerelease',
+    constants.NPM_DIST_TAG.CANARY
+  );
+  if (!nextVersionCanary) {
+    console.error(
+      `Could not bump version "${versionTagCanary}". Please check that the value is a valid semver version.`
+    );
+    process.exit(1);
+  }
+  return nextVersionCanary;
+};
+
+const getEnvVariable = name => {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required environment variable "${name}"`);
+    process.exit(1);
+  }
+  return value;
+};
+
+const getGitSha = () => {
+  if (process.env.CI) {
+    return getEnvVariable(constants.TRAVIS_COMMIT);
+  }
+  return shelljs.exec('git rev-parse --short HEAD', { silent: true });
+};
+
+/* Run program */
+const nextVersionCanary = getNextCanaryVersion();
+const nextVersionCanaryWithGitSha = `${nextVersionCanary}+${getGitSha()}`;
+console.log(
+  '==> About to release canary version:',
+  nextVersionCanaryWithGitSha
+);
+if (process.env.CI) {
+  const authToken = getEnvVariable(constants.NPM_TOKEN);
+  console.log(`==> Granting publish access to user "${constants.NPM_EMAIL}"`);
+  shelljs.exec(`npm config set email ${constants.NPM_EMAIL}`, { silent: true });
+  shelljs.exec(
+    `npm config set '//registry.npmjs.org/:_authToken' ${authToken}`,
+    { silent: true }
+  );
+}
+shelljs.exec(`npm version ${nextVersionCanaryWithGitSha} --no-git-tag-version`);
+shelljs.exec(`npm publish --tag ${constants.NPM_DIST_TAG.CANARY}`);

--- a/scripts/run-percy.sh
+++ b/scripts/run-percy.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -e
 
 # skip percy builds when this is not a pull request or when it's not master
 if [[ $TRAVIS_PULL_REQUEST != 'false' || ${TRAVIS_BRANCH} == 'master' ]]


### PR DESCRIPTION
Same idea as in https://github.com/commercetools/merchant-center-application-kit/pull/243

We need to prepare the release manually though as we are not using lerna (which has this built-in).