### PR TITLE
chore: disable emotion source maps in production builds

### DIFF
--- a/scripts/get-babel-preset.js
+++ b/scripts/get-babel-preset.js
@@ -63,11 +63,18 @@ module.exports = function getBabelPresets() {
       '@emotion/babel-preset-css-prop',
     ].filter(Boolean),
     plugins: [
+      [
+        require('babel-plugin-emotion').default,
+        {
+          sourceMap: isEnvDevelopment,
+          autoLabel: !isEnvProduction,
+        },
+      ],
+
       // Experimental macros support. Will be documented after it's had some time
       // in the wild.
       require('babel-plugin-macros').default,
       // https://github.com/emotion-js/emotion/tree/master/packages/babel-plugin-emotion
-      require('babel-plugin-emotion').default,
       // export { default } from './foo'
       require('@babel/plugin-proposal-export-default-from').default,
       // export * from './foo'


### PR DESCRIPTION
#### Summary

Since refactoring to using `emotion`, the ui-kit bundle size bloated from ~600kb to ~2.1mb. This is due to `babel-plugin-emotion` created code that looks like this.

```css("padding:", getPadding$1(props.scale), ";" + (process.env.NODE_ENV === "production" ? "" : "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImluc2V0LXNxdWlzaC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFxQlkiLCJmaWxlIjoiaW5zZXQtc3F1aXNoLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IFJlYWN0IGZyb20gJ3JlYWN0JztcbmltcG9ydCBQcm9wVHlwZXMgZnJvbSAncHJvcC10eXBlcyc7XG5pbXBvcnQgeyBjc3MgfSBmcm9tICdAZW1vdGlvbi9jb3JlJztcbmltcG9ydCB2YXJzIGZyb20gJy4uLy4uLy4uLy4uL21hdGVyaWFscy9jdXN0b20tcHJvcGVydGllcyc7XG5pbXBvcnQgZmlsdGVyRGF0YUF0dHJpYnV0ZXMgZnJvbSAnLi4vLi4vLi4vdXRpbHMvZmlsdGVyLWRhdGEtYXR0cmlidXRlcyc7XG5cbmNvbnN0IGdldFBhZGRpbmcgPSBzY2FsZSA9PiB7XG4gIHN3aXRjaCAoc2NhbGUpIHtcbiAgICBjYXNlICdzJzpcbiAgICAgIHJldHVybiBgJHt2YXJzLnNwYWNpbmc0fSAke3ZhcnMuc3BhY2luZzh9YDtcbiAgICBjYXNlICdtJzpcbiAgICAgIHJldHVybiBgJHt2YXJzLnNwYWNpbmc4fSAke3ZhcnMuc3BhY2luZzE2fWA7XG4gICAgY2FzZSAnbCc6XG4gICAgICByZXR1cm4gYCR7dmFycy5zcGFjaW5nMTZ9ICR7dmFycy5zcGFjaW5nMzJ9YDtcbiAgICBkZWZhdWx0OlxuICAgICAgcmV0dXJuIDA7XG4gIH1cbn07XG5cbmNvbnN0IEluc2V0U3F1aXNoID0gcHJvcHMgPT4gKFxuICA8ZGl2XG4gICAgY3NzPXtjc3NgXG4gICAgICBwYWRkaW5nOiAke2dldFBhZGRpbmcocHJvcHMuc2NhbGUpfTtcbiAgICBgfVxuICAgIHsuLi5maWx0ZXJEYXRhQXR0cmlidXRlcyhwcm9wcyl9XG4gID5cbiAgICB7cHJvcHMuY2hpbGRyZW59XG4gIDwvZGl2PlxuKTtcblxuSW5zZXRTcXVpc2guZGlzcGxheU5hbWUgPSAnSW5zZXRTcXVpc2gnO1xuSW5zZXRTcXVpc2gucHJvcFR5cGVzID0ge1xuICBzY2FsZTogUHJvcFR5cGVzLm9uZU9mKFsncycsICdtJywgJ2wnXSksXG4gIGNoaWxkcmVuOiBQcm9wVHlwZXMubm9kZSxcbn07XG5cbkluc2V0U3F1aXNoLmRlZmF1bHRQcm9wcyA9IHtcbiAgc2NhbGU6ICdtJyxcbn07XG5cbmV4cG9ydCBkZWZhdWx0IEluc2V0U3F1aXNoO1xuIl19 */"))```

As you can see, when the consumer builds ui-kit in production they won't get the source maps, so it doesn't actually add bloat to our consumers. But I don't think we need to include these source maps on production ui-kit builds.
