### PR TITLE
chore(circleci): use manual env variable checks for releae

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,11 +96,11 @@ commands:
           command: |
             if [ ${<< parameters.git_branch >>} != "master" ]; then
               echo "Git branch is ${<< parameters.git_branch >>}, not publishing."
-              exit 0
+              circleci-agent step halt
             fi
             else if [ -z ${<< parameters.git_tag >>}]; then
               echo "Git tag is not set, not publishing."
-              exit 0
+              circleci-agent step halt
             fi
             else
               echo "Git branch is ${<< parameters.git_branch >>} and tag is ${<< parameters.git_tag >>}, publishing."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,30 +91,27 @@ commands:
         type: string
         default: *working_directory
     steps:
-      - when:
-          condition: << parameters.git_tag >>
-          steps:
-            - run:
-                name: Checking if on master branch
-                command: |
-                  if [ "<< parameters.git_branch >>" != "master" ]; then
-                    echo "Git branch is << parameters.git_branch >>, not publishing."
-                    exit 0
-                  fi
-            - checkout
-            - restore_cache: *restore_yarn_cache
-            - install_dependencies
-            - build_artifacts
-            - run:
-                name: Authenticating with npm registry
-                command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > << parameters.working_directory >>/.npmrc
-            - run:
-                name: Publishing << parameters.git_tag >> from << parameters.git_branch >> to next dist-tag
-                command: yarn release:next
-      - unless:
-          condition: << parameters.git_tag >>
-          steps:
-            - run: echo "No git tag, not publishing."
+      - run:
+          name: Checking if on master branch
+          command: |
+            if [ ${<< parameters.git_branch >>} != "master" ]; then
+              echo "Git branch is ${<< parameters.git_branch >>}, not publishing."
+              exit 0
+            fi
+            if [ -z ${<< parameters.git_tag >>}]; then
+              echo "Git tag is not set, not publishing."
+              exit 0
+            fi
+      - checkout
+      - restore_cache: *restore_yarn_cache
+      - install_dependencies
+      - build_artifacts
+      - run:
+          name: Authenticating with npm registry
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > << parameters.working_directory >>/.npmrc
+      - run:
+          name: Publishing ${<< parameters.git_tag >>} from ${<< parameters.git_branch >>} to next dist-tag
+          command: yarn release:next
 
 jobs:
   lint_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,20 +81,40 @@ commands:
       - run: ./scripts/run-percy.sh
   publish_to_next:
     parameters:
+      git_branch:
+        type: env_var_name
+        default: CIRCLE_BRANCH
+      git_tag:
+        type: env_var_name
+        default: CIRCLE_TAG
       working_directory:
         type: string
         default: *working_directory
     steps:
-      - checkout
-      - restore_cache: *restore_yarn_cache
-      - install_dependencies
-      - build_artifacts
-      - run:
-          name: Authenticating with npm registry
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > << parameters.working_directory >>/.npmrc
-      - run:
-          name: Publishing to next dist-tag
-          command: yarn release:next
+      - when:
+          condition: << parameters.git_tag >>
+          steps:
+            - run:
+                name: Checking if on master branch
+                command: |
+                  if [ "<< parameters.git_branch >>" != "master" ]; then
+                    echo "Git branch is << parameters.git_branch >>, not publishing."
+                    exit 0
+                  fi
+            - checkout
+            - restore_cache: *restore_yarn_cache
+            - install_dependencies
+            - build_artifacts
+            - run:
+                name: Authenticating with npm registry
+                command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > << parameters.working_directory >>/.npmrc
+            - run:
+                name: Publishing << parameters.git_tag >> from << parameters.git_branch >> to next dist-tag
+                command: yarn release:next
+      - unless:
+          condition: << parameters.git_tag >>
+          steps:
+            - run: echo "No git tag, not publishing."
 
 jobs:
   lint_and_test:
@@ -143,6 +163,3 @@ workflows:
       - publish:
           requires:
             - bundle_test
-          filters:
-            tags:
-              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,9 +98,12 @@ commands:
               echo "Git branch is ${<< parameters.git_branch >>}, not publishing."
               exit 0
             fi
-            if [ -z ${<< parameters.git_tag >>}]; then
+            else if [ -z ${<< parameters.git_tag >>}]; then
               echo "Git tag is not set, not publishing."
               exit 0
+            fi
+            else
+              echo "Git branch is ${<< parameters.git_branch >>} and tag is ${<< parameters.git_tag >>}, publishing."
             fi
       - checkout
       - restore_cache: *restore_yarn_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,14 +94,14 @@ commands:
       - run:
           name: Checking if on master branch
           command: |
-            if [ ${<< parameters.git_branch >>} != "master" ]; then
+            if [ ${<< parameters.git_branch >>} != "master" ]
+            then
               echo "Git branch is ${<< parameters.git_branch >>}, not publishing."
               circleci-agent step halt
-            fi
-            else if [ -z ${<< parameters.git_tag >>}]; then
+            elif [ -z ${<< parameters.git_tag >>}]
+            then
               echo "Git tag is not set, not publishing."
               circleci-agent step halt
-            fi
             else
               echo "Git branch is ${<< parameters.git_branch >>} and tag is ${<< parameters.git_tag >>}, publishing."
             fi


### PR DESCRIPTION
#### Summary

This pull request aims to fix the release issue we're experiencing.

We currently can't manage to get the general release config suggested by CircleCI to work:

```yaml
filters:
  tags:
  	only: /^v.*/
  branches:
    ignore: /.*/
```

Never runs. While

```yaml
filters:
  tags:
  	only: /^v.*/
```

Always runs - even without a tag. Leaving us in a state of confusion. 

We can however attempt to replicate the filters with the new CircleCI 2.1 config without much bloat.