### PR TITLE
fix(text): add missing inverted prop to prop-types of text-detail

### DIFF
--- a/src/components/typography/text/text.js
+++ b/src/components/typography/text/text.js
@@ -158,6 +158,7 @@ Detail.propTypes = {
     'positive',
     'negative',
     'warning',
+    'inverted',
   ]),
   children: PropTypes.node.isRequired,
   title: nonEmptyString,


### PR DESCRIPTION
Is leading to some prop-type warnings in mc-fe now.