### PR TITLE
feat(tooltip): Add `off` prop

### DIFF
--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -73,13 +73,13 @@ const Body = styled.div`
 
 ### Conditionally displaying tooltips
 
-There may be cases when you only want to enable the display of a tooltip under a certain condition. In these cases, you may want to use the `isDisabled`.
+There may be cases when you only want to enable the display of a tooltip under a certain condition. In these cases, you may want to use the `off` prop.
 
 In the following example, the tooltip text only appears on hover when the button is disabled.
 
 ```js
 <Tooltip
-  isDisabled={!props.isDisabled}
+  off={props.isDisabled}
   title="You do not have permission to perform this action"
 >
   <button disabled={props.isDisabled}>Submit</button>

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -71,9 +71,11 @@ const Body = styled.div`
 </Tooltip>;
 ```
 
-### Disabling the tooltip functionality
+### Only displaying the tooltip under certain conditions
 
 There may be cases when you only want to enable the display of a tooltip under a certain condition. In these cases, you may want to set the `isEnabled` prop to false.
+
+In the following example, the tooltip text only appears on hover when the button is disabled.
 
 ```js
 <Tooltip

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -71,10 +71,24 @@ const Body = styled.div`
 </Tooltip>;
 ```
 
+### Disabling the tooltip functionality
+
+There may be cases when you only want to enable the display of a tooltip under a certain condition. In these cases, you may want to set the `isEnabled` prop to false.
+
+```js
+<Tooltip
+  isEnabled={!props.isDisabled}
+  title="You do not have permission to perform this action"
+>
+  <button disabled={props.isDisabled}>Submit</button>
+</Tooltip>
+```
+
 #### Properties
 
 | Props                  | Type     | Required | Values                                                                                                                                       | Default | Description                                                                                     |
 | ---------------------- | -------- | :------: | -------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `isEnabled`            | `bool`   |    -     | -                                                                                                                                            | true    | Whether or not the tooltip opens and closes as a result of event listeners.                     |
 | `isOpen`               | `bool`   |    -     | -                                                                                                                                            | -       | If passed, the tooltip's open and closed states are controlled by this prop                     |
 | `closeAfter`           | `number` |    -     | -                                                                                                                                            | 0       | Delay (in milliseconds) between the end of the user interaction, and the closing of the tooltip |
 | `onOpen`               | `func`   |    -     | -                                                                                                                                            | -       | Called when the tooltip is opened                                                               |

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -71,15 +71,15 @@ const Body = styled.div`
 </Tooltip>;
 ```
 
-### Only displaying the tooltip under certain conditions
+### Conditionally displaying tooltips
 
-There may be cases when you only want to enable the display of a tooltip under a certain condition. In these cases, you may want to set the `isEnabled` prop to false.
+There may be cases when you only want to enable the display of a tooltip under a certain condition. In these cases, you may want to set the `isDisabled` prop to false.
 
 In the following example, the tooltip text only appears on hover when the button is disabled.
 
 ```js
 <Tooltip
-  isEnabled={!props.isDisabled}
+  isDisabled={!props.isDisabled}
   title="You do not have permission to perform this action"
 >
   <button disabled={props.isDisabled}>Submit</button>
@@ -90,7 +90,7 @@ In the following example, the tooltip text only appears on hover when the button
 
 | Props                  | Type     | Required | Values                                                                                                                                       | Default | Description                                                                                     |
 | ---------------------- | -------- | :------: | -------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------- |
