### PR TITLE
chore: changelog and package.json for v8.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="8.3.1"></a>
+
+# [8.3.1](https://github.com/commercetools/ui-kit/compare/v8.3.0...v8.3.1) (2019-02-11)
+
+### Bug Fixes
+
+- SelectInputs and SelectFields: Wrong CSS is applied in case of multi and disabled states ([#532](https://github.com/commercetools/ui-kit/issues/532))
+
 <a name="8.3.0"></a>
 
 # [8.3.0](https://github.com/commercetools/ui-kit/compare/v8.2.0...v8.3.0) (2019-02-11)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercetools-frontend/ui-kit",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "UI component library based on our Design System",
   "homepage": "https://uikit.commercetools.com/",
   "bugs": "https://github.com/commercetools/ui-kit/issues",


### PR DESCRIPTION
I want to release version `8.3.1` to get the SelectInput fix in, so I can close the JIRA ticket.