### PR TITLE
fix: disable sourcemaps when building storybook

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,3 +1,4 @@
+const mri = require('mri');
 const path = require('path');
 const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 
@@ -9,9 +10,15 @@ const sourceFolders = [
   path.resolve(__dirname, '../src'),
 ];
 
+/**
+ * NOTE:
+ *    Generating source maps takes up to 30 seconds (from about 60 seconds buidl time).
+ *    This lets Netlify time out the build as it exceeds 60 seconds. As a result
+ *    the storybook build will not include source maps.
+ */
+const disableSourceMaps = process.argv.slice(2).includes('--no-source-maps');
+
 module.exports = ({ config }) => {
-  // nuke terser for speed
-  config.optimization.minimizer = [];
   config.plugins.push(
     new MomentLocalesPlugin({ localesToKeep: ['de', 'es', 'fr', 'zh-cn'] })
   );
@@ -96,6 +103,8 @@ module.exports = ({ config }) => {
       ],
     },
   ];
+
+  config.optimization.minimizer[0].options.sourceMap = disableSourceMaps;
 
   return config;
 };

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -10,6 +10,8 @@ const sourceFolders = [
 ];
 
 module.exports = ({ config }) => {
+  // nuke terser for speed
+  config.optimization.minimizer = [];
   config.plugins.push(
     new MomentLocalesPlugin({ localesToKeep: ['de', 'es', 'fr', 'zh-cn'] })
   );

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "design-tokens:build:watch": "nodemon -e yaml --quiet --watch materials/internals --exec 'yarn design-tokens:build'",
     "prebuild": "node ./scripts/generate-icon-exports.js && yarn design-tokens:build",
     "prestorybook:start": "node ./scripts/generate-icon-exports.js && yarn design-tokens:build",
-    "storybook:build": "build-storybook -o .public -s docs/assets",
+    "storybook:build": "build-storybook -o .public -s docs/assets -- --no-source-maps",
     "build": "rimraf dist && cross-env NODE_ENV=production rollup --config",
     "build:watch": "rimraf dist && cross-env NODE_ENV=production rollup --config --watch",
     "start": "yarn storybook:start",


### PR DESCRIPTION
To try to help with netlify build issues.