### PR TITLE
Refactor to remove `recompose`

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "lodash.isnil": "4.0.0",
     "lodash.mapvalues": "4.6.0",
     "lodash.omit": "4.5.0",
+    "lodash.flowright": "3.5.0",
     "lodash.sortby": "4.7.0",
     "lodash.uniq": "4.5.0",
     "lodash.without": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "react-select": "2.3.0",
     "react-textarea-autosize": "7.1.0",
     "react-virtualized": "9.21.0",
-    "recompose": "0.30.0",
     "tiny-invariant": "1.0.3",
     "warning": "4.0.2"
   },

--- a/src/components/buttons/icon-button/icon-button.js
+++ b/src/components/buttons/icon-button/icon-button.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { compose } from 'recompose';
+import flowRight from 'lodash.flowright';
 import isNil from 'lodash.isnil';
 import { css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
@@ -146,7 +146,7 @@ IconButton.defaultProps = {
 
 IconButton.displayName = 'IconButton';
 
-export default compose(
+export default flowRight(
   withMouseOverState,
   withMouseDownState
 )(IconButton);

--- a/src/components/buttons/secondary-button/secondary-button.js
+++ b/src/components/buttons/secondary-button/secondary-button.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import oneLine from 'common-tags/lib/oneLine';
 import { Link } from 'react-router-dom';
-import { compose } from 'recompose';
+import flowRight from 'lodash.flowright';
 import isNil from 'lodash.isnil';
 import requiredIf from 'react-required-if';
 import { css } from '@emotion/core';
@@ -197,7 +197,7 @@ SecondaryButton.defaultProps = {
 
 SecondaryButton.displayName = 'SecondaryButton';
 
-export default compose(
+export default flowRight(
   withMouseOverState,
   withMouseDownState
 )(SecondaryButton);

--- a/src/hocs/with-mouse-down-state/with-mouse-down-state.js
+++ b/src/hocs/with-mouse-down-state/with-mouse-down-state.js
@@ -1,5 +1,5 @@
+import flowRight from 'lodash.flowright';
 import {
-  compose,
   withState,
   withHandlers,
   wrapDisplayName,
@@ -12,7 +12,7 @@ export const stateHandlers = {
 };
 
 export default component =>
-  compose(
+  flowRight(
     setDisplayName(wrapDisplayName(component, 'WithMouseDownState')),
     withState('isMouseDown', 'setMouseDown', false),
     withHandlers(stateHandlers)

--- a/src/hocs/with-mouse-down-state/with-mouse-down-state.js
+++ b/src/hocs/with-mouse-down-state/with-mouse-down-state.js
@@ -1,19 +1,36 @@
-import flowRight from 'lodash.flowright';
-import {
-  withState,
-  withHandlers,
-  wrapDisplayName,
-  setDisplayName,
-} from 'recompose';
+import React from 'react';
+import wrapDisplayName from '../wrap-display-name';
 
 export const stateHandlers = {
   handleMouseDown: ({ setMouseDown }) => () => setMouseDown(true),
   handleMouseUp: ({ setMouseDown }) => () => setMouseDown(false),
 };
 
-export default component =>
-  flowRight(
-    setDisplayName(wrapDisplayName(component, 'WithMouseDownState')),
-    withState('isMouseDown', 'setMouseDown', false),
-    withHandlers(stateHandlers)
-  )(component);
+const withMouseDownState = BaseComponent => {
+  class WithMouseDownState extends React.Component {
+    static displayName = wrapDisplayName(BaseComponent, 'withMouseDownState');
+
+    state = {
+      isMouseDown: false,
+    };
+
+    setMouseDown = nextMouseDown =>
+      this.setState({ isMouseDown: nextMouseDown });
+
+    handleMouseDown = () => this.setMouseDown(true);
+    handleMouseUp = () => this.setMouseDown(false);
+
+    render() {
+      return React.createElement(BaseComponent, {
+        ...this.props,
+        isMouseDown: this.state.isMouseDown,
+        handleMouseDown: this.handleMouseDown,
+        handleMouseUp: this.handleMouseUp,
+      });
+    }
+  }
+
+  return WithMouseDownState;
+};
+
+export default withMouseDownState;

--- a/src/hocs/with-mouse-down-state/with-mouse-down-state.js
+++ b/src/hocs/with-mouse-down-state/with-mouse-down-state.js
@@ -21,12 +21,13 @@ const withMouseDownState = BaseComponent => {
     handleMouseUp = () => this.setMouseDown(false);
 
     render() {
-      return React.createElement(BaseComponent, {
-        ...this.props,
+      const injectedProps = {
         isMouseDown: this.state.isMouseDown,
         handleMouseDown: this.handleMouseDown,
         handleMouseUp: this.handleMouseUp,
-      });
+      };
+
+      return <BaseComponent {...{ ...this.props, ...injectedProps }} />;
     }
   }
 

--- a/src/hocs/with-mouse-over-state/with-mouse-over-state.js
+++ b/src/hocs/with-mouse-over-state/with-mouse-over-state.js
@@ -16,12 +16,13 @@ const withMouseOverState = BaseComponent => {
     handleMouseOut = () => this.setMouseOver(false);
 
     render() {
-      return React.createElement(BaseComponent, {
-        ...this.props,
+      const injectedProps = {
         isMouseOver: this.state.isMouseOver,
         handleMouseOver: this.handleMouseOver,
         handleMouseOut: this.handleMouseOut,
-      });
+      };
+
+      return <BaseComponent {...{ ...this.props, ...injectedProps }} />;
     }
   }
 

--- a/src/hocs/with-mouse-over-state/with-mouse-over-state.js
+++ b/src/hocs/with-mouse-over-state/with-mouse-over-state.js
@@ -1,5 +1,5 @@
+import flowRight from 'lodash.flowright';
 import {
-  compose,
   withState,
   withHandlers,
   wrapDisplayName,
@@ -12,7 +12,7 @@ export const stateHandlers = {
 };
 
 export default component =>
-  compose(
+  flowRight(
     setDisplayName(wrapDisplayName(component, 'WithMouseOverState')),
     withState('isMouseOver', 'setMouseOver', false),
     withHandlers(stateHandlers)

--- a/src/hocs/with-mouse-over-state/with-mouse-over-state.js
+++ b/src/hocs/with-mouse-over-state/with-mouse-over-state.js
@@ -1,19 +1,31 @@
-import flowRight from 'lodash.flowright';
-import {
-  withState,
-  withHandlers,
-  wrapDisplayName,
-  setDisplayName,
-} from 'recompose';
+import React from 'react';
+import wrapDisplayName from '../wrap-display-name';
 
-export const stateHandlers = {
-  handleMouseOver: ({ setMouseOver }) => () => setMouseOver(true),
-  handleMouseOut: ({ setMouseOver }) => () => setMouseOver(false),
+const withMouseOverState = BaseComponent => {
+  class WithMouseOverState extends React.Component {
+    static displayName = wrapDisplayName(BaseComponent, 'withMouseOverState');
+
+    state = {
+      isMouseOver: false,
+    };
+
+    setMouseOver = nextMouseOver =>
+      this.setState({ isMouseOver: nextMouseOver });
+
+    handleMouseOver = () => this.setMouseOver(true);
+    handleMouseOut = () => this.setMouseOver(false);
+
+    render() {
+      return React.createElement(BaseComponent, {
+        ...this.props,
+        isMouseOver: this.state.isMouseOver,
+        handleMouseOver: this.handleMouseOver,
+        handleMouseOut: this.handleMouseOut,
+      });
+    }
+  }
+
+  return WithMouseOverState;
 };
 
-export default component =>
-  flowRight(
-    setDisplayName(wrapDisplayName(component, 'WithMouseOverState')),
-    withState('isMouseOver', 'setMouseOver', false),
-    withHandlers(stateHandlers)
-  )(component);
+export default withMouseOverState;

--- a/src/hocs/wrap-display-name/index.js
+++ b/src/hocs/wrap-display-name/index.js
@@ -1,0 +1,1 @@
+export { default } from './wrap-display-name';

--- a/src/hocs/wrap-display-name/wrap-display-name.js
+++ b/src/hocs/wrap-display-name/wrap-display-name.js
@@ -1,0 +1,5 @@
+export default (BaseComponent, hocName) => {
+  const previousDisplayName = BaseComponent.displayName || BaseComponent.name;
+
+  return `${hocName}(${previousDisplayName || 'Component'})`;
+};

--- a/src/hocs/wrap-display-name/wrap-display-name.spec.js
+++ b/src/hocs/wrap-display-name/wrap-display-name.spec.js
@@ -1,0 +1,19 @@
+import wrapDisplayName from './wrap-display-name';
+
+function BaseComponent() {
+  return 'BaseComponent';
+}
+BaseComponent.displayName = 'BaseComponent';
+
+describe('rendering', () => {
+  const hocName = 'testHoc';
+  let wrappedDisplayName;
+
+  beforeEach(() => {
+    wrappedDisplayName = wrapDisplayName(BaseComponent, hocName);
+  });
+
+  it('should include `hocName` in wrapped display name', () => {
+    expect(wrappedDisplayName).toContain(hocName);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -9652,6 +9652,11 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
+lodash.flowright@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.flowright/-/lodash.flowright-3.5.0.tgz#2b5fff399716d7e7dc5724fe9349f67065184d67"
+  integrity sha1-K1//OZcW1+fcVyT+k0n2cGUYTWc=
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3892,11 +3892,6 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-change-emitter@^0.1.2:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
-  integrity sha1-6LL+PX8at9aaMhma/5HqaTFAlRU=
-
 character-entities-html4@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.2.tgz#c44fdde3ce66b52e8d321d6c1bf46101f0150610"
@@ -6451,7 +6446,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.0, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -7446,7 +7441,7 @@ hoist-non-react-statics@1.x.x, hoist-non-react-statics@^1.2.0:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
   integrity sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=
 
-hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0, hoist-non-react-statics@^2.5.5:
+hoist-non-react-statics@^2.5.0, hoist-non-react-statics@^2.5.5:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
@@ -12794,7 +12789,7 @@ react-is@^16.5.2, react-is@^16.6.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
   integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
 
-react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
+react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
@@ -13114,18 +13109,6 @@ rechoir@^0.6.2:
   integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
   dependencies:
     resolve "^1.1.6"
-
-recompose@0.30.0:
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.30.0.tgz#82773641b3927e8c7d24a0d87d65aeeba18aabd0"
-  integrity sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    change-emitter "^0.1.2"
-    fbjs "^0.8.1"
-    hoist-non-react-statics "^2.3.1"
-    react-lifecycles-compat "^3.0.2"
-    symbol-observable "^1.0.4"
 
 recursive-readdir@2.2.2:
   version "2.2.2"
@@ -14946,7 +14929,7 @@ svgo@^1.1.1:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
+symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==


### PR DESCRIPTION
#### Summary

This pull request removes the dependency on `recompose` and refactors all HoCs to work without while using `flowRight` from lodash instead of `compose`.

#### Description

While playing with TypeScript I noticed that `recompose` HoCs are a bit hard to type. Then I saw that we only use recompose for two rather simple HoCs. I think it's not really worth to keep recompose just for them. This should reduce bundle size a bit (if not at least simplify the code).
