### PR TITLE
Change caret size in select inputs and MoneyInput

### DIFF
--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -5,7 +5,6 @@ import has from 'lodash.has';
 import requiredIf from 'react-required-if';
 import Select, { components } from 'react-select';
 import { injectIntl } from 'react-intl';
-import ClearIndicator from '../../internals/clear-indicator';
 import DropdownIndicator from '../../internals/dropdown-indicator';
 import isNumberish from '../../../utils/is-numberish';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
@@ -38,6 +37,7 @@ SingleValue.displayName = 'SingleValue';
 
 SingleValue.propTypes = {
   id: PropTypes.string,
+  children: PropTypes.node,
 };
 
 // overwrite styles of createSelectStyles
@@ -474,12 +474,11 @@ class MoneyInput extends React.Component {
 
   render() {
     const hasNoCurrencies = this.props.currencies.length === 0;
-    const hasWarning = this.props.hasCurrencyWarning;
     const hasFocus = this.state.currencyHasFocus || this.state.amountHasFocus;
 
     const currencySelectStyles = createCurrencySelectStyles({
-      hasWarning,
-      hasError: this.props.hasCurrencyError || this.props.hasError,
+      hasWarning: this.props.hasWarning,
+      hasError: this.props.hasError,
       isDisabled: this.props.isDisabled,
       isReadOnly: this.props.isReadOnly,
       hasFocus,
@@ -550,7 +549,6 @@ class MoneyInput extends React.Component {
               components={{
                 SingleValue: props => <SingleValue {...props} id={id} />,
                 DropdownIndicator,
-                ClearIndicator,
               }}
               options={options}
               placeholder=""

--- a/src/components/internals/clear-indicator/clear-indicator.js
+++ b/src/components/internals/clear-indicator/clear-indicator.js
@@ -13,9 +13,7 @@ const ClearIndicator = props => {
       ref={ref}
       style={getStyles('clearIndicator', props)}
     >
-      <div>
-        <CloseIcon theme={props.isDisabled && 'grey'} size="medium" />
-      </div>
+      <CloseIcon theme={props.isDisabled && 'grey'} size="medium" />
     </div>
   );
 };
@@ -25,6 +23,7 @@ ClearIndicator.displayName = 'ClearIndicator';
 ClearIndicator.propTypes = {
   innerProps: PropTypes.object,
   isDisabled: PropTypes.bool,
+  getStyles: PropTypes.func.isRequired,
 };
 
 export default ClearIndicator;

--- a/src/components/internals/create-select-styles.js
+++ b/src/components/internals/create-select-styles.js
@@ -93,7 +93,7 @@ const menuListStyles = () => base => ({
 
 const optionStyles = () => (base, state) => ({
   ...base,
-  transition: '--transition-standard',
+  transition: vars['--transition-standard'],
   paddingLeft: vars['--spacing-8'],
   paddingRight: vars['--spacing-8'],
   color: do {
@@ -195,7 +195,7 @@ const containerStyles = () => (base, state) => ({
 const indicatorsContainerStyles = () => () => ({
   background: 'none',
   display: 'flex',
-  alignItems: 'baseline',
+  alignItems: 'center',
 });
 
 export default props => ({

--- a/src/components/internals/dropdown-indicator/dropdown-indicator.js
+++ b/src/components/internals/dropdown-indicator/dropdown-indicator.js
@@ -6,7 +6,7 @@ import { CaretDownIcon } from '../../icons';
 const DropdownIndicator = props => (
   <components.DropdownIndicator {...props}>
     {/* FIXME: add proper tone when tones are refactored */}
-    <CaretDownIcon theme={props.isDisabled && 'grey'} size="medium" />
+    <CaretDownIcon theme={props.isDisabled && 'grey'} size="small" />
   </components.DropdownIndicator>
 );
 


### PR DESCRIPTION
Change caret size in select inputs and avoid jumping of clear icon.

| Before | After | 
| --- | --- | 
| ![image](https://user-images.githubusercontent.com/1765075/50839414-8a531680-1360-11e9-9f6e-29101902b644.png) |  ![image](https://user-images.githubusercontent.com/1765075/50839449-a060d700-1360-11e9-9d93-89a4b3e7422e.png) |

Fixes `SelectInput` `CreatableSelectInput` `AsyncSelectInput` `AsyncCreatableSelectInput`


Also fixes `MoneyInput`

| Before | After | 
| --- | --- | 
| ![image](https://user-images.githubusercontent.com/1765075/50840242-52e56980-1362-11e9-80fb-d297486e75ba.png) | ![image](https://user-images.githubusercontent.com/1765075/50840214-4a8d2e80-1362-11e9-85f9-d7e628c5a0fa.png) |



