### PR TITLE
chore: speed up storybook build

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 const postcssImport = require('postcss-import');
 const postcssPresetEnv = require('postcss-preset-env');
 const postcssReporter = require('postcss-reporter');
@@ -21,6 +22,9 @@ const sourceFolders = [
 ];
 
 module.exports = (storybookBaseConfig, configType) => {
+  storybookBaseConfig.plugins.push[
+    new MomentLocalesPlugin({ localesToKeep: ['de', 'es'] })
+  ];
   storybookBaseConfig.devtool = 'cheap-module-source-map'; // TODO: should we use something differen?
   storybookBaseConfig.module.rules = [
     // Disable require.ensure as it's not a standard language feature.

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -22,9 +22,9 @@ const sourceFolders = [
 ];
 
 module.exports = (storybookBaseConfig, configType) => {
-  storybookBaseConfig.plugins.push[
+  storybookBaseConfig.plugins.push(
     new MomentLocalesPlugin({ localesToKeep: ['de', 'es'] })
-  ];
+  );
   storybookBaseConfig.devtool = 'cheap-module-source-map'; // TODO: should we use something differen?
   storybookBaseConfig.module.rules = [
     // Disable require.ensure as it's not a standard language feature.

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "lodash.upperfirst": "4.3.1",
     "markdown-loader": "5.0.0",
     "moment": "2.23.0",
+    "moment-locales-webpack-plugin": "1.0.7",
     "moment-timezone": "0.5.23",
     "mri": "1.1.4",
     "omit-empty": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9632,6 +9632,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.difference@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
+  integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
+
 lodash.escape@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
@@ -10370,6 +10375,13 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
+
+moment-locales-webpack-plugin@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.0.7.tgz#ce2931b8a25100dae0868adbd9e93972dcb33359"
+  integrity sha512-KjYpaAhmuzGFZl6534FlZoK7QtW3vqlxd+A17W9DlgHJ5yhXANy7AZJl7iYtZpWjAfMTAWiVrQ7YDZdkFO6uRw==
+  dependencies:
+    lodash.difference "^4.5.0"
 
 moment-timezone@0.5.23:
   version "0.5.23"


### PR DESCRIPTION
I noticed that when we build storybook, it's including all the moment locales and (I think), slowing it down a bit. So I added the plugin to strip out unused locales.

![screen shot 2019-01-23 at 3 17 52 pm](https://user-images.githubusercontent.com/2425013/51612636-244ebd80-1f22-11e9-8725-debab822591b.png)
