### PR TITLE
feat(tooltip): add option for tooltip wrapper

### DIFF
--- a/src/components/table/table.story.js
+++ b/src/components/table/table.story.js
@@ -14,7 +14,7 @@ import Readme from './README.md';
 import Table from './table';
 import Tooltip from '../tooltip';
 
-const WithPortal = props => {
+const Portal = props => {
   const domNode = document.body;
   return ReactDOM.createPortal(props.children, domNode);
 };
@@ -267,7 +267,7 @@ class BaseTable extends React.PureComponent {
     if (!showTooltip) {
       return <div>{item[col.key]}</div>;
     }
-    const components = usePortal ? { PopperWrapperComponent: WithPortal } : {};
+    const components = usePortal ? { TooltipWrapperComponent: Portal } : {};
     return (
       <Tooltip components={components} title={tooltipText} placement="left">
         <div>{item[col.key]}</div>

--- a/src/components/table/table.story.js
+++ b/src/components/table/table.story.js
@@ -1,9 +1,10 @@
 import crypto from 'crypto';
 import React from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, number } from '@storybook/addon-knobs';
+import { withKnobs, boolean, number, text } from '@storybook/addon-knobs';
 import withReadme from 'storybook-readme/with-readme';
 import sortBy from 'lodash.sortby';
 import { css, ClassNames } from '@emotion/core';
@@ -11,6 +12,12 @@ import vars from '../../../materials/custom-properties';
 import Button from '../buttons/secondary-button';
 import Readme from './README.md';
 import Table from './table';
+import Tooltip from '../tooltip';
+
+const WithPortal = props => {
+  const domNode = document.body;
+  return ReactDOM.createPortal(props.children, domNode);
+};
 
 // Data generator for story
 
@@ -85,7 +92,18 @@ const baseColumns = ({ onCheckboxClick, checkboxClassName }) => [
 storiesOf('Components|Table', module)
   .addDecorator(withKnobs)
   .addDecorator(withReadme(Readme))
-  .add('basic example', () => <BaseTable />)
+  .add('basic example', () => {
+    const showTooltip = boolean('show tooltip', false);
+    const usePortal = boolean('use portal for tooltip', true);
+    const tooltipText = text('tooltip text', 'Tooltip example');
+    return (
+      <BaseTable
+        showTooltip={showTooltip}
+        tooltipText={tooltipText}
+        usePortal={usePortal}
+      />
+    );
+  })
   .add('full example', () => (
     <Wrapper>
       {props => {
@@ -135,6 +153,12 @@ storiesOf('Components|Table', module)
 // Basic example
 class BaseTable extends React.PureComponent {
   static displayName = 'BaseTable';
+
+  static propTypes = {
+    usePortal: PropTypes.bool.isRequired,
+    showTooltip: PropTypes.bool.isRequired,
+    tooltipText: PropTypes.string.isRequired,
+  };
   state = {
     rows: [
       {
@@ -222,9 +246,16 @@ class BaseTable extends React.PureComponent {
     sortDirection: undefined,
   };
 
-  renderItem = ({ rowIndex, columnIndex }) => {
+  renderItem = ({
+    rowIndex,
+    columnIndex,
+    showTooltip,
+    usePortal,
+    tooltipText,
+  }) => {
     const col = this.columns[columnIndex];
     const item = this.state.rows[rowIndex];
+
     if (columnIndex === 0)
       return (
         <input
@@ -233,7 +264,15 @@ class BaseTable extends React.PureComponent {
           name={`${item.id}-select`}
         />
       );
-    return <div>{item[col.key]}</div>;
+    if (!showTooltip) {
+      return <div>{item[col.key]}</div>;
+    }
+    const components = usePortal ? { PopperWrapperComponent: WithPortal } : {};
+    return (
+      <Tooltip components={components} title={tooltipText} placement="left">
+        <div>{item[col.key]}</div>
+      </Tooltip>
+    );
   };
 
   onCheckboxClick = ({ rowIndex /* , columnKey */ }) => {
@@ -273,7 +312,15 @@ class BaseTable extends React.PureComponent {
               <Table
                 columns={this.columns}
                 rowCount={this.state.rows.length}
-                itemRenderer={this.renderItem}
+                itemRenderer={({ rowIndex, columnIndex }) =>
+                  this.renderItem({
+                    rowIndex,
+                    columnIndex,
+                    showTooltip: this.props.showTooltip,
+                    tooltipText: this.props.tooltipText,
+                    usePortal: this.props.usePortal,
+                  })
+                }
                 onRowClick={action('row click')}
                 shouldFillRemainingVerticalSpace={true}
                 items={this.state.rows}

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -71,6 +71,18 @@ const Body = styled.div`
 </Tooltip>;
 ```
 
+### Customizing where the portal is rendered
+
+When you are dealing with virtualized components, it can be useful to render the tooltip into another part of the document. You can define a `PopperWrapperComponent` to do this.
+
+```js
+const Portal = props => ReactDOM.renderPortal(props.children, document.body);
+
+<Tooltip title="Delete" components={{ PopperWrapperComponent: Portal }}>
+  <button>Submit</button>
+</Tooltip>;
+```
+
 ### Conditionally displaying tooltips
 
 There may be cases when you only want to enable the display of a tooltip under a certain condition. In these cases, you may want to use the `off` prop.

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -73,12 +73,12 @@ const Body = styled.div`
 
 ### Customizing where the portal is rendered
 
-When you are dealing with virtualized components, it can be useful to render the tooltip into another part of the document. You can define a `PopperWrapperComponent` to do this.
+When you are dealing with virtualized components, it can be useful to render the tooltip into another part of the document. You can define a `TooltipWrapperComponent` to do this.
 
 ```js
 const Portal = props => ReactDOM.createPortal(props.children, document.body);
 
-<Tooltip title="Delete" components={{ PopperWrapperComponent: Portal }}>
+<Tooltip title="Delete" components={{ TooltipWrapperComponent: Portal }}>
   <button>Submit</button>
 </Tooltip>;
 ```

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -76,7 +76,7 @@ const Body = styled.div`
 When you are dealing with virtualized components, it can be useful to render the tooltip into another part of the document. You can define a `PopperWrapperComponent` to do this.
 
 ```js
-const Portal = props => ReactDOM.renderPortal(props.children, document.body);
+const Portal = props => ReactDOM.createPortal(props.children, document.body);
 
 <Tooltip title="Delete" components={{ PopperWrapperComponent: Portal }}>
   <button>Submit</button>

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -15,11 +15,11 @@ const Wrapper = styled.div`
   display: inline-block;
 `;
 
-const PopperWrapperComponent = props => (
+const TooltipWrapperComponent = props => (
   <React.Fragment>{props.children}</React.Fragment>
 );
-PopperWrapperComponent.displayName = 'PopperWrapperComponent';
-PopperWrapperComponent.propTypes = {
+TooltipWrapperComponent.displayName = 'TooltipWrapperComponent';
+TooltipWrapperComponent.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
@@ -59,10 +59,10 @@ class Tooltip extends React.Component {
         }
         return null;
       },
-      PopperWrapperComponent: (props, propName) => {
+      TooltipWrapperComponent: (props, propName) => {
         if (props[propName] && !isValidElementType(props[propName])) {
           return new Error(
-            `Invalid prop 'components.PopperWrapperComponent' supplied to 'Tooltip': the prop is not a valid React component`
+            `Invalid prop 'components.TooltipWrapperComponent' supplied to 'Tooltip': the prop is not a valid React component`
           );
         }
         return null;
@@ -196,8 +196,8 @@ class Tooltip extends React.Component {
 
     const WrapperComponent = this.props.components.WrapperComponent || Wrapper;
     const BodyComponent = this.props.components.BodyComponent || Body;
-    const PopperWrapper =
-      this.props.components.PopperWrapperComponent || PopperWrapperComponent;
+    const TooltipWrapper =
+      this.props.components.TooltipWrapperComponent || TooltipWrapperComponent;
     return (
       <Manager>
         <Reference innerRef={this.setChildrenRef}>
@@ -210,7 +210,7 @@ class Tooltip extends React.Component {
           )}
         </Reference>
         {open && (
-          <PopperWrapper>
+          <TooltipWrapper>
             <Popper placement={this.props.placement} positionFixed={true}>
               {({ ref, style, placement }) => (
                 <div
@@ -228,7 +228,7 @@ class Tooltip extends React.Component {
                 </div>
               )}
             </Popper>
-          </PopperWrapper>
+          </TooltipWrapper>
         )}
       </Manager>
     );

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -15,11 +15,11 @@ const Wrapper = styled.div`
   display: inline-block;
 `;
 
-const TooltipWrapperComponent = props => (
+const TooltipWrapper = props => (
   <React.Fragment>{props.children}</React.Fragment>
 );
-TooltipWrapperComponent.displayName = 'TooltipWrapperComponent';
-TooltipWrapperComponent.propTypes = {
+TooltipWrapper.displayName = 'TooltipWrapperComponent';
+TooltipWrapper.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
@@ -196,8 +196,8 @@ class Tooltip extends React.Component {
 
     const WrapperComponent = this.props.components.WrapperComponent || Wrapper;
     const BodyComponent = this.props.components.BodyComponent || Body;
-    const TooltipWrapper =
-      this.props.components.TooltipWrapperComponent || TooltipWrapperComponent;
+    const TooltipWrapperComponent =
+      this.props.components.TooltipWrapperComponent || TooltipWrapper;
     return (
       <Manager>
         <Reference innerRef={this.setChildrenRef}>
@@ -210,7 +210,7 @@ class Tooltip extends React.Component {
           )}
         </Reference>
         {open && (
-          <TooltipWrapper>
+          <TooltipWrapperComponent>
             <Popper placement={this.props.placement} positionFixed={true}>
               {({ ref, style, placement }) => (
                 <div
@@ -228,7 +228,7 @@ class Tooltip extends React.Component {
                 </div>
               )}
             </Popper>
-          </TooltipWrapper>
+          </TooltipWrapperComponent>
         )}
       </Manager>
     );

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -15,6 +15,14 @@ const Wrapper = styled.div`
   display: inline-block;
 `;
 
+const PopperWrapperComponent = props => (
+  <React.Fragment>{props.children}</React.Fragment>
+);
+PopperWrapperComponent.displayName = 'PopperWrapperComponent';
+PopperWrapperComponent.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
 class Tooltip extends React.Component {
   static displayName = 'ToolTip';
 
@@ -47,6 +55,14 @@ class Tooltip extends React.Component {
         if (props[propName] && !isValidElementType(props[propName])) {
           return new Error(
             `Invalid prop 'components.BodyComponent' supplied to 'Tooltip': the prop is not a valid React component`
+          );
+        }
+        return null;
+      },
+      PopperWrapperComponent: (props, propName) => {
+        if (props[propName] && !isValidElementType(props[propName])) {
+          return new Error(
+            `Invalid prop 'components.PopperWrapperComponent' supplied to 'Tooltip': the prop is not a valid React component`
           );
         }
         return null;
@@ -180,7 +196,8 @@ class Tooltip extends React.Component {
 
     const WrapperComponent = this.props.components.WrapperComponent || Wrapper;
     const BodyComponent = this.props.components.BodyComponent || Body;
-
+    const PopperWrapper =
+      this.props.components.PopperWrapperComponent || PopperWrapperComponent;
     return (
       <Manager>
         <Reference innerRef={this.setChildrenRef}>
@@ -193,23 +210,25 @@ class Tooltip extends React.Component {
           )}
         </Reference>
         {open && (
-          <Popper placement={this.props.placement}>
-            {({ ref, style, placement }) => (
-              <div
-                ref={ref}
-                css={{
-                  ...style,
-                  ...getBodyStyles({
-                    constraint: this.props.horizontalConstraint,
-                    placement,
-                  }),
-                }}
-                data-placement={placement}
-              >
-                <BodyComponent>{this.props.title}</BodyComponent>
-              </div>
-            )}
-          </Popper>
+          <PopperWrapper>
+            <Popper placement={this.props.placement} positionFixed={true}>
+              {({ ref, style, placement }) => (
+                <div
+                  ref={ref}
+                  css={{
+                    ...style,
+                    ...getBodyStyles({
+                      constraint: this.props.horizontalConstraint,
+                      placement,
+                    }),
+                  }}
+                  data-placement={placement}
+                >
+                  <BodyComponent>{this.props.title}</BodyComponent>
+                </div>
+              )}
+            </Popper>
+          </PopperWrapper>
         )}
       </Manager>
     );

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -7,7 +7,7 @@ import Tooltip from './tooltip';
 jest.mock('popper.js');
 jest.useFakeTimers();
 
-const WithPortal = props => {
+const Portal = props => {
   const domNode = document.querySelector('#portal-id');
   return ReactDOM.createPortal(props.children, domNode);
 };
@@ -27,7 +27,7 @@ class TestComponent extends React.Component {
     onMouseLeave: PropTypes.func,
     onMouseOver: PropTypes.func,
     components: PropTypes.shape({
-      PopperWrapperComponent: PropTypes.any,
+      TooltipWrapperComponent: PropTypes.any,
       BodyComponent: PropTypes.any,
       WrapperComponent: PropTypes.any,
     }),
@@ -348,7 +348,7 @@ describe('when used with a custom popper wrapper component', () => {
         onBlur={onBlur}
         components={{
           BodyComponent,
-          PopperWrapperComponent: WithPortal,
+          TooltipWrapperComponent: Portal,
         }}
       />
     );


### PR DESCRIPTION
#### Summary

Adds another `component` prop to the `Tooltip` component, `TooltipWrapperComponent`. This can be used along with `ReactDOM.renderPortal` to render the Tooltip to another place inside of the document. This is useful when dealing with virtualized items, like our table.

The following example uses a simple `TooltipWrapperComponent` that renders the portal as a descendent of `document.body`. 

#### Before

![before](https://user-images.githubusercontent.com/2425013/53167976-ccb37880-35d9-11e9-9e9e-c34c279f14dc.gif)

#### After

![after](https://user-images.githubusercontent.com/2425013/53167940-adb4e680-35d9-11e9-8817-6b4062994399.gif)
