### PR TITLE
fix(date-inputs): make date-input have large z-index

### DIFF
--- a/src/components/internals/calendar-menu/calendar-menu.mod.css
+++ b/src/components/internals/calendar-menu/calendar-menu.mod.css
@@ -1,3 +1,7 @@
+:root {
+  --menu-z-index: 99999; /* copied from flatpickr */
+}
+
 .menuBase {
   overflow-y: scroll;
   color: var(--color-black);
@@ -10,7 +14,7 @@
   box-sizing: border-box;
   width: 100%;
   background-color: var(--color-white);
-  z-index: 1;
+  z-index: var(--menu-z-index);
 }
 
 .menuBase.warning {


### PR DESCRIPTION
Make z-index of open datepickers to be the same as flatpickrs, to make old behaviour of ui-kit datepickers.

[ref](https://github.com/flatpickr/flatpickr/blob/7012a3b025c6aea05e955004082d160ea7f67535/src/style/flatpickr.styl#L50)