### PR TITLE
[SPIKE] - Bundling multiple outputs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   # also skip when PR is opened by `renovate`
   # back to default in case internal travis scripts return non zero response codes.
   - "! test -f fail-tests-because-there-was-an-unhandled-rejection.lock"
-  - bash ./scripts/run-percy.sh
+  # - bash ./scripts/run-percy.sh
   - set +e
 
 before_deploy: yarn build

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -57,20 +57,33 @@ const defaultExternal = deps.concat(peerDeps);
 
 // We need to define 2 separate configs (`esm` and `cjs`) so that each can be
 // further customized.
-const config = {
-  input: 'src/index.js',
-  external: defaultExternal,
-  output: [
-    {
-      file: pkg.module,
-      format: 'esm',
-    },
-    {
-      file: pkg.main,
-      format: 'cjs',
-    },
-  ],
-  plugins,
-};
+const config = [
+  {
+    input: 'src/index.js',
+    external: defaultExternal,
+    output: [
+      {
+        file: pkg.module,
+        format: 'esm',
+      },
+      {
+        file: pkg.main,
+        format: 'cjs',
+      },
+    ],
+    plugins,
+  },
+  {
+    input: 'src/components/stamp/index.js',
+    external: defaultExternal,
+    output: [
+      {
+        file: 'dist/stamp.esm.js',
+        format: 'esm',
+      },
+    ],
+    plugins,
+  },
+];
 
 export default config;


### PR DESCRIPTION
#### Summary

I wanted to experiment with bundling multiple outputs to facilitate proper tree shaking. For an example, I used the `Stamp` component. 

If you run `yarn build`, the output contains some interesting things.

- All of the customProperties are bundled.
- All of the Spacings components are bundled, not just `Inset`


#### How / what / wtf / why

 If we were to go the approach of exporting multiple bundles, I think it would make sense to look into writing some sort of babel plugin that converts imports like 

```
import { Stamp, Spacings } from 'ui-kit';

```

to 
```
import Stamp from 'ui-kit/stamp`
import Spacings from 'ui-kit/spacings`
```