### PR TITLE
fix(localizedmoneyinput): remove 'amount/currencyCode' from event name

### DIFF
--- a/src/components/inputs/localized-money-input/README.md
+++ b/src/components/inputs/localized-money-input/README.md
@@ -11,7 +11,10 @@ states.
 import { LocalizedMoneyInput } from '@commercetools-frontend/ui-kit';
 
 <LocalizedMoneyInput
-  value={{ USD: '12.22', EUR: '41.44' }}
+  value={{
+    USD: { currencyCode: 'USD', amount: '12.22' },
+    EUR: { currencyCode: 'EUR', amount: '41.44' },
+  }}
   onChange={event => alert(event.target.name, event.target.value)}
 />;
 ```
@@ -22,7 +25,7 @@ import { LocalizedMoneyInput } from '@commercetools-frontend/ui-kit';
 | ------------------------------- | ---------------- | :------: | ---------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `id`                            | `string`         |    -     | -                                  | -       | Used as prefix of HTML `id` property. Each input field id will have the currency as a suffix (`${idPrefix}.${lang}`), e.g. `foo.en`                                                                                |
 | `name`                          | `string`         |    -     | -                                  | -       | Used as HTML `name` property for each input field. Each input field name will have the currency as a suffix (`${namePrefix}.${lang}`), e.g. `foo.en`                                                               |
-| `value`                         | `object`         |    ✅    | -                                  | -       | Values to use. Keyed by currency, the values are the actual values, e.g. `{ USD: '12.22', EUR: '41.44' }`                                                                                                          |
+| `value`                         | `object`         |    ✅    | -                                  | -       | Values to use. Keyed by currency, the values are the actual values, e.g. `{ USD: {currencyCode: 'USD', amount: '12.22'}, EUR: {currencyCode: 'EUR', amount: '41.44'} }`                                            |
 | `onChange`                      | `function`       |    ✅    | -                                  | -       | Gets called when any input is changed. Is called with the change event of the changed input.                                                                                                                       |
 | `selectedCurrency`              | `string`         |    ✅    | -                                  | -       | Specifies which currency will be shown in case the `LocalizedMoneyInput` is collapsed.                                                                                                                             |
 | `onBlur`                        | `function`       |    -     | -                                  | -       | Called when any field is blurred. Is called with the `event` of that field.                                                                                                                                        |
@@ -85,12 +88,18 @@ LocalizedMoneyInput.getEmptyCurrencies({});
 ```
 
 ```js
-LocalizedMoneyInput.getEmptyCurrencies({ USD: '', EUR: '' });
+LocalizedMoneyInput.getEmptyCurrencies({
+  USD: { currencyCode: 'USD', amount: '' },
+  EUR: { currencyCode: 'EUR', amount: '' },
+});
 // -> ['USD', 'EUR']
 ```
 
 ```js
-LocalizedMoneyInput.getEmptyCurrencies({ USD: '12.43', EUR: '' });
+LocalizedMoneyInput.getEmptyCurrencies({
+  USD: { currencyCode: 'USD', amount: '12.43' },
+  EUR: { currencyCode: 'EUR', amount: '' },
+});
 // -> ['EUR']
 ```
 
@@ -105,16 +114,28 @@ LocalizedMoneyInput.getHighPrecisionCurrencies({});
 
 ```js
 LocalizedMoneyInput.getHighPrecisionCurrencies({
-  USD: '12.2221',
-  EUR: '9.9999',
+  USD: {
+    currencyCode: 'USD',
+    amount: '12.2221',
+  },
+  EUR: {
+    currencyCode: 'EUR',
+    amount: '9.9999',
+  },
 });
 // -> ['USD', 'EUR']
 ```
 
 ```js
 LocalizedMoneyInput.getHighPrecisionCurrencies({
-  USD: '12.43',
-  EUR: '0.00001',
+  USD: {
+    currencyCode: 'USD',
+    amount: '12.43',
+  },
+  EUR: {
+    currencyCode: 'EUR',
+    amount: '0.00001',
+  },
 });
 // -> ['EUR']
 ```
@@ -153,16 +174,21 @@ Here are examples of `centPrecision` and `highPrecision` prices.
 
 ##### `LocalizedMoneyInput.parseMoneyValues`
 
