### PR TITLE
feat(localized-money-input): LocalizedMoneyInput is collapsed by default

### DIFF
--- a/src/components/inputs/localized-money-input/README.md
+++ b/src/components/inputs/localized-money-input/README.md
@@ -39,6 +39,7 @@ import { LocalizedMoneyInput } from '@commercetools-frontend/ui-kit';
 | `hasWarning`                    | `bool`           |    -     | -                       | -       | Indicates the input field has a warning                                                                                                                                |
 | `errors`                        | `objectOf(node)` |    -     | -                       | -       | Used to show errors underneath the inputs of specific currencies. Pass an object whose key is a currency and whose value is the error to show for that key.            |
 | `warnings`                      | `objectOf(node)` |    -     | -                       | -       | Used to show warnings underneath the inputs of specific currencies. Pass an object whose key is a currency and whose value is the warning to show for that key.        |
+| `isTouched`                     | `bool`           |    -     | -                       | `false` | Indicates whether the field was touched. If there are errors or warnings, input will only be expanded when it has been touched                                         |
 
 The component forwards all `data` attribute props. It further adds a `-${currency}` suffix to the values of the `data-test` and `data-track-component` attributes, e.g `data-test="foo"` will get added to the input for `en` as `data-test="foo-en"`.
 

--- a/src/components/inputs/localized-money-input/localized-money-input.js
+++ b/src/components/inputs/localized-money-input/localized-money-input.js
@@ -158,6 +158,7 @@ export class LocalizedMoneyInput extends React.Component {
     horizontalConstraint: PropTypes.oneOf(['m', 'l', 'xl', 'scale']),
     hasError: PropTypes.bool,
     hasWarning: PropTypes.bool,
+    isTouched: PropTypes.bool,
     errors: PropTypes.objectOf(PropTypes.node),
     warnings: PropTypes.objectOf(PropTypes.node),
     // HoC
@@ -220,8 +221,8 @@ export class LocalizedMoneyInput extends React.Component {
       props.hasWarning ||
       getHasWarningOnRemainingLanguages(props.warnings, props.selectedCurrency);
     const areCurrenciesOpened =
-      hasErrorOnRemainingCurrencies ||
-      hasWarningOnRemainingCurrencies ||
+      (hasErrorOnRemainingCurrencies && props.isTouched) ||
+      (hasWarningOnRemainingCurrencies && props.isTouched) ||
       props.hideCurrencyExpansionControls ||
       state.areCurrenciesOpened;
 

--- a/src/components/inputs/localized-money-input/localized-money-input.spec.js
+++ b/src/components/inputs/localized-money-input/localized-money-input.spec.js
@@ -233,10 +233,19 @@ describe('when every field has an error', () => {
     USD: 'A value is required',
     CAD: 'A value is required',
   };
-  it('should be open all fields and render errors', () => {
+  it('should not open all fields and render errors if not touched', () => {
+    const { getByLabelText, queryByLabelText } = renderLocalizedMoneyInput({
+      name: 'foo',
+      errors,
+    });
+    expect(getByLabelText('CAD')).toBeInTheDocument();
+    expect(queryByLabelText('USD')).not.toBeInTheDocument();
+  });
+  it('should be open all fields and render errors when touched', () => {
     const { getByText } = renderLocalizedMoneyInput({
       name: 'foo',
       errors,
+      isTouched: true,
     });
     expect(getByText(errors.USD)).toBeInTheDocument();
     expect(getByText(errors.CAD)).toBeInTheDocument();
@@ -252,6 +261,7 @@ describe('when the error is not on the selected currency', () => {
       selectedCurrency: 'CAD',
       name: 'foo',
       errors,
+      isTouched: true,
     });
     const usdInput = getByLabelText('USD');
     const CADInput = getByLabelText('CAD');

--- a/src/components/inputs/localized-money-input/localized-money-input.story.js
+++ b/src/components/inputs/localized-money-input/localized-money-input.story.js
@@ -77,6 +77,7 @@ storiesOf('Components|Inputs', module)
               )}
               hasError={boolean('hasError', false)}
               hasWarning={boolean('hasWarning', false)}
+              isTouched={boolean('isTouched', false)}
               errors={
                 Object.values(errors).some(error => error.length > 0)
                   ? Object.entries(errors).reduce((acc, [currency, error]) => {

--- a/src/components/inputs/localized-money-input/localized-money-input.visualroute.js
+++ b/src/components/inputs/localized-money-input/localized-money-input.visualroute.js
@@ -80,6 +80,7 @@ export const component = () => (
         selectedCurrency="CAD"
         horizontalConstraint="m"
         errors={{ EUR: <ErrorMessage>foo</ErrorMessage> }}
+        isTouched={true}
       />
     </Spec>
     <Spec label="when there is a warning for a specific currency (first one)">


### PR DESCRIPTION
#### Summary
- Define `isTouched` prop to determine if the input was touched
- If there are errors or warnings, expand input only if it has been
touched

![localized-money-input-default-collapsed](https://user-images.githubusercontent.com/3065138/52213928-b21a9900-2890-11e9-8823-af88c3e85191.gif)

