### PR TITLE
Fix parse money value in MoneyInput

### DIFF
--- a/src/components/inputs/money-input/money-input.form.story.js
+++ b/src/components/inputs/money-input/money-input.form.story.js
@@ -3,7 +3,7 @@ import { Formik } from 'formik';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { injectIntl } from 'react-intl';
-import { withKnobs } from '@storybook/addon-knobs';
+import { withKnobs, number } from '@storybook/addon-knobs';
 import withReadme from 'storybook-readme/with-readme';
 import omitEmpty from 'omit-empty';
 import ErrorMessage from '../../messages/error-message';
@@ -25,68 +25,82 @@ const validate = (formValues, locale) => {
   }
   return omitEmpty(errors);
 };
-const Story = injectIntl(props => (
-  <Section>
-    <Formik
-      initialValues={{ price: { currencyCode: '', amount: '' } }}
-      validate={formValues => validate(formValues, props.intl.locale)}
-      onSubmit={(values, formik) => {
-        // eslint-disable-next-line no-console
-        console.log(
-          'money value',
-          MoneyInput.convertToMoneyValue(values.price, props.intl.locale)
-        );
-        action('onSubmit')(values, formik);
-        formik.resetForm(values);
-      }}
-      render={formik => (
-        <Spacings.Stack scale="l">
-          <Spacings.Stack scale="s">
-            <MoneyInput
-              name="price"
-              currencies={['EUR', 'USD', 'AED', 'KWD', 'JPY']}
-              value={formik.values.price}
-              onChange={formik.handleChange}
-              onBlur={formik.handleBlur}
-              hasError={
-                MoneyInput.isTouched(formik.touched.price) &&
-                Boolean(formik.errors.price)
-              }
-              horizontalConstraint="m"
-            />
-            {MoneyInput.isTouched(formik.touched.price) &&
-              formik.errors.price &&
-              formik.errors.price.missing && (
-                <ErrorMessage>Missing price</ErrorMessage>
-              )}
-            {MoneyInput.isTouched(formik.touched.price) &&
-              formik.errors.price &&
-              formik.errors.price.unsupportedHighPrecision && (
-                <ErrorMessage>
-                  This value is a high precision value. High precision pricing
-                  is not supported for products.
-                </ErrorMessage>
-              )}
+const Story = injectIntl(props => {
+  const initialCentAmount = number('initial cent amount', 10099);
+  const initialFractionDigits = number('initial fraction digits', 2);
+  return (
+    <Section>
+      <Formik
+        initialValues={{
+          price: MoneyInput.parseMoneyValue(
+            {
+              centAmount: initialCentAmount,
+              currencyCode: 'EUR',
+              fractionDigits: initialFractionDigits,
+              type: 'centPrecision',
+            },
+            props.intl.locale
+          ),
+        }}
+        validate={formValues => validate(formValues, props.intl.locale)}
+        onSubmit={(values, formik) => {
+          // eslint-disable-next-line no-console
+          console.log(
+            'money value',
+            MoneyInput.convertToMoneyValue(values.price, props.intl.locale)
+          );
+          action('onSubmit')(values, formik);
+          formik.resetForm(values);
+        }}
+        render={formik => (
+          <Spacings.Stack scale="l">
+            <Spacings.Stack scale="s">
+              <MoneyInput
+                name="price"
+                currencies={['EUR', 'USD', 'AED', 'KWD', 'JPY']}
+                value={formik.values.price}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+                hasError={
+                  MoneyInput.isTouched(formik.touched.price) &&
+                  Boolean(formik.errors.price)
+                }
+                horizontalConstraint="m"
+              />
+              {MoneyInput.isTouched(formik.touched.price) &&
+                formik.errors.price &&
+                formik.errors.price.missing && (
+                  <ErrorMessage>Missing price</ErrorMessage>
+                )}
+              {MoneyInput.isTouched(formik.touched.price) &&
+                formik.errors.price &&
+                formik.errors.price.unsupportedHighPrecision && (
+                  <ErrorMessage>
+                    This value is a high precision value. High precision pricing
+                    is not supported for products.
+                  </ErrorMessage>
+                )}
+            </Spacings.Stack>
+            <Spacings.Inline>
+              <SecondaryButton
+                onClick={formik.handleReset}
+                isDisabled={formik.isSubmitting}
+                label="Reset"
+              />
+              <PrimaryButton
+                onClick={formik.handleSubmit}
+                isDisabled={formik.isSubmitting || !formik.dirty}
+                label="Submit"
+              />
+            </Spacings.Inline>
+            <hr />
+            <FormikBox formik={formik} />
           </Spacings.Stack>
-          <Spacings.Inline>
-            <SecondaryButton
-              onClick={formik.handleReset}
-              isDisabled={formik.isSubmitting}
-              label="Reset"
-            />
-            <PrimaryButton
-              onClick={formik.handleSubmit}
-              isDisabled={formik.isSubmitting || !formik.dirty}
-              label="Submit"
-            />
-          </Spacings.Inline>
-          <hr />
-          <FormikBox formik={formik} />
-        </Spacings.Stack>
-      )}
-    />
-  </Section>
-));
+        )}
+      />
+    </Section>
+  );
+});
 storiesOf('Examples|Forms/Inputs', module)
   .addDecorator(withKnobs)
   .addDecorator(withReadme(Readme))

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -340,7 +340,7 @@ class MoneyInput extends React.Component {
     );
 
     const amount = formatAmount(
-      String(getAmountAsNumberFromMoneyValue(moneyValue)),
+      getAmountAsNumberFromMoneyValue(moneyValue).toLocaleString(locale),
       moneyValue.currencyCode,
       locale
     );


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary
While fixing previouse issue https://github.com/commercetools/ui-kit/issues/538 another issue was added :( 
Which makes incorrect value rendered in the german locale German.
Will walk you through the issue