-The `parseMoneyValues` function will turn a [`MoneyValue`](https://docs.commercetools.com/http-api-types#money) into a value the LocalizedMoneyInput component can handle `({ currencyCode: amount })`.
+The `parseMoneyValues` function will turn a [`MoneyValue`](https://docs.commercetools.com/http-api-types#money) into a value the LocalizedMoneyInput component can handle `({ [currencyCode]: {currencyCode: [currencyCode], amount: [amount]} })`.
 
 ##### `LocalizedMoneyInput.getEmptyCurrencies`
 
 The `getEmptyCurrencies` function will return array of crrencies that don't have amount .
 
 ```js
-LocalizedMoneyInput.getEmptyCurrencies({ EUR: '', USD: '12.77' }); // -> ['EUR']
+LocalizedMoneyInput.getEmptyCurrencies({
+  EUR: { currencyCode: 'EUR', amount: '' },
+  USD: { currencyCode: 'USD', amount: '12.77' },
+}); // -> ['EUR']
 
-LocalizedMoneyInput.getEmptyCurrencies({ EUR: '12.77' }); // -> []
+LocalizedMoneyInput.getEmptyCurrencies({
+  EUR: { currencyCode: 'EUR', amount: '12.77' },
+}); // -> []
 ```
 
 ### Example
@@ -219,8 +245,8 @@ const validate = formValues => {
   const emptyCurrencies = LocalizedMoneyInput.getEmptyCurrencies(
     formValues.prices
   );
-  // ['ERU', 'USD']
-  // This form dosen't accept highprecision prices
+  // ['EUR', 'USD']
+  // This form doesn't accept high precision prices
   const highPrecisionCurrencies = LocalizedMoneyInput.getHighPrecisionCurrencies(
     formValues.prices
   );

--- a/src/components/inputs/localized-money-input/README.md
+++ b/src/components/inputs/localized-money-input/README.md
@@ -25,7 +25,7 @@ import { LocalizedMoneyInput } from '@commercetools-frontend/ui-kit';
 | ------------------------------- | ---------------- | :------: | ---------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `id`                            | `string`         |    -     | -                                  | -       | Used as prefix of HTML `id` property. Each input field id will have the currency as a suffix (`${idPrefix}.${lang}`), e.g. `foo.en`                                                                                |
 | `name`                          | `string`         |    -     | -                                  | -       | Used as HTML `name` property for each input field. Each input field name will have the currency as a suffix (`${namePrefix}.${lang}`), e.g. `foo.en`                                                               |
-| `value`                         | `object`         |    ✅    | -                                  | -       | Values to use. Keyed by currency, the values are the actual values, e.g. `{ USD: {currencyCode: 'USD', amount: '12.22'}, EUR: {currencyCode: 'EUR', amount: '41.44'} }`                                            |
+| `value`                         | `object`         |    ✅    | -                                  | -       | Values to use. Keyed by currency, the values are the money values, e.g. `{ USD: {currencyCode: 'USD', amount: '12.22'}, EUR: {currencyCode: 'EUR', amount: '41.44'} }`                                             |
 | `onChange`                      | `function`       |    ✅    | -                                  | -       | Gets called when any input is changed. Is called with the change event of the changed input.                                                                                                                       |
 | `selectedCurrency`              | `string`         |    ✅    | -                                  | -       | Specifies which currency will be shown in case the `LocalizedMoneyInput` is collapsed.                                                                                                                             |
 | `onBlur`                        | `function`       |    -     | -                                  | -       | Called when any field is blurred. Is called with the `event` of that field.                                                                                                                                        |
@@ -174,11 +174,11 @@ Here are examples of `centPrecision` and `highPrecision` prices.
 
 ##### `LocalizedMoneyInput.parseMoneyValues`
 
-The `parseMoneyValues` function will turn a [`MoneyValue`](https://docs.commercetools.com/http-api-types#money) into a value the LocalizedMoneyInput component can handle `({ [currencyCode]: {currencyCode: [currencyCode], amount: [amount]} })`.
+The `parseMoneyValues` function will turn a [`MoneyValue`](https://docs.commercetools.com/http-api-types#money) into a value the LocalizedMoneyInput component can handle `({ [currencyCode]: {currencyCode, amount} })`.
 
 ##### `LocalizedMoneyInput.getEmptyCurrencies`
 
-The `getEmptyCurrencies` function will return array of crrencies that don't have amount .
+The `getEmptyCurrencies` function will return array of currencies that don't have amount .
 
 ```js
 LocalizedMoneyInput.getEmptyCurrencies({

--- a/src/components/inputs/localized-money-input/localized-money-input.js
+++ b/src/components/inputs/localized-money-input/localized-money-input.js
@@ -117,7 +117,7 @@ export class LocalizedMoneyInput extends React.Component {
         amount: PropTypes.string.isRequired,
         currencyCode: PropTypes.string.isRequired,
       })
-    ),
+    ).isRequired,
     onChange: PropTypes.func,
     selectedCurrency: PropTypes.string.isRequired,
     onBlur: PropTypes.func,
@@ -159,9 +159,7 @@ export class LocalizedMoneyInput extends React.Component {
   };
 
   static convertToMoneyValues = values =>
-    Object.keys(values).map(currencyCode =>
-      MoneyInput.convertToMoneyValue(values[currencyCode])
-    );
+    Object.values(values).map(value => MoneyInput.convertToMoneyValue(value));
 
   static parseMoneyValues = (moneyValues = [], locale) =>
     moneyValues
@@ -175,14 +173,10 @@ export class LocalizedMoneyInput extends React.Component {
       );
 
   static getHighPrecisionCurrencies = values =>
-    Object.keys(values).filter(currency =>
-      MoneyInput.isHighPrecision(values[currency])
-    );
+    Object.values(values).filter(value => MoneyInput.isHighPrecision(value));
 
   static getEmptyCurrencies = values =>
-    Object.keys(values).filter(currency =>
-      MoneyInput.isEmpty(values[currency])
-    );
+    Object.values(values).filter(value => MoneyInput.isEmpty(value));
 
   state = {
     // This state is used to show/hide the remaining currencies

--- a/src/components/inputs/localized-money-input/localized-money-input.js
+++ b/src/components/inputs/localized-money-input/localized-money-input.js
@@ -173,10 +173,14 @@ export class LocalizedMoneyInput extends React.Component {
       );
 
   static getHighPrecisionCurrencies = values =>
-    Object.values(values).filter(value => MoneyInput.isHighPrecision(value));
+    Object.keys(values).filter(currencyCode =>
+      MoneyInput.isHighPrecision(values[currencyCode])
+    );
 
   static getEmptyCurrencies = values =>
-    Object.values(values).filter(value => MoneyInput.isEmpty(value));
+    Object.keys(values).filter(currencyCode =>
+      MoneyInput.isEmpty(values[currencyCode])
+    );
 
   state = {
     // This state is used to show/hide the remaining currencies

--- a/src/components/inputs/localized-money-input/localized-money-input.js
+++ b/src/components/inputs/localized-money-input/localized-money-input.js
@@ -67,6 +67,15 @@ class LocalizedInput extends React.Component {
     //
     // eslint-disable-next-line no-param-reassign
     event.target.currency = this.props.currency;
+
+    // We manipulate the event to remove any characters after the currencyCode.
+    // This is for use by Formik as it expects the input name to be of the form:
+    // "price.EUR"
+    // But the onChange from the MoneyInput produces an event with name of the form:
+    // "price.EUR.amount"
+    //
+    // eslint-disable-next-line no-param-reassign
+    event.target.name = event.target.name.replace(/(.*)(\..*)$/, '$1');
     this.props.onChange(event);
   };
 

--- a/src/components/inputs/localized-money-input/localized-money-input.spec.js
+++ b/src/components/inputs/localized-money-input/localized-money-input.spec.js
@@ -9,10 +9,6 @@ class TestComponent extends React.Component {
   static displayName = 'TestComponent';
   static propTypes = {
     id: PropTypes.string,
-<<<<<<< HEAD
-    value: PropTypes.objectOf(PropTypes.string).isRequired,
-    handleChange: PropTypes.func,
-=======
     value: PropTypes.objectOf(
       PropTypes.shape({
         amount: PropTypes.string.isRequired,
@@ -20,7 +16,6 @@ class TestComponent extends React.Component {
       })
     ),
     onChange: PropTypes.func,
->>>>>>> fix(localizedmoneyinput): value set to object of {amount,currencyCode}
     selectedCurrency: PropTypes.string.isRequired,
   };
   static defaultProps = {
@@ -235,33 +230,23 @@ describe('when placeholders are provided', () => {
 
 describe('when every field has an error', () => {
   const errors = {
-    USD: {
-      missing: true,
-    },
-    CAD: {
-      missing: true,
-    },
-  };
-  const errorMessages = {
     USD: 'A value is required',
     CAD: 'A value is required',
   };
-  it('should open all fields and render errors', () => {
+  it('should be open all fields and render errors', () => {
     const { getByText } = renderLocalizedMoneyInput({
       name: 'foo',
       errors,
     });
-    expect(getByText(errorMessages.USD)).toBeInTheDocument();
-    expect(getByText(errorMessages.CAD)).toBeInTheDocument();
+    expect(getByText(errors.USD)).toBeInTheDocument();
+    expect(getByText(errors.CAD)).toBeInTheDocument();
   });
 });
 
 describe('when the error is not on the selected currency', () => {
-  it('should open all fields and render errors', () => {
+  it('should be open all fields and render errors', () => {
     const errors = {
-      USD: {
-        missing: true,
-      },
+      USD: 'A value is required',
     };
     const { getByText, getByLabelText } = renderLocalizedMoneyInput({
       selectedCurrency: 'CAD',
@@ -280,9 +265,7 @@ describe('when the error is not on the selected currency', () => {
 describe('when the error is on the selected currency', () => {
   it('should display the error without expanding', () => {
     const errors = {
-      CAD: {
-        missing: true,
-      },
+      CAD: 'A value is required',
     };
     const {
       queryByLabelText,
@@ -372,7 +355,10 @@ describe('LocalizedMoneyInput.convertToMoneyValues', () => {
       ]);
       expect(
         LocalizedMoneyInput.convertToMoneyValues({
-          EUR: { currencyCode: 'EUR', amount: '' },
+          EUR: {
+            currencyCode: 'EUR',
+            amount: '',
+          },
         })
       ).toEqual([null]);
     });

--- a/src/components/inputs/localized-money-input/localized-money-input.spec.js
+++ b/src/components/inputs/localized-money-input/localized-money-input.spec.js
@@ -9,17 +9,36 @@ class TestComponent extends React.Component {
   static displayName = 'TestComponent';
   static propTypes = {
     id: PropTypes.string,
+<<<<<<< HEAD
     value: PropTypes.objectOf(PropTypes.string).isRequired,
     handleChange: PropTypes.func,
+=======
+    value: PropTypes.objectOf(
+      PropTypes.shape({
+        amount: PropTypes.string.isRequired,
+        currencyCode: PropTypes.string.isRequired,
+      })
+    ),
+    onChange: PropTypes.func,
+>>>>>>> fix(localizedmoneyinput): value set to object of {amount,currencyCode}
     selectedCurrency: PropTypes.string.isRequired,
   };
   static defaultProps = {
     id: 'some-id',
     name: 'some-name',
     value: {
-      EUR: '12.77',
-      USD: '13.55',
-      CAD: '19.82',
+      EUR: {
+        currencyCode: 'EUR',
+        amount: '12.77',
+      },
+      USD: {
+        currencyCode: 'USD',
+        amount: '13.55',
+      },
+      CAD: {
+        currencyCode: 'CAD',
+        amount: '19.82',
+      },
     },
     selectedCurrency: 'CAD',
     intl: { formatMessage: message => message.id },
@@ -35,10 +54,13 @@ class TestComponent extends React.Component {
     this.setState({
       value: {
         ...this.state.value,
-        [event.target.currency]: event.target.value,
+        [event.target.currency]: {
+          currencyCode: event.target.currency,
+          amount: event.target.value,
+        },
       },
     });
-    if (this.props.handleChange) this.props.handleChange(event);
+    if (this.props.onChange) this.props.onChange(event);
   };
 
   render() {
@@ -213,8 +235,12 @@ describe('when placeholders are provided', () => {
 
 describe('when every field has an error', () => {
   const errors = {
-    USD: 'A value is required',
-    CAD: 'A value is required',
+    USD: {
+      missing: true,
+    },
+    CAD: {
+      missing: true,
+    },
   };
   it('should be open all fields and render errors', () => {
     const { getByText } = renderLocalizedMoneyInput({
@@ -229,7 +255,9 @@ describe('when every field has an error', () => {
 describe('when the error is not on the selected currency', () => {
   it('should be open all fields and render errors', () => {
     const errors = {
-      USD: 'A value is required',
+      USD: {
+        missing: true,
+      },
     };
     const { getByText, getByLabelText } = renderLocalizedMoneyInput({
       selectedCurrency: 'CAD',
@@ -248,7 +276,9 @@ describe('when the error is not on the selected currency', () => {
 describe('when the error is on the selected currency', () => {
   it('should display the error without expanding', () => {
     const errors = {
-      CAD: 'A value is required',
+      CAD: {
+        missing: true,
+      },
     };
     const {
       queryByLabelText,
@@ -273,9 +303,18 @@ describe('LocalizedMoneyInput.convertToMoneyValues', () => {
     it('should return an error for this currency', () => {
       expect(
         LocalizedMoneyInput.convertToMoneyValues({
-          EUR: '9',
-          foo: '1',
-          USD: '12',
+          EUR: {
+            currencyCode: 'EUR',
+            amount: '9',
+          },
+          foo: {
+            currencyCode: 'foo',
+            amount: '1',
+          },
+          USD: {
+            currencyCode: 'USD',
+            amount: '12',
+          },
         })
       ).toEqual([
         {
@@ -299,9 +338,18 @@ describe('LocalizedMoneyInput.convertToMoneyValues', () => {
     it('should return an error for this currency', () => {
       expect(
         LocalizedMoneyInput.convertToMoneyValues({
-          USD: '21',
-          EUR: '',
-          EGP: '9',
+          USD: {
+            currencyCode: 'USD',
+            amount: '21',
+          },
+          EUR: {
+            currencyCode: 'EUR',
+            amount: '',
+          },
+          EGP: {
+            currencyCode: 'EGP',
+            amount: '9',
+          },
         })
       ).toEqual([
         {
@@ -328,7 +376,10 @@ describe('LocalizedMoneyInput.convertToMoneyValues', () => {
     it('should return an error for this currency', () => {
       expect(
         LocalizedMoneyInput.convertToMoneyValues({
-          EUR: 'foo',
+          EUR: {
+            currencyCode: 'EUR',
+            amount: 'foo',
+          },
         })
       ).toEqual([null]);
     });
@@ -340,7 +391,10 @@ describe('LocalizedMoneyInput.convertToMoneyValues', () => {
     it('should treat it as a decimal separator', () => {
       expect(
         LocalizedMoneyInput.convertToMoneyValues({
-          EUR: '1.2',
+          EUR: {
+            currencyCode: 'EUR',
+            amount: '1.2',
+          },
         })
       ).toEqual([
         {
@@ -353,7 +407,10 @@ describe('LocalizedMoneyInput.convertToMoneyValues', () => {
 
       expect(
         LocalizedMoneyInput.convertToMoneyValues({
-          KWD: '1.234',
+          KWD: {
+            currencyCode: 'KWD',
+            amount: '1.234',
+          },
         })
       ).toEqual([
         {
@@ -370,7 +427,10 @@ describe('LocalizedMoneyInput.convertToMoneyValues', () => {
     it('should treat it as a decimal separator', () => {
       expect(
         LocalizedMoneyInput.convertToMoneyValues({
-          EUR: '2.49',
+          EUR: {
+            currencyCode: 'EUR',
+            amount: '2.49',
+          },
         })
       ).toEqual([
         {
@@ -385,7 +445,10 @@ describe('LocalizedMoneyInput.convertToMoneyValues', () => {
       // number of. Cutting it of would result in an incorrect 239998.
       expect(
         LocalizedMoneyInput.convertToMoneyValues({
-          EUR: '2399.99',
+          EUR: {
+            currencyCode: 'EUR',
+            amount: '2399.99',
+          },
         })
       ).toEqual([
         {
@@ -402,7 +465,10 @@ describe('LocalizedMoneyInput.convertToMoneyValues', () => {
     it('should return a money value of type "highPrecision"', () => {
       expect(
         LocalizedMoneyInput.convertToMoneyValues({
-          EUR: '1.234',
+          EUR: {
+            currencyCode: 'EUR',
+            amount: '1.234',
+          },
         })
       ).toEqual([
         {
@@ -516,7 +582,12 @@ describe('LocalizedMoneyInput.parseMoneyValues', () => {
           ],
           'en'
         )
-      ).toEqual({ EUR: '12.34' });
+      ).toEqual({
+        EUR: {
+          currencyCode: 'EUR',
+          amount: '12.34',
+        },
+      });
     });
   });
   describe('when called with a full, valid centPrecision price', () => {
@@ -533,7 +604,12 @@ describe('LocalizedMoneyInput.parseMoneyValues', () => {
           ],
           'en'
         )
-      ).toEqual({ EUR: '12.34' });
+      ).toEqual({
+        EUR: {
+          currencyCode: 'EUR',
+          amount: '12.34',
+        },
+      });
     });
   });
   describe('when called with a minimal highPrecision price', () => {
@@ -550,7 +626,12 @@ describe('LocalizedMoneyInput.parseMoneyValues', () => {
           ],
           'en'
         )
-      ).toEqual({ EUR: '12.345' });
+      ).toEqual({
+        EUR: {
+          currencyCode: 'EUR',
+          amount: '12.345',
+        },
+      });
     });
   });
   describe('when called with a full highPrecision price', () => {
@@ -568,7 +649,12 @@ describe('LocalizedMoneyInput.parseMoneyValues', () => {
           ],
           'en'
         )
-      ).toEqual({ EUR: '12.345' });
+      ).toEqual({
+        EUR: {
+          currencyCode: 'EUR',
+          amount: '12.345',
+        },
+      });
     });
   });
 });
@@ -577,7 +663,9 @@ describe('LocalizedMoneyInput.getHighPrecisionCurrencies', () => {
   describe('when called with a regular precision money value', () => {
     it('should return empty array', () => {
       expect(
-        LocalizedMoneyInput.getHighPrecisionCurrencies({ EUR: '2.01' })
+        LocalizedMoneyInput.getHighPrecisionCurrencies({
+          EUR: { currencyCode: 'EUR', amount: '2.01' },
+        })
       ).toMatchObject([]);
     });
   });
@@ -585,9 +673,18 @@ describe('LocalizedMoneyInput.getHighPrecisionCurrencies', () => {
     it("should return the currencies that don't have high precision value", () => {
       expect(
         LocalizedMoneyInput.getHighPrecisionCurrencies({
-          EUR: '13.44',
-          USD: '2.001',
-          EGP: '12.00',
+          EUR: {
+            currencyCode: 'EUR',
+            amount: '13.44',
+          },
+          USD: {
+            currencyCode: 'USD',
+            amount: '2.001',
+          },
+          EGP: {
+            currencyCode: 'EGP',
+            amount: '12.00',
+          },
         })
       ).toMatchObject(['USD']);
     });
@@ -607,14 +704,32 @@ describe('LocalizedMoneyInput.getEmptyCurrencies', () => {
   describe('when value is filled out', () => {
     it('should return empty array', () => {
       expect(
-        LocalizedMoneyInput.getEmptyCurrencies({ EUR: '5.22', USD: '31.88' })
+        LocalizedMoneyInput.getEmptyCurrencies({
+          EUR: {
+            currencyCode: 'EUR',
+            amount: '5.22',
+          },
+          USD: {
+            currencyCode: 'USD',
+            amount: '31.88',
+          },
+        })
       ).toHaveLength(0);
     });
   });
   describe('when value is empty', () => {
     it("should return the currencies that don't have value", () => {
       expect(
-        LocalizedMoneyInput.getEmptyCurrencies({ EUR: '', USD: '31.88' })
+        LocalizedMoneyInput.getEmptyCurrencies({
+          EUR: {
+            currencyCode: 'EUR',
+            amount: '',
+          },
+          USD: {
+            currencyCode: 'USD',
+            amount: '31.88',
+          },
+        })
       ).toEqual(expect.arrayContaining(['EUR']));
     });
   });

--- a/src/components/inputs/localized-money-input/localized-money-input.spec.js
+++ b/src/components/inputs/localized-money-input/localized-money-input.spec.js
@@ -242,18 +242,22 @@ describe('when every field has an error', () => {
       missing: true,
     },
   };
-  it('should be open all fields and render errors', () => {
+  const errorMessages = {
+    USD: 'A value is required',
+    CAD: 'A value is required',
+  };
+  it('should open all fields and render errors', () => {
     const { getByText } = renderLocalizedMoneyInput({
       name: 'foo',
       errors,
     });
-    expect(getByText(errors.USD)).toBeInTheDocument();
-    expect(getByText(errors.CAD)).toBeInTheDocument();
+    expect(getByText(errorMessages.USD)).toBeInTheDocument();
+    expect(getByText(errorMessages.CAD)).toBeInTheDocument();
   });
 });
 
 describe('when the error is not on the selected currency', () => {
-  it('should be open all fields and render errors', () => {
+  it('should open all fields and render errors', () => {
     const errors = {
       USD: {
         missing: true,
@@ -367,7 +371,9 @@ describe('LocalizedMoneyInput.convertToMoneyValues', () => {
         },
       ]);
       expect(
-        LocalizedMoneyInput.convertToMoneyValues({ EUR: undefined })
+        LocalizedMoneyInput.convertToMoneyValues({
+          EUR: { currencyCode: 'EUR', amount: '' },
+        })
       ).toEqual([null]);
     });
   });

--- a/src/components/inputs/localized-money-input/localized-money-input.story.js
+++ b/src/components/inputs/localized-money-input/localized-money-input.story.js
@@ -46,7 +46,10 @@ storiesOf('Components|Inputs', module)
                 action('onChange')(event);
                 onChange({
                   ...value,
-                  [event.target.currency]: event.target.value,
+                  [event.target.currency]: {
+                    currencyCode: event.target.currency,
+                    amount: event.target.value,
+                  },
                 });
               }}
               selectedCurrency={select(

--- a/src/components/inputs/localized-money-input/localized-money-input.story.js
+++ b/src/components/inputs/localized-money-input/localized-money-input.story.js
@@ -31,7 +31,11 @@ storiesOf('Components|Inputs', module)
     return (
       <Section>
         <Value
-          defaultValue={{ EUR: '', USD: '', EGP: '' }}
+          defaultValue={{
+            EUR: { currencyCode: 'EUR', amount: '' },
+            USD: { currencyCode: 'USD', amount: '' },
+            EGP: { currencyCode: 'EGP', amount: '' },
+          }}
           render={(value, onChange) => (
             <LocalizedMoneyInput
               key={key}

--- a/src/components/inputs/localized-money-input/localized-money-input.visualroute.js
+++ b/src/components/inputs/localized-money-input/localized-money-input.visualroute.js
@@ -3,9 +3,18 @@ import { LocalizedMoneyInput, ErrorMessage, WarningMessage } from 'ui-kit';
 import { Suite, Spec } from '../../../../test/percy';
 
 const value = {
-  EUR: '12.77',
-  USD: '13.55',
-  CAD: '19.82',
+  EUR: {
+    currencyCode: 'EUR',
+    amount: '12.77',
+  },
+  USD: {
+    currencyCode: 'USD',
+    amount: '13.55',
+  },
+  CAD: {
+    currencyCode: 'CAD',
+    amount: '19.82',
+  },
 };
 
 export const routePath = '/localized-money-input';


### PR DESCRIPTION
#### Summary
- Re-define component values as object of `{amount, currencyCode}`

#### Description
This PR re-defines the `values` prop expected by the `LocalizedMoneyInput` as an object of `{amount, currencyCode}`. This PR changes the required values 
**from**:
```
{EUR: '12.00', USD: '25.00'}
```
**to**:
```
{EUR: {
  amount: '12.00',
  currencyCode: 'EUR',
},
USD: {
  amount: '25.00',
  currencyCode: 'USD',
}}
```
This is required to keep the change event signature consistent with the event from the contained `MoneyInput` components.

#### Visual diffs
| Before  | After   |
| :------ | :------ |
|![localized-money-input-onchange-before](https://user-images.githubusercontent.com/3065138/50902344-e67a7100-141a-11e9-8467-143cdc27116c.gif)|![localized-money-input-onchange-v2-after](https://user-images.githubusercontent.com/3065138/50902355-ef6b4280-141a-11e9-92c3-5ab31d55857c.gif)|
