### PR TITLE
refactoring(RadioInput): hovered and focus state changes

### DIFF
--- a/src/components/inputs/radio-input/radio-option.js
+++ b/src/components/inputs/radio-input/radio-option.js
@@ -11,8 +11,6 @@ import { getLabelStyles, getContainerStyles } from './radio-option.styles';
 const Input = styled.input`
   ${props =>
     !props.readOnly &&
-    !props.hasError &&
-    !props.hasWarning &&
     `
     &:focus + div > svg [id$='borderAndContent'] > [id$='border'] {
       stroke: ${vars.borderColorInputFocus};

--- a/src/components/inputs/radio-input/radio-option.js
+++ b/src/components/inputs/radio-input/radio-option.js
@@ -9,12 +9,9 @@ import accessibleHiddenInputStyles from '../../internals/accessible-hidden-input
 import { getLabelStyles, getContainerStyles } from './radio-option.styles';
 
 const Input = styled.input`
-  ${props =>
-    !props.readOnly &&
-    `
-    &:focus + div > svg [id$='borderAndContent'] > [id$='border'] {
-      stroke: ${vars.borderColorInputFocus};
-    }`}
+  &:focus + div > svg [id$='borderAndContent'] > [id$='border'] {
+    stroke: ${vars.borderColorInputFocus};
+  }
 `;
 
 const Option = props => (
@@ -32,8 +29,6 @@ const Option = props => (
       name={props.name}
       value={props.value}
       onChange={props.isReadOnly ? undefined : props.onChange}
-      hasError={props.hasError}
-      hasWarning={props.hasWarning}
       disabled={props.isDisabled}
       checked={props.isChecked}
       type="radio"

--- a/src/components/inputs/radio-input/radio-option.js
+++ b/src/components/inputs/radio-input/radio-option.js
@@ -1,11 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
-import Spacings from '../../spacings';
 import Icons from './icons';
+import accessibleHiddenInputStyles from '../../internals/accessible-hidden-input.styles';
 import { getLabelStyles, getContainerStyles } from './radio-option.styles';
+
+const Input = styled.input`
+  ${props =>
+    !props.readOnly &&
+    !props.hasError &&
+    !props.hasWarning &&
+    `
+    &:focus + div > svg [id$='borderAndContent'] > [id$='border'] {
+      stroke: ${vars.borderColorInputFocus};
+    }`}
+`;
 
 const Option = props => (
   <label
@@ -16,38 +28,37 @@ const Option = props => (
     onBlur={props.onBlur}
     htmlFor={props.id}
   >
-    <Spacings.Inline scale="s" alignItems="center">
-      <div css={getContainerStyles(props)}>
-        {props.isChecked ? <Icons.Checked /> : <Icons.Default />}
-      </div>
-      <div
-        css={css`
-          width: 100%;
-          font-size: 1rem;
-          font-family: ${vars.fontFamilyDefault};
-          color: ${props.isDisabled
-            ? vars.fontColorDisabled
-            : vars.fontColorDefault};
-        `}
-      >
-        {props.children}
-      </div>
-      <input
-        css={css`
-          display: none;
-        `}
-        id={props.id}
-        name={props.name}
-        value={props.value}
-        onChange={props.isReadOnly ? undefined : props.onChange}
-        disabled={props.isDisabled}
-        checked={props.isChecked}
-        type="radio"
-        readOnly={props.isReadOnly}
-        aria-readonly={props.isReadOnly}
-        {...filterDataAttributes(props)}
-      />
-    </Spacings.Inline>
+    <Input
+      css={accessibleHiddenInputStyles}
+      id={props.id}
+      name={props.name}
+      value={props.value}
+      onChange={props.isReadOnly ? undefined : props.onChange}
+      hasError={props.hasError}
+      hasWarning={props.hasWarning}
+      disabled={props.isDisabled}
+      checked={props.isChecked}
+      type="radio"
+      readOnly={props.isReadOnly}
+      aria-readonly={props.isReadOnly}
+      {...filterDataAttributes(props)}
+    />
+    <div css={getContainerStyles(props)}>
+      {props.isChecked ? <Icons.Checked /> : <Icons.Default />}
+    </div>
+    <div
+      css={css`
+        width: 100%;
+        margin-left: ${vars.spacingS};
+        font-size: 1rem;
+        font-family: ${vars.fontFamilyDefault};
+        color: ${props.isDisabled
+          ? vars.fontColorDisabled
+          : vars.fontColorDefault};
+      `}
+    >
+      {props.children}
+    </div>
   </label>
 );
 Option.displayName = 'RadioOption';
@@ -67,6 +78,7 @@ Option.propTypes = {
   isDisabled: PropTypes.bool,
   isReadOnly: PropTypes.bool,
   hasError: PropTypes.bool,
+  hasWarning: PropTypes.bool,
   onChange: PropTypes.func,
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,

--- a/src/components/inputs/radio-input/radio-option.styles.js
+++ b/src/components/inputs/radio-input/radio-option.styles.js
@@ -108,9 +108,6 @@ const getLabelStyles = props => {
       baseStyles,
       css`
         color: ${vars.fontColorError};
-        &:hover svg [id$='borderAndContent'] > [id$='border'] {
-          stroke: ${vars.borderColorInputError};
-        }
       `,
     ];
   }
@@ -119,9 +116,6 @@ const getLabelStyles = props => {
       baseStyles,
       css`
         color: ${vars.fontColorWarning};
-        &:hover svg [id$='borderAndContent'] > [id$='border'] {
-          stroke: ${vars.borderColorInputWarning};
-        }
       `,
     ];
   }

--- a/src/components/inputs/radio-input/radio-option.styles.js
+++ b/src/components/inputs/radio-input/radio-option.styles.js
@@ -80,6 +80,9 @@ const getContainerStyles = props => {
 const getLabelStyles = props => {
   const baseStyles = css`
     cursor: pointer;
+    display: flex;
+    align-items: center;
+    position: relative;
     &:hover svg [id$='borderAndContent'] > [id$='border'] {
       stroke: ${vars.borderColorInputFocus};
     }

--- a/src/components/inputs/radio-input/radio-option.styles.js
+++ b/src/components/inputs/radio-input/radio-option.styles.js
@@ -108,6 +108,9 @@ const getLabelStyles = props => {
       baseStyles,
       css`
         color: ${vars.fontColorError};
+        &:hover svg [id$='borderAndContent'] > [id$='border'] {
+          stroke: ${vars.borderColorInputError};
+        }
       `,
     ];
   }
@@ -116,6 +119,9 @@ const getLabelStyles = props => {
       baseStyles,
       css`
         color: ${vars.fontColorWarning};
+        &:hover svg [id$='borderAndContent'] > [id$='border'] {
+          stroke: ${vars.borderColorInputWarning};
+        }
       `,
     ];
   }


### PR DESCRIPTION
#### Summary

Better visual feedback for `RadioOptions`. Also makes them accessible with the keyboard.

Changes
* Focus when input is in `hasWarning` or `hasError` states does a green underline

Design changes come from discussion with @mariabarrena 