### PR TITLE
fix: Right border of removable tag

### DIFF
--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -266,7 +266,8 @@ const Tag = props => (
                 background: inherit;
                 border-style: solid;
                 border-width: 1px 1px 1px 1px;
-                &:hover {
+                &:hover,
+                &:focus {
                   border-color: ${overwrittenVars[
                     designTokens.borderColorForTagWarning
                   ]};
@@ -283,10 +284,6 @@ const Tag = props => (
               `,
               props.isDisabled &&
                 css`
-                  &:hover {
-                    background: inherit;
-                    box-shadow: none;
-                  }
                   > svg * {
                     fill: ${overwrittenVars[
                       designTokens.fontColorForTagWhenDisabled

--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -26,6 +26,7 @@ const getContentWrapperStyles = (props, theme) => {
   };
 
   return css`
+    position: relative;
     display: flex;
     box-sizing: border-box;
     align-items: center;
@@ -93,6 +94,16 @@ export const TagLinkBody = props => {
           isRemoveable &&
           css`
             padding-right: ${vars.spacing8};
+            &:hover {
+              &:after {
+                position: absolute;
+                right: -1px;
+                content: '';
+                background-color: ${vars.borderColorForTagWhenFocused};
+                width: 1px;
+                height: 100%;
+              }
+            }
           `,
         !props.isDisabled &&
           getClickableContentWrapperStyles({
@@ -168,6 +179,14 @@ export const TagNormalBody = props => (
         css`
           &:hover {
             box-shadow: ${vars.shadowBoxTagHover};
+            &:after {
+              position: absolute;
+              right: -1px;
+              content: '';
+              background-color: ${vars.borderColorForTagWhenFocused};
+              width: 1px;
+              height: 100%;
+            }
           }
         `,
     ]}


### PR DESCRIPTION
#### Summary

Fixes #638 

![Kapture 2019-04-05 at 14 23 46](https://user-images.githubusercontent.com/2941328/55628093-1a61fa00-57b0-11e9-8fd2-6ddc6fcc1039.gif)
(GIF compression messing those colours 🧐)

#### Description

Using a regular `border` doesn't fit the design because the border takes space and would add a little edge or a flicker between the tag and the removal button.

The easiest alternative would be using `box-shadow` to emulate the border, just on the right side, but when the tag has an onClick prop, it has a box-shadow of its own when hovered, so this new box-shadow border would have to be merged with the current box-shadow and added to the design tokens.
I didn't like where this was going so I tried another approach:

So I used an absolutely positioned `:after` pseudo-element, and it does the job.
