### PR TITLE
fix(select-input): fix for disabled state with multi values selected

### DIFF
--- a/src/components/inputs/select-input/select-input.visualroute.js
+++ b/src/components/inputs/select-input/select-input.visualroute.js
@@ -73,6 +73,25 @@ const DefaultRoute = () => (
         hasWarning={true}
       />
     </Spec>
+    <Spec label="with multiple values selected">
+      <SelectInput
+        value={['one', 'two']}
+        onChange={() => {}}
+        options={options}
+        isMulti={true}
+        horizontalConstraint="m"
+      />
+    </Spec>
+    <Spec label="with multiple values selected and disabled">
+      <SelectInput
+        value={['one', 'two']}
+        onChange={() => {}}
+        options={options}
+        isMulti={true}
+        isDisabled={true}
+        horizontalConstraint="m"
+      />
+    </Spec>
   </Suite>
 );
 

--- a/src/components/internals/create-select-styles.js
+++ b/src/components/internals/create-select-styles.js
@@ -135,9 +135,13 @@ const multiValueStyles = () => base => ({
   padding: '0',
 });
 
-const multiValueLabelStyles = () => base => ({
+const multiValueLabelStyles = () => (base, state) => ({
   ...base,
   fontSize: vars.fontSizeSmall,
+  color: (() => {
+    if (state.isDisabled) return vars.fontColorForInputWhenDisabled;
+    return base.color;
+  })(),
   padding: `${vars.spacing4} ${vars.spacing8}`,
   borderRadius: vars.borderRadiusTag,
   border: `1px ${vars.borderColorTagPristine} solid`,

--- a/src/components/internals/tag-remove/tag-remove.js
+++ b/src/components/internals/tag-remove/tag-remove.js
@@ -4,13 +4,19 @@ import { CloseBoldIcon } from '../../icons';
 
 const TagRemove = props => (
   <div {...props.innerProps}>
-    <CloseBoldIcon size="medium" />
+    <CloseBoldIcon
+      theme={props.selectProps.isDisabled ? 'grey' : 'black'}
+      size="medium"
+    />
   </div>
 );
 
 TagRemove.displayName = 'TagRemove';
 
 TagRemove.propTypes = {
+  selectProps: PropTypes.shape({
+    isDisabled: PropTypes.bool.isRequired,
+  }).isRequired,
   innerProps: PropTypes.object,
 };
 


### PR DESCRIPTION
#### Summary

When `SelectInput`s are set to `isMulti`, then when they are disabled, the labels should look disabled.

I updated the VRTs as well, which should illustrate the fix.