### PR TITLE
feat(icons): make icons themeable (breaking change)

### DIFF
--- a/src/components/buttons/flat-button/flat-button.js
+++ b/src/components/buttons/flat-button/flat-button.js
@@ -12,15 +12,15 @@ import AccessibleButton from '../accessible-button';
 const getIconElement = props => {
   if (!props.icon) return null;
 
-  let iconTheme = 'black';
-  if (props.isDisabled) iconTheme = 'grey';
-  else if (props.tone === 'primary') iconTheme = 'green';
+  let iconColor = 'solid';
+  if (props.isDisabled) iconColor = 'neutral60';
+  else if (props.tone === 'primary') iconColor = 'primary';
   else if (props.tone === 'secondary' && props.isMouseOver)
-    iconTheme = 'orange';
+    iconColor = 'warning';
 
   return React.cloneElement(props.icon, {
     size: 'medium',
-    theme: iconTheme,
+    color: iconColor,
   });
 };
 

--- a/src/components/buttons/icon-button/icon-button.js
+++ b/src/components/buttons/icon-button/icon-button.js
@@ -22,13 +22,13 @@ const getIconThemeColor = props => {
   // if button has a theme, icon should be white when hovering/clicking
   if (props.theme !== 'default' && (isActive || props.isMouseOver)) {
     if (props.isDisabled) {
-      return 'grey';
+      return 'neutral60';
     }
-    return 'white';
+    return 'surface';
   }
 
   // if button is disabled, icon should be grey
-  if (props.isDisabled) return 'grey';
+  if (props.isDisabled) return 'neutral60';
   // if button is not disabled nor has a theme, return icon's default color
   return props.icon.props.theme;
 };

