### PR TITLE
fix(primary-action-dropdown): use secondary tone when disabled

### DIFF
--- a/src/components/dropdowns/primary-action-dropdown/primary-action-dropdown.js
+++ b/src/components/dropdowns/primary-action-dropdown/primary-action-dropdown.js
@@ -36,7 +36,9 @@ class DropdownHead extends React.PureComponent {
             })}
           </span>
           <span className={styles.primaryActionTextWrapper}>
-            <Text.Detail>{this.props.children}</Text.Detail>
+            <Text.Detail tone={this.props.isDisabled ? 'secondary' : undefined}>
+              {this.props.children}
+            </Text.Detail>
           </span>
         </AccessibleButton>
         {this.props.chevron}

--- a/src/components/dropdowns/primary-action-dropdown/primary-actions-dropdown.mod.css
+++ b/src/components/dropdowns/primary-action-dropdown/primary-actions-dropdown.mod.css
@@ -43,7 +43,6 @@
 .disabledDropdownHeadChevron {
   box-shadow: none;
   background-color: var(--color-navy-98);
-  color: var(--color-gray);
 }
 
 .primaryOptionChevron {


### PR DESCRIPTION
Use font-color gray-60 when input is disabled (when all options are disabled) as requested by @filippobocik.

| Before | After |
| ---- | --- |
| ![image](https://user-images.githubusercontent.com/1765075/50836678-131a8400-135a-11e9-8f29-401da02cdad9.png) | ![image](https://user-images.githubusercontent.com/1765075/50836687-19106500-135a-11e9-8fa1-12bda3c3a7d7.png) |
