### PR TITLE
chore: update vrt tests for icons

### DIFF
--- a/src/components/icons/icons.visualroute.js
+++ b/src/components/icons/icons.visualroute.js
@@ -1,11 +1,28 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import { Switch, Route } from 'react-router-dom';
 import * as UIKit from 'ui-kit';
 import { Suite, Spec } from '../../../test/percy';
 
-const Inline = styled.div`
+const IconList = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+`;
+
+const IconItem = styled.div`
+  padding: 16px;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+`;
+
+const IconContainer = styled.div`
+  margin: 8px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: ${props => (props.big ? '50px' : '25px')};
 `;
 
 const icons = Object.keys(UIKit).filter(thing => thing.endsWith('Icon'));
@@ -24,23 +41,41 @@ const themes = [
 
 export const routePath = '/icons';
 
+const renderIcon = (iconName, theme, size) => {
+  const Icon = UIKit[iconName];
+  return (
+    <IconItem key={iconName}>
+      <IconContainer big={size === 'scale'}>
+        <Icon theme={theme} size={size} />
+      </IconContainer>
+      <UIKit.Text.Body>{iconName}</UIKit.Text.Body>
+    </IconItem>
+  );
+};
+
 export const component = () => (
-  <Suite>
-    {icons.map(iconName => {
-      const Icon = UIKit[iconName];
-      return sizes.map(size => (
-        <Spec
-          key={`${iconName}-${size}`}
-          label={`${iconName} - ${size}`}
-          omitPropsList
-        >
-          <Inline>
-            {themes.map(theme => (
-              <Icon key={theme} size={size} theme={theme} />
+  <Switch>
+    {themes.map(theme => (
+      <Route
+        key={theme}
+        path={`${routePath}/${theme}`}
+        exact
+        render={() => (
+          <Suite>
+            {sizes.map(size => (
+              <Spec
+                key={size}
+                label={`All Icons - Theme: ${theme} / Size: ${size}`}
+                omitPropsList
+              >
+                <IconList>
+                  {icons.map(iconName => renderIcon(iconName, theme, size))}
+                </IconList>
+              </Spec>
             ))}
-          </Inline>
-        </Spec>
-      ));
-    })}
-  </Suite>
+          </Suite>
+        )}
+      />
+    ))}
+  </Switch>
 );

--- a/src/components/icons/icons.visualspec.js
+++ b/src/components/icons/icons.visualspec.js
@@ -1,12 +1,27 @@
 import { percySnapshot } from '@percy/puppeteer';
 
-describe('Icons', () => {
-  beforeAll(async () => {
-    await page.goto(`${HOST}/icons`);
-  });
+// let's go wide, to fit more icons.
+const snapshot = (page, description) =>
+  percySnapshot(page, description, { widths: [1600] });
 
-  it('Default', async () => {
-    await expect(page).toMatch('AddBoldIcon');
-    await percySnapshot(page, 'Icons');
-  });
+const capitalize = s => s[0].toUpperCase() + s.slice(1);
+const themes = [
+  'black',
+  'grey',
+  'white',
+  'blue',
+  'green',
+  'green-light',
+  'orange',
+  'red',
+];
+
+describe('Icons', () => {
+  themes.map(theme =>
+    it(capitalize(theme), async () => {
+      await page.goto(`${HOST}/icons/${theme}`);
+      await expect(page).toMatch(theme);
+      await snapshot(page, `Icons - Theme: ${theme}`);
+    })
+  );
 });


### PR DESCRIPTION
#### Summary

Currently we are taking one percy snapshot for all of our icons in all of their states, leading to a webpage with a ridiculous height, and when percy snapshots it, it gets cut off.

#### Approach

Take one snapshot per `theme`. This way we use 8 snapshots for icons, but we can ensure that all icons are included in the snapshot.

Closes #437 