### PR TITLE
feat(tooltip): allow passing in custom `BodyComponent`

### DIFF
--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -59,7 +59,17 @@ const FullWidthButton = styled.button`
 
 ### Customizing the tooltip body
 
-`Tooltip` accepts a `BodyComponent` prop to allow customizing the look and feel of the tooltip.
+You can customize the look and feel of the tooltip body by passing in a custom `BodyComponent`
+
+```js
+const Body = styled.div`
+  color: red;
+`;
+
+<Tooltip title="Delete" components={{ BodyComponent: Body }}>
+  <button>Submit</button>
+</Tooltip>;
+```
 
 #### Properties
 

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -57,6 +57,10 @@ const FullWidthButton = styled.button`
 </Tooltip>;
 ```
 
+### Customizing the tooltip body
+
+`Tooltip` accepts a `BodyComponent` prop to allow customizing the look and feel of the tooltip.
+
 #### Properties
 
 | Props                  | Type     | Required | Values                                                                                                                                       | Default | Description                                                                                     |
@@ -68,4 +72,4 @@ const FullWidthButton = styled.button`
 | `position`             | `object` |    -     | `top`, `top-start`, `top-end`, `right`, `right-start`, `right-end`, `bottom`, `bottom-end`, `bottom-start`, `left`, `left-start`, `left-end` | `top`   | How the tooltip is positioned relative to the child element                                     |
 | `horizontalConstraint` | `object` |    -     | `xs`, `s`, `m`, `l`, `xl`, `scale`                                                                                                           | `scale` | Horizontal size limit of the tooltip                                                            |
 | `children`             | `node`   |    ✅    | -                                                                                                                                            | -       | Content rendered within the tooltip                                                             |
-| `components`           | `object` |    -     | `WrapperComponent`                                                                                                                           | -       | If passed, the tooltip will wrap your component with this element                               |
+| `components`           | `object` |    -     | `WrapperComponent`, `BodyComponent`                                                                                                          | -       | If passed, the tooltip will wrap your component with this element                               |

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -7,7 +7,7 @@ import { Manager, Reference, Popper } from 'react-popper';
 import getFieldId from '../../utils/get-field-id';
 import createSequentialId from '../../utils/create-sequential-id';
 import RootRef from '../internals/root-ref';
-import { getBodyStyles } from './tooltip.styles';
+import { Body, getBodyStyles } from './tooltip.styles';
 
 const sequentialId = createSequentialId('tooltip-');
 
