### PR TITLE
chore: Spacings.Inline to render a span instead of div

### DIFF
--- a/src/components/spacings/inline/inline.js
+++ b/src/components/spacings/inline/inline.js
@@ -4,9 +4,9 @@ import filterDataAttributes from '../../../utils/filter-data-attributes';
 import getStyles from './inline.styles';
 
 const Inline = props => (
-  <div css={getStyles(props)} {...filterDataAttributes(props)}>
+  <span css={getStyles(props)} {...filterDataAttributes(props)}>
     {props.children}
-  </div>
+  </span>
 );
 
 Inline.displayName = 'Inline';


### PR DESCRIPTION
Following #627 and related to #588: 

Since the `Spacings.Inline` component may often be used as an inline element itself, it shouldn't render a `div` but a `span` instead (which is inherently _inline_).

For instance, if used inside of a `p` it causes an invalid DOM nesting warning because a `p` shouldn't have a nested `div`.
This is already happening when using a `LinkButton` within a paragraph, as shown in #588.

This doesn't affect the layout itself because the way the element is styled, but only the HTML semantic.