### PR TITLE
feat(spacings): support justify-content prop for Inline/Stack components

### DIFF
--- a/src/components/spacings/inline/README.md
+++ b/src/components/spacings/inline/README.md
@@ -18,11 +18,12 @@ import { Spacings } from '@commercetools-frontend/ui-kit';
 
 ## Properties
 
-| Props        | Type             | Required | Values                                                      | Default     |
-| ------------ | ---------------- | :------: | ----------------------------------------------------------- | ----------- |
-| `scale`      | `String`         |    -     | `['xs', 's', 'm', 'l', 'xl']`                               | `s`         |
-| `alignItems` | `oneOf`          |    -     | `['stretch', 'flexStart', 'flexEnd', 'center', 'baseline']` | `flexStart` |
-| `children`   | `PropTypes.node` |    -     | -                                                           | -           |
+| Props            | Type             | Required | Values                                                                                  | Default      |
+| ---------------- | ---------------- | :------: | --------------------------------------------------------------------------------------- | ------------ |
+| `scale`          | `String`         |    -     | `['xs', 's', 'm', 'l', 'xl']`                                                           | `s`          |
+| `alignItems`     | `oneOf`          |    -     | `['stretch', 'flex-start', 'flex-end', 'center', 'baseline']`                           | `flex-start` |
+| `justifyContent` | `oneOf`          |    -     | `['flex-start', 'flex-end', 'center', 'space-between', 'space-around', 'space-evenly']` | `flex-start` |
+| `children`       | `PropTypes.node` |    -     | -                                                                                       | -            |
 
 ## Scales
 

--- a/src/components/spacings/inline/inline.js
+++ b/src/components/spacings/inline/inline.js
@@ -14,17 +14,29 @@ Inline.propTypes = {
   scale: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
   alignItems: PropTypes.oneOf([
     'stretch',
-    'flexStart',
-    'flexEnd',
+    'flex-start',
+    'flex-end',
     'center',
     'baseline',
+    // Deprecated
+    'flexStart',
+    'flexEnd',
+  ]),
+  justifyContent: PropTypes.oneOf([
+    'flex-start',
+    'flex-end',
+    'center',
+    'space-between',
+    'space-around',
+    'space-evenly',
   ]),
   children: PropTypes.node,
 };
 
 Inline.defaultProps = {
   scale: 's',
-  alignItems: 'flexStart',
+  alignItems: 'flex-start',
+  justifyContent: 'flex-start',
 };
 
 export default Inline;

