### PR TITLE
fix(select-input): fix for prop type

### DIFF
--- a/src/components/fields/async-creatable-select-field/async-creatable-select-field.js
+++ b/src/components/fields/async-creatable-select-field/async-creatable-select-field.js
@@ -6,6 +6,7 @@ import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import AsyncCreatableSelectInput from '../../inputs/async-creatable-select-input';
 import getFieldId from '../../../utils/get-field-id';
+import getElement from '../../../utils/get-element';
 import createSequentialId from '../../../utils/create-sequential-id';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import FieldErrors from '../../field-errors';
@@ -13,6 +14,8 @@ import FieldErrors from '../../field-errors';
 const sequentialId = createSequentialId('async-creatable-select-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
+
+const PropTypeElement = getElement();
 
 export default class SelectField extends React.Component {
   static displayName = 'SelectField';
@@ -45,7 +48,7 @@ export default class SelectField extends React.Component {
     isMulti: PropTypes.bool,
     isSearchable: PropTypes.bool,
     maxMenuHeight: PropTypes.number,
-    menuPortalTarget: PropTypes.instanceOf(PropTypes.element),
+    menuPortalTarget: PropTypes.instanceOf(PropTypeElement),
     menuPortalZIndex: PropTypes.number,
     menuShouldBlockScroll: PropTypes.bool,
     name: PropTypes.string,

--- a/src/components/fields/async-creatable-select-field/async-creatable-select-field.js
+++ b/src/components/fields/async-creatable-select-field/async-creatable-select-field.js
@@ -5,8 +5,8 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import AsyncCreatableSelectInput from '../../inputs/async-creatable-select-input';
+import SafeHTMLElement from '../../../utils/helpers/safeHTMLElement';
 import getFieldId from '../../../utils/get-field-id';
-import getElement from '../../../utils/get-element';
 import createSequentialId from '../../../utils/create-sequential-id';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import FieldErrors from '../../field-errors';
@@ -14,8 +14,6 @@ import FieldErrors from '../../field-errors';
 const sequentialId = createSequentialId('async-creatable-select-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
-
-const PropTypeElement = getElement();
 
 export default class SelectField extends React.Component {
   static displayName = 'SelectField';
@@ -48,7 +46,7 @@ export default class SelectField extends React.Component {
     isMulti: PropTypes.bool,
     isSearchable: PropTypes.bool,
     maxMenuHeight: PropTypes.number,
-    menuPortalTarget: PropTypes.instanceOf(PropTypeElement),
+    menuPortalTarget: PropTypes.instanceOf(SafeHTMLElement),
     menuPortalZIndex: PropTypes.number,
     menuShouldBlockScroll: PropTypes.bool,
     name: PropTypes.string,

--- a/src/components/fields/async-select-field/async-select-field.js
+++ b/src/components/fields/async-select-field/async-select-field.js
@@ -6,6 +6,7 @@ import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import AsyncSelectInput from '../../inputs/async-select-input';
 import getFieldId from '../../../utils/get-field-id';
+import getElement from '../../../utils/get-element';
 import createSequentialId from '../../../utils/create-sequential-id';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import FieldErrors from '../../field-errors';
@@ -13,6 +14,8 @@ import FieldErrors from '../../field-errors';
 const sequentialId = createSequentialId('async-select-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
+
+const PropTypeElement = getElement();
 
 export default class AsyncSelectField extends React.Component {
   static displayName = 'AsyncSelectField';
@@ -45,7 +48,7 @@ export default class AsyncSelectField extends React.Component {
     isMulti: PropTypes.bool,
     isSearchable: PropTypes.bool,
     maxMenuHeight: PropTypes.number,
-    menuPortalTarget: PropTypes.instanceOf(PropTypes.element),
+    menuPortalTarget: PropTypes.instanceOf(PropTypeElement),
     menuPortalZIndex: PropTypes.number,
     menuShouldBlockScroll: PropTypes.bool,
     name: PropTypes.string,

--- a/src/components/fields/async-select-field/async-select-field.js
+++ b/src/components/fields/async-select-field/async-select-field.js
@@ -5,8 +5,8 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import AsyncSelectInput from '../../inputs/async-select-input';
+import SafeHTMLElement from '../../../utils/helpers/safeHTMLElement';
 import getFieldId from '../../../utils/get-field-id';
-import getElement from '../../../utils/get-element';
 import createSequentialId from '../../../utils/create-sequential-id';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import FieldErrors from '../../field-errors';
@@ -14,8 +14,6 @@ import FieldErrors from '../../field-errors';
 const sequentialId = createSequentialId('async-select-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
-
-const PropTypeElement = getElement();
 
 export default class AsyncSelectField extends React.Component {
   static displayName = 'AsyncSelectField';
@@ -48,7 +46,7 @@ export default class AsyncSelectField extends React.Component {
     isMulti: PropTypes.bool,
     isSearchable: PropTypes.bool,
     maxMenuHeight: PropTypes.number,
-    menuPortalTarget: PropTypes.instanceOf(PropTypeElement),
+    menuPortalTarget: PropTypes.instanceOf(SafeHTMLElement),
     menuPortalZIndex: PropTypes.number,
     menuShouldBlockScroll: PropTypes.bool,
     name: PropTypes.string,

--- a/src/components/fields/creatable-select-field/creatable-select-field.js
+++ b/src/components/fields/creatable-select-field/creatable-select-field.js
@@ -5,8 +5,8 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import CreatableSelectInput from '../../inputs/creatable-select-input';
+import SafeHTMLElement from '../../../utils/helpers/safeHTMLElement';
 import getFieldId from '../../../utils/get-field-id';
-import getElement from '../../../utils/get-element';
 import createSequentialId from '../../../utils/create-sequential-id';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import FieldErrors from '../../field-errors';
@@ -14,8 +14,6 @@ import FieldErrors from '../../field-errors';
 const sequentialId = createSequentialId('creatable-select-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
-
-const PropTypeElement = getElement();
 
 export default class SelectField extends React.Component {
   static displayName = 'SelectField';
@@ -48,7 +46,7 @@ export default class SelectField extends React.Component {
     isMulti: PropTypes.bool,
     isSearchable: PropTypes.bool,
     maxMenuHeight: PropTypes.number,
-    menuPortalTarget: PropTypes.instanceOf(PropTypeElement),
+    menuPortalTarget: PropTypes.instanceOf(SafeHTMLElement),
     menuPortalZIndex: PropTypes.number,
     menuShouldBlockScroll: PropTypes.bool,
     name: PropTypes.string,

--- a/src/components/fields/creatable-select-field/creatable-select-field.js
+++ b/src/components/fields/creatable-select-field/creatable-select-field.js
@@ -6,6 +6,7 @@ import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import CreatableSelectInput from '../../inputs/creatable-select-input';
 import getFieldId from '../../../utils/get-field-id';
+import getElement from '../../../utils/get-element';
 import createSequentialId from '../../../utils/create-sequential-id';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import FieldErrors from '../../field-errors';
@@ -13,6 +14,8 @@ import FieldErrors from '../../field-errors';
 const sequentialId = createSequentialId('creatable-select-field-');
 
 const hasErrors = errors => errors && Object.values(errors).some(Boolean);
+
+const PropTypeElement = getElement();
 
 export default class SelectField extends React.Component {
   static displayName = 'SelectField';
@@ -45,7 +48,7 @@ export default class SelectField extends React.Component {
     isMulti: PropTypes.bool,
     isSearchable: PropTypes.bool,
     maxMenuHeight: PropTypes.number,
-    menuPortalTarget: PropTypes.instanceOf(PropTypes.element),
+    menuPortalTarget: PropTypes.instanceOf(PropTypeElement),
     menuPortalZIndex: PropTypes.number,
     menuShouldBlockScroll: PropTypes.bool,
     name: PropTypes.string,

--- a/src/components/fields/money-field/money-field.js
+++ b/src/components/fields/money-field/money-field.js
@@ -6,6 +6,7 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import MoneyInput from '../../inputs/money-input';
+import SafeHTMLElement from '../../../utils/helpers/safeHTMLElement';
 import getFieldId from '../../../utils/get-field-id';
 import createSequentialId from '../../../utils/create-sequential-id';
 import FieldErrors from '../../field-errors';
@@ -59,7 +60,7 @@ class MoneyField extends React.Component {
     isReadOnly: PropTypes.bool,
     isAutofocussed: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
-    menuPortalTarget: PropTypes.instanceOf(PropTypes.element),
+    menuPortalTarget: PropTypes.instanceOf(SafeHTMLElement),
     menuPortalZIndex: PropTypes.number,
     menuShouldBlockScroll: PropTypes.bool,
 

--- a/src/components/fields/select-field/select-field.js
+++ b/src/components/fields/select-field/select-field.js
@@ -5,13 +5,11 @@ import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
 import SelectInput from '../../inputs/select-input';
+import SafeHTMLElement from '../../../utils/helpers/safeHTMLElement';
 import getFieldId from '../../../utils/get-field-id';
 import createSequentialId from '../../../utils/create-sequential-id';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import FieldErrors from '../../field-errors';
-import getElement from '../../../utils/get-element';
-
-const PropTypeElement = getElement();
 
 const sequentialId = createSequentialId('select-field-');
 
@@ -48,7 +46,7 @@ export default class SelectField extends React.Component {
     isMulti: PropTypes.bool,
     isSearchable: PropTypes.bool,
     maxMenuHeight: PropTypes.number,
-    menuPortalTarget: PropTypes.instanceOf(PropTypeElement),
+    menuPortalTarget: PropTypes.instanceOf(SafeHTMLElement),
     menuPortalZIndex: PropTypes.number,
     menuShouldBlockScroll: PropTypes.bool,
     name: PropTypes.string,

--- a/src/components/fields/select-field/select-field.js
+++ b/src/components/fields/select-field/select-field.js
@@ -9,6 +9,9 @@ import getFieldId from '../../../utils/get-field-id';
 import createSequentialId from '../../../utils/create-sequential-id';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import FieldErrors from '../../field-errors';
+import getElement from '../../../utils/get-element';
+
+const PropTypeElement = getElement();
 
 const sequentialId = createSequentialId('select-field-');
 
@@ -45,7 +48,7 @@ export default class SelectField extends React.Component {
     isMulti: PropTypes.bool,
     isSearchable: PropTypes.bool,
     maxMenuHeight: PropTypes.number,
-    menuPortalTarget: PropTypes.instanceOf(PropTypes.element),
+    menuPortalTarget: PropTypes.instanceOf(PropTypeElement),
     menuPortalZIndex: PropTypes.number,
     menuShouldBlockScroll: PropTypes.bool,
     name: PropTypes.string,

--- a/src/components/inputs/async-creatable-select-input/async-creatable-select-input.js
+++ b/src/components/inputs/async-creatable-select-input/async-creatable-select-input.js
@@ -7,6 +7,7 @@ import {
 } from 'react-select';
 import Constraints from '../../constraints';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
+import getElement from '../../../utils/get-element';
 import addStaticFields from '../../../utils/add-static-fields';
 import LoadingIndicator from '../../internals/loading-indicator';
 import ClearIndicator from '../../internals/clear-indicator';
@@ -21,6 +22,8 @@ const customizedComponents = {
   LoadingIndicator,
   MultiValue,
 };
+
+const PropTypeElement = getElement();
 
 export class AsyncCreatableSelectInput extends React.Component {
   // Formik will set the field to an array on submission, so we always have to
@@ -71,7 +74,7 @@ export class AsyncCreatableSelectInput extends React.Component {
     isMulti: PropTypes.bool,
     isSearchable: PropTypes.bool,
     maxMenuHeight: PropTypes.number,
-    menuPortalTarget: PropTypes.instanceOf(PropTypes.element),
+    menuPortalTarget: PropTypes.instanceOf(PropTypeElement),
     menuPortalZIndex: PropTypes.number.isRequired,
     menuShouldBlockScroll: PropTypes.bool,
     name: PropTypes.string,

--- a/src/components/inputs/async-creatable-select-input/async-creatable-select-input.js
+++ b/src/components/inputs/async-creatable-select-input/async-creatable-select-input.js
@@ -6,8 +6,8 @@ import {
   AsyncCreatable as AsyncCreatableSelect,
 } from 'react-select';
 import Constraints from '../../constraints';
+import SafeHTMLElement from '../../../utils/helpers/safeHTMLElement';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
-import getElement from '../../../utils/get-element';
 import addStaticFields from '../../../utils/add-static-fields';
 import LoadingIndicator from '../../internals/loading-indicator';
 import ClearIndicator from '../../internals/clear-indicator';
@@ -22,8 +22,6 @@ const customizedComponents = {
   LoadingIndicator,
   MultiValue,
 };
-
-const PropTypeElement = getElement();
 
 export class AsyncCreatableSelectInput extends React.Component {
   // Formik will set the field to an array on submission, so we always have to
@@ -74,7 +72,7 @@ export class AsyncCreatableSelectInput extends React.Component {
     isMulti: PropTypes.bool,
     isSearchable: PropTypes.bool,
     maxMenuHeight: PropTypes.number,
-    menuPortalTarget: PropTypes.instanceOf(PropTypeElement),
+    menuPortalTarget: PropTypes.instanceOf(SafeHTMLElement),
     menuPortalZIndex: PropTypes.number.isRequired,
     menuShouldBlockScroll: PropTypes.bool,
     name: PropTypes.string,

--- a/src/components/inputs/async-select-input/async-select-input.js
+++ b/src/components/inputs/async-select-input/async-select-input.js
@@ -7,6 +7,7 @@ import {
 } from 'react-select';
 import Constraints from '../../constraints';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
+import getElement from '../../../utils/get-element';
 import addStaticFields from '../../../utils/add-static-fields';
 import ClearIndicator from '../../internals/clear-indicator';
 import MultiValue from '../../internals/multivalue';
@@ -21,6 +22,8 @@ const customizedComponents = {
   LoadingIndicator,
   MultiValue,
 };
+
+const PropTypeElement = getElement();
 
 export class AsyncSelectInput extends React.Component {
   // Formik will set the field to an array on submission, so we always have to
@@ -73,7 +76,7 @@ export class AsyncSelectInput extends React.Component {
     isMulti: PropTypes.bool,
     isSearchable: PropTypes.bool,
     maxMenuHeight: PropTypes.number,
-    menuPortalTarget: PropTypes.instanceOf(PropTypes.element),
+    menuPortalTarget: PropTypes.instanceOf(PropTypeElement),
     menuPortalZIndex: PropTypes.number.isRequired,
     menuShouldBlockScroll: PropTypes.bool,
     name: PropTypes.string,

--- a/src/components/inputs/async-select-input/async-select-input.js
+++ b/src/components/inputs/async-select-input/async-select-input.js
@@ -6,8 +6,8 @@ import {
   Async as AsyncSelect,
 } from 'react-select';
 import Constraints from '../../constraints';
+import SafeHTMLElement from '../../../utils/helpers/safeHTMLElement';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
-import getElement from '../../../utils/get-element';
 import addStaticFields from '../../../utils/add-static-fields';
 import ClearIndicator from '../../internals/clear-indicator';
 import MultiValue from '../../internals/multivalue';
@@ -22,8 +22,6 @@ const customizedComponents = {
   LoadingIndicator,
   MultiValue,
 };
-
-const PropTypeElement = getElement();
 
 export class AsyncSelectInput extends React.Component {
   // Formik will set the field to an array on submission, so we always have to
@@ -76,7 +74,7 @@ export class AsyncSelectInput extends React.Component {
     isMulti: PropTypes.bool,
     isSearchable: PropTypes.bool,
     maxMenuHeight: PropTypes.number,
-    menuPortalTarget: PropTypes.instanceOf(PropTypeElement),
+    menuPortalTarget: PropTypes.instanceOf(SafeHTMLElement),
     menuPortalZIndex: PropTypes.number.isRequired,
     menuShouldBlockScroll: PropTypes.bool,
     name: PropTypes.string,

--- a/src/components/inputs/creatable-select-input/creatable-select-input.js
+++ b/src/components/inputs/creatable-select-input/creatable-select-input.js
@@ -7,6 +7,7 @@ import {
 } from 'react-select';
 import Constraints from '../../constraints';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
+import getElement from '../../../utils/get-element';
 import addStaticFields from '../../../utils/add-static-fields';
 import ClearIndicator from '../../internals/clear-indicator';
 import DropdownIndicator from '../../internals/dropdown-indicator';
@@ -19,6 +20,8 @@ const customizedComponents = {
   ClearIndicator,
   MultiValue,
 };
+
+const PropTypeElement = getElement();
 
 export class CreatableSelectInput extends React.Component {
   static displayName = 'SelectInput';
@@ -59,7 +62,7 @@ export class CreatableSelectInput extends React.Component {
     isMulti: PropTypes.bool,
     isSearchable: PropTypes.bool,
     maxMenuHeight: PropTypes.number,
-    menuPortalTarget: PropTypes.instanceOf(PropTypes.element),
+    menuPortalTarget: PropTypes.instanceOf(PropTypeElement),
     menuPortalZIndex: PropTypes.number.isRequired,
     menuShouldBlockScroll: PropTypes.bool,
     name: PropTypes.string,

--- a/src/components/inputs/creatable-select-input/creatable-select-input.js
+++ b/src/components/inputs/creatable-select-input/creatable-select-input.js
@@ -6,8 +6,8 @@ import {
   Creatable as CreatableSelect,
 } from 'react-select';
 import Constraints from '../../constraints';
+import SafeHTMLElement from '../../../utils/helpers/safeHTMLElement';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
-import getElement from '../../../utils/get-element';
 import addStaticFields from '../../../utils/add-static-fields';
 import ClearIndicator from '../../internals/clear-indicator';
 import DropdownIndicator from '../../internals/dropdown-indicator';
@@ -20,8 +20,6 @@ const customizedComponents = {
   ClearIndicator,
   MultiValue,
 };
-
-const PropTypeElement = getElement();
 
 export class CreatableSelectInput extends React.Component {
   static displayName = 'SelectInput';
@@ -62,7 +60,7 @@ export class CreatableSelectInput extends React.Component {
     isMulti: PropTypes.bool,
     isSearchable: PropTypes.bool,
     maxMenuHeight: PropTypes.number,
-    menuPortalTarget: PropTypes.instanceOf(PropTypeElement),
+    menuPortalTarget: PropTypes.instanceOf(SafeHTMLElement),
     menuPortalZIndex: PropTypes.number.isRequired,
     menuShouldBlockScroll: PropTypes.bool,
     name: PropTypes.string,

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -10,6 +10,7 @@ import styled from '@emotion/styled';
 import vars from '../../../../materials/custom-properties';
 import DropdownIndicator from '../../internals/dropdown-indicator';
 import isNumberish from '../../../utils/is-numberish';
+import SafeHTMLElement from '../../../utils/helpers/safeHTMLElement';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import Contraints from '../../constraints';
 import Tooltip from '../../tooltip';
@@ -394,7 +395,7 @@ class MoneyInput extends React.Component {
     isReadOnly: PropTypes.bool,
     isAutofocussed: PropTypes.bool,
     onChange: requiredIf(PropTypes.func, props => !props.isReadOnly),
-    menuPortalTarget: PropTypes.instanceOf(PropTypes.element),
+    menuPortalTarget: PropTypes.instanceOf(SafeHTMLElement),
     menuPortalZIndex: PropTypes.number.isRequired,
     menuShouldBlockScroll: PropTypes.bool,
     hasError: PropTypes.bool,

--- a/src/components/inputs/select-input/select-input.js
+++ b/src/components/inputs/select-input/select-input.js
@@ -12,12 +12,15 @@ import DropdownIndicator from '../../internals/dropdown-indicator';
 import MultiValue from '../../internals/multivalue';
 import messages from './messages';
 import createSelectStyles from '../../internals/create-select-styles';
+import getElement from '../../../utils/get-element';
 
 const customizedComponents = {
   DropdownIndicator,
   ClearIndicator,
   MultiValue,
 };
+
+const PropTypeElement = getElement();
 
 export class SelectInput extends React.Component {
   static displayName = 'SelectInput';
@@ -87,7 +90,7 @@ export class SelectInput extends React.Component {
     // menuIsOpen: PropTypes.bool,
     // menuPlacement: PropTypes.oneOf(['auto', 'bottom', 'top']),
     // menuPosition: PropTypes.oneOf(['absolute', 'fixed']),
-    menuPortalTarget: PropTypes.instanceOf(PropTypes.element),
+    menuPortalTarget: PropTypes.instanceOf(PropTypeElement),
     menuPortalZIndex: PropTypes.number.isRequired,
     menuShouldBlockScroll: PropTypes.bool,
     // menuShouldScrollIntoView: PropTypes.bool,

--- a/src/components/inputs/select-input/select-input.js
+++ b/src/components/inputs/select-input/select-input.js
@@ -5,6 +5,7 @@ import has from 'lodash/has';
 import flatMap from 'lodash/flatMap';
 import Select, { components as defaultComponents } from 'react-select';
 import Constraints from '../../constraints';
+import SafeHTMLElement from '../../../utils/helpers/safeHTMLElement';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import addStaticFields from '../../../utils/add-static-fields';
 import ClearIndicator from '../../internals/clear-indicator';
@@ -12,15 +13,12 @@ import DropdownIndicator from '../../internals/dropdown-indicator';
 import MultiValue from '../../internals/multivalue';
 import messages from './messages';
 import createSelectStyles from '../../internals/create-select-styles';
-import getElement from '../../../utils/get-element';
 
 const customizedComponents = {
   DropdownIndicator,
   ClearIndicator,
   MultiValue,
 };
-
-const PropTypeElement = getElement();
 
 export class SelectInput extends React.Component {
   static displayName = 'SelectInput';
@@ -90,7 +88,7 @@ export class SelectInput extends React.Component {
     // menuIsOpen: PropTypes.bool,
     // menuPlacement: PropTypes.oneOf(['auto', 'bottom', 'top']),
     // menuPosition: PropTypes.oneOf(['absolute', 'fixed']),
-    menuPortalTarget: PropTypes.instanceOf(PropTypeElement),
+    menuPortalTarget: PropTypes.instanceOf(SafeHTMLElement),
     menuPortalZIndex: PropTypes.number.isRequired,
     menuShouldBlockScroll: PropTypes.bool,
     // menuShouldScrollIntoView: PropTypes.bool,

--- a/src/utils/get-element.js
+++ b/src/utils/get-element.js
@@ -1,0 +1,3 @@
+const getElement = () => (typeof Element === 'undefined' ? () => {} : Element);
+
+export default getElement;

--- a/src/utils/get-element.js
+++ b/src/utils/get-element.js
@@ -1,3 +1,0 @@
-const getElement = () => (typeof Element === 'undefined' ? () => {} : Element);
-
-export default getElement;

--- a/src/utils/helpers/exenv.js
+++ b/src/utils/helpers/exenv.js
@@ -1,0 +1,6 @@
+// eslint-disable-next-line import/prefer-default-export
+export const canUseDOM = !!(
+  typeof window !== 'undefined' &&
+  window.document &&
+  window.document.createElement
+);

--- a/src/utils/helpers/safeHTMLElement.js
+++ b/src/utils/helpers/safeHTMLElement.js
@@ -1,0 +1,5 @@
+import { canUseDOM } from './exenv';
+
+const SafeHTMLElement = canUseDOM ? window.HTMLElement : {};
+
+export default SafeHTMLElement;


### PR DESCRIPTION
#### Summary

We can't use `PropTypes.element` because that defines a react element.

We can't use `Element` because it's undefined in node and crashes the MC at compile time.

More info [here](https://github.com/reactjs/react-modal/issues/15)