### PR TITLE
feat(text): Add `as` prop while deprecating `elementType`

### DIFF
--- a/.storybook/decorators/formik-box/formik-box.js
+++ b/.storybook/decorators/formik-box/formik-box.js
@@ -15,15 +15,15 @@ export default class FormikBox extends React.Component {
     return (
       <Spacings.Stack scale="l">
         <div>
-          <Text.Subheadline elementType="h4">formik.values</Text.Subheadline>
+          <Text.Subheadline as="h4">formik.values</Text.Subheadline>
           <pre>{JSON.stringify(this.props.formik.values, null, 2)}</pre>
         </div>
         <div>
-          <Text.Subheadline elementType="h4">formik.touched</Text.Subheadline>
+          <Text.Subheadline as="h4">formik.touched</Text.Subheadline>
           <pre>{JSON.stringify(this.props.formik.touched, null, 2)}</pre>
         </div>
         <div>
-          <Text.Subheadline elementType="h4">formik.errors</Text.Subheadline>
+          <Text.Subheadline as="h4">formik.errors</Text.Subheadline>
           <pre>{JSON.stringify(this.props.formik.errors, null, 2)}</pre>
         </div>
       </Spacings.Stack>

--- a/examples/form-fields.example.story.js
+++ b/examples/form-fields.example.story.js
@@ -395,7 +395,7 @@ const Story = injectIntl(props => (
           }}
           render={formik => (
             <Spacings.Stack scale="l">
-              <Text.Headline elementType="h2">The form</Text.Headline>
+              <Text.Headline as="h2">The form</Text.Headline>
               <div>
                 <ProductForm formik={formik} />
               </div>

--- a/examples/form-inputs.example.story.js
+++ b/examples/form-inputs.example.story.js
@@ -576,7 +576,7 @@ const Story = injectIntl(props => {
             }}
             render={formik => (
               <Spacings.Stack scale="l">
-                <Text.Headline elementType="h2">The form</Text.Headline>
+                <Text.Headline as="h2">The form</Text.Headline>
                 <div>
                   <ProductForm
                     formik={formik}

--- a/src/components/buttons/link-button/link-button.js
+++ b/src/components/buttons/link-button/link-button.js
@@ -50,7 +50,7 @@ const LinkButton = props => (
           size: 'medium',
           color: props.isDisabled ? 'neutral60' : 'primary',
         })}
-      <Text.Body isInline={true}>{props.label}</Text.Body>
+      <Text.Body as="span">{props.label}</Text.Body>
     </Spacings.Inline>
   </Link>
 );

--- a/src/components/grid/grid.story.js
+++ b/src/components/grid/grid.story.js
@@ -79,7 +79,7 @@ storiesOf('Components|Grid', module)
                 ' is the most powerful layout system available in CSS. It is a 2-dimensional system, meaning it can handle both columns and rows, unlike flexbox which is largely a 1-dimensional system. You work with Grid Layout by applying CSS rules both to a parent element (which becomes the Grid Container) and to that elements children (which become Grid Items).'
               }
             </Text.Body>
-            <Text.Headline elementType="h3">{'Getting started'}</Text.Headline>
+            <Text.Headline as="h3">{'Getting started'}</Text.Headline>
             <Text.Body>
               {
                 'In the Knobs section on the right panel, you can see all the supported CSS Grid properties, both for the parent container and for the children elements (items).'

--- a/src/components/internals/calendar-header/calendar-header.js
+++ b/src/components/internals/calendar-header/calendar-header.js
@@ -33,7 +33,7 @@ const CalendarHeader = props => (
         onClick={props.onNextMonthClick}
         icon={<AngleRightIcon size="medium" />}
       />
-      <Text.Body isInline={true} isBold={true}>
+      <Text.Body as="span" isBold={true}>
         {props.monthLabel}
       </Text.Body>
     </Spacings.Inline>

--- a/src/components/panels/collapsible-panel/collapsible-panel-header.js
+++ b/src/components/panels/collapsible-panel/collapsible-panel-header.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Text from '../../typography/text';
 
 const CollapsiblePanelHeader = props => (
-  <Text.Subheadline elementType="h4" isBold={true} truncate={true}>
+  <Text.Subheadline as="h4" isBold={true} truncate={true}>
     {props.children}
   </Text.Subheadline>
 );

--- a/src/components/spacings/inline/inline.story.js
+++ b/src/components/spacings/inline/inline.story.js
@@ -76,7 +76,7 @@ storiesOf('Components|Spacings', module)
             <InlineColorWrapper>
               <Scale>
                 <Inset scale="s" alignItems="center">
-                  <Text.Subheadline elementType="h4">
+                  <Text.Subheadline as="h4">
                     {size.name.toUpperCase()}
                     <Text.Detail>{size.pixels}</Text.Detail>
                   </Text.Subheadline>

--- a/src/components/spacings/inset-squish/inset-squish.story.js
+++ b/src/components/spacings/inset-squish/inset-squish.story.js
@@ -50,7 +50,7 @@ storiesOf('Components|Spacings', module)
             <InsetColorWrapper key={size.name}>
               <InsetSquish scale={size.name}>
                 <Button>
-                  <Text.Subheadline elementType="h4">
+                  <Text.Subheadline as="h4">
                     {size.name.toUpperCase()}
                     <Text.Detail>{size.pixels}</Text.Detail>
                   </Text.Subheadline>

--- a/src/components/spacings/inset/inset.story.js
+++ b/src/components/spacings/inset/inset.story.js
@@ -53,7 +53,7 @@ storiesOf('Components|Spacings', module)
             <InsetColorWrapper key={size.name}>
               <Inset scale={size.name}>
                 <Square>
-                  <Text.Subheadline elementType="h4">
+                  <Text.Subheadline as="h4">
                     {size.name.toUpperCase()}
                     <Text.Detail>{size.pixels}</Text.Detail>
                   </Text.Subheadline>

--- a/src/components/spacings/spacings.visualroute.js
+++ b/src/components/spacings/spacings.visualroute.js
@@ -113,7 +113,7 @@ const StackExample = ({ alignItems }) => (
     {sizes.map(size => (
       <StackColorWrapper key={size.name}>
         <Spacings.Inset scale="m">
-          <Text.Subheadline elementType="h4">
+          <Text.Subheadline as="h4">
             {size.name.toUpperCase()}
             <Text.Detail>{size.pixels}</Text.Detail>
           </Text.Subheadline>
@@ -145,7 +145,7 @@ const InlineExample = ({ alignItems }) => (
         <InlineColorWrapper>
           <Scale>
             <Spacings.Inset scale="s" alignItems="center">
-              <Text.Subheadline elementType="h4">
+              <Text.Subheadline as="h4">
                 {size.name.toUpperCase()}
                 <Text.Detail>{size.pixels}</Text.Detail>
               </Text.Subheadline>
@@ -189,7 +189,7 @@ export const component = () => (
             <InsetColorWrapper key={size.name}>
               <Spacings.Inset scale={size.name}>
                 <Square>
-                  <Text.Subheadline elementType="h4">
+                  <Text.Subheadline as="h4">
                     {size.name.toUpperCase()}
                     <Text.Detail>{size.pixels}</Text.Detail>
                   </Text.Subheadline>
@@ -207,7 +207,7 @@ export const component = () => (
             <InsetSquishColorWrapper key={size.name}>
               <Spacings.InsetSquish scale={size.name}>
                 <Button>
-                  <Text.Subheadline elementType="h4">
+                  <Text.Subheadline as="h4">
                     {size.name.toUpperCase()}
                     <Text.Detail>{size.pixels}</Text.Detail>
                   </Text.Subheadline>

--- a/src/components/spacings/stack/stack.story.js
+++ b/src/components/spacings/stack/stack.story.js
@@ -46,7 +46,7 @@ storiesOf('Components|Spacings', module)
         {sizes.map(size => (
           <StackColorWrapper key={size.name}>
             <Inset scale="m">
-              <Text.Subheadline elementType="h4">
+              <Text.Subheadline as="h4">
                 {size.name.toUpperCase()}
                 <Text.Detail>{size.pixels}</Text.Detail>
               </Text.Subheadline>

--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -47,6 +47,10 @@ const getContentWrapperStyles = (props, theme) => {
 
     /* fixing things for IE11 ... */
     width: 100%;
+
+    small {
+      color: ${getTextDetailColor(props.isDisabled, theme)};
+    }
   `;
 };
 
@@ -126,22 +130,10 @@ export const TagLinkBody = props => {
             text-decoration: none;
           `}
         >
-          <Text.Detail
-            css={theme => css`
-              color: ${getTextDetailColor(props.isDisabled, theme)};
-            `}
-          >
-            {props.children}
-          </Text.Detail>
+          <Text.Detail>{props.children}</Text.Detail>
         </Link>
       ) : (
-        <Text.Detail
-          css={theme => css`
-            color: ${getTextDetailColor(props.isDisabled, theme)};
-          `}
-        >
-          {props.children}
-        </Text.Detail>
+        <Text.Detail>{props.children}</Text.Detail>
       )}
     </div>
   );
@@ -196,13 +188,7 @@ export const TagNormalBody = props => (
     ]}
     onClick={props.isDisabled ? undefined : props.onClick}
   >
-    <Text.Detail
-      css={theme => css`
-        color: ${getTextDetailColor(props.isDisabled, theme)};
-      `}
-    >
-      {props.children}
-    </Text.Detail>
+    <Text.Detail>{props.children}</Text.Detail>
   </div>
 );
 TagNormalBody.displayName = 'TagNormalBody';

--- a/src/components/typography/text/README.md
+++ b/src/components/typography/text/README.md
@@ -15,7 +15,7 @@ Wraps the given text in the given HTML header `size`.
 #### Usage
 
 ```js
-<Text.Headline elementType="h1">{'The title'}</Text.Headline>
+<Text.Headline as="h1">{'The title'}</Text.Headline>
 ```
 
 #### Properties

--- a/src/components/typography/text/README.md
+++ b/src/components/typography/text/README.md
@@ -22,11 +22,12 @@ Wraps the given text in the given HTML header `size`.
 
 | Props         | Type             | Required | Values               | Default | Description                                                          |
 | ------------- | ---------------- | :------: | -------------------- | ------- | -------------------------------------------------------------------- |
-| `elementType` | `String`         |    ✅    | `['h1', 'h2', 'h3']` | -       | -                                                                    |
+| `as`          | `String`         |    ✅    | `['h1', 'h2', 'h3']` | -       | -                                                                    |
 | `children`    | `PropTypes.node` | ✅ (\*)  | -                    | -       | -                                                                    |
 | `intlMessage` | `intl message`   | ✅ (\*)  | -                    | -       | An intl message object that will be rendered with `FormattedMessage` |
 | `title`       | `String`         |    -     | -                    | -       | Text to show in a tooltip on hover over the element                  |
 | `truncate`    | `Bool`           |    -     | -                    | `false` | Option for truncate content in case the screen has small width       |
+| `elementType` | `String`         |    -     | `['h1', 'h2', 'h3']` | -       | ⚠️ Deprecated                                                        |
 
 > `*`: `children` is required only if `intlMessage` is not provided
 
@@ -50,13 +51,14 @@ Wraps the given text in the given HTML header `size`.
 
 | Props         | Type             | Required | Values                                                            | Default |
 | ------------- | ---------------- | :------: | ----------------------------------------------------------------- | ------- |
-| `elementType` | `String`         |    ✅    | `['h4', 'h5']`                                                    | -       |
+| `as`          | `String`         |    ✅    | `['h4', 'h5']`                                                    | -       |
 | `isBold`      | `Boolean`        |    -     | -                                                                 | `false` |
 | `tone`        | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative']` | -       |
 | `children`    | `PropTypes.node` | ✅ (\*)  | -                                                                 | -       |
 | `intlMessage` | `intl message`   | ✅ (\*)  | -                                                                 | -       | An intl message object that will be rendered with `FormattedMessage` |
 | `title`       | `String`         |    -     | -                                                                 | -       |
 | `truncate`    | `Bool`           |    -     | -                                                                 | `false` |
+| `elementType` | `String`         |    -     | `['h4', 'h5']`                                                    | -       | ⚠️ Deprecated |
 
 > `*`: `children` is required only if `intlMessage` is not provided
 
@@ -94,6 +96,7 @@ Wraps the given text in a `<p>` element, for normal content.
 
 | Props         | Type             | Required | Values                                                                        | Default |
 | ------------- | ---------------- | :------: | ----------------------------------------------------------------------------- | ------- |
+| `as`          | `String`         |    -     | `['p', 'span']`                                                               | -       |
 | `isBold`      | `Boolean`        |    -     | -                                                                             | `false` |
 | `isItalic`    | `Boolean`        |    -     | -                                                                             | `false` |
 | `tone`        | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative', 'inverted']` | -       |
@@ -101,7 +104,7 @@ Wraps the given text in a `<p>` element, for normal content.
 | `intlMessage` | `intl message`   | ✅ (\*)  | -                                                                             | -       | An intl message object that will be rendered with `FormattedMessage` |
 | `title`       | `String`         |    -     | -                                                                             | -       |
 | `truncate`    | `Bool`           |    -     | -                                                                             | `false` |
-| `isInline`    | `Bool`           |    -     | -                                                                             | `false` |
+| `isInline`    | `Bool`           |    -     | -                                                                             | `false` | ⚠️ Deprecated |
 
 > `*`: `children` is required only if `intlMessage` is not provided
 

--- a/src/components/typography/text/text.js
+++ b/src/components/typography/text/text.js
@@ -48,23 +48,10 @@ const Headline = props => {
 
 Headline.displayName = 'TextHeadline';
 Headline.propTypes = {
-  as(props, propName, componentName, ...rest) {
-    // is required if the prop 'elementType' is not defined
-    if (!props.elementType) {
-      return PropTypes.oneOf(['h1', 'h2', 'h3']).isRequired(
-        props,
-        propName,
-        componentName,
-        ...rest
-      );
-    }
-    return PropTypes.oneOf(['h1', 'h2', 'h3'])(
-      props,
-      propName,
-      componentName,
-      ...rest
-    );
-  },
+  as: requiredIf(
+    PropTypes.oneOf(['h1', 'h2', 'h3']),
+    props => !props.elementType
+  ),
   elementType(props, propName, componentName, ...rest) {
     if (props[propName] != null) {
       const message = oneLine`
@@ -93,7 +80,6 @@ Headline.propTypes = {
       ...rest
     );
   },
-  children: PropTypes.node.isRequired,
   title: nonEmptyString,
   truncate: PropTypes.bool,
   intlMessage: requiredIf(intlMessageShape, props => !props.children),
@@ -119,23 +105,7 @@ const Subheadline = props => {
 
 Subheadline.displayName = 'TextSubheadline';
 Subheadline.propTypes = {
-  as(props, propName, componentName, ...rest) {
-    // is required only if the prop 'elementType' is not defined
-    if (!props.elementType) {
-      return PropTypes.oneOf(['h4', 'h5']).isRequired(
-        props,
-        propName,
-        componentName,
-        ...rest
-      );
-    }
-    return PropTypes.oneOf(['h4', 'h5'])(
-      props,
-      propName,
-      componentName,
-      ...rest
-    );
-  },
+  as: requiredIf(PropTypes.oneOf(['h4', 'h5']), props => !props.elementType),
   elementType(props, propName, componentName, ...rest) {
     if (props[propName] != null) {
       const message = oneLine`

--- a/src/components/typography/text/text.js
+++ b/src/components/typography/text/text.js
@@ -4,8 +4,9 @@ import { FormattedMessage } from 'react-intl';
 import requiredIf from 'react-required-if';
 import isNil from 'lodash/isNil';
 import { oneLine } from 'common-tags';
-import warning from 'warning';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
+import throwDeprecationWarning from '../../../utils/warn-deprecated-prop';
+
 import {
   bodyStyles,
   detailStyles,
@@ -54,11 +55,11 @@ Headline.propTypes = {
   ),
   elementType(props, propName, componentName, ...rest) {
     if (props[propName] != null) {
-      const message = oneLine`
-            "${propName}" property of "${componentName}" has been deprecated
-            and will be removed in the next major version.\n
-            Please use "as" prop instead.`;
-      warning(false, message);
+      throwDeprecationWarning(
+        propName,
+        componentName,
+        `\n Please use "as" prop instead.`
+      );
 
       if (props.as) {
         return new Error(oneLine`
@@ -108,11 +109,11 @@ Subheadline.propTypes = {
   as: requiredIf(PropTypes.oneOf(['h4', 'h5']), props => !props.elementType),
   elementType(props, propName, componentName, ...rest) {
     if (props[propName] != null) {
-      const message = oneLine`
-            "${propName}" property of "${componentName}" has been deprecated
-            and will be removed in the next major version.\n
-            Please use "as" prop instead.`;
-      warning(false, message);
+      throwDeprecationWarning(
+        propName,
+        componentName,
+        `\n Please use "as" prop instead.`
+      );
 
       if (props.as) {
         return new Error(oneLine`
@@ -218,11 +219,11 @@ Body.propTypes = {
   isItalic: PropTypes.bool,
   isInline(props, propName, componentName, ...rest) {
     if (!isNil(props[propName])) {
-      const message = oneLine`
-            "${propName}" property of "${componentName}" has been deprecated
-            and will be removed in the next major version.\n
-            Please use "as" prop instead.`;
-      warning(false, message);
+      throwDeprecationWarning(
+        propName,
+        componentName,
+        `\n Please use "as" prop instead.`
+      );
 
       if (props.as) {
         return new Error(oneLine`

--- a/src/components/typography/text/text.js
+++ b/src/components/typography/text/text.js
@@ -252,7 +252,6 @@ const Detail = props => (
     css={theme => detailStyles(props, theme)}
     title={props.title}
     {...filterDataAttributes(props)}
-    className={props.className}
   >
     {props.intlMessage ? (
       <FormattedMessage {...props.intlMessage} />
@@ -276,7 +275,6 @@ Detail.propTypes = {
     'warning',
     'inverted',
   ]),
-  className: PropTypes.string,
   title: nonEmptyString,
   truncate: PropTypes.bool,
   intlMessage: requiredIf(intlMessageShape, props => !props.children),

--- a/src/components/typography/text/text.js
+++ b/src/components/typography/text/text.js
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import requiredIf from 'react-required-if';
+import isNil from 'lodash/isNil';
+import { oneLine } from 'common-tags';
+import warning from 'warning';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import {
   bodyStyles,
@@ -27,7 +30,7 @@ const nonEmptyString = (props, propName, componentName) => {
 };
 
 const Headline = props => {
-  const HeadlineElement = props.elementType;
+  const HeadlineElement = props.as || props.elementType;
   return (
     <HeadlineElement
       css={theme => headlineStyles(props, theme)}
@@ -45,7 +48,52 @@ const Headline = props => {
 
 Headline.displayName = 'TextHeadline';
 Headline.propTypes = {
-  elementType: PropTypes.oneOf(['h1', 'h2', 'h3']).isRequired,
+  as(props, propName, componentName, ...rest) {
+    // is required if the prop 'elementType' is not defined
+    if (!props.elementType) {
+      return PropTypes.oneOf(['h1', 'h2', 'h3']).isRequired(
+        props,
+        propName,
+        componentName,
+        ...rest
+      );
+    }
+    return PropTypes.oneOf(['h1', 'h2', 'h3'])(
+      props,
+      propName,
+      componentName,
+      ...rest
+    );
+  },
+  elementType(props, propName, componentName, ...rest) {
+    if (props[propName] != null) {
+      const message = oneLine`
+            "${propName}" property of "${componentName}" has been deprecated
+            and will be removed in the next major version.\n
+            Please use "as" prop instead.`;
+      warning(false, message);
+
+      if (props.as) {
+        return new Error(oneLine`
+          Invalid prop "${propName}" supplied to "${componentName}".
+          "${propName}" does not have any effect when "as" is defined`);
+      }
+
+      return PropTypes.oneOf(['h1', 'h2', 'h3']).isRequired(
+        props,
+        propName,
+        componentName,
+        ...rest
+      );
+    }
+    return PropTypes.oneOf(['h1', 'h2', 'h3'])(
+      props,
+      propName,
+      componentName,
+      ...rest
+    );
+  },
+  children: PropTypes.node.isRequired,
   title: nonEmptyString,
   truncate: PropTypes.bool,
   intlMessage: requiredIf(intlMessageShape, props => !props.children),
@@ -53,7 +101,7 @@ Headline.propTypes = {
 };
 
 const Subheadline = props => {
-  const SubheadlineElement = props.elementType;
+  const SubheadlineElement = props.as || props.elementType;
   return (
     <SubheadlineElement
       title={props.title}
@@ -71,7 +119,51 @@ const Subheadline = props => {
 
 Subheadline.displayName = 'TextSubheadline';
 Subheadline.propTypes = {
-  elementType: PropTypes.oneOf(['h4', 'h5']).isRequired,
+  as(props, propName, componentName, ...rest) {
+    // is required only if the prop 'elementType' is not defined
+    if (!props.elementType) {
+      return PropTypes.oneOf(['h4', 'h5']).isRequired(
+        props,
+        propName,
+        componentName,
+        ...rest
+      );
+    }
+    return PropTypes.oneOf(['h4', 'h5'])(
+      props,
+      propName,
+      componentName,
+      ...rest
+    );
+  },
+  elementType(props, propName, componentName, ...rest) {
+    if (props[propName] != null) {
+      const message = oneLine`
+            "${propName}" property of "${componentName}" has been deprecated
+            and will be removed in the next major version.\n
+            Please use "as" prop instead.`;
+      warning(false, message);
+
+      if (props.as) {
+        return new Error(oneLine`
+          Invalid prop "${propName}" supplied to "${componentName}".
+          "${propName}" does not have any effect when "as" is defined`);
+      }
+
+      return PropTypes.oneOf(['h4', 'h5']).isRequired(
+        props,
+        propName,
+        componentName,
+        ...rest
+      );
+    }
+    return PropTypes.oneOf(['h4', 'h5'])(
+      props,
+      propName,
+      componentName,
+      ...rest
+    );
+  },
   isBold: PropTypes.bool,
   tone: PropTypes.oneOf([
     'primary',
@@ -107,8 +199,22 @@ Wrap.propTypes = {
   children: requiredIf(PropTypes.node, props => !props.intlMessage),
 };
 
-const Body = props =>
-  props.isInline ? (
+const Body = props => {
+  if (props.as) {
+    const BodyElement = props.as;
+
+    return (
+      <BodyElement
+        css={bodyStyles(props)}
+        title={props.title}
+        {...filterDataAttributes(props)}
+      >
+        {props.children}
+      </BodyElement>
+    );
+  }
+
+  return props.isInline ? (
     <span
       css={theme => bodyStyles(props, theme)}
       title={props.title}
@@ -133,12 +239,30 @@ const Body = props =>
       )}
     </p>
   );
+};
 
 Body.displayName = 'TextBody';
 Body.propTypes = {
+  as: PropTypes.oneOf(['span', 'p']),
   isBold: PropTypes.bool,
   isItalic: PropTypes.bool,
-  isInline: PropTypes.bool,
+  isInline(props, propName, componentName, ...rest) {
+    if (!isNil(props[propName])) {
+      const message = oneLine`
+            "${propName}" property of "${componentName}" has been deprecated
+            and will be removed in the next major version.\n
+            Please use "as" prop instead.`;
+      warning(false, message);
+
+      if (props.as) {
+        return new Error(oneLine`
+        Invalid prop "${propName}" supplied to "${componentName}".
+        "${propName}" does not have any effect when "as" is defined`);
+      }
+    }
+
+    return PropTypes.bool(props, propName, componentName, ...rest);
+  },
   tone: PropTypes.oneOf([
     'primary',
     'secondary',

--- a/src/components/typography/text/text.spec.js
+++ b/src/components/typography/text/text.spec.js
@@ -28,7 +28,7 @@ describe('exports', () => {
 describe('<Headline>', () => {
   it('should render element tag h1', () => {
     const { container } = render(
-      <Text.Headline elementType="h1" title="tooltip text">
+      <Text.Headline as="h1" title="tooltip text">
         {'Title'}
       </Text.Headline>
     );
@@ -38,7 +38,7 @@ describe('<Headline>', () => {
 
   it('should render given text', () => {
     const { container } = render(
-      <Text.Headline elementType="h1" title="tooltip text">
+      <Text.Headline as="h1" title="tooltip text">
         {'Title'}
       </Text.Headline>
     );
@@ -58,7 +58,7 @@ describe('<Headline>', () => {
 
   it('should set `title` attribute', () => {
     const { queryByTitle } = render(
-      <Text.Headline elementType="h1" title="tooltip text">
+      <Text.Headline as="h1" title="tooltip text">
         {'Title'}
       </Text.Headline>
     );
@@ -67,7 +67,7 @@ describe('<Headline>', () => {
 
   it('should forward data attriutes', () => {
     const { getByTitle } = render(
-      <Text.Headline elementType="h1" data-foo="bar" title="headline">
+      <Text.Headline as="h1" data-foo="bar" title="headline">
         {'Title'}
       </Text.Headline>
     );
@@ -78,7 +78,7 @@ describe('<Headline>', () => {
 describe('<Subheadline>', () => {
   it('should render element tag h4', () => {
     const { container } = render(
-      <Text.Subheadline elementType="h4" title="tooltip text">
+      <Text.Subheadline as="h4" title="tooltip text">
         {'Title'}
       </Text.Subheadline>
     );
@@ -87,7 +87,7 @@ describe('<Subheadline>', () => {
 
   it('should render given text', () => {
     const { container } = render(
-      <Text.Subheadline elementType="h4" title="tooltip text">
+      <Text.Subheadline as="h4" title="tooltip text">
         {'Subtitle'}
       </Text.Subheadline>
     );
@@ -107,7 +107,7 @@ describe('<Subheadline>', () => {
 
   it('should set `title` attribute', () => {
     const { queryByTitle } = render(
-      <Text.Subheadline elementType="h4" title="tooltip text">
+      <Text.Subheadline as="h4" title="tooltip text">
         {'Title'}
       </Text.Subheadline>
     );
@@ -116,7 +116,7 @@ describe('<Subheadline>', () => {
 
   it('should forward data attriutes', () => {
     const { getByTitle } = render(
-      <Text.Subheadline elementType="h4" data-foo="bar" title="subheadline">
+      <Text.Subheadline as="h4" data-foo="bar" title="subheadline">
         {'Title'}
       </Text.Subheadline>
     );
@@ -187,10 +187,10 @@ describe('<Body>', () => {
     expect(getByTitle('body')).toHaveAttribute('data-foo', 'bar');
   });
 
-  describe('when inline', () => {
-    it('should render element tag span', () => {
+  describe('when `as` prop is set to `span`', () => {
+    it('should render as a span', () => {
       const { container } = render(
-        <Text.Body title="tooltip text" isInline={true}>
+        <Text.Body title="tooltip text" as="span">
           {'Body'}
         </Text.Body>
       );

--- a/src/components/typography/text/text.spec.js
+++ b/src/components/typography/text/text.spec.js
@@ -47,11 +47,7 @@ describe('<Headline>', () => {
 
   it('should render given text with react-intl', () => {
     const { container } = render(
-      <Text.Headline
-        elementType="h1"
-        title="tooltip text"
-        intlMessage={intlMessage}
-      />
+      <Text.Headline as="h1" title="tooltip text" intlMessage={intlMessage} />
     );
     expect(container).toHaveTextContent('Hello');
   });
@@ -97,7 +93,7 @@ describe('<Subheadline>', () => {
   it('should render given text with react-intl', () => {
     const { container } = render(
       <Text.Subheadline
-        elementType="h4"
+        as="h4"
         title="tooltip text"
         intlMessage={intlMessage}
       />

--- a/src/components/typography/text/text.styles.js
+++ b/src/components/typography/text/text.styles.js
@@ -86,7 +86,7 @@ export const bodyStyles = (props, theme) => css`
 export const headlineStyles = (props, theme) => css`
   ${getBaseStyles(props, theme)}
   margin: 0;
-  font-size: ${getElementFontSize(props.elementType)};
+  font-size: ${getElementFontSize(props.as || props.elementType)};
   font-weight: 300;
   ${props.truncate && truncate}
 `;
@@ -94,7 +94,7 @@ export const headlineStyles = (props, theme) => css`
 export const subheadlineStyles = (props, theme) => css`
 ${getBaseStyles(props, theme)}
   margin: 0;
-  font-size: ${getElementFontSize(props.elementType)};
+  font-size: ${getElementFontSize(props.as || props.elementType)};
   font-weight: normal;
   ${props.truncate && truncate}
   ${props.isBold && bold}

--- a/src/components/typography/text/text.visualroute.js
+++ b/src/components/typography/text/text.visualroute.js
@@ -15,68 +15,64 @@ export const routePath = '/text';
 export const component = ({ themes }) => (
   <Suite>
     <Spec label="Headline - h1">
-      <Text.Headline elementType="h1">{'Title H1'}</Text.Headline>
+      <Text.Headline as="h1">{'Title H1'}</Text.Headline>
     </Spec>
     <NarrowBox>
       <Spec label="Headline - h1 - truncated">
-        <Text.Headline elementType="h1" truncate={true}>
+        <Text.Headline as="h1" truncate={true}>
           {'A longer title that should be truncated'}
         </Text.Headline>
       </Spec>
     </NarrowBox>
 
     <Spec label="Headline - h2">
-      <Text.Headline elementType="h2">{'Title H2'}</Text.Headline>
+      <Text.Headline as="h2">{'Title H2'}</Text.Headline>
     </Spec>
     <Spec label="Headline - h3">
-      <Text.Headline elementType="h3">{'Title H3'}</Text.Headline>
+      <Text.Headline as="h3">{'Title H3'}</Text.Headline>
     </Spec>
     <Spec label="Subheadline - h4">
-      <Text.Subheadline elementType="h4">
-        {'Bigger subheadline'}
-      </Text.Subheadline>
+      <Text.Subheadline as="h4">{'Bigger subheadline'}</Text.Subheadline>
     </Spec>
     <NarrowBox>
       <Spec label="Subheadline - h4 - truncated">
-        <Text.Subheadline elementType="h4" truncate={true}>
+        <Text.Subheadline as="h4" truncate={true}>
           {'A longer subheadline that should be truncated'}
         </Text.Subheadline>
       </Spec>
     </NarrowBox>
     <Spec label="Subheadline - h4 - bold">
-      <Text.Subheadline isBold={true} elementType="h4">
+      <Text.Subheadline isBold={true} as="h4">
         {'Bold subheadline'}
       </Text.Subheadline>
     </Spec>
     <Spec label="Subheadline - tone - primary">
-      <Text.Subheadline tone="primary" elementType="h4">
+      <Text.Subheadline tone="primary" as="h4">
         {'Subheadline tone primary'}
       </Text.Subheadline>
     </Spec>
     <Spec label="Subheadline - tone - secondary">
-      <Text.Subheadline tone="secondary" elementType="h4">
+      <Text.Subheadline tone="secondary" as="h4">
         {'Subheadline tone secondary'}
       </Text.Subheadline>
     </Spec>
     <Spec label="Subheadline - tone - information">
-      <Text.Subheadline tone="information" elementType="h4">
+      <Text.Subheadline tone="information" as="h4">
         {'Subheadline tone information'}
       </Text.Subheadline>
     </Spec>
     <Spec label="Subheadline - tone - positive">
-      <Text.Subheadline tone="positive" elementType="h4">
+      <Text.Subheadline tone="positive" as="h4">
         {'Subheadline tone positive'}
       </Text.Subheadline>
     </Spec>
     <Spec label="Subheadline - tone - negative">
-      <Text.Subheadline tone="negative" elementType="h4">
+      <Text.Subheadline tone="negative" as="h4">
         {'Subheadline tone negative'}
       </Text.Subheadline>
     </Spec>
     <Spec label="Subheadline - h5">
-      <Text.Subheadline elementType="h5">
-        {'Smaller subheadline'}
-      </Text.Subheadline>
+      <Text.Subheadline as="h5">{'Smaller subheadline'}</Text.Subheadline>
     </Spec>
     <NarrowBox>
       <Spec label="Wrap">
@@ -127,8 +123,8 @@ export const component = ({ themes }) => (
       </Spec>
     </NarrowBox>
     <Spec label="Body - inline" omitPropsList>
-      <Text.Body isInline={true}>One inline body text{'. '}</Text.Body>
-      <Text.Body isInline={true}>A second inline text.</Text.Body>
+      <Text.Body as="span">One inline body text{'. '}</Text.Body>
+      <Text.Body as="span">A second inline text.</Text.Body>
     </Spec>
     <Spec label="Detail">
       <Text.Detail>Detail text</Text.Detail>

--- a/src/components/typography/text/text.visualroute.js
+++ b/src/components/typography/text/text.visualroute.js
@@ -169,19 +169,19 @@ export const component = ({ themes }) => (
       <Text.Detail isInline={true}>A second inline text.</Text.Detail>
     </Spec>
     <Spec label="Headline - h1 (intl message)">
-      <Text.Headline elementType="h1" intlMessage={intlMessage} />
+      <Text.Headline as="h1" intlMessage={intlMessage} />
     </Spec>
     <Spec label="Headline - h2 (intl message)">
-      <Text.Headline elementType="h2" intlMessage={intlMessage} />
+      <Text.Headline as="h2" intlMessage={intlMessage} />
     </Spec>
     <Spec label="Headline - h3 (intl message)">
-      <Text.Headline elementType="h3" intlMessage={intlMessage} />
+      <Text.Headline as="h3" intlMessage={intlMessage} />
     </Spec>
     <Spec label="Subheadline - h4 (intl message)">
-      <Text.Subheadline elementType="h4" intlMessage={intlMessage} />
+      <Text.Subheadline as="h4" intlMessage={intlMessage} />
     </Spec>
     <Spec label="Subheadline - h5 (intl message)">
-      <Text.Subheadline elementType="h5" intlMessage={intlMessage} />
+      <Text.Subheadline as="h5" intlMessage={intlMessage} />
     </Spec>
     <Spec label="Wrap (intl message)">
       <Text.Wrap
@@ -200,10 +200,10 @@ export const component = ({ themes }) => (
     </Spec>
     <ThemeProvider theme={themes.darkTheme}>
       <Spec label="Headline (dark theme)">
-        <Text.Headline elementType="h1">Dark theme</Text.Headline>
+        <Text.Headline as="h1">Dark theme</Text.Headline>
       </Spec>
       <Spec label="Subheadline (dark theme)">
-        <Text.Subheadline elementType="h4">Dark theme</Text.Subheadline>
+        <Text.Subheadline as="h4">Dark theme</Text.Subheadline>
       </Spec>
       <Spec label="Body (dark theme)">
         <Text.Body>Dark theme</Text.Body>

--- a/src/components/typography/typography.story.js
+++ b/src/components/typography/typography.story.js
@@ -18,7 +18,7 @@ storiesOf('Basics|Typography/Text', module)
   .add('Headline', () => (
     <Section>
       <Text.Headline
-        elementType={select('Element type', ['h1', 'h2', 'h3'], 'h1')}
+        as={select('as', ['h1', 'h2', 'h3'], 'h1')}
         title={text('title', 'Text to be shown as tooltip on hover')}
         truncate={boolean('truncate', false)}
       >
@@ -29,7 +29,7 @@ storiesOf('Basics|Typography/Text', module)
   .add('Subheadline', () => (
     <Section>
       <Text.Subheadline
-        elementType={select('Element type', ['h4', 'h5'], 'h4')}
+        as={select('as', ['h4', 'h5'], 'h4')}
         isBold={boolean('bold', false)}
         tone={select('Text tone', {
           none: null,
@@ -63,8 +63,12 @@ storiesOf('Basics|Typography/Text', module)
   .add('Body', () => (
     <Section>
       <Text.Body
+        as={select('as', {
+          default: null,
+          p: 'p',
+          span: 'span',
+        })}
         isBold={boolean('bold', false)}
-        isInline={boolean('inline', false)}
         isItalic={boolean('italic', false)}
         tone={select('Text tone', {
           none: null,


### PR DESCRIPTION
#### Summary

This PR adds a `as` prop to the Text components, as suggested by @tdeekens in https://github.com/commercetools/ui-kit/issues/588#issuecomment-469685493.

Deprecates `elementType` prop of `Text.Headline` and `Text.Subheadline` components.
Deprecates `isInline` prop of `Text.Body` component.

#### Questions

- **Which element types should we allow to render for the `Body` component?** (currently just `span` and `p`)