--- a/src/components/spacings/inline/inline.story.js
+++ b/src/components/spacings/inline/inline.story.js
@@ -54,7 +54,7 @@ storiesOf('Components|Spacings', module)
   .add('Inline', () => {
     const alignItems = select(
       'Align items',
-      ['flexStart', 'center', 'flexEnd', 'stretch', 'baseline'],
+      ['flex-start', 'center', 'flex-end', 'stretch', 'baseline'],
       'stretch'
     );
     return (

--- a/src/components/spacings/inline/inline.styles.js
+++ b/src/components/spacings/inline/inline.styles.js
@@ -1,18 +1,14 @@
 import { css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
 
-const getAlignItems = alignment => {
+const getAlignItem = alignment => {
   switch (alignment) {
-    case 'center':
-      return `align-items: center;`;
     case 'flexStart':
-      return `align-items: flex-start;`;
+      return `flex-start`;
     case 'flexEnd':
-      return `align-items: flex-end;`;
-    case 'stretch':
-      return `align-items: stretch;`;
+      return `flex-end`;
     default:
-      return ``;
+      return alignment;
   }
 };
 
@@ -35,7 +31,8 @@ const getMargin = scale => {
 
 export default props => css`
   display: flex;
-  ${getAlignItems(props.alignItems)}
+  align-items: ${getAlignItem(props.alignItems)};
+  justify-content: ${props.justifyContent};
 
   > * + * {
     margin: 0 0 0 ${getMargin(props.scale)};

--- a/src/components/spacings/spacings.visualroute.js
+++ b/src/components/spacings/spacings.visualroute.js
@@ -233,7 +233,7 @@ export const component = () => (
     ].map(prop => (
       <Spec
         key={`inline-justify-${prop}`}
-        label={`Inset - when justifyContent is ${prop}`}
+        label={`Inline - when justifyContent is ${prop}`}
       >
         <View>
           <Constraints.Horizontal constraint="scale">

--- a/src/components/spacings/spacings.visualroute.js
+++ b/src/components/spacings/spacings.visualroute.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { Spacings, Text } from 'ui-kit';
+import { Spacings, Text, Constraints } from 'ui-kit';
 import { Suite, Spec } from '../../../test/percy';
 
 export const routePath = '/spacings';
@@ -105,7 +105,7 @@ const insetSquishSizes = [
   { name: 'l', pixels: '16px x 32px' },
 ];
 
-const flexProps = ['stretch', 'flexStart', 'flexEnd', 'center'];
+const flexProps = ['stretch', 'flex-start', 'flex-end', 'center'];
 const exampleHeights = ['50px', '60px', '76px', '40px', '66px'];
 
 const StackExample = ({ alignItems }) => (
@@ -221,6 +221,36 @@ export const component = () => (
     {flexProps.map(prop => (
       <Spec key={`stack-${prop}`} label={`Stack - when alignItems is ${prop}`}>
         <StackExample alignItems={prop} />
+      </Spec>
+    ))}
+    {[
+      'flex-start',
+      'flex-end',
+      'center',
+      'space-between',
+      'space-around',
+      'space-evenly',
+    ].map(prop => (
+      <Spec
+        key={`inline-justify-${prop}`}
+        label={`Inset - when justifyContent is ${prop}`}
+      >
+        <View>
+          <Constraints.Horizontal constraint="scale">
+            <Spacings.Inline
+              scale="s"
+              alignItems="center"
+              justifyContent={prop}
+            >
+              <div>
+                <Text.Body>{'Text on the left'}</Text.Body>
+              </div>
+              <div>
+                <Text.Body>{'Text on the right'}</Text.Body>
+              </div>
+            </Spacings.Inline>
+          </Constraints.Horizontal>
+        </View>
       </Spec>
     ))}
   </Suite>

--- a/src/components/spacings/stack/README.md
+++ b/src/components/spacings/stack/README.md
@@ -18,12 +18,11 @@ import { Spacings } from '@commercetools-frontend/ui-kit';
 
 ## Properties
 
-| Props            | Type             | Required | Values                                                                                  | Default      |
-| ---------------- | ---------------- | :------: | --------------------------------------------------------------------------------------- | ------------ |
-| `scale`          | `String`         |    -     | `['xs', 's', 'm', 'l', 'xl']`                                                           | `s`          |
-| `alignItems`     | `oneOf`          |    -     | `['stretch', 'flex-start', 'flex-end', 'center']`                                       | `flex-start` |
-| `justifyContent` | `oneOf`          |    -     | `['flex-start', 'flex-end', 'center', 'space-between', 'space-around', 'space-evenly']` | `flex-start` |
-| `children`       | `PropTypes.node` |    -     | -                                                                                       | -            |
+| Props        | Type             | Required | Values                                            | Default      |
+| ------------ | ---------------- | :------: | ------------------------------------------------- | ------------ |
+| `scale`      | `String`         |    -     | `['xs', 's', 'm', 'l', 'xl']`                     | `s`          |
+| `alignItems` | `oneOf`          |    -     | `['stretch', 'flex-start', 'flex-end', 'center']` | `flex-start` |
+| `children`   | `PropTypes.node` |    -     | -                                                 | -            |
 
 ## Scales
 

--- a/src/components/spacings/stack/README.md
+++ b/src/components/spacings/stack/README.md
@@ -18,11 +18,12 @@ import { Spacings } from '@commercetools-frontend/ui-kit';
 
 ## Properties
 
-| Props        | Type             | Required | Values                                          | Default     |
-| ------------ | ---------------- | :------: | ----------------------------------------------- | ----------- |
-| `scale`      | `String`         |    -     | `['xs', 's', 'm', 'l', 'xl']`                   | `s`         |
-| `alignItems` | `oneOf`          |    -     | `['stretch', 'flexStart', 'flexEnd', 'center']` | `flexStart` |
-| `children`   | `PropTypes.node` |    -     | -                                               | -           |
+| Props            | Type             | Required | Values                                                                                  | Default      |
+| ---------------- | ---------------- | :------: | --------------------------------------------------------------------------------------- | ------------ |
+| `scale`          | `String`         |    -     | `['xs', 's', 'm', 'l', 'xl']`                                                           | `s`          |
+| `alignItems`     | `oneOf`          |    -     | `['stretch', 'flex-start', 'flex-end', 'center']`                                       | `flex-start` |
+| `justifyContent` | `oneOf`          |    -     | `['flex-start', 'flex-end', 'center', 'space-between', 'space-around', 'space-evenly']` | `flex-start` |
+| `children`       | `PropTypes.node` |    -     | -                                                                                       | -            |
 
 ## Scales
 

--- a/src/components/spacings/stack/stack.js
+++ b/src/components/spacings/stack/stack.js
@@ -13,12 +13,29 @@ Stack.displayName = 'Stack';
 Stack.propTypes = {
   scale: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
   children: PropTypes.node,
-  alignItems: PropTypes.oneOf(['stretch', 'flexStart', 'flexEnd', 'center']),
+  alignItems: PropTypes.oneOf([
+    'stretch',
+    'flex-start',
+    'flex-end',
+    'center',
+    // Deprecated
+    'flexStart',
+    'flexEnd',
+  ]),
+  justifyContent: PropTypes.oneOf([
+    'flex-start',
+    'flex-end',
+    'center',
+    'space-between',
+    'space-around',
+    'space-evenly',
+  ]),
 };
 
 Stack.defaultProps = {
   scale: 's',
   alignItems: 'stretch',
+  justifyContent: 'flex-start',
 };
 
 export default Stack;

--- a/src/components/spacings/stack/stack.js
+++ b/src/components/spacings/stack/stack.js
@@ -22,20 +22,11 @@ Stack.propTypes = {
     'flexStart',
     'flexEnd',
   ]),
-  justifyContent: PropTypes.oneOf([
-    'flex-start',
-    'flex-end',
-    'center',
-    'space-between',
-    'space-around',
-    'space-evenly',
-  ]),
 };
 
 Stack.defaultProps = {
   scale: 's',
   alignItems: 'stretch',
-  justifyContent: 'flex-start',
 };
 
 export default Stack;

--- a/src/components/spacings/stack/stack.story.js
+++ b/src/components/spacings/stack/stack.story.js
@@ -38,7 +38,7 @@ storiesOf('Components|Spacings', module)
   .add('Stack', () => {
     const alignItems = select(
       'Align items',
-      ['flexStart', 'center', 'flexEnd', 'stretch'],
+      ['flex-start', 'center', 'flex-end', 'stretch'],
       'stretch'
     );
     return (

--- a/src/components/spacings/stack/stack.styles.js
+++ b/src/components/spacings/stack/stack.styles.js
@@ -1,18 +1,14 @@
 import { css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
 
-const getAlignItems = alignment => {
+const getAlignItem = alignment => {
   switch (alignment) {
-    case 'center':
-      return `align-items: center;`;
     case 'flexStart':
-      return `align-items: flex-start;`;
+      return `flex-start`;
     case 'flexEnd':
-      return `align-items: flex-end;`;
-    case 'stretch':
-      return `align-items: stretch;`;
+      return `flex-end`;
     default:
-      return ``;
+      return alignment;
   }
 };
 
@@ -36,7 +32,8 @@ const getMargin = scale => {
 export default props => css`
   display: flex;
   flex-direction: column;
-  ${getAlignItems(props.alignItems)}
+  align-items: ${getAlignItem(props.alignItems)};
+  justify-content: ${props.justifyContent};
 
   > * + * {
     margin: ${getMargin(props.scale)} 0 0;

--- a/src/components/spacings/stack/stack.styles.js
+++ b/src/components/spacings/stack/stack.styles.js
@@ -33,7 +33,6 @@ export default props => css`
   display: flex;
   flex-direction: column;
   align-items: ${getAlignItem(props.alignItems)};
-  justify-content: ${props.justifyContent};
 
   > * + * {
     margin: ${getMargin(props.scale)} 0 0;


### PR DESCRIPTION
Fixes #552

#### Additional change

I also deprecated the `alignItems` values written in camelCase, which I found weird as we should simply pass the normal css values. So the "old" values are still supported for backwards compatibility.