### PR TITLE
refactor(checkbox-input): accessibility fix

### DIFF
--- a/src/components/inputs/checkbox-input/checkbox-input.js
+++ b/src/components/inputs/checkbox-input/checkbox-input.js
@@ -19,10 +19,11 @@ const Label = styled.label`
   align-items: center;
   cursor: ${props => (props.isDisabled ? 'not-allowed' : 'pointer')};
   position: relative;
-
-  &:hover svg [id$='borderAndContent'] > [id$='border'] {
+  ${props =>
+    !props.hasError &&
+    `  &:hover svg [id$='borderAndContent'] > [id$='border'] {
     stroke: ${vars.borderColorInputFocus};
-  }
+  }`}
 `;
 
 class CheckboxInput extends React.PureComponent {
@@ -63,7 +64,7 @@ class CheckboxInput extends React.PureComponent {
 
   render() {
     return (
-      <Label htmlFor={this.state.id}>
+      <Label htmlFor={this.state.id} hasError={this.props.hasError}>
         <Checkbox
           type="checkbox"
           id={this.state.id}

--- a/src/components/inputs/checkbox-input/checkbox-input.js
+++ b/src/components/inputs/checkbox-input/checkbox-input.js
@@ -20,11 +20,9 @@ const Label = styled.label`
   cursor: ${props => (props.isDisabled ? 'not-allowed' : 'pointer')};
   position: relative;
 
-  ${props =>
-    !props.hasError &&
-    `  &:hover svg [id$='borderAndContent'] > [id$='border'] {
+  &:hover svg [id$='borderAndContent'] > [id$='border'] {
     stroke: ${vars.borderColorInputFocus};
-  }`}
+  }
 `;
 
 class CheckboxInput extends React.PureComponent {
@@ -65,7 +63,7 @@ class CheckboxInput extends React.PureComponent {
 
   render() {
     return (
-      <Label htmlFor={this.state.id} hasError={this.props.hasError}>
+      <Label htmlFor={this.state.id}>
         <Checkbox
           type="checkbox"
           id={this.state.id}
@@ -75,7 +73,6 @@ class CheckboxInput extends React.PureComponent {
           isDisabled={this.props.isDisabled}
           isChecked={this.props.isChecked}
           isIndeterminate={this.props.isIndeterminate}
-          hasError={this.props.hasError}
           {...filterDataAttributes(this.props)}
           {...filterAriaAttributes(this.props)}
         />

--- a/src/components/inputs/checkbox-input/checkbox.js
+++ b/src/components/inputs/checkbox-input/checkbox.js
@@ -6,12 +6,9 @@ import vars from '../../../../materials/custom-properties';
 
 // accessible input :)
 const Input = styled.input`
-  ${props =>
-    !props.hasError &&
-    `
   &:focus + div > svg [id$='borderAndContent'] > [id$='border'] {
     stroke: ${vars.borderColorInputFocus};
-  }`}
+  }
 `;
 
 class Checkbox extends React.Component {
@@ -25,7 +22,6 @@ class Checkbox extends React.Component {
     isIndeterminate: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
     isDisabled: PropTypes.bool,
-    hasError: PropTypes.bool,
   };
 
   componentDidMount() {
@@ -52,7 +48,6 @@ class Checkbox extends React.Component {
         disabled={this.props.isDisabled}
         checked={this.props.isChecked && !this.props.isIndeterminate}
         onChange={this.props.onChange}
-        hasError={this.props.hasError}
         ref={this.ref}
         {...this.props}
       />


### PR DESCRIPTION
Follow up to #721. Based on discussion with @mariabarrena 

Now when a checkbox has error state, we still give it the green hover, and same for "focus".