### PR TITLE
refactor(checkbox-input): accessibility concerns

### DIFF
--- a/src/components/inputs/checkbox-input/checkbox-input.js
+++ b/src/components/inputs/checkbox-input/checkbox-input.js
@@ -18,9 +18,11 @@ const Label = styled.label`
   cursor: ${props => (props.isDisabled ? 'not-allowed' : 'pointer')};
   position: relative;
 
-  &:hover svg [id$='borderAndContent'] > [id$='border'] {
+  ${props =>
+    !props.hasError &&
+    `  &:hover svg [id$='borderAndContent'] > [id$='border'] {
     stroke: ${vars.borderColorInputFocus};
-  }
+  }`}
 `;
 
 class CheckboxInput extends React.PureComponent {
@@ -61,7 +63,7 @@ class CheckboxInput extends React.PureComponent {
 
   render() {
     return (
-      <Label htmlFor={this.state.id}>
+      <Label htmlFor={this.state.id} hasError={this.props.hasError}>
         <Spacings.Inline alignItems="center">
           <Checkbox
             type="checkbox"
@@ -72,6 +74,7 @@ class CheckboxInput extends React.PureComponent {
             disabled={this.props.isDisabled}
             checked={this.props.isChecked && !this.props.isIndeterminate}
             isIndeterminate={this.props.isIndeterminate}
+            hasError={this.props.hasError}
             {...filterDataAttributes(this.props)}
           />
 

--- a/src/components/inputs/checkbox-input/checkbox-input.js
+++ b/src/components/inputs/checkbox-input/checkbox-input.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import { css } from '@emotion/core';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import getFieldId from '../../../utils/get-field-id';
 import createSequentialId from '../../../utils/create-sequential-id';
 import Text from '../../typography/text';
-import Spacings from '../../spacings';
 import Icons from './icons';
 import { getCheckboxWrapperStyles } from './checkbox-input.styles';
 import Checkbox from './checkbox';
@@ -14,7 +14,8 @@ import vars from '../../../../materials/custom-properties';
 const sequentialId = createSequentialId('checkbox-input-');
 
 const Label = styled.label`
-  display: block;
+  display: flex;
+  align-items: center;
   cursor: ${props => (props.isDisabled ? 'not-allowed' : 'pointer')};
   position: relative;
 
@@ -64,36 +65,39 @@ class CheckboxInput extends React.PureComponent {
   render() {
     return (
       <Label htmlFor={this.state.id} hasError={this.props.hasError}>
-        <Spacings.Inline alignItems="center">
-          <Checkbox
-            type="checkbox"
-            id={this.state.id}
-            name={this.props.name}
-            value={this.props.value}
-            onChange={this.props.onChange}
-            disabled={this.props.isDisabled}
-            checked={this.props.isChecked && !this.props.isIndeterminate}
-            isIndeterminate={this.props.isIndeterminate}
-            hasError={this.props.hasError}
-            {...filterDataAttributes(this.props)}
-          />
-
-          <div css={getCheckboxWrapperStyles(this.props)}>
-            {(() => {
-              if (this.props.isIndeterminate) return <Icons.Indeterminate />;
-              if (this.props.isChecked) return <Icons.Checked />;
-              return <Icons.Unchecked />;
-            })()}
-          </div>
-          {this.props.children && (
+        <Checkbox
+          type="checkbox"
+          id={this.state.id}
+          name={this.props.name}
+          value={this.props.value}
+          onChange={this.props.onChange}
+          disabled={this.props.isDisabled}
+          checked={this.props.isChecked && !this.props.isIndeterminate}
+          isIndeterminate={this.props.isIndeterminate}
+          hasError={this.props.hasError}
+          {...filterDataAttributes(this.props)}
+        />
+        <div css={getCheckboxWrapperStyles(this.props)}>
+          {(() => {
+            if (this.props.isIndeterminate) return <Icons.Indeterminate />;
+            if (this.props.isChecked) return <Icons.Checked />;
+            return <Icons.Unchecked />;
+          })()}
+        </div>
+        {this.props.children && (
+          <div
+            css={css`
+              margin-left: ${vars.spacingS};
+            `}
+          >
             <Text.Body
               // FIXME: add proper tones when we have disabled/primary in tones
               tone={this.props.isDisabled ? 'secondary' : undefined}
             >
               {this.props.children}
             </Text.Body>
-          )}
-        </Spacings.Inline>
+          </div>
+        )}
       </Label>
     );
   }

--- a/src/components/inputs/checkbox-input/checkbox-input.js
+++ b/src/components/inputs/checkbox-input/checkbox-input.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
+import filterAriaAttributes from '../../../utils/filter-aria-attributes';
 import getFieldId from '../../../utils/get-field-id';
 import createSequentialId from '../../../utils/create-sequential-id';
 import Text from '../../typography/text';
@@ -71,11 +72,12 @@ class CheckboxInput extends React.PureComponent {
           name={this.props.name}
           value={this.props.value}
           onChange={this.props.onChange}
-          disabled={this.props.isDisabled}
-          checked={this.props.isChecked && !this.props.isIndeterminate}
+          isDisabled={this.props.isDisabled}
+          isChecked={this.props.isChecked}
           isIndeterminate={this.props.isIndeterminate}
           hasError={this.props.hasError}
           {...filterDataAttributes(this.props)}
+          {...filterAriaAttributes(this.props)}
         />
         <div css={getCheckboxWrapperStyles(this.props)}>
           {(() => {

--- a/src/components/inputs/checkbox-input/checkbox-input.js
+++ b/src/components/inputs/checkbox-input/checkbox-input.js
@@ -1,18 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { css } from '@emotion/core';
+import styled from '@emotion/styled';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import getFieldId from '../../../utils/get-field-id';
 import createSequentialId from '../../../utils/create-sequential-id';
 import Text from '../../typography/text';
 import Spacings from '../../spacings';
 import Icons from './icons';
-import {
-  getLabelStyles,
-  getCheckboxWrapperStyles,
-} from './checkbox-input.styles';
+import { getCheckboxWrapperStyles } from './checkbox-input.styles';
+import Checkbox from './checkbox';
+import vars from '../../../../materials/custom-properties';
 
 const sequentialId = createSequentialId('checkbox-input-');
+
+const Label = styled.label`
+  display: block;
+  cursor: ${props => (props.isDisabled ? 'not-allowed' : 'pointer')};
+  position: relative;
+
+  &:hover svg [id$='borderAndContent'] > [id$='border'] {
+    stroke: ${vars.borderColorInputFocus};
+  }
+`;
 
 class CheckboxInput extends React.PureComponent {
   static displayName = 'CheckboxInput';
@@ -52,40 +61,37 @@ class CheckboxInput extends React.PureComponent {
 
   render() {
     return (
-      <div>
-        <label htmlFor={this.state.id} css={getLabelStyles(this.props)}>
-          <Spacings.Inline alignItems="center">
-            <div css={getCheckboxWrapperStyles(this.props)}>
-              {(() => {
-                if (this.props.isIndeterminate) return <Icons.Indeterminate />;
-                if (this.props.isChecked) return <Icons.Checked />;
-                return <Icons.Unchecked />;
-              })()}
-            </div>
-            {this.props.children && (
-              <Text.Body
-                // FIXME: add proper tones when we have disabled/primary in tones
-                tone={this.props.isDisabled ? 'secondary' : undefined}
-              >
-                {this.props.children}
-              </Text.Body>
-            )}
-            <input
-              css={css`
-                display: none;
-              `}
-              type="checkbox"
-              id={this.state.id}
-              name={this.props.name}
-              value={this.props.value}
-              onChange={this.props.onChange}
-              disabled={this.props.isDisabled}
-              checked={this.props.isChecked && !this.props.isIndeterminate}
-              {...filterDataAttributes(this.props)}
-            />
-          </Spacings.Inline>
-        </label>
-      </div>
+      <Label htmlFor={this.state.id}>
+        <Spacings.Inline alignItems="center">
+          <Checkbox
+            type="checkbox"
+            id={this.state.id}
+            name={this.props.name}
+            value={this.props.value}
+            onChange={this.props.onChange}
+            disabled={this.props.isDisabled}
+            checked={this.props.isChecked && !this.props.isIndeterminate}
+            isIndeterminate={this.props.isIndeterminate}
+            {...filterDataAttributes(this.props)}
+          />
+
+          <div css={getCheckboxWrapperStyles(this.props)}>
+            {(() => {
+              if (this.props.isIndeterminate) return <Icons.Indeterminate />;
+              if (this.props.isChecked) return <Icons.Checked />;
+              return <Icons.Unchecked />;
+            })()}
+          </div>
+          {this.props.children && (
+            <Text.Body
+              // FIXME: add proper tones when we have disabled/primary in tones
+              tone={this.props.isDisabled ? 'secondary' : undefined}
+            >
+              {this.props.children}
+            </Text.Body>
+          )}
+        </Spacings.Inline>
+      </Label>
     );
   }
 }

--- a/src/components/inputs/checkbox-input/checkbox-input.styles.js
+++ b/src/components/inputs/checkbox-input/checkbox-input.styles.js
@@ -1,23 +1,6 @@
 import { css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
 
-const getLabelStyles = props => {
-  if (props.isDisabled) {
-    return css`
-      cursor: not-allowed;
-    `;
-  }
-  if (props.hasError) {
-    return css``;
-  }
-  return css`
-    cursor: pointer;
-    &:hover svg [id$='borderAndContent'] > [id$='border'] {
-      stroke: ${vars.borderColorInputFocus};
-    }
-  `;
-};
-
 const getCheckboxWrapperStyles = props => {
   const baseStyles = css`
     display: flex;
@@ -69,4 +52,5 @@ const getCheckboxWrapperStyles = props => {
   return baseStyles;
 };
 
-export { getLabelStyles, getCheckboxWrapperStyles };
+// eslint-disable-next-line import/prefer-default-export
+export { getCheckboxWrapperStyles };

--- a/src/components/inputs/checkbox-input/checkbox.js
+++ b/src/components/inputs/checkbox-input/checkbox.js
@@ -25,7 +25,14 @@ class Checkbox extends React.Component {
   static displayName = 'Checkbox';
 
   static propTypes = {
+    id: PropTypes.string,
+    name: PropTypes.string,
+    value: PropTypes.string,
+    isChecked: PropTypes.bool,
     isIndeterminate: PropTypes.bool,
+    onChange: PropTypes.func.isRequired,
+    isDisabled: PropTypes.bool,
+    hasError: PropTypes.bool,
   };
 
   componentDidMount() {
@@ -43,7 +50,19 @@ class Checkbox extends React.Component {
   ref = React.createRef();
 
   render() {
-    return <Input ref={this.ref} {...this.props} />;
+    return (
+      <Input
+        id={this.props.id}
+        name={this.props.name}
+        value={this.props.value}
+        disabled={this.props.isDisabled}
+        checked={this.props.isChecked && !this.props.isIndeterminate}
+        onChange={this.props.onChange}
+        hasError={this.props.hasError}
+        ref={this.ref}
+        {...this.props}
+      />
+    );
   }
 }
 

--- a/src/components/inputs/checkbox-input/checkbox.js
+++ b/src/components/inputs/checkbox-input/checkbox.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import vars from '../../../../materials/custom-properties';
+
+// accessible input :)
+const Input = styled.input`
+  pointer-events: none;
+  height: 100%;
+  left: 0;
+  opacity: 0.0001;
+  position: absolute;
+  top: 0;
+  width: 100%;
+
+  &:focus + div > svg [id$='borderAndContent'] > [id$='border'] {
+    stroke: ${vars.borderColorInputFocus};
+  }
+`;
+
+class Checkbox extends React.Component {
+  static displayName = 'Checkbox';
+
+  static propTypes = {
+    isIndeterminate: PropTypes.bool,
+  };
+
+  componentDidMount() {
+    if (this.props.isIndeterminate) {
+      this.ref.current.indeterminate = true;
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.isIndeterminate !== this.props.isIndeterminate) {
+      this.ref.current.indeterminate = this.props.isIndeterminate;
+    }
+  }
+
+  ref = React.createRef();
+
+  render() {
+    return <Input ref={this.ref} {...this.props} />;
+  }
+}
+
+export default Checkbox;

--- a/src/components/inputs/checkbox-input/checkbox.js
+++ b/src/components/inputs/checkbox-input/checkbox.js
@@ -13,9 +13,12 @@ const Input = styled.input`
   top: 0;
   width: 100%;
 
+  ${props =>
+    !props.hasError &&
+    `
   &:focus + div > svg [id$='borderAndContent'] > [id$='border'] {
     stroke: ${vars.borderColorInputFocus};
-  }
+  }`}
 `;
 
 class Checkbox extends React.Component {


### PR DESCRIPTION
#### Summary

This PR makes two changes to the `CheckboxInput`. Neither change affects the design of the component.

1. When the `Input` is focused, we treat it the same as the hovered state. This matches the behaviour in most of our `Input` components, including (but not limited to) `TextInput`, `LocalizedTextInput`, `MoneyInput`, etc, etc.

2. When the `CheckboxInput` is in an indeterminate state, we render it with this HTML property, to help screenreaders.