### PR TITLE
Remove some experimental babel features

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -97,5 +97,3 @@ rules:
   'prefer-promise-reject-errors': 'warn'
   'react/jsx-no-target-blank': 0
   'lines-between-class-members': 0
-  # NOTE: The regular rule does not support do-expressions. The equivalent rule of babel does.
-  'no-unused-expressions': 0

--- a/examples/form-inputs.example.story.js
+++ b/examples/form-inputs.example.story.js
@@ -474,11 +474,13 @@ class ProductForm extends React.Component {
             }
           />
           {MoneyInput.isTouched(this.props.formik.touched.price) &&
-            this.props.formik.errors.price?.missing && (
+            this.props.formik.errors.price &&
+            this.props.formik.errors.price.missing && (
               <ErrorMessage>Missing price</ErrorMessage>
             )}
           {MoneyInput.isTouched(this.props.formik.touched.price) &&
-            this.props.formik.errors.price?.unsupportedHighPrecision && (
+            this.props.formik.errors.price &&
+            this.props.formik.errors.price.unsupportedHighPrecision && (
               <ErrorMessage>
                 This value is a high precision value. High precision pricing is
                 not supported for products.

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
   "devDependencies": {
     "@babel/core": "7.2.2",
     "@babel/plugin-proposal-class-properties": "7.2.3",
-    "@babel/plugin-proposal-do-expressions": "7.2.0",
     "@babel/plugin-proposal-export-default-from": "7.2.0",
     "@babel/plugin-proposal-export-namespace-from": "7.2.0",
     "@babel/plugin-proposal-object-rest-spread": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "@babel/plugin-proposal-export-default-from": "7.2.0",
     "@babel/plugin-proposal-export-namespace-from": "7.2.0",
     "@babel/plugin-proposal-object-rest-spread": "7.2.0",
-    "@babel/plugin-proposal-optional-chaining": "7.2.0",
     "@babel/plugin-transform-destructuring": "7.2.0",
     "@babel/plugin-transform-react-constant-elements": "7.2.0",
     "@babel/plugin-transform-runtime": "7.2.0",

--- a/scripts/get-babel-preset.js
+++ b/scripts/get-babel-preset.js
@@ -116,7 +116,6 @@ module.exports = function getBabelPresets() {
           async: false,
         },
       ],
-      require('@babel/plugin-proposal-optional-chaining').default,
       // Adds syntax support for import()
       require('@babel/plugin-syntax-dynamic-import').default,
       isEnvTest &&

--- a/scripts/get-babel-preset.js
+++ b/scripts/get-babel-preset.js
@@ -116,7 +116,6 @@ module.exports = function getBabelPresets() {
           async: false,
         },
       ],
-      require('@babel/plugin-proposal-do-expressions').default,
       require('@babel/plugin-proposal-optional-chaining').default,
       // Adds syntax support for import()
       require('@babel/plugin-syntax-dynamic-import').default,

--- a/src/components/avatar/avatar.js
+++ b/src/components/avatar/avatar.js
@@ -26,10 +26,10 @@ const getInitialsFromName = ({ firstName = '', lastName = '' }) =>
 const createGravatarImgUrl = (md5Hash, size) =>
   `https://www.gravatar.com/avatar/${md5Hash}?s=${size}&d=blank`;
 
-const getSizeInPx = size => do {
-  if (size === 'l') 100;
-  else if (size === 'm') 48;
-  else 26;
+const getSizeInPx = size => {
+  if (size === 'l') return 100;
+  if (size === 'm') return 48;
+  return 26;
 };
 
 const GravatarImg = props => (

--- a/src/components/collapsible-motion/collapsible-motion.js
+++ b/src/components/collapsible-motion/collapsible-motion.js
@@ -30,17 +30,14 @@ export class ToggleAnimation extends React.Component {
       ? { height: 'auto' }
       : { height: 0, overflow: 'hidden' };
 
-    const animation = do {
-      if (props.isOpen !== state.isOpen) {
-        if (props.isOpen) {
-          createOpeningAnimation(state.fullHeight);
-        } else {
-          createClosingAnimation(state.fullHeight);
-        }
+    let animation = null;
+    if (props.isOpen !== state.isOpen) {
+      if (props.isOpen) {
+        animation = createOpeningAnimation(state.fullHeight);
       } else {
-        null;
+        animation = createClosingAnimation(state.fullHeight);
       }
-    };
+    }
 
     return {
       isOpen: props.isOpen,
@@ -132,6 +129,7 @@ class CollapsibleMotion extends React.PureComponent {
 
                   if (animation) {
                     // By calling `css`, emotion injects the required CSS into the document head.
+                    // eslint-disable-next-line no-unused-expressions
                     css`
                       animation: ${animation} 200ms forwards;
                     `;

--- a/src/components/fields/async-creatable-select-field/async-creatable-select-field.js
+++ b/src/components/fields/async-creatable-select-field/async-creatable-select-field.js
@@ -5,11 +5,9 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import AsyncCreatableSelectInput from '../../inputs/async-creatable-select-input';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import FieldErrors from '../../field-errors';
-
-const sequentialId = createSequentialId('async-creatable-select-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 
@@ -116,11 +114,7 @@ export default class SelectField extends React.Component {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    },
+    id: getFieldId(props, state, 'async-creatable-select-field-'),
   });
 
   render() {

--- a/src/components/fields/async-select-field/async-select-field.js
+++ b/src/components/fields/async-select-field/async-select-field.js
@@ -5,11 +5,9 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import AsyncSelectInput from '../../inputs/async-select-input';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import FieldErrors from '../../field-errors';
-
-const sequentialId = createSequentialId('async-select-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 
@@ -98,11 +96,7 @@ export default class AsyncSelectField extends React.Component {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    },
+    id: getFieldId(props, state, 'async-select-field-'),
   });
 
   render() {

--- a/src/components/fields/creatable-select-field/creatable-select-field.js
+++ b/src/components/fields/creatable-select-field/creatable-select-field.js
@@ -5,11 +5,9 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import CreatableSelectInput from '../../inputs/creatable-select-input';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import FieldErrors from '../../field-errors';
-
-const sequentialId = createSequentialId('creatable-select-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 
@@ -104,11 +102,7 @@ export default class SelectField extends React.Component {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    },
+    id: getFieldId(props, state, 'creatable-select-field-'),
   });
 
   render() {

--- a/src/components/fields/date-field/date-field.js
+++ b/src/components/fields/date-field/date-field.js
@@ -5,11 +5,9 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import DateInput from '../../inputs/date-input';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import FieldErrors from '../../field-errors';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
-
-const sequentialId = createSequentialId('date-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 
@@ -59,11 +57,7 @@ class DateField extends React.Component {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    },
+    id: getFieldId(props, state, 'date-field-'),
   });
 
   render() {

--- a/src/components/fields/date-range-field/date-range-field.js
+++ b/src/components/fields/date-range-field/date-range-field.js
@@ -5,11 +5,9 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import DateRangeInput from '../../inputs/date-range-input';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import FieldErrors from '../../field-errors';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
-
-const sequentialId = createSequentialId('date-range-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 
@@ -59,11 +57,7 @@ class DateRangeField extends React.Component {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    },
+    id: getFieldId(props, state, 'date-range-field-'),
   });
 
   render() {

--- a/src/components/fields/date-time-field/date-time-field.js
+++ b/src/components/fields/date-time-field/date-time-field.js
@@ -5,11 +5,9 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import DateTimeInput from '../../inputs/date-time-input';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import FieldErrors from '../../field-errors';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
-
-const sequentialId = createSequentialId('date-time-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 
@@ -60,11 +58,7 @@ class DateTimeField extends React.Component {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    },
+    id: getFieldId(props, state, 'date-time-field-'),
   });
 
   render() {

--- a/src/components/fields/localized-multiline-text-field/localized-multiline-text-field.js
+++ b/src/components/fields/localized-multiline-text-field/localized-multiline-text-field.js
@@ -6,11 +6,9 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import LocalizedMultilineTextInput from '../../inputs/localized-multiline-text-input';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import FieldErrors from '../../field-errors';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
-
-const sequentialId = createSequentialId('localized-multiline-text-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 
@@ -80,11 +78,7 @@ class LocalizedMultilineTextField extends React.Component {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    },
+    id: getFieldId(props, state, 'localized-multiline-text-field-'),
   });
 
   render() {

--- a/src/components/fields/localized-text-field/localized-text-field.js
+++ b/src/components/fields/localized-text-field/localized-text-field.js
@@ -6,11 +6,9 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import LocalizedTextInput from '../../inputs/localized-text-input';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import FieldErrors from '../../field-errors';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
-
-const sequentialId = createSequentialId('localized-text-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 
@@ -79,11 +77,7 @@ class LocalizedTextField extends React.Component {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    },
+    id: getFieldId(props, state, 'localized-text-field-'),
   });
 
   render() {

--- a/src/components/fields/money-field/money-field.js
+++ b/src/components/fields/money-field/money-field.js
@@ -7,14 +7,12 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import MoneyInput from '../../inputs/money-input';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import FieldErrors from '../../field-errors';
 import { VerifiedIcon } from '../../icons';
 import Text from '../../typography/text';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import messages from './messages';
-
-const sequentialId = createSequentialId('money-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 
@@ -85,11 +83,7 @@ class MoneyField extends React.Component {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    },
+    id: getFieldId(props, state, 'money-field-'),
   });
 
   render() {

--- a/src/components/fields/multiline-text-field/multiline-text-field.js
+++ b/src/components/fields/multiline-text-field/multiline-text-field.js
@@ -5,11 +5,9 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import MultilineTextInput from '../../inputs/multiline-text-input';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import FieldErrors from '../../field-errors';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
-
-const sequentialId = createSequentialId('multiline-text-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 
@@ -62,11 +60,7 @@ class MultilineTextField extends React.Component {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    },
+    id: getFieldId(props, state, 'multiline-text-field-'),
   });
 
   render() {

--- a/src/components/fields/number-field/number-field.js
+++ b/src/components/fields/number-field/number-field.js
@@ -6,10 +6,8 @@ import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import FieldErrors from '../../field-errors';
 import NumberInput from '../../inputs/number-input';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
-
-const sequentialId = createSequentialId('number-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 
@@ -64,11 +62,7 @@ class NumberField extends React.Component {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    },
+    id: getFieldId(props, state, 'number-field-'),
   });
 
   render() {

--- a/src/components/fields/password-field/password-field.js
+++ b/src/components/fields/password-field/password-field.js
@@ -5,11 +5,9 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import PasswordInput from '../../inputs/password-input';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import FieldErrors from '../../field-errors';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
-
-const sequentialId = createSequentialId('password-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 
@@ -63,11 +61,7 @@ class PasswordField extends React.Component {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    },
+    id: getFieldId(props, state, 'password-field-'),
   });
 
   render() {

--- a/src/components/fields/select-field/select-field.js
+++ b/src/components/fields/select-field/select-field.js
@@ -5,11 +5,9 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import SelectInput from '../../inputs/select-input';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import FieldErrors from '../../field-errors';
-
-const sequentialId = createSequentialId('select-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 
@@ -91,11 +89,7 @@ export default class SelectField extends React.Component {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    },
+    id: getFieldId(props, state, 'select-field-'),
   });
 
   render() {

--- a/src/components/fields/text-field/text-field.js
+++ b/src/components/fields/text-field/text-field.js
@@ -5,11 +5,9 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import TextInput from '../../inputs/text-input';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import FieldErrors from '../../field-errors';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
-
-const sequentialId = createSequentialId('text-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 
@@ -61,11 +59,7 @@ class TextField extends React.Component {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    },
+    id: getFieldId(props, state, 'text-field-'),
   });
 
   render() {

--- a/src/components/fields/time-field/time-field.js
+++ b/src/components/fields/time-field/time-field.js
@@ -5,11 +5,9 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import TimeInput from '../../inputs/time-input';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import FieldErrors from '../../field-errors';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
-
-const sequentialId = createSequentialId('time-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 
@@ -60,11 +58,7 @@ class TimeField extends React.Component {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    },
+    id: getFieldId(props, state, 'time-field-'),
   });
 
   render() {

--- a/src/components/inputs/checkbox-input/checkbox-input.js
+++ b/src/components/inputs/checkbox-input/checkbox-input.js
@@ -2,13 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import Text from '../../typography/text';
 import Spacings from '../../spacings';
 import Icons from './icons';
 import styles from './checkbox-input.mod.css';
-
-const sequentialId = createSequentialId('checkbox-');
 
 class CheckboxInput extends React.PureComponent {
   static displayName = 'CheckboxInput';
@@ -43,11 +41,7 @@ class CheckboxInput extends React.PureComponent {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    },
+    id: getFieldId(props, state, 'checkbox-'),
   });
 
   render() {

--- a/src/components/inputs/date-input/date-input.js
+++ b/src/components/inputs/date-input/date-input.js
@@ -185,13 +185,11 @@ class DateInput extends React.Component {
               this.props.intl
             );
 
-            const paddingDays = do {
-              const weekday = getPaddingDayCount(
-                this.state.calendarDate,
-                this.props.intl.locale
-              );
-              Array(weekday).fill();
-            };
+            const paddingDayCount = getPaddingDayCount(
+              this.state.calendarDate,
+              this.props.intl.locale
+            );
+            const paddingDays = Array(paddingDayCount).fill();
 
             const weekdays = getWeekdayNames(this.props.intl.locale);
             const today = getToday();

--- a/src/components/inputs/date-range-input/date-range-input.js
+++ b/src/components/inputs/date-range-input/date-range-input.js
@@ -53,21 +53,26 @@ const getRange = ({ item, value, startDate, highlightedItem }) => {
   const isBetween =
     highlightedItem && isBetweenDates(item, startDate, highlightedItem);
 
-  const isRangeStart = do {
-    if (isRangeSelectionInProgress) isStartDate;
-    else if (hasSelection) value[0] === item;
-    else false;
-  };
-  const isRangeBetween = do {
-    if (isRangeSelectionInProgress) isBetween;
-    else if (hasSelection) isBetweenDates(item, value[0], value[1]);
-    else false;
-  };
-  const isRangeEnd = do {
-    if (isRangeSelectionInProgress) item === highlightedItem;
-    else if (hasSelection) value[1] === item;
-    else false;
-  };
+  let isRangeStart = false;
+  if (isRangeSelectionInProgress) {
+    isRangeStart = isStartDate;
+  } else if (hasSelection) {
+    isRangeStart = value[0] === item;
+  }
+
+  let isRangeBetween = false;
+  if (isRangeSelectionInProgress) {
+    isRangeBetween = isBetween;
+  } else if (hasSelection) {
+    isRangeBetween = isBetweenDates(item, value[0], value[1]);
+  }
+
+  let isRangeEnd = false;
+  if (isRangeSelectionInProgress) {
+    isRangeEnd = item === highlightedItem;
+  } else if (hasSelection) {
+    isRangeEnd = value[1] === item;
+  }
 
   return {
     isRangeStart,
@@ -242,19 +247,21 @@ class DateRangeCalendar extends React.Component {
                   startDate: prevState.startDate ? null : changes.selectedItem,
                   calendarDate: changes.selectedItem,
                   isOpen: !hasFinishedRangeSelection,
-                  inputValue: do {
-                    if (hasFinishedRangeSelection)
-                      formatRange(
+                  inputValue: (() => {
+                    if (hasFinishedRangeSelection) {
+                      return formatRange(
                         [prevState.startDate, changes.selectedItem],
                         this.props.intl.locale
                       );
-                    else if (hasStartedRangeSelection)
-                      formatRange(
+                    }
+                    if (hasStartedRangeSelection) {
+                      return formatRange(
                         [changes.selectedItem],
                         this.props.intl.locale
                       );
-                    else '';
-                  },
+                    }
+                    return '';
+                  })(),
                 };
               }
 
@@ -311,10 +318,8 @@ class DateRangeCalendar extends React.Component {
             );
             const allItems = [...this.state.suggestedItems, ...calendarItems];
 
-            const paddingDays = do {
-              const weekday = getPaddingDayCount(this.state.calendarDate);
-              Array(weekday).fill();
-            };
+            const paddingDayCount = getPaddingDayCount(this.state.calendarDate);
+            const paddingDays = Array(paddingDayCount).fill();
 
             const weekdays = getWeekdayNames('en');
             const today = getToday();

--- a/src/components/inputs/date-time-input/date-time-input.js
+++ b/src/components/inputs/date-time-input/date-time-input.js
@@ -254,14 +254,12 @@ class DateTimeInput extends React.Component {
               this.props.timeZone
             );
 
-            const paddingDays = do {
-              const weekday = getPaddingDayCount(
-                this.state.calendarDate,
-                this.props.intl.locale,
-                this.props.timeZone
-              );
-              Array(weekday).fill();
-            };
+            const paddingDayCount = getPaddingDayCount(
+              this.state.calendarDate,
+              this.props.intl.locale,
+              this.props.timeZone
+            );
+            const paddingDays = Array(paddingDayCount).fill();
 
             const weekdays = getWeekdayNames(this.props.intl.locale);
             const today = getToday();

--- a/src/components/inputs/localized-money-input/README.md
+++ b/src/components/inputs/localized-money-input/README.md
@@ -267,10 +267,10 @@ const initialValues = docToFormValues(doc);
 const renderErrors = errors => {
   Object.keys(errors.prices).reduce(currency => {
     const error =
-      (errors.prices[currency]?.missing && (
+      (errors.prices[currency] && errors.prices[currency].missing && (
         <ErrorMessage>This field is required!</ErrorMessage>
       )) ||
-      (errors.prices[currency]?.highPrecision && (
+      (errors.prices[currency] && errors.prices[currency].highPrecision && (
         <ErrorMessage>High precision prices not supported here!</ErrorMessage>
       ));
     return {

--- a/src/components/inputs/localized-money-input/localized-money-input.js
+++ b/src/components/inputs/localized-money-input/localized-money-input.js
@@ -12,13 +12,12 @@ import {
   getId,
   getName,
 } from '../../../utils/localized';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import MoneyInput from '../money-input';
 import CurrencyControl from './currency-control';
 import styles from './localized-money-input.mod.css';
 
-const sequentialId = createSequentialId('localized-money-input-');
 // sorts the currencies with the following priority:
 // - The selected currency is placed first (e.g EUR)
 // - All other currencies follow, sorted alphabetically as well
@@ -89,11 +88,11 @@ class LocalizedInput extends React.Component {
         </div>
         <div className={styles.commandsContainer}>
           <div className={styles.commandsLeft}>
-            {do {
-              if (this.props.error) <div>{this.props.error}</div>;
-              else if (this.props.warning) <div>{this.props.warning}</div>;
-              else this.props.currenciesControl;
-            }}
+            {(() => {
+              if (this.props.error) return <div>{this.props.error}</div>;
+              if (this.props.warning) return <div>{this.props.warning}</div>;
+              return this.props.currenciesControl;
+            })()}
           </div>
         </div>
         {(this.props.error || this.props.warning) &&
@@ -209,11 +208,7 @@ export class LocalizedMoneyInput extends React.Component {
       props.hideCurrencyExpansionControls ||
       state.areCurrenciesOpened;
 
-    const id = do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    };
+    const id = getFieldId(props, state, 'localized-money-input-');
 
     return { areCurrenciesOpened, id };
   };

--- a/src/components/inputs/localized-multiline-text-input/translation-input.js
+++ b/src/components/inputs/localized-multiline-text-input/translation-input.js
@@ -139,11 +139,11 @@ export default class TranslationInput extends React.Component {
         </div>
         <div className={styles.commandsContainer}>
           <div className={styles.commandsLeft}>
-            {do {
-              if (this.props.error) <div>{this.props.error}</div>;
-              else if (this.props.warning) <div>{this.props.warning}</div>;
-              else this.props.languagesControl;
-            }}
+            {(() => {
+              if (this.props.error) return <div>{this.props.error}</div>;
+              if (this.props.warning) return <div>{this.props.warning}</div>;
+              return this.props.languagesControl;
+            })()}
           </div>
           <div className={styles.commandsExpand}>
             {!this.props.isCollapsed && contentExceedsShownRows && (

--- a/src/components/inputs/localized-text-input/localized-text-input.js
+++ b/src/components/inputs/localized-text-input/localized-text-input.js
@@ -19,12 +19,10 @@ import {
   getId,
   getName,
 } from '../../../utils/localized';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import LanguagesButton from './languages-button';
 import messages from './messages';
 import styles from './localized-text-input.mod.css';
-
-const sequentialId = createSequentialId('localized-text-field-');
 
 // NOTE: order is important here
 // * a disabled-field currently does not display warning/error-states so it takes precedence
@@ -184,11 +182,7 @@ export default class LocalizedTextInput extends React.Component {
       props.hideLanguageExpansionControls ||
       state.areLanguagesExpanded;
 
-    const id = do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    };
+    const id = getFieldId(props, state, 'localized-text-input-');
 
     return { areLanguagesExpanded, id };
   };

--- a/src/components/inputs/money-input/money-input.form.story.js
+++ b/src/components/inputs/money-input/money-input.form.story.js
@@ -58,11 +58,13 @@ storiesOf('Examples|Forms/Inputs', module)
                 horizontalConstraint="m"
               />
               {MoneyInput.isTouched(formik.touched.price) &&
-                formik.errors.price?.missing && (
+                formik.errors.price &&
+                formik.errors.price.missing && (
                   <ErrorMessage>Missing price</ErrorMessage>
                 )}
               {MoneyInput.isTouched(formik.touched.price) &&
-                formik.errors.price?.unsupportedHighPrecision && (
+                formik.errors.price &&
+                formik.errors.price.unsupportedHighPrecision && (
                   <ErrorMessage>
                     This value is a high precision value. High precision pricing
                     is not supported for products.

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -57,36 +57,36 @@ const createCurrencySelectStyles = ({
       borderBottomRightRadius: '0',
       borderRight: '0',
       minWidth: '72px',
-      borderColor: do {
-        if (isDisabled) vars['--border-color-input-disabled'];
-        else if (isReadOnly) vars['--border-color-input-readonly'];
-        else if (hasError) vars['--border-color-input-error'];
-        else if (hasWarning) vars['--border-color-input-warning'];
-        else if (hasFocus) vars['--border-color-input-focus'];
-        else vars['--border-color-input-pristine'];
-      },
-      '&:hover': do {
-        if (isDisabled) vars['--border-color-input-disabled'];
-        else if (isReadOnly) vars['--border-color-input-readonly'];
-        else if (hasError) vars['--border-color-input-error'];
-        else if (hasWarning) vars['--border-color-input-warning'];
-        else if (hasFocus) vars['--border-color-input-focus'];
-        else vars['--border-color-input-pristine'];
-      },
-      backgroundColor: do {
-        if (isReadOnly) vars['--background-color-input-pristine'];
-        else base.backgroundColor;
-      },
+      borderColor: (() => {
+        if (isDisabled) return vars['--border-color-input-disabled'];
+        if (isReadOnly) return vars['--border-color-input-readonly'];
+        if (hasError) return vars['--border-color-input-error'];
+        if (hasWarning) return vars['--border-color-input-warning'];
+        if (hasFocus) return vars['--border-color-input-focus'];
+        return vars['--border-color-input-pristine'];
+      })(),
+      '&:hover': (() => {
+        if (isDisabled) return vars['--border-color-input-disabled'];
+        if (isReadOnly) return vars['--border-color-input-readonly'];
+        if (hasError) return vars['--border-color-input-error'];
+        if (hasWarning) return vars['--border-color-input-warning'];
+        if (hasFocus) return vars['--border-color-input-focus'];
+        return vars['--border-color-input-pristine'];
+      })(),
+      backgroundColor: (() => {
+        if (isReadOnly) return vars['--background-color-input-pristine'];
+        return base.backgroundColor;
+      })(),
     }),
     singleValue: base => ({
       ...base,
       marginLeft: 0,
       maxWidth: 'initial',
-      color: do {
-        if (hasError) vars['--font-color-error'];
-        else if (hasWarning) vars['--font-color-warning'];
-        else base.color;
-      },
+      color: (() => {
+        if (hasError) return vars['--font-color-error'];
+        if (hasWarning) return vars['--font-color-warning'];
+        return base.color;
+      })(),
     }),
   };
 };
@@ -499,21 +499,21 @@ class MoneyInput extends React.Component {
       value: currencyCode,
     }));
 
-    const option = do {
+    const option = (() => {
       const matchedOption = options.find(
         optionCandidate =>
           optionCandidate.value === this.props.value.currencyCode
       );
-      if (matchedOption) matchedOption;
+      if (matchedOption) return matchedOption;
       // ensure an option is found, even when the currencies don't include
       // the money value's currencyCode
-      else if (this.props.value.currencyCode.trim() !== '')
-        ({
+      if (this.props.value.currencyCode.trim() !== '')
+        return {
           label: this.props.value.currencyCode,
           value: this.props.value.currencyCode,
-        });
-      else null;
-    };
+        };
+      return null;
+    })();
     const id = MoneyInput.getCurrencyDropdownId(this.props.id);
     return (
       <Contraints.Horizontal constraint={this.props.horizontalConstraint}>

--- a/src/components/inputs/time-input/time-input.js
+++ b/src/components/inputs/time-input/time-input.js
@@ -2,13 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
-import createSequentialId from '../../../utils/create-sequential-id';
+import getFieldId from '../../../utils/get-field-id';
 import Constraints from '../../constraints';
 import { parseTime } from '../../../utils/parse-time';
 import TimeInputBody from './time-input-body';
 import messages from './messages';
-
-const sequentialId = createSequentialId('time-input-');
 
 const leftPad = (value, length = 2) => String(value).padStart(length, '0');
 
@@ -61,11 +59,7 @@ export class TimeInput extends React.Component {
   };
 
   static getDerivedStateFromProps = (props, state) => ({
-    id: do {
-      if (props.id) props.id;
-      else if (state.id) state.id;
-      else sequentialId();
-    },
+    id: getFieldId(props, state, 'time-input-'),
   });
 
   static defaultProps = {

--- a/src/components/internals/calendar-day/calendar-day.js
+++ b/src/components/internals/calendar-day/calendar-day.js
@@ -7,25 +7,20 @@ import styles from './calendar-day.mod.css';
 const CalendarDay = props => (
   <li className={styles.wrapper}>
     <div
-      className={classnames(
-        do {
-          if (props.type === 'heading') styles.heading;
-          else if (props.type === 'spacing') styles.spacing;
-          else styles.day;
-        },
-        {
-          [styles.highlighted]: props.isHighlighted,
-          [styles.selected]: props.isSelected,
-          [styles.rangeStart]: props.isRangeStart,
-          [styles.rangeBetween]: props.isRangeBetween,
-          [styles.rangeEnd]: props.isRangeEnd,
-          [styles.today]:
-            !props.isSelected &&
-            !props.isRangeStart &&
-            !props.isRangeEnd &&
-            props.isToday,
-        }
-      )}
+      className={classnames({
+        [styles.day]: !['heading', 'spacing'].includes(props.type),
+        [styles.heading]: ['heading', 'spacing'].includes(props.type),
+        [styles.highlighted]: props.isHighlighted,
+        [styles.selected]: props.isSelected,
+        [styles.rangeStart]: props.isRangeStart,
+        [styles.rangeBetween]: props.isRangeBetween,
+        [styles.rangeEnd]: props.isRangeEnd,
+        [styles.today]:
+          !props.isSelected &&
+          !props.isRangeStart &&
+          !props.isRangeEnd &&
+          props.isToday,
+      })}
       {...omit(props, [
         'isHighlighted',
         'isSelected',

--- a/src/components/internals/create-select-styles.js
+++ b/src/components/internals/create-select-styles.js
@@ -16,13 +16,13 @@ const controlStyles = props => (base, state) => ({
   backgroundColor: state.isDisabled
     ? vars['--background-color-input-disabled']
     : vars['--background-color-input-pristine'],
-  borderColor: do {
-    if (state.isDisabled) vars['--border-color-input-disabled'];
-    else if (props.hasError) vars['--border-color-input-error'];
-    else if (props.hasWarning) vars['--border-color-input-warning'];
-    else if (state.isFocused) vars['--border-color-input-focus'];
-    else vars['--border-color-input-pristine'];
-  },
+  borderColor: (() => {
+    if (state.isDisabled) return vars['--border-color-input-disabled'];
+    if (props.hasError) return vars['--border-color-input-error'];
+    if (props.hasWarning) return vars['--border-color-input-warning'];
+    if (state.isFocused) return vars['--border-color-input-focus'];
+    return vars['--border-color-input-pristine'];
+  })(),
   borderRadius: vars['--border-radius-input'],
   minHeight: vars['--size-height-input'],
   cursor: state.isDisabled ? 'not-allowed' : 'pointer',
@@ -55,11 +55,11 @@ const menuStyles = props => base => ({
   boxShadow: vars['--shadow-7'],
   fontSize: vars['--font-size-default'],
   margin: `${vars['--spacing-4']} 0 0 0`,
-  borderColor: do {
-    if (props.hasError) vars['--border-color-input-error'];
-    else if (props.hasWarning) vars['--border-color-input-warning'];
-    else base.borderColor;
-  },
+  borderColor: (() => {
+    if (props.hasError) return vars['--border-color-input-error'];
+    if (props.hasWarning) return vars['--border-color-input-warning'];
+    return base.borderColor;
+  })(),
 });
 
 const indicatorSeparatorStyles = () => base => ({
@@ -96,22 +96,22 @@ const optionStyles = () => (base, state) => ({
   transition: vars['--transition-standard'],
   paddingLeft: vars['--spacing-8'],
   paddingRight: vars['--spacing-8'],
-  color: do {
-    if (!state.isDisabled) vars['--font-size-default'];
-    else if (state.isSelected) vars['--font-color-default'];
-    else base.color;
-  },
-  backgroundColor: do {
-    if (state.isSelected) vars['--background-color-input-selected'];
-    else if (state.isFocused) vars['--background-color-input-hover'];
-    else base.backgroundColor;
-  },
+  color: (() => {
+    if (!state.isDisabled) return vars['--font-size-default'];
+    if (state.isSelected) return vars['--font-color-default'];
+    return base.color;
+  })(),
+  backgroundColor: (() => {
+    if (state.isSelected) return vars['--background-color-input-selected'];
+    if (state.isFocused) return vars['--background-color-input-hover'];
+    return base.backgroundColor;
+  })(),
 
   '&:active': {
-    color: do {
-      if (!state.isDisabled) vars['--font-color-default'];
-      else base.color;
-    },
+    color: (() => {
+      if (!state.isDisabled) return vars['--font-color-default'];
+      return base.color;
+    })(),
     backgroundColor: vars['--background-color-input-selected'],
   },
 });

--- a/src/components/notifications/content-notification/content-notification.js
+++ b/src/components/notifications/content-notification/content-notification.js
@@ -5,6 +5,19 @@ import { ErrorIcon, WarningIcon, InfoIcon, CheckBoldIcon } from '../../icons';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import styles from './content-notification.mod.css';
 
+const getIconByType = type => {
+  switch (type) {
+    case 'error':
+      return ErrorIcon;
+    case 'info':
+      return InfoIcon;
+    case 'warning':
+      return WarningIcon;
+    default:
+      return CheckBoldIcon;
+  }
+};
+
 class NotificationIcon extends React.PureComponent {
   static displayName = 'NotificationIcon';
   static propTypes = {
@@ -13,13 +26,7 @@ class NotificationIcon extends React.PureComponent {
   };
 
   render() {
-    const Icon = do {
-      if (this.props.type === 'error') ErrorIcon;
-      else if (this.props.type === 'info') InfoIcon;
-      else if (this.props.type === 'warning') WarningIcon;
-      else CheckBoldIcon;
-    };
-
+    const Icon = getIconByType(this.props.type);
     return (
       <div className={styles.iconContainer}>
         <Icon theme="white" />

--- a/src/components/panels/collapsible-panel/header-icon.js
+++ b/src/components/panels/collapsible-panel/header-icon.js
@@ -4,10 +4,10 @@ import classnames from 'classnames';
 import { AngleDownIcon, AngleRightIcon } from '../../icons';
 import styles from './collapsible-panel.mod.css';
 
-const getArrowTheme = ({ tone, isDisabled }) => do {
-  if (isDisabled) 'grey';
-  else if (tone === 'urgent') 'white';
-  else 'black';
+const getArrowTheme = ({ tone, isDisabled }) => {
+  if (isDisabled) return 'grey';
+  if (tone === 'urgent') return 'white';
+  return 'black';
 };
 
 const HeaderIcon = props => (

--- a/src/utils/get-field-id.js
+++ b/src/utils/get-field-id.js
@@ -1,0 +1,6 @@
+import createSequentialId from './create-sequential-id';
+
+const getFieldId = (props, state, prefix) =>
+  props.id || state.id || createSequentialId(prefix)();
+
+export default getFieldId;

--- a/src/utils/parse-time.js
+++ b/src/utils/parse-time.js
@@ -59,12 +59,12 @@ export const parseTime = rawTime => {
   // invalid value to avoid edge cases like the day jumping forward
   // if (amPm === 'pm' && Number(hours) === 12) return null;
 
-  const hourOffset = do {
-    if (amPm === 'am' && hours === 12) -12;
-    else if (amPm === 'am') 0;
-    else if (amPm === 'pm' && hours !== 12) 12;
-    else 0;
-  };
+  const hourOffset = (() => {
+    if (amPm === 'am' && hours === 12) return -12;
+    if (amPm === 'am') return 0;
+    if (amPm === 'pm' && hours !== 12) return 12;
+    return 0;
+  })();
 
   return {
     hours: Number(hours) + hourOffset,

--- a/yarn.lock
+++ b/yarn.lock
@@ -296,14 +296,6 @@
     "@babel/helper-split-export-declaration" "^7.0.0"
     "@babel/plugin-syntax-decorators" "^7.1.0"
 
-"@babel/plugin-proposal-do-expressions@7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-do-expressions/-/plugin-proposal-do-expressions-7.2.0.tgz#7abf56d27125f2b040c9cb0ab03119cf117128a9"
-  integrity sha512-2bWN48zQHf/W5T8XvemGQJSi8hzhIo7y4kv/RiA08UcMLQ73lkTknhlaFGf1HjCJzG8FGopgsq6pSe1C+10fPg==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-do-expressions" "^7.2.0"
-
 "@babel/plugin-proposal-export-default-from@7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.2.0.tgz#737b0da44b9254b6152fe29bb99c64e5691f6f68"
@@ -387,13 +379,6 @@
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz#c50b1b957dcc69e4b1127b65e1c33eef61570c1b"
   integrity sha512-38QdqVoXdHUQfTpZo3rQwqQdWtCn5tMv4uV6r2RMfTqNBuv4ZBhz79SfaQWKTVmxHjeFv/DnXVC/+agHCklYWA==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-
-"@babel/plugin-syntax-do-expressions@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-do-expressions/-/plugin-syntax-do-expressions-7.2.0.tgz#f3d4b01be05ecde2892086d7cfd5f1fa1ead5a2a"
-  integrity sha512-/u4rJ+XEmZkIhspVuKRS+7WLvm7Dky9j9TvGK5IgId8B3FKir9MG+nQxDZ9xLn10QMBvW58dZ6ABe2juSmARjg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -344,14 +344,6 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
 
-"@babel/plugin-proposal-optional-chaining@7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.2.0.tgz#ae454f4c21c6c2ce8cb2397dc332ae8b420c5441"
-  integrity sha512-ea3Q6edZC/55wEBVZAEz42v528VulyO0eir+7uky/sT4XRcdkWJcFi1aPtitTlwUzGnECWJNExWww1SStt+yWw==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-optional-chaining" "^7.2.0"
-
 "@babel/plugin-proposal-unicode-property-regex@^7.0.0", "@babel/plugin-proposal-unicode-property-regex@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.2.0.tgz#abe7281fe46c95ddc143a65e5358647792039520"
@@ -442,13 +434,6 @@
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz#a94013d6eda8908dfe6a477e7f9eda85656ecf5c"
   integrity sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-
-"@babel/plugin-syntax-optional-chaining@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.2.0.tgz#a59d6ae8c167e7608eaa443fda9fa8fa6bf21dff"
-  integrity sha512-HtGCtvp5Uq/jH/WNUPkK6b7rufnCPLLlDAFN7cmACoIjaOOiXxUt3SswU5loHqrhtqTsa/WoLQ1OQ1AGuZqaWA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 


### PR DESCRIPTION
Removes `do-expressions` and `optional-chaning` babel plugins.

Those commits have been cherry-picked from #447 , to have cleaner diffs.

### Motivation

- they are not feature supported by TS out of the box (as far as I understand)
- we kind of agreed to not use those in our open source libraries (yet)
- the usage was very minimal and at times quite useless