### PR TITLE
chore: have ci run lint

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -78,7 +78,7 @@ rules:
     'import/no-named-as-default': 0
     # ui-kit is a mapped module in bundle tests, so it will not be found
     # We exclude it from the checks
-    'import/no-unresolved': [2, { ignore: ['^ui-kit$'] }]
+    'import/no-unresolved': [2, { ignore: ['ui-kit'] }]
     'import/first': 0
     'import/order': 2
     'no-restricted-globals': ['error', 'find', 'name', 'location']

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
   # instruct bash to quit if there is a non zero response code (error)
   # https://github.com/commercetools/ui-kit/pull/284
   - set -e
+  - yarn run jest --projects jest.eslint.config.js --maxWorkers=4 --reporters jest-silent-reporter
   - yarn run jest --projects jest.test.config.js --maxWorkers=4 --reporters jest-silent-reporter
   # the jest.bundle.config.js tests run on the bundle,
   # so we need to build it first

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ script:
   # instruct bash to quit if there is a non zero response code (error)
   # https://github.com/commercetools/ui-kit/pull/284
   - set -e
-  - yarn run jest --projects jest.eslint.config.js --maxWorkers=4 --reporters jest-silent-reporter
-  - yarn run jest --projects jest.test.config.js --maxWorkers=4 --reporters jest-silent-reporter
+  - yarn run jest --projects jest.test.config.js jest.stylelint.config.js jest.eslint.config.js --maxWorkers=4 --reporters jest-silent-reporter
   # the jest.bundle.config.js tests run on the bundle,
   # so we need to build it first
   - yarn build


### PR DESCRIPTION
#### Summary

Currently, we **aren't** running our linters on CI.

We had some lint errors make their way into master awhile ago, and they had to be fixed in #423.

#### Summary

Make travis run our linters again.