### PR TITLE
fix(money-input): avoid messing with floating point numbers

### DIFF
--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -221,7 +221,18 @@ export const createMoneyValue = (currencyCode, rawAmount) => {
       currencyCode,
       centAmount,
       preciseAmount: parseInt(
-        amountAsNumber * 10 ** fractionDigitsOfAmount,
+        // Here we need to convert  a number like 8.066652 to its centamount
+        // We could do that by multiplying it with 10 ** number-of-fraction-digits
+        // but then we'll run into problems with JavaScript's floating point
+        // number precision and end up with 8066651.9999999, and then parseInt
+        // cuts off the remainder.
+        // So instead of using maths to convert the number, we just replace
+        // the dot inside the number which does the same thing.
+        // We don't need to replace "," as well, as numbers always us a dot
+        // when converted using String().
+        //
+        // The mathematical way: amountAsNumber * 10 ** fractionDigitsOfAmount,
+        String(amountAsNumber).replace('.', ''),
         10
       ),
       fractionDigits: fractionDigitsOfAmount,

--- a/src/components/inputs/money-input/money-input.spec.js
+++ b/src/components/inputs/money-input/money-input.spec.js
@@ -160,6 +160,19 @@ describe('MoneyInput.convertToMoneyValue', () => {
         fractionDigits: 2,
       });
 
+      expect(
+        MoneyInput.convertToMoneyValue({
+          currencyCode: 'EUR',
+          amount: '8.066652',
+        })
+      ).toEqual({
+        type: 'highPrecision',
+        currencyCode: 'EUR',
+        centAmount: 807,
+        preciseAmount: 8066652,
+        fractionDigits: 6,
+      });
+
       // This test ensures that rounding is used instead of just cutting the
       // number of. Cutting it of would result in an incorrect 239998.
       expect(


### PR DESCRIPTION
### Problem

Certain values get rounded on blur:

![moneymoneymoney](https://user-images.githubusercontent.com/1765075/51389683-65635e00-1b2d-11e9-8629-070a79314dce.gif)

### Problem

We run into JavaScript floating point number problems with our current calculations.

We are executing `amountAsNumber * 10 ** fractionDigitsOfAmount` which boils down to e.g. `8.066652 * 10 ** 6` for a high-precision price. However this is where we're running into floating point problems:

![image](https://user-images.githubusercontent.com/1765075/51389983-41ece300-1b2e-11e9-8bb7-dc0acd4d5393.png)

The function above converts `8.066652` into `8066652`

### Solution

We avoid floating point math problems by using string manipulation to get the `preciseAmount` instead.

---

Affects: `MoneyInput`, `MoneyField`, `LocalizedMoneyInput`, `LocalizedMoneyField`