| Before | After |
|-|-|
| ![if-fix-parse-money-value-before](https://user-images.githubusercontent.com/7680511/54355234-cf454300-4658-11e9-82ca-8f3b7cbef3aa.gif) | ![money-input after](https://user-images.githubusercontent.com/7680511/54355233-cf454300-4658-11e9-8a6f-b2a2440489b1.gif) |

### The issue
Let's say that the output from `getAmountAsNumberFromMoneyValue` was `14.55`

1. When we get the formatted amount in `parseMoneyValue`,  we stringify the amount first using `String` function. (which doesn't consider the locale ) so the output of `String(getAmountAsNumberFromMoneyValue(moneyValue))` in our case will be `"14.55"` no matter what the locale was
https://github.com/commercetools/ui-kit/blob/e124de8154c84a8cc20769cd2cd744a034e06862/src/components/inputs/money-input/money-input.js#L343 
2. And in the `formatAmount` function we create the money value using this string (rawAmount is `"14.55"`)
https://github.com/commercetools/ui-kit/blob/e124de8154c84a8cc20769cd2cd744a034e06862/src/components/inputs/money-input/money-input.js#L277
3. And in `createMoneyValue` function 
we parse  (rawAmount is `"14.55"`)  https://github.com/commercetools/ui-kit/blob/e124de8154c84a8cc20769cd2cd744a034e06862/src/components/inputs/money-input/money-input.js#L210

4. And in `parseRawAmountToNumber` function 
we remove the thousand separator (`.` in `de` locale, `,` in `en` locale) from the rawAmount
https://github.com/commercetools/ui-kit/blob/e124de8154c84a8cc20769cd2cd744a034e06862/src/components/inputs/money-input/money-input.js#L180

## Proposed fix
In the beginning, when we stringify the value, use a function that stringify with respect to the locale, because we'll latter remove the thousands spirators based on the provided locale

## Why did we miss this issue during development
- The issue happens when we convert to formValues in `de` locale ( or `es` or any locale that uses `.` as a thousands separator).
And in our story, we initialise the form with empty values.
- Also the test env doesn't have `de` locale, so we can't reproduce it in tests

## Repreduce on MC
- Switch your profile to `de` locale
- in [Merchant Center cart discount list](https://mc.escemo.com/sunrise-data-alex/discounts/carts?query=eyJzZWFyY2hUZXh0IjoidGVzdC1pbmNvbnNpc3RlbnQtdmFsaWRpdHkiLCJzb3J0aW5nIjp7ImtleSI6InNvcnRPcmRlciIsIm9yZGVyIjoiYXNjIn0sImZpbHRlcnMiOnt9LCJwYWdlIjoxLCJwZXJQYWdlIjoyMH0%3D) notice the value of a discount, then
- open the details, you'll find that the value is not accurate.