### PR TITLE
refactor(collapsible-panel): add `min-height`

### DIFF
--- a/src/components/panels/collapsible-panel/collapsible-panel.js
+++ b/src/components/panels/collapsible-panel/collapsible-panel.js
@@ -106,7 +106,10 @@ export default class CollapsiblePanel extends React.PureComponent {
               <Spacings.InsetSquish scale={scale}>
                 <div
                   {...dataProps}
-                  css={getHeaderStyles({ isDisabled: this.props.isDisabled })}
+                  css={getHeaderStyles({
+                    isCondensed: this.props.condensed,
+                    isDisabled: this.props.isDisabled,
+                  })}
                 >
                   <div
                     css={css`

--- a/src/components/panels/collapsible-panel/collapsible-panel.styles.js
+++ b/src/components/panels/collapsible-panel/collapsible-panel.styles.js
@@ -61,7 +61,7 @@ const getHeaderContainerStyles = ({ isDisabled, isOpen, isSticky, theme }) => {
   ];
 };
 
-const getHeaderStyles = ({ isDisabled }) => {
+const getHeaderStyles = ({ isDisabled, isCondensed }) => {
   const baseStyles = css`
     display: flex;
     flex: 1;
@@ -96,7 +96,16 @@ const getHeaderStyles = ({ isDisabled }) => {
       `,
     ];
   }
-  return baseStyles;
+  return [
+    baseStyles,
+    !isCondensed &&
+      css`
+        /**
+         We set a min-height of 32px to anticipate use-cases where SecondaryButton or PrimaryButton
+         are rendered in the headerControl */
+        min-height: ${vars.spacing32};
+      `,
+  ];
 };
 
 const getContentStyles = () => css`


### PR DESCRIPTION
#### Summary

- adds `min-height` of `32px` on CollapsiblePanel's header section
This is done to anticipate use cases that renders `{Secondary|Primary}Button` on the header

With this, we can experience that the header's height "jumps" when `{Secondary|Primary}Button` are conditionally rendered