### PR TITLE
fix(select-inputs): always show scrollbar

### DIFF
--- a/src/components/internals/create-select-styles.js
+++ b/src/components/internals/create-select-styles.js
@@ -96,7 +96,6 @@ const menuListStyles = () => base => ({
   '&::-webkit-scrollbar-track': {
     '-webkit-border-radius': '5px',
     borderRadius: '5px',
-    // background: 'rgba(0,0,0,0.1)',
   },
 
   '&::-webkit-scrollbar-thumb': {

--- a/src/components/internals/create-select-styles.js
+++ b/src/components/internals/create-select-styles.js
@@ -90,13 +90,27 @@ const menuListStyles = () => base => ({
   backgroundColor: vars.backgroundColorInputPristine,
 
   '&::-webkit-scrollbar': {
-    '-webkit-appearance': 'none',
-    width: '7px',
+    width: '9px',
+  },
+
+  '&::-webkit-scrollbar-track': {
+    '-webkit-border-radius': '5px',
+    borderRadius: '5px',
+    background: 'rgba(0,0,0,0.1)',
   },
 
   '&::-webkit-scrollbar-thumb': {
-    borderRadius: '4px',
-    backgroundColor: 'rgba(0, 0, 0, .5)',
+    '-webkit-border-radius': '5px',
+    borderRadius: '5px',
+    background: 'rgba(0,0,0,0.2)',
+  },
+
+  '&::-webkit-scrollbar-thumb:hover': {
+    background: 'rgba(0,0,0,0.4)',
+  },
+
+  '&::-webkit-scrollbar-thumb:window-inactive': {
+    // background: 'rgba(0,0,0,0.05)',
   },
 });
 

--- a/src/components/internals/create-select-styles.js
+++ b/src/components/internals/create-select-styles.js
@@ -96,7 +96,7 @@ const menuListStyles = () => base => ({
   '&::-webkit-scrollbar-track': {
     '-webkit-border-radius': '5px',
     borderRadius: '5px',
-    background: 'rgba(0,0,0,0.1)',
+    // background: 'rgba(0,0,0,0.1)',
   },
 
   '&::-webkit-scrollbar-thumb': {
@@ -110,7 +110,7 @@ const menuListStyles = () => base => ({
   },
 
   '&::-webkit-scrollbar-thumb:window-inactive': {
-    // background: 'rgba(0,0,0,0.05)',
+    background: 'rgba(0,0,0,0.05)',
   },
 });
 

--- a/src/components/internals/create-select-styles.js
+++ b/src/components/internals/create-select-styles.js
@@ -27,7 +27,6 @@ const controlStyles = props => (base, state) => ({
   minHeight: vars.sizeHeightInput,
   cursor: state.isDisabled ? 'not-allowed' : 'pointer',
   padding: `0 ${vars.spacing8}`,
-
   boxShadow: state.isFocused ? 'none' : base.boxShadow,
 
   '&:hover': {
@@ -89,6 +88,16 @@ const menuListStyles = () => base => ({
   padding: '0',
   borderRadius: vars.borderRadiusInput,
   backgroundColor: vars.backgroundColorInputPristine,
+
+  '&::-webkit-scrollbar': {
+    '-webkit-appearance': 'none',
+    width: '7px',
+  },
+
+  '&::-webkit-scrollbar-thumb': {
+    borderRadius: '4px',
+    backgroundColor: 'rgba(0, 0, 0, .5)',
+  },
 });
 
 const optionStyles = () => (base, state) => ({

--- a/src/components/internals/create-select-styles.js
+++ b/src/components/internals/create-select-styles.js
@@ -89,6 +89,10 @@ const menuListStyles = () => base => ({
   borderRadius: vars.borderRadiusInput,
   backgroundColor: vars.backgroundColorInputPristine,
 
+  // this CSS is here to override the default scroll behaviour in Mac OSX
+  // that hides the scrollbar unless you are scrolling.
+  // it comes from here http://blog.0100.tv/2012/11/webkit-scrollbars-on-os-x/
+
   '&::-webkit-scrollbar': {
     width: '9px',
   },


### PR DESCRIPTION
#### Summary

The design team requested for us to always show the scroll bar in the `SelectInputs`. Right now it's not very obvious to users when they can scroll inside the select inputs.

This PR introduces that change.

#### Before

![beforeS](https://user-images.githubusercontent.com/2425013/55236148-921faa00-522f-11e9-9939-9c7655a126f2.gif)


#### After

![afterS](https://user-images.githubusercontent.com/2425013/55236152-951a9a80-522f-11e9-8f6f-91ab0602f7af.gif)
