### PR TITLE
fix(link-button): add hover effect for icon

### DIFF
--- a/src/components/buttons/link-button/link-button.js
+++ b/src/components/buttons/link-button/link-button.js
@@ -32,11 +32,11 @@ const LinkButton = props => (
         `,
       !props.isDisabled &&
         css`
-          span {
-            color: ${vars.colorPrimary25};
-          }
-
           &:hover {
+            span {
+              color: ${vars.colorPrimary25};
+            }
+
             * {
               fill: ${vars.colorPrimary25};
             }

--- a/src/components/buttons/link-button/link-button.js
+++ b/src/components/buttons/link-button/link-button.js
@@ -23,14 +23,7 @@ const LinkButton = props => (
         cursor: pointer;
         text-decoration: none;
         span {
-          color: ${vars.colorPrimary};
-          ${props.isDisabled ? `color: ${vars.colorNeutral};` : ''}
-        }
-        &:hover {
-          span {
-            color: ${vars.colorPrimary25};
-            ${props.isDisabled ? `color: ${vars.colorNeutral});` : ''}
-          }
+          color: ${props.isDisabled ? vars.colorNeutral : vars.colorPrimary};
         }
       `,
       props.isDisabled &&
@@ -39,6 +32,10 @@ const LinkButton = props => (
         `,
       !props.isDisabled &&
         css`
+          span {
+            color: ${vars.colorPrimary25};
+          }
+
           &:hover {
             * {
               fill: ${vars.colorPrimary25};

--- a/src/components/buttons/link-button/link-button.js
+++ b/src/components/buttons/link-button/link-button.js
@@ -37,6 +37,14 @@ const LinkButton = props => (
         css`
           cursor: not-allowed;
         `,
+      !props.isDisabled &&
+        css`
+          &:hover {
+            * {
+              fill: ${vars.colorPrimary25};
+            }
+          }
+        `,
     ]}
     onClick={props.isDisabled ? event => event.preventDefault() : undefined}
     data-track-component="LinkButton"


### PR DESCRIPTION
#### Summary

Fixes two bugs

* When the `LinkButton` is hovered, both the text and the icon should change color.
* When the `LinkButton` is disabled and hovered, the text should not change color.

#### Before

![before](https://user-images.githubusercontent.com/2425013/57452713-c9d53500-7264-11e9-9e69-9fe222abec38.gif)
![disabled-hover-befo](https://user-images.githubusercontent.com/2425013/57452716-ccd02580-7264-11e9-83bc-126be263ab73.gif)

#### After

![after](https://user-images.githubusercontent.com/2425013/57452723-d0fc4300-7264-11e9-9951-65de2560d7f9.gif)
![disabled-hover-after](https://user-images.githubusercontent.com/2425013/57452724-d194d980-7264-11e9-9eb2-7c0c45938c43.gif)