@@ -42,10 +42,18 @@ class Tooltip extends React.Component {
     ]),
     title: PropTypes.string.isRequired,
     components: PropTypes.shape({
+      BodyComponent: (props, propName) => {
+        if (props[propName] && !isValidElementType(props[propName])) {
+          return new Error(
+            `Invalid prop 'component' supplied to 'BodyComponent': the prop is not a valid React component`
+          );
+        }
+        return null;
+      },
       WrapperComponent: (props, propName) => {
         if (props[propName] && !isValidElementType(props[propName])) {
           return new Error(
-            `Invalid prop 'component' supplied to 'WrappedComponent': the prop is not a valid React component`
+            `Invalid prop 'component' supplied to 'WrapperComponent': the prop is not a valid React component`
           );
         }
         return null;
@@ -163,6 +171,7 @@ class Tooltip extends React.Component {
     };
 
     const WrapperComponent = this.props.components.WrapperComponent || Wrapper;
+    const BodyComponent = this.props.components.BodyComponent || Body;
 
     return (
       <Manager>
@@ -189,7 +198,7 @@ class Tooltip extends React.Component {
                 }}
                 data-placement={placement}
               >
-                {this.props.title}
+                <BodyComponent>{this.props.title}</BodyComponent>
               </div>
             )}
           </Popper>

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -45,7 +45,7 @@ class Tooltip extends React.Component {
       BodyComponent: (props, propName) => {
         if (props[propName] && !isValidElementType(props[propName])) {
           return new Error(
-            `Invalid prop 'component' supplied to 'BodyComponent': the prop is not a valid React component`
+            `Invalid prop 'components.BodyComponent' supplied to 'Tooltip': the prop is not a valid React component`
           );
         }
         return null;
@@ -53,7 +53,7 @@ class Tooltip extends React.Component {
       WrapperComponent: (props, propName) => {
         if (props[propName] && !isValidElementType(props[propName])) {
           return new Error(
-            `Invalid prop 'component' supplied to 'WrapperComponent': the prop is not a valid React component`
+            `Invalid prop 'components.WrapperComponent' supplied to 'Tooltip': the prop is not a valid React component`
           );
         }
         return null;

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -20,6 +20,7 @@ class TestComponent extends React.Component {
     onMouseLeave: PropTypes.func,
     onMouseOver: PropTypes.func,
     components: PropTypes.shape({
+      BodyComponent: PropTypes.any,
       WrapperComponent: PropTypes.any,
     }),
   };
@@ -226,6 +227,54 @@ const TooltipWrapper = React.forwardRef((props, ref) => (
 TooltipWrapper.propTypes = {
   children: PropTypes.node.isRequired,
 };
+
+const BodyComponent = props => (
+  <div data-testid="tooltip-custom-body">{props.children}</div>
+);
+
+BodyComponent.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+describe('when used with a custom body component', () => {
+  it('should render custom body and interact with keyboard', () => {
+    const onFocus = jest.fn();
+    const onBlur = jest.fn();
+    const onClose = jest.fn();
+    const onOpen = jest.fn();
+    const { container, queryByText, getByText } = render(
+      <TestComponent
+        onClose={onClose}
+        onOpen={onOpen}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        components={{ BodyComponent }}
+      />
+    );
+
+    const button = getByText('Submit');
+    fireEvent.focus(button);
+    // should call callbacks
+    expect(onFocus).toHaveBeenCalled();
+    expect(onOpen).toHaveBeenCalled();
+    // should show the tooltip and show the custom body
+    expect(
+      container.querySelector("[data-testid='tooltip-custom-body']")
+    ).toBeInTheDocument();
+
+    expect(getByText('What kind of bear is best?')).toBeInTheDocument();
+    // should remove the title
+    expect(button).toHaveProperty('title', '');
+    fireEvent.blur(button);
+    // should call callbacks
+    expect(onBlur).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+    // should hide tooltip
+    expect(queryByText('What kind of bear is best?')).not.toBeInTheDocument();
+    // should add the title again
+    expect(button).toHaveProperty('title', 'What kind of bear is best?');
+  });
+});
 
 describe('when used with a custom wrapper component', () => {
   it('should render custom wrapper and interact with keyboard', () => {

--- a/src/components/tooltip/tooltip.story.js
+++ b/src/components/tooltip/tooltip.story.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
@@ -21,10 +20,10 @@ const CustomWrapper = styled.div`
   background-color: pink;
 `;
 
-CustomWrapper.propTypes = {
-  children: PropTypes.node,
-};
-CustomWrapper.displayName = 'CustomWrapper';
+const CustomBody = styled.div`
+  font-size: 0.875rem;
+  color: red;
+`;
 
 storiesOf('Components|Tooltips', module)
   .addDecorator(withKnobs)
@@ -60,6 +59,7 @@ storiesOf('Components|Tooltips', module)
     const closeAfter = number('close after', 1000);
 
     const fullWidth = boolean('full width wrapper', false);
+    const customBodyWrapper = boolean('custom body wrapper', false);
 
     return (
       <Section>
@@ -74,7 +74,10 @@ storiesOf('Components|Tooltips', module)
             closeAfter={closeAfter}
             placement={placement}
             horizontalConstraint={constraint}
-            components={{ WrapperComponent: fullWidth ? CustomWrapper : null }}
+            components={{
+              WrapperComponent: fullWidth ? CustomWrapper : null,
+              BodyComponent: customBodyWrapper ? CustomBody : null,
+            }}
           >
             <PrimaryButton
               onClick={() => {}}

--- a/src/components/tooltip/tooltip.styles.js
+++ b/src/components/tooltip/tooltip.styles.js
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import vars from '../../../materials/custom-properties';
 
 const getOffsetMargin = ({ placement }) => {
@@ -32,22 +33,24 @@ const getMaxWidth = ({ constraint }) => {
   }
 };
 
+export const Body = styled.div`
+  font-family: ${vars.fontFamilyDefault};
+  border-radius: ${vars.borderRadius6};
+  padding: ${vars.spacing4} ${vars.spacing8};
+  border: 'none';
+  box-shadow: ${vars.shadow15};
+  font-size: 0.857rem;
+  opacity: 0.95;
+  color: ${vars.colorWhite};
+  background-color: ${vars.colorNavy};
+`;
 // here we use object styles so we can spread these
 // with the styles we get from react-popper :D
 // eslint-disable-next-line import/prefer-default-export
 export const getBodyStyles = ({ constraint, placement }) => ({
   fontFamily: vars.fontFamilyDefault,
-  borderRadius: vars.borderRadius6,
-  padding: `${vars.spacing4} ${vars.spacing8}`,
   margin: getOffsetMargin({ placement }),
-  border: 'none',
-  boxShadow: vars.shadow15,
-  verticalAlign: 'middle',
-  fontSize: '0.857rem',
-  opacity: '0.95',
   maxWidth: getMaxWidth({ constraint }),
   // so hovering over the tooltip when the tooltip overlaps the component
   pointerEvents: 'none',
-  color: vars.colorWhite,
-  backgroundColor: vars.colorNavy,
 });

--- a/src/components/tooltip/tooltip.visualroute.js
+++ b/src/components/tooltip/tooltip.visualroute.js
@@ -1,10 +1,16 @@
 import React from 'react';
 import { css } from '@emotion/core';
+import styled from '@emotion/styled';
 import { PrimaryButton, Tooltip } from 'ui-kit';
 import { Suite, Spec } from '../../../test/percy';
 
 const title = 'What kind of bear is best';
 const noop = () => {};
+
+const Body = styled.div`
+  color: red;
+  margin-top: 12px;
+`;
 
 export const routePath = '/tooltip';
 
@@ -22,6 +28,16 @@ export const component = () => (
         `}
       />
       <Tooltip title={title} isOpen={true}>
+        <PrimaryButton onClick={noop} label="Hello" />
+      </Tooltip>
+    </Spec>
+    <Spec label="Open with custom body component" omitPropsList>
+      <div
+        css={css`
+          margin-top: 50px;
+        `}
+      />
+      <Tooltip title={title} isOpen={true} components={{ BodyComponent: Body }}>
         <PrimaryButton onClick={noop} label="Hello" />
       </Tooltip>
     </Spec>


### PR DESCRIPTION
#### Summary

Allows customizing the tooltip body by passing in a custom body component. This way the consumer can apply the styles they want to the tooltip.