### PR TITLE
feat(checkbox-input): use design tokens / add theming

### DIFF
--- a/src/components/inputs/checkbox-input/checkbox-input.js
+++ b/src/components/inputs/checkbox-input/checkbox-input.js
@@ -77,7 +77,7 @@ class CheckboxInput extends React.PureComponent {
           {...filterDataAttributes(this.props)}
           {...filterAriaAttributes(this.props)}
         />
-        <div css={getCheckboxWrapperStyles(this.props)}>
+        <div css={theme => getCheckboxWrapperStyles(this.props, theme)}>
           {(() => {
             if (this.props.isIndeterminate) return <Icons.Indeterminate />;
             if (this.props.isChecked) return <Icons.Checked />;

--- a/src/components/inputs/checkbox-input/checkbox-input.styles.js
+++ b/src/components/inputs/checkbox-input/checkbox-input.styles.js
@@ -1,15 +1,21 @@
 import { css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
+import designTokens from '../../../../materials/design-tokens';
 
-const getCheckboxWrapperStyles = props => {
+const getCheckboxWrapperStyles = (props, theme) => {
+  const overwrittenVars = {
+    ...vars,
+    ...theme,
+  };
   const baseStyles = css`
     display: flex;
     align-items: center;
     svg [id$='borderAndContent'] > [id$='border'] {
-      stroke: 1px ${vars.borderColorInputPristine} solid;
+      stroke: ${overwrittenVars[designTokens.borderColorForInput]};
+      fill: ${overwrittenVars[designTokens.backgroundColorForInput]};
     }
     svg [id$='borderAndContent'] > [id$='content'] {
-      fill: ${vars.borderColorInputFocus};
+      fill: ${overwrittenVars[designTokens.borderColorForInputWhenFocused]};
     }
   `;
   if (props.isDisabled) {
@@ -17,10 +23,12 @@ const getCheckboxWrapperStyles = props => {
       baseStyles,
       css`
         svg [id$='borderAndContent'] > [id$='content'] {
-          fill: ${vars.fontColorDisabled};
+          fill: ${overwrittenVars[designTokens.fontColorForInputWhenDisabled]};
         }
         svg [id$='borderAndContent'] > [id$='border'] {
-          stroke: ${vars.borderColorInputDisabled};
+          stroke: ${overwrittenVars[
+            designTokens.borderColorForInputWhenDisabled
+          ]};
         }
       `,
     ];
@@ -30,11 +38,11 @@ const getCheckboxWrapperStyles = props => {
       baseStyles,
       css`
         svg [id$='borderAndContent'] > [id$='content'] {
-          fill: ${vars.borderColorInputError};
+          fill: ${overwrittenVars[designTokens.borderColorForInputWhenError]};
         }
 
         svg [id$='borderAndContent'] > [id$='border'] {
-          stroke: ${vars.fontColorError};
+          stroke: ${overwrittenVars[designTokens.fontColorForInputWhenError]};
         }
       `,
     ];
@@ -44,7 +52,9 @@ const getCheckboxWrapperStyles = props => {
       baseStyles,
       css`
         svg [id$='borderAndContent'] > [id$='border'] {
-          stroke: ${vars.borderColorInputFocus};
+          stroke: ${overwrittenVars[
+            designTokens.borderColorForInputWhenFocused
+          ]};
         }
       `,
     ];

--- a/src/components/inputs/checkbox-input/checkbox-input.visualroute.js
+++ b/src/components/inputs/checkbox-input/checkbox-input.visualroute.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import { ThemeProvider } from 'emotion-theming';
 import { CheckboxInput } from 'ui-kit';
 import { Suite, Spec } from '../../../../test/percy';
 
 export const routePath = '/checkbox-input';
 
-export const component = () => (
+export const component = ({ themes }) => (
   <Suite>
     <Spec label="when default">
       <CheckboxInput onChange={() => {}} value="value">
@@ -96,5 +97,12 @@ export const component = () => (
         I want mezcal with a worm
       </CheckboxInput>
     </Spec>
+    <ThemeProvider theme={themes.darkTheme}>
+      <Spec label="with custom (dark) theme">
+        <CheckboxInput onChange={() => {}} value="value">
+          I want kale
+        </CheckboxInput>
+      </Spec>
+    </ThemeProvider>
   </Suite>
 );

--- a/src/components/inputs/checkbox-input/checkbox-input.visualroute.js
+++ b/src/components/inputs/checkbox-input/checkbox-input.visualroute.js
@@ -103,6 +103,11 @@ export const component = ({ themes }) => (
           I want kale
         </CheckboxInput>
       </Spec>
+      <Spec label="with custom (dark) theme checked">
+        <CheckboxInput onChange={() => {}} value="value" isChecked={true}>
+          I want pizza
+        </CheckboxInput>
+      </Spec>
     </ThemeProvider>
   </Suite>
 );


### PR DESCRIPTION
#### Summary

* Use design tokens for `CheckboxInput`
* Make `CheckboxInput` theme-able