### PR TITLE
fix: select-input cursor when disabled

### DIFF
--- a/src/components/internals/create-select-styles.js
+++ b/src/components/internals/create-select-styles.js
@@ -31,19 +31,24 @@ const controlStyles = props => (base, state) => ({
   boxShadow: state.isFocused ? 'none' : base.boxShadow,
 
   '&:hover': {
-    borderColor: vars.borderColorForInputWhenFocused,
+    borderColor: state.isDisabled
+      ? vars.borderColorForInputWhenDisabled
+      : vars.borderColorForInputWhenFocused,
     boxShadow: 'none',
   },
   '&:active': {
-    borderColor: vars.borderColorForInputWhenFocused,
+    borderColor: state.isDisabled
+      ? vars.borderColorForInputWhenDisabled
+      : vars.borderColorForInputWhenFocused,
     boxShadow: 'none',
   },
   '&:focus': {
-    borderColor: vars.borderColorForInputWhenFocused,
+    borderColor: state.isDisabled
+      ? vars.borderColorForInputWhenDisabled
+      : vars.borderColorForInputWhenFocused,
     boxShadow: 'none',
   },
-
-  pointerEvents: state.isDisabled ? 'none' : base.pointerEvents,
+  pointerEvents: 'all',
   color: state.isDisabled
     ? vars.fontColorForInputWhenDisabled
     : base.fontColorForInput,


### PR DESCRIPTION
#### Summary

Currently, `cursor: not-allowed` doesn't work with SelectInputs. 

This fixes that.