### PR TITLE
fix(time-input): call onChange with generated ID if none passed

### DIFF
--- a/src/components/inputs/time-input/time-input.js
+++ b/src/components/inputs/time-input/time-input.js
@@ -82,7 +82,7 @@ export class TimeInput extends React.Component {
 
   emitChange = value => {
     const event = {
-      target: { id: this.props.id, name: this.props.name, value },
+      target: { id: this.state.id, name: this.props.name, value },
     };
     this.props.onChange(event);
   };

--- a/src/components/inputs/time-input/time-input.spec.js
+++ b/src/components/inputs/time-input/time-input.spec.js
@@ -119,7 +119,11 @@ describe('TimeInput', () => {
     container.querySelector('input').blur();
     expect(container.querySelector('input')).not.toHaveFocus();
     expect(onChange).toHaveBeenCalledWith({
-      target: { id: undefined, name: undefined, value: '2:03 AM' },
+      target: {
+        id: expect.stringMatching(/^time-input-/i),
+        name: undefined,
+        value: '2:03 AM',
+      },
     });
   });
 
@@ -136,7 +140,7 @@ describe('TimeInput', () => {
     expect(container.querySelector('input')).not.toHaveFocus();
     expect(onChange).toHaveBeenCalledWith({
       target: {
-        id: undefined,
+        id: expect.stringMatching(/^time-input-/i),
         name: undefined,
         // There is a limitation in node where the underlying Intl API used by
         // react-intl does not contain the full locale data and  falls back to


### PR DESCRIPTION
#### Summary

If `TimeInput` is used without an `id` prop, we should call onChange with the generated sequential id.
