### PR TITLE
fix(money-input): use narrow styling when no currencies are passed

### DIFF
--- a/src/components/inputs/money-input/money-input.mod.css
+++ b/src/components/inputs/money-input/money-input.mod.css
@@ -8,7 +8,6 @@
   border-right: 0;
   padding: 0 var(--spacing-8);
   align-items: center;
-  min-width: 72px;
   font-size: var(--font-size-default);
   box-sizing: border-box;
 }


### PR DESCRIPTION
Use narrow styling when no currencies are passed

| Before | After |
| --- | --- |
| ![bildschirmfoto 2019-01-08 um 16 39 27](https://user-images.githubusercontent.com/1765075/50841076-31857d00-1364-11e9-990d-654cdaeac904.png) | ![bildschirmfoto 2019-01-08 um 16 39 09](https://user-images.githubusercontent.com/1765075/50841075-30ece680-1364-11e9-8f94-f4ef8abc4a6e.png) |

### More context

There are two modes the `MoneyInput` can be used in:
- letting users select currency and amount (`currencies` prop is passed, even when it only contains one currency)
- letting users select an amount only (`currencies` prop is not passed, but `value` already has `value.currencyCode` set to a currency)

Previously, we were setting a min-width for the case where the currency can't be selected. @filippobocik has requested to make the currency more narrow in that case.

