### PR TITLE
refactoring(css): move `accessible-input-styles` to internals

### DIFF
--- a/src/components/inputs/checkbox-input/checkbox.js
+++ b/src/components/inputs/checkbox-input/checkbox.js
@@ -1,18 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import accessibleHiddenInputStyles from '../../internals/accessible-hidden-input.styles';
 import vars from '../../../../materials/custom-properties';
 
 // accessible input :)
 const Input = styled.input`
-  pointer-events: none;
-  height: 100%;
-  left: 0;
-  opacity: 0.0001;
-  position: absolute;
-  top: 0;
-  width: 100%;
-
   ${props =>
     !props.hasError &&
     `
@@ -52,6 +45,7 @@ class Checkbox extends React.Component {
   render() {
     return (
       <Input
+        css={accessibleHiddenInputStyles}
         id={this.props.id}
         name={this.props.name}
         value={this.props.value}

--- a/src/components/internals/accessible-hidden-input.styles.js
+++ b/src/components/internals/accessible-hidden-input.styles.js
@@ -1,0 +1,13 @@
+import { css } from '@emotion/core';
+
+const accessibleHiddenInputStyles = css`
+  pointer-events: none;
+  height: 100%;
+  left: 0;
+  opacity: 0.0001;
+  position: absolute;
+  top: 0;
+  width: 100%;
+`;
+
+export default accessibleHiddenInputStyles;


### PR DESCRIPTION
#### Summary

As we will be using these styles in `RadioOptions`, `Checkbox` and `Toggle`, it makes sense not to reinvent the wheel 3 times.