### PR TITLE
chore: update proptype of Radio

### DIFF
--- a/src/components/switches/radio/radio-group.js
+++ b/src/components/switches/radio/radio-group.js
@@ -12,7 +12,7 @@ class Group extends React.PureComponent {
     direction: PropTypes.oneOf(['stack', 'inline']),
     onChange: PropTypes.func.isRequired,
     name: PropTypes.string.isRequired,
-    value: PropTypes.string.isRequired,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
     children: PropTypes.node.isRequired,
     scale: PropTypes.string,
   };

--- a/src/components/switches/radio/radio-option.js
+++ b/src/components/switches/radio/radio-option.js
@@ -10,7 +10,7 @@ import styles from './radio-option.mod.css';
 export class Option extends React.PureComponent {
   static displayName = 'RadioOption';
   static propTypes = {
-    value: PropTypes.string.isRequired,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
     // This prop forces Radio.Option to be rendered in a hovered state (thought isDisabled takes
     // precedence over that). We need that to address a use-case when hovering is comming
     // from somewhere up the hierarchy. There is no need to touch this prop in case


### PR DESCRIPTION
To make the Radio more inline with how our consumers are using it, we should update the proptype "value" to accept either booleans or strings. 

This is how it's currently being used by the PCM team

