### PR TITLE
fix(time-input): readonly fix

### DIFF
--- a/src/components/inputs/time-input/time-input-body.js
+++ b/src/components/inputs/time-input/time-input-body.js
@@ -75,7 +75,7 @@ export default class TimeInputBody extends React.Component {
             id={this.props.id}
             name={this.props.name}
             autoComplete={this.props.autoComplete}
-            css={getTimeInputStyles(this.props)}
+            css={theme => getTimeInputStyles(this.props, theme)}
             placeholder={this.props.placeholder}
             autoFocus={this.props.isAutofocussed}
             disabled={this.props.isDisabled}
@@ -99,7 +99,7 @@ export default class TimeInputBody extends React.Component {
           <label
             htmlFor={this.props.id}
             data-toggle
-            css={getClockIconContainerStyles(this.props)}
+            css={theme => getClockIconContainerStyles(this.props, theme)}
           >
             <ClockIcon theme={this.props.isDisabled ? 'grey' : 'black'} />
           </label>

--- a/src/components/inputs/time-input/time-input-body.js
+++ b/src/components/inputs/time-input/time-input-body.js
@@ -19,7 +19,7 @@ const getIconTheme = (isDisabled, isMouseOver) => {
 
 export const ClearSection = props => (
   <div
-    onClick={props.isDisabled ? undefined : props.onClear}
+    onClick={props.isDisabled || props.isReadOnly ? undefined : props.onClear}
     css={getClearSectionStyles(props)}
     onMouseOver={props.handleMouseOver}
     onMouseOut={props.handleMouseOut}
@@ -35,6 +35,7 @@ export const ClearSection = props => (
 ClearSection.displayName = 'ClearSection';
 ClearSection.propTypes = {
   isDisabled: PropTypes.bool,
+  isReadOnly: PropTypes.bool,
   hasError: PropTypes.bool,
   isMouseOver: PropTypes.bool.isRequired,
   onClear: PropTypes.func,

--- a/src/components/inputs/time-input/time-input-body.js
+++ b/src/components/inputs/time-input/time-input-body.js
@@ -20,7 +20,7 @@ const getIconTheme = (isDisabled, isMouseOver) => {
 export const ClearSection = props => (
   <div
     onClick={props.isDisabled || props.isReadOnly ? undefined : props.onClear}
-    css={getClearSectionStyles(props)}
+    css={theme => getClearSectionStyles(props, theme)}
     onMouseOver={props.handleMouseOver}
     onMouseOut={props.handleMouseOut}
   >

--- a/src/components/inputs/time-input/time-input-body.js
+++ b/src/components/inputs/time-input/time-input-body.js
@@ -78,6 +78,7 @@ export default class TimeInputBody extends React.Component {
             placeholder={this.props.placeholder}
             autoFocus={this.props.isAutofocussed}
             disabled={this.props.isDisabled}
+            readOnly={this.props.isReadOnly}
             value={this.props.value}
             onChange={this.props.onChange}
             onFocus={this.props.onFocus}
@@ -85,10 +86,13 @@ export default class TimeInputBody extends React.Component {
             {...filterDataAttributes(this.props)}
             /* ARIA */
             role="textbox"
+            aria-readonly={this.props.isReadOnly}
+            contentEditable={!this.props.isReadOnly}
           />
           <ClearSectionWithMouseOverState
             isDisabled={this.props.isDisabled}
             hasError={this.props.hasError}
+            isReadOnly={this.props.isReadOnly}
             onClear={this.props.onClear}
           />
           <label

--- a/src/components/inputs/time-input/time-input-body.styles.js
+++ b/src/components/inputs/time-input/time-input-body.styles.js
@@ -10,10 +10,10 @@ const getClearSectionStyles = props => {
   const baseIconStyles = css`
     align-items: center;
     box-sizing: border-box;
-    background-color: ${vars.backgroundColorInputPristine};
+    background-color: ${vars.backgroundColorForInput};
     border-bottom: 1px solid ${vars.borderColorForInput};
-    border-right: 1px solid ${vars.borderColorInputPristine};
-    border-top: 1px solid ${vars.borderColorInputPristine};
+    border-right: 1px solid ${vars.borderColorForInput};
+    border-top: 1px solid ${vars.borderColorForInput};
     border-left: none;
     height: ${vars.sizeHeightInput};
     display: flex;
@@ -26,9 +26,9 @@ const getClearSectionStyles = props => {
       baseIconStyles,
       css`
         cursor: not-allowed;
-        background-color: ${vars.backgroundColorInputDisabled};
-        color: ${vars.fontColorDisabled};
-        border-color: ${vars.borderColorInputDisabled};
+        background-color: ${vars.backgroundColorForInputWhenDisabled};
+        color: ${vars.fontColorForInputWhenDisabled};
+        border-color: ${vars.borderColorForInputWhenDisabled};
       `,
     ];
   }
@@ -50,8 +50,8 @@ const getClearSectionStyles = props => {
     return [
       baseIconStyles,
       css`
-        color: ${vars.fontColorError};
-        border-color: ${vars.borderColorInputError};
+        color: ${vars.fontColorForInputWhenError};
+        border-color: ${vars.borderColorForInputWhenError};
       `,
     ];
   }
@@ -62,25 +62,25 @@ const getClockIconContainerStyles = props => {
   const baseIconStyles = css`
     align-items: center;
     box-sizing: border-box;
-    background-color: ${vars.backgroundColorInputPristine};
-    border-bottom: 1px solid ${vars.borderColorInputPristine};
-    border-right: 1px solid ${vars.borderColorInputPristine};
-    border-top: 1px solid ${vars.borderColorInputPristine};
+    background-color: ${vars.backgroundColorForInput};
+    border-bottom: 1px solid ${vars.borderColorForInput};
+    border-right: 1px solid ${vars.borderColorForInput};
+    border-top: 1px solid ${vars.borderColorForInput};
     border-left: none;
     height: ${vars.sizeHeightInput};
     display: flex;
     padding: ${vars.spacingXs};
-    border-top-right-radius: ${vars.borderRadiusInput};
-    border-bottom-right-radius: ${vars.borderRadiusInput};
+    border-top-right-radius: ${vars.borderRadiusForInput};
+    border-bottom-right-radius: ${vars.borderRadiusForInput};
   `;
   if (props.isDisabled) {
     return [
       baseIconStyles,
       css`
         cursor: not-allowed;
-        background-color: ${vars.backgroundColorInputDisabled};
-        color: ${vars.fontColorDisabled};
-        border-color: ${vars.borderColorInputDisabled};
+        background-color: ${vars.backgroundColorForInputWhenDisabled};
+        color: ${vars.fontColorForInputWhenDisabled};
+        border-color: ${vars.borderColorForInputWhenDisabled};
       `,
     ];
   }
@@ -102,8 +102,8 @@ const getClockIconContainerStyles = props => {
     return [
       baseIconStyles,
       css`
-        color: ${vars.fontColorError};
-        border-color: ${vars.borderColorInputError};
+        color: ${vars.fontColorFolorInputWhenError};
+        border-color: ${vars.borderColorForInputWhenError};
       `,
     ];
   }
@@ -114,8 +114,8 @@ const getInputContainerStyles = () => css`
   width: 100%;
   align-items: center;
   display: flex;
-  font-size: ${vars.fontSizeDefault};
-  font-family: ${vars.fontFamilyDefault};
+  font-size: ${vars.fontSizeForInput};
+  font-family: ${vars.fontSizeForInput};
 `;
 
 const getTimeInputStyles = props => [
@@ -128,8 +128,8 @@ const getTimeInputStyles = props => [
     &:active,
     &:focus + *,
     &:active + * {
-      border-color: ${vars.borderColorInputFocus};
-      color: ${vars.fontColorDefault};
+      border-color: ${vars.borderColorForInputWhenFocused};
+      color: ${vars.fontColorForInput};
       transition: ${vars.transitionStandard};
     }
 
@@ -138,9 +138,9 @@ const getTimeInputStyles = props => [
     }
 
     &:disabled {
-      background-color: ${vars.backgroundColorInputDisabled};
-      color: ${vars.fontColorDisabled};
-      border-color: ${vars.borderColorInputDisabled};
+      background-color: ${vars.backgroundColorForInputWhenDisabled};
+      color: ${vars.fontColorForInputWhenDisabled};
+      border-color: ${vars.borderColorForInputWhenDisabled};
       opacity: 1; /* fix for mobile safari */
     }
   `,

--- a/src/components/inputs/time-input/time-input-body.styles.js
+++ b/src/components/inputs/time-input/time-input-body.styles.js
@@ -11,13 +11,14 @@ const getClearSectionStyles = props => {
     align-items: center;
     box-sizing: border-box;
     background-color: ${vars.backgroundColorInputPristine};
-    border-bottom: 1px solid ${vars.borderColorInputPristine};
+    border-bottom: 1px solid ${vars.borderColorForInput};
     border-right: 1px solid ${vars.borderColorInputPristine};
     border-top: 1px solid ${vars.borderColorInputPristine};
     border-left: none;
     height: ${vars.sizeHeightInput};
     display: flex;
     padding: ${vars.spacingXs};
+    transition: ${vars.transitionStandard};
     cursor: pointer;
   `;
   if (props.isDisabled) {
@@ -28,6 +29,20 @@ const getClearSectionStyles = props => {
         background-color: ${vars.backgroundColorInputDisabled};
         color: ${vars.fontColorDisabled};
         border-color: ${vars.borderColorInputDisabled};
+      `,
+    ];
+  }
+  if (props.isReadOnly) {
+    return [
+      baseIconStyles,
+      css`
+        cursor: default;
+        color: ${vars.fontColorForInputWhenReadonly};
+        border-color: ${vars.borderColorForInputWhenReadonly};
+
+        svg path {
+          fill: ${vars.fontColorForInputWhenReadonly};
+        }
       `,
     ];
   }
@@ -66,6 +81,20 @@ const getClockIconContainerStyles = props => {
         background-color: ${vars.backgroundColorInputDisabled};
         color: ${vars.fontColorDisabled};
         border-color: ${vars.borderColorInputDisabled};
+      `,
+    ];
+  }
+  if (props.isReadOnly) {
+    return [
+      baseIconStyles,
+      css`
+        cursor: default;
+        color: ${vars.fontColorForInputWhenReadonly};
+        border-color: ${vars.borderColorForInputWhenReadonly};
+
+        svg path {
+          fill: ${vars.fontColorForInputWhenReadonly};
+        }
       `,
     ];
   }
@@ -108,8 +137,7 @@ const getTimeInputStyles = props => [
       cursor: not-allowed;
     }
 
-    &:disabled,
-    &:read-only {
+    &:disabled {
       background-color: ${vars.backgroundColorInputDisabled};
       color: ${vars.fontColorDisabled};
       border-color: ${vars.borderColorInputDisabled};

--- a/src/components/inputs/time-input/time-input-body.styles.js
+++ b/src/components/inputs/time-input/time-input-body.styles.js
@@ -1,24 +1,32 @@
 import { css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
+import designTokens from '../../../../materials/design-tokens';
+
 import { getInputStyles } from '../styles';
 
 // NOTE: order is important here
 // * a disabled-field currently does not display warning/error-states so it takes precedence
 // * a readonly-field cannot be changed, but it might be relevant for validation, so error and warning are checked first
 // how you can interact with the field is controlled separately by the props, this only influences visuals
-const getClearSectionStyles = props => {
+const getClearSectionStyles = (props, theme) => {
+  const overwrittenVars = {
+    ...vars,
+    ...theme,
+  };
+
   const baseIconStyles = css`
     align-items: center;
     box-sizing: border-box;
-    background-color: ${vars.backgroundColorForInput};
-    border-bottom: 1px solid ${vars.borderColorForInput};
-    border-right: 1px solid ${vars.borderColorForInput};
-    border-top: 1px solid ${vars.borderColorForInput};
+    background-color: ${overwrittenVars[designTokens.backgroundColorForInput]};
+    border-bottom: 1px solid
+      ${overwrittenVars[designTokens.borderColorForInput]};
+    border-right: 1px solid ${overwrittenVars[designTokens.borderColorForInput]};
+    border-top: 1px solid ${overwrittenVars[designTokens.borderColorForInput]};
     border-left: none;
-    height: ${vars.sizeHeightInput};
+    height: ${overwrittenVars.sizeHeightInput};
     display: flex;
-    padding: ${vars.spacingXs};
-    transition: ${vars.transitionStandard};
+    padding: ${overwrittenVars.spacingXs};
+    transition: ${overwrittenVars.transitionStandard};
     cursor: pointer;
   `;
   if (props.isDisabled) {
@@ -26,9 +34,13 @@ const getClearSectionStyles = props => {
       baseIconStyles,
       css`
         cursor: not-allowed;
-        background-color: ${vars.backgroundColorForInputWhenDisabled};
-        color: ${vars.fontColorForInputWhenDisabled};
-        border-color: ${vars.borderColorForInputWhenDisabled};
+        background-color: ${overwrittenVars[
+          designTokens.backgroundColorForInputWhenDisabled
+        ]};
+        color: ${overwrittenVars[designTokens.fontColorForInputWhenDisabled]};
+        border-color: ${overwrittenVars[
+          designTokens.borderColorForInputWhenDisabled
+        ]};
       `,
     ];
   }
@@ -37,11 +49,13 @@ const getClearSectionStyles = props => {
       baseIconStyles,
       css`
         cursor: default;
-        color: ${vars.fontColorForInputWhenReadonly};
-        border-color: ${vars.borderColorForInputWhenReadonly};
+        color: ${overwrittenVars[designTokens.fontColorForInputWhenReadonly]};
+        border-color: ${overwrittenVars[
+          designTokens.borderColorForInputWhenReadonly
+        ]};
 
         svg path {
-          fill: ${vars.fontColorForInputWhenReadonly};
+          fill: ${overwrittenVars[designTokens.fontColorForInputWhenReadonly]};
         }
       `,
     ];
@@ -50,37 +64,53 @@ const getClearSectionStyles = props => {
     return [
       baseIconStyles,
       css`
-        color: ${vars.fontColorForInputWhenError};
-        border-color: ${vars.borderColorForInputWhenError};
+        color: ${overwrittenVars[designTokens.fontColorForInputWhenError]};
+        border-color: ${overwrittenVars[
+          designTokens.borderColorForInputWhenError
+        ]};
       `,
     ];
   }
   return baseIconStyles;
 };
 
-const getClockIconContainerStyles = props => {
+const getClockIconContainerStyles = (props, theme) => {
+  const overwrittenVars = {
+    ...vars,
+    ...theme,
+  };
+
   const baseIconStyles = css`
     align-items: center;
     box-sizing: border-box;
-    background-color: ${vars.backgroundColorForInput};
-    border-bottom: 1px solid ${vars.borderColorForInput};
-    border-right: 1px solid ${vars.borderColorForInput};
-    border-top: 1px solid ${vars.borderColorForInput};
+    background-color: ${overwrittenVars[designTokens.backgroundColorForInput]};
+    border-bottom: 1px solid
+      ${overwrittenVars[designTokens.borderColorForInput]};
+    border-right: 1px solid ${overwrittenVars[designTokens.borderColorForInput]};
+    border-top: 1px solid ${overwrittenVars[designTokens.borderColorForInput]};
     border-left: none;
-    height: ${vars.sizeHeightInput};
+    height: ${overwrittenVars.sizeHeightInput};
     display: flex;
-    padding: ${vars.spacingXs};
-    border-top-right-radius: ${vars.borderRadiusForInput};
-    border-bottom-right-radius: ${vars.borderRadiusForInput};
+    padding: ${overwrittenVars.spacingXs};
+    border-top-right-radius: ${overwrittenVars[
+      designTokens.borderRadiusForInput
+    ]};
+    border-bottom-right-radius: ${overwrittenVars[
+      designTokens.borderRadiusForInput
+    ]};
   `;
   if (props.isDisabled) {
     return [
       baseIconStyles,
       css`
         cursor: not-allowed;
-        background-color: ${vars.backgroundColorForInputWhenDisabled};
-        color: ${vars.fontColorForInputWhenDisabled};
-        border-color: ${vars.borderColorForInputWhenDisabled};
+        background-color: ${overwrittenVars[
+          designTokens.backgroundColorForInputWhenDisabled
+        ]};
+        color: ${overwrittenVars[designTokens.fontColorForInputWhenDisabled]};
+        border-color: ${overwrittenVars[
+          designTokens.borderColorForInputWhenDisabled
+        ]};
       `,
     ];
   }
@@ -89,11 +119,13 @@ const getClockIconContainerStyles = props => {
       baseIconStyles,
       css`
         cursor: default;
-        color: ${vars.fontColorForInputWhenReadonly};
-        border-color: ${vars.borderColorForInputWhenReadonly};
+        color: ${overwrittenVars[designTokens.fontColorForInputWhenReadonly]};
+        border-color: ${overwrittenVars[
+          designTokens.borderColorForInputWhenReadonly
+        ]};
 
         svg path {
-          fill: ${vars.fontColorForInputWhenReadonly};
+          fill: ${overwrittenVars[designTokens.fontColorForInputWhenReadonly]};
         }
       `,
     ];
@@ -102,49 +134,72 @@ const getClockIconContainerStyles = props => {
     return [
       baseIconStyles,
       css`
-        color: ${vars.fontColorFolorInputWhenError};
-        border-color: ${vars.borderColorForInputWhenError};
+        color: ${overwrittenVars[designTokens.fontColorFolorInputWhenError]};
+        border-color: ${overwrittenVars[
+          designTokens.borderColorForInputWhenError
+        ]};
       `,
     ];
   }
   return baseIconStyles;
 };
 
-const getInputContainerStyles = () => css`
-  width: 100%;
-  align-items: center;
-  display: flex;
-  font-size: ${vars.fontSizeForInput};
-  font-family: ${vars.fontSizeForInput};
-`;
+const getInputContainerStyles = (props, theme) => {
+  const overwrittenVars = {
+    ...props,
+    ...theme,
+  };
 
-const getTimeInputStyles = props => [
-  getInputStyles(props),
-  css`
-    border-radius: ${vars.borderRadiusInput} 0 0 ${vars.borderRadiusInput};
-    border-right: none;
+  return css`
+    width: 100%;
+    align-items: center;
+    display: flex;
+    font-size: ${overwrittenVars[designTokens.fontSizeForInput]};
+    font-family: ${overwrittenVars[designTokens.fontSizeForInput]};
+  `;
+};
 
-    &:focus,
-    &:active,
-    &:focus + *,
-    &:active + * {
-      border-color: ${vars.borderColorForInputWhenFocused};
-      color: ${vars.fontColorForInput};
-      transition: ${vars.transitionStandard};
-    }
+const getTimeInputStyles = (props, theme) => {
+  const overwrittenVars = {
+    ...props,
+    ...theme,
+  };
 
-    &:disabled {
-      cursor: not-allowed;
-    }
+  return [
+    getInputStyles(props, theme),
+    css`
+      border-radius: ${overwrittenVars[designTokens.borderRadiusInput]} 0 0
+        ${overwrittenVars[designTokens.borderRadiusInput]};
+      border-right: none;
 
-    &:disabled {
-      background-color: ${vars.backgroundColorForInputWhenDisabled};
-      color: ${vars.fontColorForInputWhenDisabled};
-      border-color: ${vars.borderColorForInputWhenDisabled};
-      opacity: 1; /* fix for mobile safari */
-    }
-  `,
-];
+      &:focus,
+      &:active,
+      &:focus + *,
+      &:active + * {
+        border-color: ${overwrittenVars[
+          designTokens.borderColorForInputWhenFocused
+        ]};
+        color: ${overwrittenVars[designTokens.fontColorForInput]};
+        transition: ${overwrittenVars.transitionStandard};
+      }
+
+      &:disabled {
+        cursor: not-allowed;
+      }
+
+      &:disabled {
+        background-color: ${overwrittenVars[
+          designTokens.backgroundColorForInputWhenDisabled
+        ]};
+        color: ${overwrittenVars[designTokens.fontColorForInputWhenDisabled]};
+        border-color: ${overwrittenVars[
+          designTokens.borderColorForInputWhenDisabled
+        ]};
+        opacity: 1; /* fix for mobile safari */
+      }
+    `,
+  ];
+};
 
 export {
   getClearSectionStyles,

--- a/src/components/inputs/time-input/time-input.js
+++ b/src/components/inputs/time-input/time-input.js
@@ -149,6 +149,7 @@ export class TimeInput extends React.Component {
           isAutofocussed={this.props.isAutofocussed}
           isDisabled={this.props.isDisabled}
           hasError={this.props.hasError}
+          isReadOnly={this.props.isReadOnly}
           onClear={() => this.emitChange('')}
           placeholder={
             typeof this.props.placeholder === 'string'

--- a/src/components/inputs/time-input/time-input.story.js
+++ b/src/components/inputs/time-input/time-input.story.js
@@ -23,6 +23,7 @@ storiesOf('Components|Inputs', module)
               placeholder={text('placeholder', 'Enter time')}
               isAutofocussed={boolean('isAutofocussed', false)}
               isDisabled={boolean('isDisabled', false)}
+              isReadOnly={boolean('isReadOnly', false)}
               value={text('value', value)}
               onChange={event => {
                 action('onChange')(event);

--- a/src/components/inputs/time-input/time-input.visualroute.js
+++ b/src/components/inputs/time-input/time-input.visualroute.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { TimeInput } from 'ui-kit';
+import { ThemeProvider } from 'emotion-theming';
 import { Suite, Spec } from '../../../../test/percy';
 
 const value = '3:00 PM';
 
 export const routePath = '/time-input';
 
-export const component = () => (
+export const component = ({ themes }) => (
   <Suite>
     <Spec label="minimal">
       <TimeInput value={value} onChange={() => {}} horizontalConstraint="m" />
@@ -43,5 +44,15 @@ export const component = () => (
         isReadOnly={true}
       />
     </Spec>
+    <ThemeProvider theme={themes.darkTheme}>
+      <Spec label="with custom (inverted) theme">
+        <TimeInput
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint="m"
+          isReadOnly={true}
+        />
+      </Spec>
+    </ThemeProvider>
   </Suite>
 );

--- a/src/components/inputs/time-input/time-input.visualroute.js
+++ b/src/components/inputs/time-input/time-input.visualroute.js
@@ -35,5 +35,13 @@ export const component = () => (
         hasError={true}
       />
     </Spec>
+    <Spec label="when readonly">
+      <TimeInput
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        isReadOnly={true}
+      />
+    </Spec>
   </Suite>
 );

--- a/src/components/inputs/time-input/time-input.visualroute.js
+++ b/src/components/inputs/time-input/time-input.visualroute.js
@@ -46,12 +46,7 @@ export const component = ({ themes }) => (
     </Spec>
     <ThemeProvider theme={themes.darkTheme}>
       <Spec label="with custom (inverted) theme">
-        <TimeInput
-          value={value}
-          onChange={() => {}}
-          horizontalConstraint="m"
-          isReadOnly={true}
-        />
+        <TimeInput value={value} onChange={() => {}} horizontalConstraint="m" />
       </Spec>
     </ThemeProvider>
   </Suite>


### PR DESCRIPTION
This PRd does two things

* Properly support the `isReadOnly` prop for the `TimeInput` component.
* Refactor `TimeInput` component to use design tokens and to be themeable. 

NOTE: Until we merge `10.0.0`, a themed TimeInput looks a bit weird because the icons aren't themable. 

Closes #723 