### PR TITLE
chore: support aria attributes on buttons

### DIFF
--- a/src/components/buttons/flat-button/README.md
+++ b/src/components/buttons/flat-button/README.md
@@ -36,6 +36,8 @@ iconClass label url onClick
 | `iconPosition` | `oneOf`   |    -     | `left`, `right`             | `left`    | The position of the icon                              |
 | `isDisabled`   | `boolean` |    -     | -                           | -         | Tells when the button should present a disabled state |
 
+The component further forwards all `data-` and `aria-` attributes to the underlying `button` component.
+
 #### Where to use
 
 Main Functions and use cases are:

--- a/src/components/buttons/flat-button/flat-button.js
+++ b/src/components/buttons/flat-button/flat-button.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
 import withMouseOverState from '../../../hocs/with-mouse-over-state';
+import filterAriaAttributes from '../../../utils/filter-aria-attributes';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import Text from '../../typography/text';
 import Spacings from '../../spacings';
@@ -37,6 +38,7 @@ const getTextColor = (tone, isHover = false) => {
 export const FlatButton = props => {
   const dataProps = {
     'data-track-component': 'LinkButton',
+    ...filterAriaAttributes(props),
     ...filterDataAttributes(props),
   };
 

--- a/src/components/buttons/flat-button/flat-button.spec.js
+++ b/src/components/buttons/flat-button/flat-button.spec.js
@@ -26,6 +26,15 @@ describe('rendering', () => {
     expect(getByLabelText('Add')).toBeInTheDocument();
     expect(getByLabelText('Add')).not.toHaveAttribute('disabled');
   });
+  it('should pass aria attributes"', () => {
+    const { getByLabelText } = render(
+      <FlatButton {...props} isDisabled={true} aria-describedby="tooltip-1" />
+    );
+    expect(getByLabelText('Add')).toHaveAttribute(
+      'aria-describedby',
+      'tooltip-1'
+    );
+  });
   it('should be marked as "disabled"', () => {
     const { getByLabelText } = render(
       <FlatButton {...props} isDisabled={true} />

--- a/src/components/buttons/icon-button/README.md
+++ b/src/components/buttons/icon-button/README.md
@@ -36,6 +36,8 @@ Icon Buttons are "icon-only" buttons. They trigger an action when clicked
 | `size`           | `oneOf`  |    -     | `big`, `medium`, `small`    | `big`           | -                                                                                                                                                |
 | `theme`          | `oneOf`  |    -     | `default`                   | `blue`, `green` | The component may have a theme only if `isToggleButton` is true                                                                                  |
 
+The component further forwards all `data-` and `aria-` attributes to the underlying `button` component.
+
 #### Where to use
 
 Main Functions and use cases are:

--- a/src/components/buttons/icon-button/icon-button.js
+++ b/src/components/buttons/icon-button/icon-button.js
@@ -6,6 +6,7 @@ import { css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
 import withMouseDownState from '../../../hocs/with-mouse-down-state';
 import withMouseOverState from '../../../hocs/with-mouse-over-state';
+import filterAriaAttributes from '../../../utils/filter-aria-attributes';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import AccessibleButton from '../accessible-button';
 import {
@@ -35,6 +36,7 @@ const getIconThemeColor = props => {
 export const IconButton = props => {
   const buttonAttributes = {
     'data-track-component': 'IconButton',
+    ...filterAriaAttributes(props),
     ...filterDataAttributes(props),
   };
   const isActive = props.isToggleButton && props.isToggled;

--- a/src/components/buttons/icon-button/icon-button.spec.js
+++ b/src/components/buttons/icon-button/icon-button.spec.js
@@ -30,6 +30,15 @@ describe('rendering', () => {
     expect(getByLabelText('test-button')).toBeInTheDocument();
     expect(getByLabelText('test-button')).not.toHaveAttribute('disabled');
   });
+  it('should be pass aria attributes', () => {
+    const { getByLabelText } = render(
+      <IconButton {...props} aria-describedby="tooltip-1" />
+    );
+    expect(getByLabelText('test-button')).toHaveAttribute(
+      'aria-describedby',
+      'tooltip-1'
+    );
+  });
   it('should be marked as "disabled"', () => {
     const { getByLabelText } = render(
       <IconButton {...props} isDisabled={true} />

--- a/src/components/buttons/link-button/README.md
+++ b/src/components/buttons/link-button/README.md
@@ -33,6 +33,8 @@ Link buttons are similar to Flat buttons, however they are constructed as a
 | `iconLeft`   | `element`                                                         |    -     | -      | -       | The icon of the button                                |
 | `isDisabled` | `boolean`                                                         |    -     | -      | -       | Tells when the button should present a disabled state |
 
+The component further forwards all `data-` and `aria-` attributes to the underlying `button` component.
+
 Main Functions and use cases are:
 
 - Back to list _example: a link to going back to another page_

--- a/src/components/buttons/link-button/link-button.js
+++ b/src/components/buttons/link-button/link-button.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
+import filterAriaAttributes from '../../../utils/filter-aria-attributes';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import Text from '../../typography/text';
 import Spacings from '../../spacings';
@@ -39,6 +40,7 @@ const LinkButton = props => (
     ]}
     onClick={props.isDisabled ? event => event.preventDefault() : undefined}
     data-track-component="LinkButton"
+    {...filterAriaAttributes(props)}
     {...filterDataAttributes(props)}
     aria-label={props.label}
   >

--- a/src/components/buttons/link-button/link-button.spec.js
+++ b/src/components/buttons/link-button/link-button.spec.js
@@ -27,6 +27,15 @@ describe('rendering', () => {
       expect(history.location.pathname).toBe('/foo/bar');
     });
   });
+  it('should pass aria attributes"', () => {
+    const { getByLabelText } = render(
+      <LinkButton {...props} aria-describedby="tooltip-1" />
+    );
+    expect(getByLabelText('test-button')).toHaveAttribute(
+      'aria-describedby',
+      'tooltip-1'
+    );
+  });
   it('should prevent the navigation when "disabled"', async () => {
     const { getByLabelText, history } = render(
       <LinkButton {...props} isDisabled={true} />

--- a/src/components/buttons/primary-button/README.md
+++ b/src/components/buttons/primary-button/README.md
@@ -36,6 +36,8 @@ label for accessibility reasons.
 | `size`             | `oneOf`  |    -     | `big`, `small`              | `big`     | -                                                                                                                                                |
 | `tone`             | `oneOf`  |    -     | `urgent`, `primary`         | `primary` | The component may have a theme only if `isToggleButton` is true                                                                                  |
 
+The component further forwards all `data-` and `aria-` attributes to the underlying `button` component.
+
 Main Functions and use cases are:
 
 - Primary action _example: Save changes_

--- a/src/components/buttons/primary-button/primary-button.js
+++ b/src/components/buttons/primary-button/primary-button.js
@@ -3,6 +3,7 @@ import React from 'react';
 import isNil from 'lodash.isnil';
 import { css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
+import filterAriaAttributes from '../../../utils/filter-aria-attributes';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import Spacings from '../../spacings';
 import AccessibleButton from '../accessible-button';
@@ -14,6 +15,7 @@ import {
 const PrimaryButton = props => {
   const dataProps = {
     'data-track-component': 'PrimaryButton',
+    ...filterAriaAttributes(props),
     ...filterDataAttributes(props),
   };
   const isActive = props.isToggleButton && props.isToggled;

--- a/src/components/buttons/primary-button/primary-button.spec.js
+++ b/src/components/buttons/primary-button/primary-button.spec.js
@@ -30,6 +30,15 @@ describe('rendering', () => {
     );
     expect(queryByTestId('icon')).not.toBeInTheDocument();
   });
+  it('should pass as aria attributes', () => {
+    const { getByLabelText } = render(
+      <PrimaryButton {...props} aria-describedby="tooltip-1" />
+    );
+    expect(getByLabelText('Add')).toHaveAttribute(
+      'aria-describedby',
+      'tooltip-1'
+    );
+  });
   it('should be marked as "disabled"', () => {
     const { getByLabelText } = render(
       <PrimaryButton {...props} isDisabled={true} />

--- a/src/components/buttons/secondary-button/README.md
+++ b/src/components/buttons/secondary-button/README.md
@@ -37,6 +37,8 @@ accessibility reasons.
 | `onClick`          | `func`               |          | -                           | -         | What the button will trigger when clicked                                                                                                        |
 | `linkTo`           | `string` or `object` |    -     | -                           | -         | Where the button should redirect when clicked                                                                                                    |
 
+The component further forwards all `data-` and `aria-` attributes to the underlying `button` component.
+
 Main Functions and use cases are:
 
 - Secondary action _example: Discard changes_

--- a/src/components/buttons/secondary-button/secondary-button.js
+++ b/src/components/buttons/secondary-button/secondary-button.js
@@ -11,6 +11,7 @@ import Spacings from '../../spacings';
 import AccessibleButton from '../accessible-button';
 import withMouseOverState from '../../../hocs/with-mouse-over-state';
 import withMouseDownState from '../../../hocs/with-mouse-down-state';
+import filterAriaAttributes from '../../../utils/filter-aria-attributes';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import { getStateStyles, getThemeStyles } from './secondary-button.styles';
 
@@ -32,6 +33,7 @@ export const getIconThemeColor = props => {
 export const SecondaryButton = props => {
   const dataProps = {
     'data-track-component': 'SecondaryButton',
+    ...filterAriaAttributes(props),
     ...filterDataAttributes(props),
   };
   const isActive = props.isToggleButton && props.isToggled;

--- a/src/components/buttons/secondary-button/secondary-button.spec.js
+++ b/src/components/buttons/secondary-button/secondary-button.spec.js
@@ -30,6 +30,15 @@ describe('rendering', () => {
     );
     expect(queryByTestId('icon')).not.toBeInTheDocument();
   });
+  it('should pass aria attributes', () => {
+    const { getByLabelText } = render(
+      <SecondaryButton {...props} aria-describedby="tooltip-1" />
+    );
+    expect(getByLabelText('Add')).toHaveAttribute(
+      'aria-describedby',
+      'tooltip-1'
+    );
+  });
   it('should be marked as "disabled"', () => {
     const { getByLabelText } = render(
       <SecondaryButton {...props} isDisabled={true} />

--- a/src/components/buttons/secondary-icon-button/secondary-icon-button.js
+++ b/src/components/buttons/secondary-icon-button/secondary-icon-button.js
@@ -2,12 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import withMouseOverState from '../../../hocs/with-mouse-over-state';
+import filterAriaAttributes from '../../../utils/filter-aria-attributes';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import AccessibleButton from '../accessible-button';
 
 export const SecondaryIconButton = props => {
   const buttonAttributes = {
     'data-track-component': 'SecondaryIconButton',
+    ...filterAriaAttributes(props),
     ...filterDataAttributes(props),
   };
   let iconTheme = 'black';

--- a/src/components/buttons/secondary-icon-button/secondary-icon-button.spec.js
+++ b/src/components/buttons/secondary-icon-button/secondary-icon-button.spec.js
@@ -24,6 +24,15 @@ describe('rendering', () => {
     const { getByTestId } = render(<SecondaryIconButton {...props} />);
     expect(getByTestId('icon')).toBeInTheDocument();
   });
+  it('should pass aria attributes', () => {
+    const { getByLabelText } = render(
+      <SecondaryIconButton {...props} aria-describedby="tooltip-1" />
+    );
+    expect(getByLabelText('test-button')).toHaveAttribute(
+      'aria-describedby',
+      'tooltip-1'
+    );
+  });
   it('should be marked as "disabled"', () => {
     const { getByLabelText } = render(
       <SecondaryIconButton {...props} isDisabled={true} />


### PR DESCRIPTION
#### Summary

While working on the `Tooltip` implementation, I realized that we should use `aria-describedby` on the wrapped component. So our buttons (and perhaps our `inputs`) should support this attribute.

If we are okay with this approach, I can add it to `inputs` as well.

From talking to @filippobocik , it seems like we mostly use `Tooltips` with `Buttons` and a bit with disabled inputs like RadioInputs. 🤔 