### PR TITLE
chore(collapsible-panel): move onClick in header

### DIFF
--- a/src/components/panels/collapsible-panel/collapsible-panel.js
+++ b/src/components/panels/collapsible-panel/collapsible-panel.js
@@ -89,6 +89,7 @@ export default class CollapsiblePanel extends React.PureComponent {
             })}
           >
             <div
+              onClick={this.props.isDisabled ? undefined : toggle}
               className={classnames(styles['base-header-container'], {
                 [styles['header-container-theme-light']]:
                   this.props.theme === 'light',
@@ -100,11 +101,7 @@ export default class CollapsiblePanel extends React.PureComponent {
               })}
             >
               <Spacings.InsetSquish scale={scale}>
-                <div
-                  {...dataProps}
-                  onClick={this.props.isDisabled ? undefined : toggle}
-                  className={styles.header}
-                >
+                <div {...dataProps} className={styles.header}>
                   <div className={styles['truncate-header']}>
                     <Spacings.Inline alignItems="center" scale="s">
                       {!this.props.isDisabled && (

--- a/src/components/panels/collapsible-panel/collapsible-panel.spec.js
+++ b/src/components/panels/collapsible-panel/collapsible-panel.spec.js
@@ -1,6 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { render } from '../../../test-utils';
 import CollapsiblePanel from './collapsible-panel';
+
+const HeaderControls = props => (
+  <div onClick={props.onClick}>Header Controls</div>
+);
+
+HeaderControls.propTypes = {
+  onClick: PropTypes.func,
+};
 
 it('should smoke', () => {
   const { getByText } = render(
@@ -8,6 +17,45 @@ it('should smoke', () => {
   );
   expect(getByText('Header')).toBeInTheDocument();
   expect(getByText('Children')).toBeInTheDocument();
+});
+
+describe('header controls', () => {
+  describe('when passed header controls without an onClick', () => {
+    it('should not call onToggle when headerControls are clicked', () => {
+      const onToggle = jest.fn();
+      const { getByText } = render(
+        <CollapsiblePanel
+          header="Header"
+          onToggle={onToggle}
+          headerControls={<HeaderControls />}
+          className="foo"
+          isClosed={true}
+        >
+          Children
+        </CollapsiblePanel>
+      );
+      getByText('Header Controls').click();
+      expect(onToggle).not.toHaveBeenCalled();
+    });
+  });
+  describe('when passed header controls with an onClick', () => {
+    it('should call not onToggle when headerControls are clicked', () => {
+      const onToggle = jest.fn();
+      const { getByText } = render(
+        <CollapsiblePanel
+          header="Header"
+          onToggle={onToggle}
+          headerControls={<HeaderControls onClick={() => {}} />}
+          className="foo"
+          isClosed={true}
+        >
+          Children
+        </CollapsiblePanel>
+      );
+      getByText('Header Controls').click();
+      expect(onToggle).not.toHaveBeenCalled();
+    });
+  });
 });
 
 // We really shouldn't be accepting arbitrary class-names

--- a/src/components/panels/collapsible-panel/collapsible-panel.spec.js
+++ b/src/components/panels/collapsible-panel/collapsible-panel.spec.js
@@ -21,7 +21,7 @@ it('should smoke', () => {
 
 describe('header controls', () => {
   describe('when passed header controls without an onClick', () => {
-    it('should not call onToggle when headerControls are clicked', () => {
+    it('should not call onToggle when headerControls is clicked', () => {
       const onToggle = jest.fn();
       const { getByText } = render(
         <CollapsiblePanel
@@ -39,7 +39,7 @@ describe('header controls', () => {
     });
   });
   describe('when passed header controls with an onClick', () => {
-    it('should call not onToggle when headerControls are clicked', () => {
+    it('should not call onToggle when headerControls is clicked', () => {
       const onToggle = jest.fn();
       const { getByText } = render(
         <CollapsiblePanel


### PR DESCRIPTION
This has bugged me for awhile. You should be able to toggle the `CollapsiblePanel` by clicking anywhere in the header.