--- a/src/components/buttons/icon-button/icon-button.js
+++ b/src/components/buttons/icon-button/icon-button.js
@@ -19,7 +19,7 @@ import {
 // Gets the color which the icon should have based on context of button's state/cursor behavior
 const getIconThemeColor = props => {
   const isActive = props.isToggleButton && props.isToggled;
-  // if button has a theme, icon should be white when hovering/clicking
+  // if button has a theme, icon should be surface when hovering/clicking
   if (props.theme !== 'default' && (isActive || props.isMouseOver)) {
     if (props.isDisabled) {
       return 'neutral60';
@@ -27,7 +27,7 @@ const getIconThemeColor = props => {
     return 'surface';
   }
 
-  // if button is disabled, icon should be grey
+  // if button is disabled, icon should be neutral60
   if (props.isDisabled) return 'neutral60';
   // if button is not disabled nor has a theme, return icon's default color
   return props.icon.props.theme;

--- a/src/components/buttons/icon-button/icon-button.js
+++ b/src/components/buttons/icon-button/icon-button.js
@@ -84,7 +84,7 @@ export const IconButton = props => {
           {props.icon &&
             React.cloneElement(props.icon, {
               size: props.size,
-              theme: getIconThemeColor(props),
+              color: getIconThemeColor(props),
             })}
         </div>
       </AccessibleButton>

--- a/src/components/buttons/link-button/link-button.js
+++ b/src/components/buttons/link-button/link-button.js
@@ -48,7 +48,7 @@ const LinkButton = props => (
       {Boolean(props.iconLeft) &&
         React.cloneElement(props.iconLeft, {
           size: 'medium',
-          theme: props.isDisabled ? 'grey' : 'green',
+          color: props.isDisabled ? 'neutral60' : 'primary',
         })}
       <Text.Body isInline={true}>{props.label}</Text.Body>
     </Spacings.Inline>

--- a/src/components/buttons/primary-button/primary-button.js
+++ b/src/components/buttons/primary-button/primary-button.js
@@ -43,7 +43,7 @@ const PrimaryButton = props => {
               `}
             >
               {React.cloneElement(props.iconLeft, {
-                theme: props.isDisabled ? 'grey' : 'white',
+                color: props.isDisabled ? 'neutral60' : 'surface',
                 size: props.size === 'small' ? 'medium' : 'big',
               })}
             </span>

--- a/src/components/buttons/secondary-button/secondary-button.js
+++ b/src/components/buttons/secondary-button/secondary-button.js
@@ -24,7 +24,7 @@ export const getIconColor = props => {
     (isActive || (props.isMouseOver && !props.isDisabled))
   )
     return 'info'; // returns the passed in theme without overwriting
-  // if button is disabled, icon should be grey
+  // if button is disabled, icon should be neutral60
   if (props.isDisabled) return 'neutral60';
   // if button is not disabled nor has a theme, return icon's default color
   return props.iconLeft.props.color;

--- a/src/components/buttons/secondary-button/secondary-button.js
+++ b/src/components/buttons/secondary-button/secondary-button.js
@@ -16,18 +16,18 @@ import filterDataAttributes from '../../../utils/filter-data-attributes';
 import { getStateStyles, getThemeStyles } from './secondary-button.styles';
 
 // Gets the color which the icon should have based on context of button's state/cursor behavior
-export const getIconThemeColor = props => {
+export const getIconColor = props => {
   const isActive = props.isToggleButton && props.isToggled;
   // if button has a theme, icon should be the same color as the theme on hover/active states
   if (
     props.theme !== 'default' &&
     (isActive || (props.isMouseOver && !props.isDisabled))
   )
-    return props.theme; // returns the passed in theme without overwriting
+    return 'info'; // returns the passed in theme without overwriting
   // if button is disabled, icon should be grey
-  if (props.isDisabled) return 'grey';
+  if (props.isDisabled) return 'neutral60';
   // if button is not disabled nor has a theme, return icon's default color
-  return props.iconLeft.props.theme;
+  return props.iconLeft.props.color;
 };
 
 export const SecondaryButton = props => {
@@ -81,7 +81,7 @@ export const SecondaryButton = props => {
             `}
           >
             {React.cloneElement(props.iconLeft, {
-              theme: getIconThemeColor(props),
+              color: getIconColor(props),
             })}
           </span>
         )}
@@ -142,7 +142,7 @@ SecondaryButton.propTypes = {
         `Invalid prop \`${propName}\` supplied to \`${componentName}\`. Only toggle buttons may have a theme.`
       );
     }
-    return PropTypes.oneOf(['default', 'blue'])(
+    return PropTypes.oneOf(['default', 'info'])(
       props,
       propName,
       componentName,

--- a/src/components/buttons/secondary-icon-button/secondary-icon-button.js
+++ b/src/components/buttons/secondary-icon-button/secondary-icon-button.js
@@ -12,9 +12,9 @@ export const SecondaryIconButton = props => {
     ...filterAriaAttributes(props),
     ...filterDataAttributes(props),
   };
-  let iconTheme = 'black';
-  if (props.isDisabled) iconTheme = 'grey';
-  else if (props.isMouseOver) iconTheme = 'green';
+  let iconColor = 'solid';
+  if (props.isDisabled) iconColor = 'neutral60';
+  else if (props.isMouseOver) iconColor = 'primary';
   return (
     <div
       onMouseOver={props.handleMouseOver}
@@ -43,7 +43,7 @@ export const SecondaryIconButton = props => {
             justify-content: center;
           `}
         >
-          {React.cloneElement(props.icon, { theme: iconTheme })}
+          {React.cloneElement(props.icon, { color: iconColor })}
         </div>
       </AccessibleButton>
     </div>

--- a/src/components/dropdowns/primary-action-dropdown/primary-action-dropdown.js
+++ b/src/components/dropdowns/primary-action-dropdown/primary-action-dropdown.js
@@ -79,7 +79,7 @@ class DropdownHead extends React.PureComponent {
           >
             {React.cloneElement(this.props.iconLeft, {
               size: 'big',
-              theme: this.props.isDisabled ? 'grey' : 'black',
+              color: this.props.isDisabled ? 'neutral60' : 'solid',
             })}
           </span>
           <span
@@ -134,7 +134,7 @@ const DropdownChevron = React.forwardRef((props, ref) => (
       {React.cloneElement(
         props.isOpen && !props.isDisabled ? <CaretUpIcon /> : <CaretDownIcon />,
         {
-          theme: props.isDisabled ? 'grey' : 'black',
+          color: props.isDisabled ? 'neutral60' : 'solid',
           size: 'small',
         }
       )}

--- a/src/components/field-label/README.md
+++ b/src/components/field-label/README.md
@@ -39,7 +39,7 @@ The `hintIcon` also accepts a custom `theme` while defaulting to `orange` in the
   onInfoButtonClick={() => {}} />}
   hint={<FormattedMessage {...messages.hint} />}
 - hintIcon={<WarningIcon />}
-+ hintIcon={<WarningIcon theme="green" />}
++ hintIcon={<WarningIcon color="green" />}
   description={<FormattedMessage {...messages.description} />}
   badge={<FlatButton tone="primary" label="show" />}
   htmlFor="sampleInput"

--- a/src/components/field-label/README.md
+++ b/src/components/field-label/README.md
@@ -30,7 +30,7 @@ import { FieldLabel } from '@commercetools-frontend/ui-kit';
 />
 ```
 
-The `hintIcon` also accepts a custom `theme` while defaulting to `orange` in the case above. The `hintIcon` does **not** support the `size` prop, and will always be rendered in the size `medium`.
+The `hintIcon` also accepts a custom `color` while defaulting to `warning` in the case above. The `hintIcon` does **not** support the `size` prop, and will always be rendered in the size `medium`.
 
 ```diff
 <FieldLabel
@@ -39,7 +39,7 @@ The `hintIcon` also accepts a custom `theme` while defaulting to `orange` in the
   onInfoButtonClick={() => {}} />}
   hint={<FormattedMessage {...messages.hint} />}
 - hintIcon={<WarningIcon />}
-+ hintIcon={<WarningIcon color="green" />}
++ hintIcon={<WarningIcon color="primary" />}
   description={<FormattedMessage {...messages.description} />}
   badge={<FlatButton tone="primary" label="show" />}
   htmlFor="sampleInput"

--- a/src/components/field-label/field-label.js
+++ b/src/components/field-label/field-label.js
@@ -46,7 +46,7 @@ export const FieldLabel = props => {
               // FIXME: add proper tone when tones are refactored
               React.cloneElement(props.hintIcon, {
                 size: 'medium',
-                theme: props.hintIcon.props.theme || 'orange',
+                color: props.hintIcon.props.color || 'warning',
               })}
             {props.hint && <Text.Detail>{props.hint}</Text.Detail>}
           </Spacings.Inline>

--- a/src/components/icons/README.md
+++ b/src/components/icons/README.md
@@ -19,10 +19,10 @@ You can find a list of all available icons in the UIKit.
 
 #### Properties
 
-| Props   | Type     | Required | Values                                                        | Default | Description                                                                                            |
-| ------- | -------- | :------: | ------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| `size`  | `string` |          | 'small', 'medium', 'big', 'scale'                             | 'big'   | Specifies the icon size (if `scale` is selected, the dimensions will scale according with the parents) |
-| `color` | `string` |          | 'solid', 'neutral60', 'info', 'primary40', 'warning', 'error' | 'solid' | Specifies the icon color                                                                               |
+| Props   | Type     | Required | Values                                                                   | Default | Description                                                                                            |
+| ------- | -------- | :------: | ------------------------------------------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------ |
+| `size`  | `string` |          | 'small', 'medium', 'big', 'scale'                                        | 'big'   | Specifies the icon size (if `scale` is selected, the dimensions will scale according with the parents) |
+| `color` | `string` |          | 'solid', 'neutral60', 'info', 'primary', 'primary40', 'warning', 'error' | 'solid' | Specifies the icon color                                                                               |
 
 #### Where to use
 

--- a/src/components/icons/README.md
+++ b/src/components/icons/README.md
@@ -19,10 +19,10 @@ You can find a list of all available icons in the UIKit.
 
 #### Properties
 
-| Props   | Type     | Required | Values                                            | Default | Description                                                                                            |
-| ------- | -------- | :------: | ------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| `size`  | `string` |          | 'small', 'medium', 'big', 'scale'                 | 'big'   | Specifies the icon size (if `scale` is selected, the dimensions will scale according with the parents) |
-| `theme` | `string` |          | 'black', 'grey', 'blue', 'green', 'orange', 'red' | 'black' | Specifies the icon theme                                                                               |
+| Props   | Type     | Required | Values                                                        | Default | Description                                                                                            |
+| ------- | -------- | :------: | ------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `size`  | `string` |          | 'small', 'medium', 'big', 'scale'                             | 'big'   | Specifies the icon size (if `scale` is selected, the dimensions will scale according with the parents) |
+| `color` | `string` |          | 'solid', 'neutral60', 'info', 'primary40', 'warning', 'error' | 'solid' | Specifies the icon color                                                                               |
 
 #### Where to use
 

--- a/src/components/icons/create-styled-icon.js
+++ b/src/components/icons/create-styled-icon.js
@@ -33,37 +33,26 @@ const getSizeStyle = size => {
   }
 };
 
+const capitalize = s => s[0].toUpperCase() + s.slice(1);
+
 const getColor = (color, theme) => {
   if (!color) return 'inherit';
   const overwrittenVars = {
     ...vars,
     ...theme,
   };
-  switch (color) {
-    case 'solid':
-      return overwrittenVars.colorSolid;
-    case 'neutral60':
-      return overwrittenVars.colorNeutral60;
-    case 'surface':
-      return overwrittenVars.colorSurface;
-    case 'info':
-      return overwrittenVars.colorInfo;
-    case 'primary':
-      return overwrittenVars.colorPrimary;
-    case 'primary40':
-      return overwrittenVars.colorPrimary40;
-    case 'warning':
-      return overwrittenVars.colorWarning;
-    case 'error':
-      return overwrittenVars.colorError;
-    default: {
-      invariant(
-        color,
-        `ui-kit/Icon: the specified color '${color}' is not supported.`
-      );
-      return 'inherit';
-    }
+
+  const iconColor = overwrittenVars[`color${capitalize(color)}`];
+
+  if (!iconColor) {
+    invariant(
+      color,
+      `ui-kit/Icon: the specified color '${color}' is not supported.`
+    );
+    return 'inherit';
   }
+
+  return iconColor;
 };
 
 export default function createStyledIcon(Component, displayName) {

--- a/src/components/icons/create-styled-icon.js
+++ b/src/components/icons/create-styled-icon.js
@@ -33,29 +33,33 @@ const getSizeStyle = size => {
   }
 };
 
-const getColor = theme => {
-  if (!theme) return 'inherit';
-  switch (theme) {
-    case 'black':
-      return vars.colorSolid;
-    case 'grey':
-      return vars.colorNeutral60;
-    case 'white':
-      return vars.colorSurface;
-    case 'blue':
-      return vars.colorInfo;
-    case 'green':
-      return vars.colorPrimary;
-    case 'green-light':
-      return vars.colorPrimary40;
-    case 'orange':
-      return vars.colorWarning;
-    case 'red':
-      return vars.colorError;
+const getColor = (color, theme) => {
+  if (!color) return 'inherit';
+  const overwrittenVars = {
+    ...vars,
+    ...theme,
+  };
+  switch (color) {
+    case 'solid':
+      return overwrittenVars.colorSolid;
+    case 'neutral60':
+      return overwrittenVars.colorNeutral60;
+    case 'surface':
+      return overwrittenVars.colorSurface;
+    case 'info':
+      return overwrittenVars.colorInfo;
+    case 'primary':
+      return overwrittenVars.colorPrimary;
+    case 'primary40':
+      return overwrittenVars.colorPrimary40;
+    case 'warning':
+      return overwrittenVars.colorWarning;
+    case 'error':
+      return overwrittenVars.colorError;
     default: {
       invariant(
-        theme,
-        `ui-kit/Icon: the specified theme '${theme}' is not supported.`
+        color,
+        `ui-kit/Icon: the specified color '${color}' is not supported.`
       );
       return 'inherit';
     }
@@ -66,22 +70,22 @@ export default function createStyledIcon(Component, displayName) {
   const StyledComponent = styled(Component)(
     props => `
     * {
-      fill: ${getColor(props.theme)};
+      fill: ${getColor(props.color, props.theme)};
     }
     ${getSizeStyle(props.size)}
   `
   );
   StyledComponent.displayName = displayName;
   StyledComponent.propTypes = {
-    theme: PropTypes.oneOf([
-      'black',
-      'grey',
-      'white',
-      'blue',
-      'green',
-      'green-light',
-      'orange',
-      'red',
+    color: PropTypes.oneOf([
+      'solid',
+      'neutral60',
+      'surface',
+      'info',
+      'primary',
+      'primary40',
+      'warning',
+      'error',
     ]),
     size: PropTypes.oneOf(['small', 'medium', 'big', 'scale']),
   };

--- a/src/components/icons/icon.story.js
+++ b/src/components/icons/icon.story.js
@@ -52,19 +52,19 @@ storiesOf('Components|Icons', module)
             <IconContainer style={containerWidth}>
               <Icon
                 size={sizeValue}
-                theme={select(
-                  'theme',
+                color={select(
+                  'color',
                   [
-                    'black',
-                    'grey',
-                    'white',
-                    'blue',
-                    'green',
-                    'green-light',
-                    'orange',
-                    'red',
+                    'solid',
+                    'neutral60',
+                    'surface',
+                    'info',
+                    'primary',
+                    'primary40',
+                    'warning',
+                    'error',
                   ],
-                  'black'
+                  'solid'
                 )}
               />
             </IconContainer>

--- a/src/components/icons/icons.visualroute.js
+++ b/src/components/icons/icons.visualroute.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { Switch, Route } from 'react-router-dom';
+import { ThemeProvider } from 'emotion-theming';
 import * as UIKit from 'ui-kit';
 import { Suite, Spec } from '../../../test/percy';
 
@@ -28,48 +29,49 @@ const IconContainer = styled.div`
 const icons = Object.keys(UIKit).filter(thing => thing.endsWith('Icon'));
 
 const sizes = ['small', 'medium', 'big', 'scale'];
-const themes = [
-  'black',
-  'grey',
-  'white',
-  'blue',
-  'green',
-  'green-light',
-  'orange',
-  'red',
+
+const colors = [
+  'solid',
+  'neutral60',
+  'surface',
+  'info',
+  'primary',
+  'primary40',
+  'warning',
+  'error',
 ];
 
 export const routePath = '/icons';
 
-const renderIcon = (iconName, theme, size) => {
+const renderIcon = (iconName, color, size) => {
   const Icon = UIKit[iconName];
   return (
     <IconItem key={iconName}>
       <IconContainer big={size === 'scale'}>
-        <Icon theme={theme} size={size} />
+        <Icon color={color} size={size} />
       </IconContainer>
       <UIKit.Text.Body>{iconName}</UIKit.Text.Body>
     </IconItem>
   );
 };
 
-export const component = () => (
+export const component = ({ themes }) => (
   <Switch>
-    {themes.map(theme => (
+    {colors.map(color => (
       <Route
-        key={theme}
-        path={`${routePath}/${theme}`}
+        key={color}
+        path={`${routePath}/${color}`}
         exact
         render={() => (
           <Suite>
             {sizes.map(size => (
               <Spec
                 key={size}
-                label={`All Icons - Theme: ${theme} / Size: ${size}`}
+                label={`All Icons - Color: ${color} / Size: ${size}`}
                 omitPropsList
               >
                 <IconList>
-                  {icons.map(iconName => renderIcon(iconName, theme, size))}
+                  {icons.map(iconName => renderIcon(iconName, color, size))}
                 </IconList>
               </Spec>
             ))}
@@ -77,5 +79,24 @@ export const component = () => (
         )}
       />
     ))}
+    <Route
+      exact
+      path={`${routePath}/theme`}
+      render={() => (
+        <Suite>
+          <ThemeProvider theme={themes.darkTheme}>
+            {colors.map(color => (
+              <Spec
+                key={color}
+                label={`All Icons - Color: ${color}`}
+                omitPropsList
+              >
+                <IconList>{renderIcon('ClockIcon', color, 'big')}</IconList>
+              </Spec>
+            ))}
+          </ThemeProvider>
+        </Suite>
+      )}
+    />
   </Switch>
 );

--- a/src/components/icons/icons.visualroute.js
+++ b/src/components/icons/icons.visualroute.js
@@ -88,7 +88,7 @@ export const component = ({ themes }) => (
             {colors.map(color => (
               <Spec
                 key={color}
-                label={`All Icons - Color: ${color}`}
+                label={`Themed Icons - Color: ${color}`}
                 omitPropsList
               >
                 <IconList>{renderIcon('ClockIcon', color, 'big')}</IconList>

--- a/src/components/icons/icons.visualspec.js
+++ b/src/components/icons/icons.visualspec.js
@@ -24,4 +24,9 @@ describe('Icons', () => {
       await snapshot(page, `Icons - Color: ${color}`);
     })
   );
+  it('Default', async () => {
+    await page.goto(`${HOST}/icons/theme`);
+    await expect(page).toMatch('Themed Icons');
+    await percySnapshot(page, `Icons - Dark theme`);
+  });
 });

--- a/src/components/icons/icons.visualspec.js
+++ b/src/components/icons/icons.visualspec.js
@@ -5,23 +5,23 @@ const snapshot = (page, description) =>
   percySnapshot(page, description, { widths: [1600] });
 
 const capitalize = s => s[0].toUpperCase() + s.slice(1);
-const themes = [
-  'black',
-  'grey',
-  'white',
-  'blue',
-  'green',
-  'green-light',
-  'orange',
-  'red',
+const colors = [
+  'solid',
+  'neutral60',
+  'surface',
+  'info',
+  'primary',
+  'primary40',
+  'warning',
+  'error',
 ];
 
 describe('Icons', () => {
-  themes.map(theme =>
-    it(capitalize(theme), async () => {
-      await page.goto(`${HOST}/icons/${theme}`);
-      await expect(page).toMatch(theme);
-      await snapshot(page, `Icons - Theme: ${theme}`);
+  colors.map(color =>
+    it(capitalize(color), async () => {
+      await page.goto(`${HOST}/icons/${color}`);
+      await expect(page).toMatch(color);
+      await snapshot(page, `Icons - Color: ${color}`);
     })
   );
 });

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -688,7 +688,7 @@ class MoneyInput extends React.Component {
                   }}
                 >
                   <FractionDigitsIcon
-                    theme={this.props.isDisabled ? 'grey' : 'blue'}
+                    color={this.props.isDisabled ? 'neutral60' : 'info'}
                   />
                 </Tooltip>
               </div>

--- a/src/components/inputs/time-input/time-input-body.js
+++ b/src/components/inputs/time-input/time-input-body.js
@@ -11,7 +11,7 @@ import {
   getInputContainerStyles,
 } from './time-input-body.styles';
 
-const getIconTheme = (isDisabled, isMouseOver) => {
+const getIconColor = (isDisabled, isMouseOver) => {
   if (isDisabled) return 'neutral60';
   if (isMouseOver) return 'warning';
   return 'solid';
@@ -27,7 +27,7 @@ export const ClearSection = props => (
     {!props.isDisabled && (
       <CloseIcon
         size="medium"
-        theme={getIconTheme(props.isDisabled, props.isMouseOver)}
+        color={getIconColor(props.isDisabled, props.isMouseOver)}
       />
     )}
   </div>

--- a/src/components/inputs/time-input/time-input-body.js
+++ b/src/components/inputs/time-input/time-input-body.js
@@ -12,9 +12,9 @@ import {
 } from './time-input-body.styles';
 
 const getIconTheme = (isDisabled, isMouseOver) => {
-  if (isDisabled) return 'grey';
-  if (isMouseOver) return 'orange';
-  return 'black';
+  if (isDisabled) return 'neutral60';
+  if (isMouseOver) return 'warning';
+  return 'solid';
 };
 
 export const ClearSection = props => (

--- a/src/components/inputs/time-input/time-input-body.js
+++ b/src/components/inputs/time-input/time-input-body.js
@@ -96,7 +96,7 @@ export default class TimeInputBody extends React.Component {
             data-toggle
             css={getClockIconContainerStyles(this.props)}
           >
-            <ClockIcon theme={this.props.isDisabled ? 'grey' : 'black'} />
+            <ClockIcon color={this.props.isDisabled ? 'neutral60' : 'solid'} />
           </label>
         </div>
       </Spacings.Inline>

--- a/src/components/internals/calendar-body/calendar-body.js
+++ b/src/components/internals/calendar-body/calendar-body.js
@@ -15,7 +15,10 @@ export const ClearSection = props => (
     css={getClearSectionStyles(props)}
   >
     {!props.isDisabled && (
-      <CloseIcon size="medium" theme={props.isDisabled ? 'grey' : 'black'} />
+      <CloseIcon
+        size="medium"
+        color={props.isDisabled ? 'neutral60' : 'solid'}
+      />
     )}
   </div>
 );
@@ -100,9 +103,13 @@ export default class CalendarBody extends React.PureComponent {
             }}
           >
             {this.props.icon === 'clock' ? (
-              <ClockIcon theme={this.props.isDisabled ? 'grey' : 'black'} />
+              <ClockIcon
+                color={this.props.isDisabled ? 'neutral60' : 'solid'}
+              />
             ) : (
-              <CalendarIcon theme={this.props.isDisabled ? 'grey' : 'black'} />
+              <CalendarIcon
+                color={this.props.isDisabled ? 'neutral60' : 'solid'}
+              />
             )}
           </button>
         </div>

--- a/src/components/internals/clear-indicator/clear-indicator.js
+++ b/src/components/internals/clear-indicator/clear-indicator.js
@@ -13,7 +13,7 @@ const ClearIndicator = props => {
       ref={ref}
       style={getStyles('clearIndicator', props)}
     >
-      <CloseIcon theme={props.isDisabled && 'grey'} size="medium" />
+      <CloseIcon color={props.isDisabled && 'neutral60'} size="medium" />
     </div>
   );
 };

--- a/src/components/internals/dropdown-indicator/dropdown-indicator.js
+++ b/src/components/internals/dropdown-indicator/dropdown-indicator.js
@@ -6,7 +6,10 @@ import { CaretDownIcon } from '../../icons';
 const DropdownIndicator = props => (
   <components.DropdownIndicator {...props}>
     {/* FIXME: add proper tone when tones are refactored */}
-    <CaretDownIcon theme={props.isDisabled ? 'grey' : undefined} size="small" />
+    <CaretDownIcon
+      color={props.isDisabled ? 'neutral60' : undefined}
+      size="small"
+    />
   </components.DropdownIndicator>
 );
 

--- a/src/components/notifications/content-notification/content-notification.js
+++ b/src/components/notifications/content-notification/content-notification.js
@@ -56,7 +56,7 @@ class NotificationIcon extends React.PureComponent {
           }
         `}
       >
-        <Icon theme="white" />
+        <Icon color="surface" />
       </div>
     );
   }

--- a/src/components/panels/collapsible-panel/header-icon.js
+++ b/src/components/panels/collapsible-panel/header-icon.js
@@ -7,10 +7,10 @@ import vars from '../../../../materials/custom-properties';
 const sizeIconContainer = '24px';
 const sizeIconContainerSmall = '16px';
 
-const getArrowTheme = ({ tone, isDisabled }) => {
-  if (isDisabled) return 'grey';
-  if (tone === 'urgent') return 'white';
-  return 'black';
+const getArrowColor = ({ tone, isDisabled }) => {
+  if (isDisabled) return 'neutral60';
+  if (tone === 'urgent') return 'surface';
+  return 'solid';
 };
 
 const HeaderIcon = props => (
@@ -41,7 +41,7 @@ const HeaderIcon = props => (
   >
     {props.isClosed ? (
       <AngleRightIcon
-        theme={getArrowTheme({
+        color={getArrowColor({
           tone: props.tone,
           isDisabled: props.isDisabled,
         })}
@@ -49,7 +49,7 @@ const HeaderIcon = props => (
       />
     ) : (
       <AngleDownIcon
-        theme={getArrowTheme({
+        color={getArrowColor({
           tone: props.tone,
           isDisabled: props.isDisabled,
         })}

--- a/src/components/table/sortable-header/sortable-header.js
+++ b/src/components/table/sortable-header/sortable-header.js
@@ -29,7 +29,7 @@ Logic of arrow indicating sort order is slightly complex:
 
 const SortableHeader = props => {
   const isActive = props.sortBy === props.columnKey;
-  const theme = props.isMouseOver ? 'grey' : 'white';
+  const color = props.isMouseOver ? 'neutral60' : 'surface';
   const isArrowDown =
     (!isActive && props.isMouseOver) ||
     (isActive && !props.isMouseOver && props.sortDirection === 'ASC') ||
@@ -74,9 +74,9 @@ const SortableHeader = props => {
         ]}
       >
         {isArrowDown ? (
-          <AngleDownIcon size="medium" theme={theme} />
+          <AngleDownIcon size="medium" color={color} />
         ) : (
-          <AngleUpIcon size="small" theme={theme} />
+          <AngleUpIcon size="small" color={color} />
         )}
       </span>
     </div>


### PR DESCRIPTION
## Summary

As we discussed on slack, in order to make the icons themeable, we need to do something about the `theme` prop. When you use a styled component in emotion, it injects its `theme` prop, which we were overwriting since we had an identically named prop. 

### 💣 BREAKING CHANGES 💣

* Renames the prop `theme` to `color`. Renames it's possible values from being our old colour decisions (white, green, etc) to our new colour decisions (surface, primary, etc).

### Why do we need themeable icons? 

Components that use icons, like for example, the `TimeInput` need this to maintain consistency. 

#### Why are you spelling colour wrong? 

😭 

This will be merged into the `10.0.0` branch. The PR is set to master now so that Percy runs.