-| `isEnabled`            | `bool`   |    -     | -                                                                                                                                            | true    | Whether or not the tooltip opens and closes as a result of event listeners.                     |
+| `isDisabled`           | `bool`   |    -     | -                                                                                                                                            | false   | Whether or not the tooltip opens and closes as a result of event listeners.                     |
 | `isOpen`               | `bool`   |    -     | -                                                                                                                                            | -       | If passed, the tooltip's open and closed states are controlled by this prop                     |
 | `closeAfter`           | `number` |    -     | -                                                                                                                                            | 0       | Delay (in milliseconds) between the end of the user interaction, and the closing of the tooltip |
 | `onOpen`               | `func`   |    -     | -                                                                                                                                            | -       | Called when the tooltip is opened                                                               |

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -73,7 +73,7 @@ const Body = styled.div`
 
 ### Conditionally displaying tooltips
 
-There may be cases when you only want to enable the display of a tooltip under a certain condition. In these cases, you may want to set the `isDisabled` prop to false.
+There may be cases when you only want to enable the display of a tooltip under a certain condition. In these cases, you may want to use the `isDisabled`.
 
 In the following example, the tooltip text only appears on hover when the button is disabled.
 

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -23,6 +23,7 @@ class Tooltip extends React.Component {
     horizontalConstraint: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl', 'scale'])
       .isRequired,
     closeAfter: PropTypes.number.isRequired,
+    isEnabled: PropTypes.bool.isRequired,
     isOpen: PropTypes.bool,
     onClose: PropTypes.func,
     onOpen: PropTypes.func,
@@ -65,6 +66,7 @@ class Tooltip extends React.Component {
     components: {},
     closeAfter: 0,
     horizontalConstraint: 'scale',
+    isEnabled: true,
     placement: 'top',
     type: 'info',
   };
@@ -83,7 +85,6 @@ class Tooltip extends React.Component {
 
   handleEnter = event => {
     const childrenProps = this.props.children.props;
-
     // Remove the title ahead of time.
     // We don't want to wait for the next render commit.
     // We would risk displaying two tooltips at the same time (native + this one).
@@ -161,14 +162,21 @@ class Tooltip extends React.Component {
       title:
         !open && typeof this.props.title === 'string' ? this.props.title : null,
       ...this.props.children.props,
+      // don't pass event listeners to children
+      onFocus: null,
+      onMouseOver: null,
+      onMouseLeave: null,
+      onBlur: null,
     };
 
-    const eventListeners = {
-      onMouseOver: this.handleEnter,
-      onMouseLeave: this.handleLeave,
-      onFocus: this.handleEnter,
-      onBlur: this.handleLeave,
-    };
+    const eventListeners = this.props.isEnabled
+      ? {
+          onMouseOver: this.handleEnter,
+          onMouseLeave: this.handleLeave,
+          onFocus: this.handleEnter,
+          onBlur: this.handleLeave,
+        }
+      : {};
 
     const WrapperComponent = this.props.components.WrapperComponent || Wrapper;
     const BodyComponent = this.props.components.BodyComponent || Body;

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -23,7 +23,7 @@ class Tooltip extends React.Component {
     horizontalConstraint: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl', 'scale'])
       .isRequired,
     closeAfter: PropTypes.number.isRequired,
-    isDisabled: PropTypes.bool.isRequired,
+    off: PropTypes.bool.isRequired,
     isOpen: PropTypes.bool,
     onClose: PropTypes.func,
     onOpen: PropTypes.func,
@@ -66,7 +66,7 @@ class Tooltip extends React.Component {
     components: {},
     closeAfter: 0,
     horizontalConstraint: 'scale',
-    isDisabled: false,
+    off: false,
     placement: 'top',
     type: 'info',
   };
@@ -169,7 +169,7 @@ class Tooltip extends React.Component {
       onBlur: null,
     };
 
-    const eventListeners = !this.props.isDisabled
+    const eventListeners = !this.props.off
       ? {
           onMouseOver: this.handleEnter,
           onMouseLeave: this.handleLeave,

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -23,7 +23,7 @@ class Tooltip extends React.Component {
     horizontalConstraint: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl', 'scale'])
       .isRequired,
     closeAfter: PropTypes.number.isRequired,
-    isEnabled: PropTypes.bool.isRequired,
+    isDisabled: PropTypes.bool.isRequired,
     isOpen: PropTypes.bool,
     onClose: PropTypes.func,
     onOpen: PropTypes.func,
@@ -66,7 +66,7 @@ class Tooltip extends React.Component {
     components: {},
     closeAfter: 0,
     horizontalConstraint: 'scale',
-    isEnabled: true,
+    isDisabled: false,
     placement: 'top',
     type: 'info',
   };
@@ -169,7 +169,7 @@ class Tooltip extends React.Component {
       onBlur: null,
     };
 
-    const eventListeners = this.props.isEnabled
+    const eventListeners = !this.props.isDisabled
       ? {
           onMouseOver: this.handleEnter,
           onMouseLeave: this.handleLeave,

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -12,7 +12,7 @@ class TestComponent extends React.Component {
     buttonLabel: PropTypes.string.isRequired,
     isOpen: PropTypes.bool,
     id: PropTypes.string,
-    isEnabled: PropTypes.bool.isRequired,
+    isDisabled: PropTypes.bool,
     onOpen: PropTypes.func,
     onClose: PropTypes.func,
     onFocus: PropTypes.func,
@@ -27,7 +27,6 @@ class TestComponent extends React.Component {
   };
 
   static defaultProps = {
-    isEnabled: true,
     title: 'What kind of bear is best?',
     buttonLabel: 'Submit',
   };
@@ -48,7 +47,7 @@ class TestComponent extends React.Component {
         <Tooltip
           title={this.props.title}
           onClose={this.props.onClose}
-          isEnabled={this.props.isEnabled}
+          isDisabled={this.props.isDisabled}
           onOpen={this.props.onOpen}
           isOpen={this.state.open}
           id={this.props.id}
@@ -320,7 +319,7 @@ describe('when used with a custom wrapper component', () => {
   });
 });
 
-describe('when isEnabled is false', () => {
+describe('when isDisabled is true', () => {
   it('should not render a tooltip and not call callbacks', () => {
     const onMouseOver = jest.fn();
     const onMouseLeave = jest.fn();
@@ -330,7 +329,7 @@ describe('when isEnabled is false', () => {
     const onOpen = jest.fn();
     const { queryByText, getByText } = render(
       <TestComponent
-        isEnabled={false}
+        isDisabled={true}
         onClose={onClose}
         onOpen={onOpen}
         onFocus={onFocus}

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -12,7 +12,7 @@ class TestComponent extends React.Component {
     buttonLabel: PropTypes.string.isRequired,
     isOpen: PropTypes.bool,
     id: PropTypes.string,
-    isDisabled: PropTypes.bool,
+    off: PropTypes.bool,
     onOpen: PropTypes.func,
     onClose: PropTypes.func,
     onFocus: PropTypes.func,
@@ -47,7 +47,7 @@ class TestComponent extends React.Component {
         <Tooltip
           title={this.props.title}
           onClose={this.props.onClose}
-          isDisabled={this.props.isDisabled}
+          off={this.props.off}
           onOpen={this.props.onOpen}
           isOpen={this.state.open}
           id={this.props.id}
@@ -319,7 +319,7 @@ describe('when used with a custom wrapper component', () => {
   });
 });
 
-describe('when isDisabled is true', () => {
+describe('when off is true', () => {
   it('should not render a tooltip and not call callbacks', () => {
     const onMouseOver = jest.fn();
     const onMouseLeave = jest.fn();
@@ -329,7 +329,7 @@ describe('when isDisabled is true', () => {
     const onOpen = jest.fn();
     const { queryByText, getByText } = render(
       <TestComponent
-        isDisabled={true}
+        off={true}
         onClose={onClose}
         onOpen={onOpen}
         onFocus={onFocus}

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -12,6 +12,7 @@ class TestComponent extends React.Component {
     buttonLabel: PropTypes.string.isRequired,
     isOpen: PropTypes.bool,
     id: PropTypes.string,
+    isEnabled: PropTypes.bool.isRequired,
     onOpen: PropTypes.func,
     onClose: PropTypes.func,
     onFocus: PropTypes.func,
@@ -26,6 +27,7 @@ class TestComponent extends React.Component {
   };
 
   static defaultProps = {
+    isEnabled: true,
     title: 'What kind of bear is best?',
     buttonLabel: 'Submit',
   };
@@ -46,6 +48,7 @@ class TestComponent extends React.Component {
         <Tooltip
           title={this.props.title}
           onClose={this.props.onClose}
+          isEnabled={this.props.isEnabled}
           onOpen={this.props.onOpen}
           isOpen={this.state.open}
           id={this.props.id}
@@ -314,5 +317,60 @@ describe('when used with a custom wrapper component', () => {
     expect(queryByText('What kind of bear is best?')).not.toBeInTheDocument();
     // should add the title again
     expect(button).toHaveProperty('title', 'What kind of bear is best?');
+  });
+});
+
+describe('when isEnabled is false', () => {
+  it('should not render a tooltip and not call callbacks', () => {
+    const onMouseOver = jest.fn();
+    const onMouseLeave = jest.fn();
+    const onFocus = jest.fn();
+    const onBlur = jest.fn();
+    const onClose = jest.fn();
+    const onOpen = jest.fn();
+    const { queryByText, getByText } = render(
+      <TestComponent
+        isEnabled={false}
+        onClose={onClose}
+        onOpen={onOpen}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        onMouseOver={onMouseOver}
+        onMouseLeave={onMouseLeave}
+      />
+    );
+
+    const button = getByText('Submit');
+    fireEvent.focus(button);
+    // should not call callbacks when using keyboard
+    expect(onFocus).not.toHaveBeenCalled();
+    expect(onOpen).not.toHaveBeenCalled();
+
+    // should not be visible
+    expect(queryByText('What kind of bear is best?')).not.toBeInTheDocument();
+    // should not remove title
+    expect(button).toHaveProperty('title', 'What kind of bear is best?');
+
+    fireEvent.blur(button);
+
+    expect(onBlur).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+
+    // should not call callbacks when using mouse
+
+    fireEvent.mouseOver(button);
+
+    expect(onMouseOver).not.toHaveBeenCalled();
+    expect(onOpen).not.toHaveBeenCalled();
+
+    // should not be visible
+    expect(queryByText('What kind of bear is best?')).not.toBeInTheDocument();
+    // should not remove title
+    expect(button).toHaveProperty('title', 'What kind of bear is best?');
+
+    fireEvent.mouseLeave(button);
+
+    expect(onMouseLeave).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
#### Summary

Adds the prop `isEnabled` to the tooltip. It sort of mirrors the old "display" prop from the core tooltip.

#### Motivation

While refactoring the MC and adding the new tooltip, I found a lot of cases when I had to make code like this 

```js
const Button = props =>
  props.isDisabled ? (
    <Tooltip title="Disabled">
      <button disabled>Submit</button>
    </Tooltip>
  ) : (
    <button>Submit</button>
  );
```

This prop should make it a bit cleaner.

```js
const Button = props => (
    <Tooltip title="Disabled" off={!props.isDisabled}>
      <button disabled={props.isDisabled}>Submit</button>
    </Tooltip>
  );
```
