### PR TITLE
chore: adds a few interaction based VRT tests

### DIFF
--- a/src/components/dropdowns/primary-action-dropdown/primary-action-dropdown.visualroute.js
+++ b/src/components/dropdowns/primary-action-dropdown/primary-action-dropdown.visualroute.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Route, Switch } from 'react-router-dom';
 import {
   PrimaryActionDropdown,
   PrimaryActionDropdownOption,
@@ -8,7 +9,28 @@ import { Suite, Spec } from '../../../../test/percy';
 
 export const routePath = '/primary-action-dropdown';
 
-export const component = () => (
+const InteractionRoute = () => (
+  <Suite>
+    <Spec label="when open">
+      <PrimaryActionDropdown>
+        <PrimaryActionDropdownOption
+          iconLeft={<AddBoldIcon />}
+          onClick={() => {}}
+        >
+          Primary option
+        </PrimaryActionDropdownOption>
+        <PrimaryActionDropdownOption onClick={() => {}}>
+          Another option
+        </PrimaryActionDropdownOption>
+        <PrimaryActionDropdownOption isDisabled onClick={() => {}}>
+          Disabled option
+        </PrimaryActionDropdownOption>
+      </PrimaryActionDropdown>
+    </Spec>
+  </Suite>
+);
+
+const DefaultRoute = () => (
   <Suite>
     <Spec label="regular">
       <PrimaryActionDropdown>
@@ -38,4 +60,11 @@ export const component = () => (
       </PrimaryActionDropdown>
     </Spec>
   </Suite>
+);
+
+export const component = () => (
+  <Switch>
+    <Route path={`${routePath}/interaction`} component={InteractionRoute} />
+    <Route path={routePath} component={DefaultRoute} />
+  </Switch>
 );

--- a/src/components/dropdowns/primary-action-dropdown/primary-action-dropdown.visualspec.js
+++ b/src/components/dropdowns/primary-action-dropdown/primary-action-dropdown.visualspec.js
@@ -1,12 +1,22 @@
 import { percySnapshot } from '@percy/puppeteer';
+import { getDocument, queries } from 'pptr-testing-library';
+
+const { getByLabelText } = queries;
 
 describe('PrimaryActionDropdown', () => {
-  beforeAll(async () => {
+  it('Default', async () => {
     await page.goto(`${HOST}/primary-action-dropdown`);
+    const doc = await getDocument(page);
+    const dropdown = await getByLabelText(doc, 'Open Dropdown');
+    await expect(dropdown).toBeTruthy();
+    await percySnapshot(page, 'PrimaryActionDropdown');
   });
 
-  it('Default', async () => {
-    await expect(page).toMatch('Primary option');
-    await percySnapshot(page, 'PrimaryActionDropdown');
+  it('When open', async () => {
+    await page.goto(`${HOST}/primary-action-dropdown/interaction`);
+    const doc = await getDocument(page);
+    const dropdown = await getByLabelText(doc, 'Open Dropdown');
+    await dropdown.click();
+    await percySnapshot(page, 'PrimaryActionDropdown - Open');
   });
 });

--- a/src/components/fields/async-creatable-select-field/async-creatable-select-field.visualroute.js
+++ b/src/components/fields/async-creatable-select-field/async-creatable-select-field.visualroute.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Switch, Route } from 'react-router-dom';
 import { AsyncCreatableSelectField } from 'ui-kit';
 import { Suite, Spec } from '../../../../test/percy';
 
@@ -12,7 +13,7 @@ const value = { value: 'one', label: 'One' };
 
 export const routePath = '/async-creatable-select-field';
 
-export const component = () => (
+const DefaultRoute = () => (
   <Suite>
     <Spec label="minimal">
       <AsyncCreatableSelectField
@@ -67,4 +68,52 @@ export const component = () => (
       />
     </Spec>
   </Suite>
+);
+
+const InteractionRoute = () => (
+  <Switch>
+    <Route
+      path={`${routePath}/interaction/without-default-options`}
+      render={() => (
+        <Suite>
+          <Spec label="with defaultOptions disabled">
+            <AsyncCreatableSelectField
+              title="State"
+              name="form-field-name"
+              value={value}
+              onChange={() => {}}
+              loadOptions={loadOptions}
+              horizontalConstraint="m"
+            />
+          </Spec>
+        </Suite>
+      )}
+    />
+
+    <Route
+      path={`${routePath}/interaction`}
+      render={() => (
+        <Suite>
+          <Spec label="with defaultOptions enabled">
+            <AsyncCreatableSelectField
+              title="State"
+              name="form-field-name"
+              value={value}
+              onChange={() => {}}
+              defaultOptions={true}
+              loadOptions={loadOptions}
+              horizontalConstraint="m"
+            />
+          </Spec>
+        </Suite>
+      )}
+    />
+  </Switch>
+);
+
+export const component = () => (
+  <Switch>
+    <Route path={`${routePath}/interaction`} component={InteractionRoute} />
+    <Route path={routePath} component={DefaultRoute} />
+  </Switch>
 );

--- a/src/components/fields/async-creatable-select-field/async-creatable-select-field.visualspec.js
+++ b/src/components/fields/async-creatable-select-field/async-creatable-select-field.visualspec.js
@@ -1,12 +1,43 @@
 import { percySnapshot } from '@percy/puppeteer';
+import { getDocument, queries } from 'pptr-testing-library';
+
+const { getByLabelText } = queries;
 
 describe('AsyncCreatableSelectField', () => {
-  beforeAll(async () => {
+  it('Default', async () => {
     await page.goto(`${HOST}/async-creatable-select-field`);
-  });
-
-  it('AsyncCreatableSelectField', async () => {
-    await expect(page).toMatch('State');
+    const doc = await getDocument(page);
+    const select = await getByLabelText(doc, 'State');
+    await expect(select).toBeTruthy();
     await percySnapshot(page, 'AsyncCreatableSelectField');
+  });
+  describe('with defaultOptions', () => {
+    it('When open', async () => {
+      await page.goto(`${HOST}/async-creatable-select-field/interaction`);
+      const doc = await getDocument(page);
+      const select = await getByLabelText(doc, 'State');
+      await select.click();
+      await percySnapshot(page, 'AsyncCreatableSelectField - Open');
+    });
+  });
+  describe('without defaultOptions', () => {
+    it('When open', async () => {
+      await page.goto(
+        `${HOST}/async-creatable-select-field/interaction/without-default-options`
+      );
+      const doc = await getDocument(page);
+      const select = await getByLabelText(doc, 'State');
+      await select.click();
+      await percySnapshot(
+        page,
+        'AsyncCreatableSelectField - withDefaultOptions disabled - open'
+      );
+      // typing triggers async loadOptions
+      await select.type(' ');
+      await percySnapshot(
+        page,
+        'AsyncCreatableSelectField - withDefaultOptions disabled - open - after typing'
+      );
+    });
   });
 });

--- a/src/components/fields/async-creatable-select-field/async-creatable-select-field.visualspec.js
+++ b/src/components/fields/async-creatable-select-field/async-creatable-select-field.visualspec.js
@@ -33,7 +33,7 @@ describe('AsyncCreatableSelectField', () => {
         'AsyncCreatableSelectField - withDefaultOptions disabled - open'
       );
       // typing triggers async loadOptions
-      await select.type(' ');
+      await select.type('Three');
       await percySnapshot(
         page,
         'AsyncCreatableSelectField - withDefaultOptions disabled - open - after typing'

--- a/src/components/fields/async-select-field/async-select-field.visualroute.js
+++ b/src/components/fields/async-select-field/async-select-field.visualroute.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Switch, Route } from 'react-router-dom';
 import { AsyncSelectField } from 'ui-kit';
 import { Suite, Spec } from '../../../../test/percy';
 
@@ -12,7 +13,7 @@ const value = { value: 'one', label: 'One' };
 
 export const routePath = '/async-select-field';
 
-export const component = () => (
+const DefaultRoute = () => (
   <Suite>
     <Spec label="minimal">
       <AsyncSelectField
@@ -67,4 +68,52 @@ export const component = () => (
       />
     </Spec>
   </Suite>
+);
+
+const InteractionRoute = () => (
+  <Switch>
+    <Route
+      path={`${routePath}/interaction/without-default-options`}
+      render={() => (
+        <Suite>
+          <Spec omitPropsList label="with defaultOptions disabled">
+            <AsyncSelectField
+              title="State"
+              name="form-field-name"
+              value={value}
+              onChange={() => {}}
+              defaultOptions={false}
+              loadOptions={loadOptions}
+              horizontalConstraint="m"
+            />
+          </Spec>
+        </Suite>
+      )}
+    />
+    <Route
+      path={`${routePath}/interaction`}
+      render={() => (
+        <Suite>
+          <Spec omitPropsList label="with defaultOptions enabled">
+            <AsyncSelectField
+              title="State"
+              name="form-field-name"
+              value={value}
+              onChange={() => {}}
+              defaultOptions={true}
+              loadOptions={loadOptions}
+              horizontalConstraint="m"
+            />
+          </Spec>
+        </Suite>
+      )}
+    />
+  </Switch>
+);
+
+export const component = () => (
+  <Switch>
+    <Route path={`${routePath}/interaction`} component={InteractionRoute} />
+    <Route exact path={routePath} component={DefaultRoute} />
+  </Switch>
 );

--- a/src/components/fields/async-select-field/async-select-field.visualspec.js
+++ b/src/components/fields/async-select-field/async-select-field.visualspec.js
@@ -1,12 +1,45 @@
 import { percySnapshot } from '@percy/puppeteer';
+import { getDocument, queries } from 'pptr-testing-library';
+
+const { getByLabelText } = queries;
 
 describe('AsyncSelectField', () => {
-  beforeAll(async () => {
+  it('Default', async () => {
     await page.goto(`${HOST}/async-select-field`);
+    const doc = await getDocument(page);
+    const select = await getByLabelText(doc, 'State');
+    await expect(select).toBeTruthy();
+    await percySnapshot(page, 'AsyncSelectField');
   });
 
-  it('Default', async () => {
-    await expect(page).toMatch('State');
-    await percySnapshot(page, 'AsyncSelectField');
+  describe('with defaultOptions', () => {
+    it('Open', async () => {
+      await page.goto(`${HOST}/async-select-field/interaction`);
+      const doc = await getDocument(page);
+      const select = await getByLabelText(doc, 'State');
+      await select.click();
+      await percySnapshot(page, 'AsyncSelectField - withDefaultOptions - open');
+    });
+  });
+
+  describe('without defaultOptions', () => {
+    it('Open', async () => {
+      await page.goto(
+        `${HOST}/async-select-field/interaction/without-default-options`
+      );
+      const doc = await getDocument(page);
+      const select = await getByLabelText(doc, 'State');
+      await select.click();
+      await percySnapshot(
+        page,
+        'AsyncSelectField - withDefaultOptions disabled - open'
+      );
+      // typing triggers async loadOptions
+      await select.type(' ');
+      await percySnapshot(
+        page,
+        'AsyncSelectField - withDefaultOptions disabled - open - after typing'
+      );
+    });
   });
 });

--- a/src/components/fields/async-select-field/async-select-field.visualspec.js
+++ b/src/components/fields/async-select-field/async-select-field.visualspec.js
@@ -35,7 +35,7 @@ describe('AsyncSelectField', () => {
         'AsyncSelectField - withDefaultOptions disabled - open'
       );
       // typing triggers async loadOptions
-      await select.type(' ');
+      await select.type('O');
       await percySnapshot(
         page,
         'AsyncSelectField - withDefaultOptions disabled - open - after typing'


### PR DESCRIPTION
#### Summary

Adds interaction VRT tests for `PrimaryActionDropdown`, `AsyncSelectField` and `AsyncCreatableSelectField`. 

I could use some feedback for these tests and the approach before we go on and add interaction VRT tests for more components.