### PR TITLE
fix: storybook build times

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -13,6 +13,19 @@ module.exports = ({ config }) => {
   config.plugins.push(
     new MomentLocalesPlugin({ localesToKeep: ['de', 'es', 'fr', 'zh-cn'] })
   );
+
+  if (process.env.NODE_ENV === 'production') {
+    // remove progress plugin
+    // progress plugin outputs a lot of console logs, which makes
+    // netlify build realllllllllllllllly slow.
+    config.plugins = config.plugins.filter(
+      plugin => plugin.constructor.name !== 'ProgressPlugin'
+    );
+    config.devtool = 'none'; // TODO: should we use something differen?
+  } else {
+    config.devtool = 'cheap-module-source-map'; // TODO: should we use something differen?
+  }
+
   config.devtool = 'cheap-module-source-map'; // TODO: should we use something differen?
   config.module.rules = [
     // Disable require.ensure as it's not a standard language feature.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "design-tokens:build:watch": "nodemon -e yaml --quiet --watch materials/internals --exec 'yarn design-tokens:build'",
     "prebuild": "node ./scripts/generate-icon-exports.js && yarn design-tokens:build",
     "prestorybook:start": "node ./scripts/generate-icon-exports.js && yarn design-tokens:build",
-    "storybook:build": "build-storybook -o .public -s docs/assets",
+    "storybook:build": "NODE_ENV=production build-storybook -o .public -s docs/assets",
     "build": "rimraf dist && cross-env NODE_ENV=production rollup --config",
     "build:watch": "rimraf dist && cross-env NODE_ENV=production rollup --config --watch",
     "start": "yarn storybook:start",


### PR DESCRIPTION
I emailed netlify support about our build time issues.

They noticed that our builds have a lot of console logs. They suggested removing them.

`ProgressPlugin` spits out a lot of console logs. So let's disable it.

