### PR TITLE
fix(circleci): releasing to next

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,3 +148,5 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,5 +147,4 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              only:
-                - master
+              ignore: /.*/


### PR DESCRIPTION
#### Summary

On CircleCI we currently attempt to release from `master` without a tag. Which fails as the previous version already exists.

Given this configuration:

```yml
workflows:
  version: 2
  build-n-deploy:
    jobs:
      - build:
          filters:  # required since `deploy` has tag filters AND requires `build`
            tags:
              only: /.*/
      - deploy:
          requires:
            - build
          filters:
            tags:
              only: /^v.*/
            branches:
              ignore: /.*/
```

- The build job runs for all branches and all tags.
- The deploy job runs for no branches and only for tags starting with ‘v’.

