### PR TITLE
fix(flat-button): focus fixes

### DIFF
--- a/src/components/buttons/flat-button/flat-button.js
+++ b/src/components/buttons/flat-button/flat-button.js
@@ -58,15 +58,27 @@ export const FlatButton = props => {
           padding: 0;
           min-height: initial;
           p {
-            color: ${props.isDisabled
-              ? vars.colorGray
-              : getTextColor(props.tone)};
+            color: ${
+              props.isDisabled ? vars.colorGray : getTextColor(props.tone)
+            };
           }
-          &:hover {
+          &:hover,
+          &:focus {
             p {
-              color: ${props.isDisabled
-                ? vars.colorGray
-                : getTextColor(props.tone, true)};
+              color: ${
+                props.isDisabled
+                  ? vars.colorGray
+                  : getTextColor(props.tone, true)
+              };
+            }
+
+            svg * {
+                fill: ${
+                  props.isDisabled
+                    ? vars.colorGray
+                    : getTextColor(props.tone, true)
+                };
+              }
             }
           }
         `}


### PR DESCRIPTION
When you navigate to a `FlatButton` using tab, currently there is no indication that this element is focused. I added the same effect that we have for hover now for focus. Also, I coloured the SVG element the same colour as the text on hover and focus.

After

![passwordfield](https://user-images.githubusercontent.com/2425013/55626291-6bbbba80-57ab-11e9-853d-fa2c3c2cc909.gif)
