### PR TITLE
fix(table): to remove jumpy effect on hover

### DIFF
--- a/src/components/table/sortable-header/sortable-header.js
+++ b/src/components/table/sortable-header/sortable-header.js
@@ -42,6 +42,7 @@ const SortableHeader = props => {
       css={[
         css`
           display: flex;
+          align-items: center;
           justify-content: space-between;
           &:hover {
             cursor: pointer;


### PR DESCRIPTION
#### Summary

On tables with a sortable header, the column title jumps on hover because it aligns differently when the arrow shows up.
![Kapture 2019-03-15 at 18 21 34](https://user-images.githubusercontent.com/2941328/54450289-5cb78e80-4750-11e9-8edb-0df2a1d75ef8.gif)

This PR fixes this bug.