### PR TITLE
fix: LinkButton to use inline TextBody

### DIFF
--- a/src/components/buttons/link-button/link-button.js
+++ b/src/components/buttons/link-button/link-button.js
@@ -22,12 +22,12 @@ const LinkButton = props => (
         min-height: initial;
         cursor: pointer;
         text-decoration: none;
-        p {
+        span {
           color: ${vars.colorGreen};
           ${props.isDisabled ? `color: ${vars.colorGray};` : ''}
         }
         &:hover {
-          p {
+          span {
             color: ${vars.colorGreen25};
             ${props.isDisabled ? `color: ${vars.colorGray});` : ''}
           }
@@ -50,7 +50,7 @@ const LinkButton = props => (
           size: 'medium',
           theme: props.isDisabled ? 'grey' : 'green',
         })}
-      <Text.Body>{props.label}</Text.Body>
+      <Text.Body isInline={true}>{props.label}</Text.Body>
     </Spacings.Inline>
   </Link>
 );

--- a/src/components/typography/text/README.md
+++ b/src/components/typography/text/README.md
@@ -94,7 +94,7 @@ Wraps the given text in a `<p>` element, for normal content.
 | `children` | `PropTypes.node` |    ✅    | -                                                                             | -       |
 | `title`    | `String`         |    -     | -                                                                             | -       |
 | `truncate` | `Bool`           |    -     | -                                                                             | `false` |
-| `inline`   | `Bool`           |    -     | -                                                                             | `false` |
+| `isInline` | `Bool`           |    -     | -                                                                             | `false` |
 
 The component further forwards all `data-` attributes to the underlying component.
 
@@ -124,7 +124,7 @@ properly style the text.
 | `children` | `PropTypes.node` |    ✅    | -                                                                             | -       |
 | `title`    | `String`         |    -     | -                                                                             | -       |
 | `truncate` | `Bool`           |    -     | -                                                                             | `false` |
-| `inline`   | `Bool`           |    -     | -                                                                             | `false` |
+| `isInline` | `Bool`           |    -     | -                                                                             | `false` |
 
 The component further forwards all `data-` attributes to the underlying component.
 

--- a/src/components/typography/text/README.md
+++ b/src/components/typography/text/README.md
@@ -94,6 +94,7 @@ Wraps the given text in a `<p>` element, for normal content.
 | `children` | `PropTypes.node` |    ✅    | -                                                                             | -       |
 | `title`    | `String`         |    -     | -                                                                             | -       |
 | `truncate` | `Bool`           |    -     | -                                                                             | `false` |
+| `inline`   | `Bool`           |    -     | -                                                                             | `false` |
 
 The component further forwards all `data-` attributes to the underlying component.
 
@@ -123,6 +124,7 @@ properly style the text.
 | `children` | `PropTypes.node` |    ✅    | -                                                                             | -       |
 | `title`    | `String`         |    -     | -                                                                             | -       |
 | `truncate` | `Bool`           |    -     | -                                                                             | `false` |
+| `inline`   | `Bool`           |    -     | -                                                                             | `false` |
 
 The component further forwards all `data-` attributes to the underlying component.
 


### PR DESCRIPTION
#### Summary

This PR:
- Updates documentation of `Text.Body` and `Text.Detail` to include the `isInline` prop.
- Fixes #588 by using the aforementioned prop.

#### Description

There is still a problem with the `LinkButton` rendering a `div` (from the `Spacings.Inline` wrapper), which inside a `p` is also an invalid DOM nesting. I shall address this in a follow-up PR.
