### PR TITLE
feat: add new `<Link>` component.

### DIFF
--- a/src/components/links/link/README.md
+++ b/src/components/links/link/README.md
@@ -1,0 +1,39 @@
+# Links: Link
+
+## Usage
+
+```js
+import { Link } from '@commercetools-frontend/ui-kit';
+```
+
+#### Description
+
+Link buttons are similar to Flat buttons, however they are constructed as a
+`<Link>` and they do not have types.
+
+> Requires `react-router`.
+
+#### Usage
+
+```js
+<Link to={'/foo/bar'}>Go to foo bar</Link>
+```
+
+```js
+<Link isExternal={true} to={'https://kanyetothe.com'}>
+  Go to external link
+</Link>
+```
+
+#### Properties
+
+| Props        | Type                                                              | Required | Values | Default | Description                                                                 |
+| ------------ | ----------------------------------------------------------------- | :------: | ------ | ------- | --------------------------------------------------------------------------- |
+| `to`         | `string` or `{ pathname: String, search: String, query: Object }` |    ✅    | -      | -       | The URL that the Link should point to                                       |
+| `isExternal` | `boolean`                                                         |    -     | -      | false   | If true, a regular <a> is rendered instead of the default React Router Link |
+
+The component further forwards all remaining props to the underlying component.
+
+Main Functions and use cases are:
+
+- Used within Content/Text paragraphs

--- a/src/components/links/link/README.md
+++ b/src/components/links/link/README.md
@@ -8,8 +8,7 @@ import { Link } from '@commercetools-frontend/ui-kit';
 
 #### Description
 
-Link buttons are similar to Flat buttons, however they are constructed as a
-`<Link>` and they do not have types.
+Links are used either to link to other ui routes, or to link to external pages. This component is a very thin wrapper over either a React Router Link, or a normal HTML <a> tag.
 
 > Requires `react-router`.
 

--- a/src/components/links/link/index.js
+++ b/src/components/links/link/index.js
@@ -1,0 +1,1 @@
+export { default } from './link';

--- a/src/components/links/link/link.js
+++ b/src/components/links/link/link.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import requiredIf from 'react-required-if';
+import { Link as ReactRouterLink } from 'react-router-dom';
+import Styled from '@emotion/styled';
+import vars from '../../../../materials/custom-properties';
+
+const createStyledComponent = component => Styled(component)`
+  font-family: ${vars.fontFamily};
+  color: ${vars.colorPrimary};
+  font-size: ${vars.fontSizeDefault};
+
+  &:hover {
+    color: ${vars.colorPrimary25};
+  }
+`;
+
+const StyledReactRouterLink = createStyledComponent(ReactRouterLink);
+const StyledExternalLink = createStyledComponent('a');
+
+const componentProps = ['isExternal', 'to'];
+
+const Link = props => {
+  // instead of object destructing
+  const remainingProps = Object.keys(props)
+    .filter(key => !componentProps.includes(key))
+    .reduce((obj, key) => {
+      // eslint-disable-next-line no-param-reassign
+      obj[key] = props[key];
+      return obj;
+    }, {});
+
+  if (props.isExternal) {
+    return <StyledExternalLink href={props.to} {...remainingProps} />;
+  }
+  return <StyledReactRouterLink to={props.to} {...remainingProps} />;
+};
+
+Link.displayName = 'Link';
+
+Link.propTypes = {
+  isExternal: PropTypes.bool.isRequired,
+  to: requiredIf(
+    PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({
+        pathname: PropTypes.string.isRequired,
+        search: PropTypes.string.isRequired,
+        hash: PropTypes.string,
+        state: PropTypes.object,
+      }),
+    ]),
+    props => !props.isExternal
+  ),
+  children: PropTypes.node.isRequired,
+};
+
+Link.defaultProps = {
+  isExternal: false,
+};
+
+export default Link;

--- a/src/components/links/link/link.js
+++ b/src/components/links/link/link.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import requiredIf from 'react-required-if';
 import { Link as ReactRouterLink } from 'react-router-dom';
 import Styled from '@emotion/styled';
+import getPassThroughProps from '../../../utils/get-pass-through-props';
 import vars from '../../../../materials/custom-properties';
 
 const createStyledComponent = component => Styled(component)`
@@ -21,14 +22,7 @@ const StyledExternalLink = createStyledComponent('a');
 const componentProps = ['isExternal', 'to'];
 
 const Link = props => {
-  // instead of object destructing
-  const remainingProps = Object.keys(props)
-    .filter(key => !componentProps.includes(key))
-    .reduce((obj, key) => {
-      // eslint-disable-next-line no-param-reassign
-      obj[key] = props[key];
-      return obj;
-    }, {});
+  const remainingProps = getPassThroughProps(props, componentProps);
 
   if (props.isExternal) {
     return <StyledExternalLink href={props.to} {...remainingProps} />;

--- a/src/components/links/link/link.js
+++ b/src/components/links/link/link.js
@@ -10,7 +10,7 @@ const createStyledComponent = component => Styled(component)`
   color: ${vars.colorPrimary};
   font-size: ${vars.fontSizeDefault};
 
-  &:hover {
+  &:hover, &:focus, &:active {
     color: ${vars.colorPrimary25};
   }
 `;

--- a/src/components/links/link/link.spec.js
+++ b/src/components/links/link/link.spec.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render } from '../../../test-utils';
+import Link from './link';
+
+const createTestProps = custom => ({
+  to: 'https://facebook.com',
+  ...custom,
+});
+
+describe('rendering', () => {
+  let props;
+  describe('when rendering a default (react-router) link', () => {
+    beforeEach(() => {
+      props = createTestProps();
+    });
+    it('should render a react router link', () => {
+      const { getByText } = render(<Link {...props}>Link</Link>);
+      const link = getByText('Link');
+      expect(link).toBeInTheDocument();
+    });
+  });
+  describe('when rendering an external link', () => {
+    beforeEach(() => {
+      props = createTestProps({
+        isExternal: true,
+        to: 'https://www.kanyetothe.com/',
+      });
+    });
+    it('should render a react router link', () => {
+      const { getByText } = render(<Link {...props}>Link</Link>);
+      const link = getByText('Link');
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveProperty('href', props.to);
+    });
+  });
+});

--- a/src/components/links/link/link.story.js
+++ b/src/components/links/link/link.story.js
@@ -2,13 +2,14 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, text, boolean } from '@storybook/addon-knobs/react';
 import { BrowserRouter as Router } from 'react-router-dom';
-// import withReadme from 'storybook-readme/with-readme';
+import withReadme from 'storybook-readme/with-readme';
 import Section from '../../../../.storybook/decorators/section';
+import Readme from './README.md';
 import Link from './link';
 
 storiesOf('Components|Links', module)
   .addDecorator(withKnobs)
-  // .addDecorator(withReadme(Readme))
+  .addDecorator(withReadme(Readme))
   .add('Link', () => (
     <Router>
       <Section>

--- a/src/components/links/link/link.story.js
+++ b/src/components/links/link/link.story.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, text, boolean } from '@storybook/addon-knobs/react';
+import { BrowserRouter as Router } from 'react-router-dom';
+// import withReadme from 'storybook-readme/with-readme';
+import Section from '../../../../.storybook/decorators/section';
+import Link from './link';
+
+storiesOf('Components|Links', module)
+  .addDecorator(withKnobs)
+  // .addDecorator(withReadme(Readme))
+  .add('Link', () => (
+    <Router>
+      <Section>
+        <Link
+          to={text('to', '/foo/bar')}
+          isExternal={boolean('isExternal', false)}
+        >
+          {text('label', 'Accessibility text')}
+        </Link>
+      </Section>
+    </Router>
+  ));

--- a/src/components/links/link/link.visualroute.js
+++ b/src/components/links/link/link.visualroute.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Link } from 'ui-kit';
+import { Suite, Spec } from '../../../../test/percy';
+
+export const routePath = '/link';
+
+export const component = () => (
+  <Suite>
+    <Spec label="regular">
+      <Link to="/">A label text</Link>
+    </Spec>
+    <Spec label="external">
+      <Link to="/" isExternal={true}>
+        A label text
+      </Link>
+    </Spec>
+  </Suite>
+);

--- a/src/components/links/link/link.visualspec.js
+++ b/src/components/links/link/link.visualspec.js
@@ -1,0 +1,12 @@
+import { percySnapshot } from '@percy/puppeteer';
+
+describe('Link', () => {
+  beforeAll(async () => {
+    await page.goto(`${HOST}/link`);
+  });
+
+  it('Default', async () => {
+    await expect(page).toMatch('A label text');
+    await percySnapshot(page, 'Link');
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,8 @@ export {
   default as SecondaryIconButton,
 } from './components/buttons/secondary-icon-button';
 
+export { default as Link } from './components/links/link';
+
 export { default as Collapsible } from './components/collapsible';
 export { default as CollapsibleMotion } from './components/collapsible-motion';
 

--- a/src/utils/get-pass-through-props.js
+++ b/src/utils/get-pass-through-props.js
@@ -1,10 +1,10 @@
 const getPassThroughProps = (props, componentProps) =>
   Object.keys(props)
     .filter(key => !componentProps.includes(key))
-    .reduce((obj, key) => {
+    .reduce((passThroughProps, key) => {
       // eslint-disable-next-line no-param-reassign
-      obj[key] = props[key];
-      return obj;
+      passThroughProps[key] = props[key];
+      return passThroughProps;
     }, {});
 
 export default getPassThroughProps;

--- a/src/utils/get-pass-through-props.js
+++ b/src/utils/get-pass-through-props.js
@@ -1,0 +1,10 @@
+const getPassThroughProps = (props, componentProps) =>
+  Object.keys(props)
+    .filter(key => !componentProps.includes(key))
+    .reduce((obj, key) => {
+      // eslint-disable-next-line no-param-reassign
+      obj[key] = props[key];
+      return obj;
+    }, {});
+
+export default getPassThroughProps;

--- a/src/utils/get-pass-through-props.spec.js
+++ b/src/utils/get-pass-through-props.spec.js
@@ -1,0 +1,21 @@
+import getPassThroughProps from './get-pass-through-props';
+
+describe('getPassThroughProps', () => {
+  it('filters out component props', () => {
+    const props = {
+      isDisabled: true,
+      to: {
+        a: 1,
+        b: 2,
+      },
+      'aria-label': 'help us obi wan',
+      href: 'asdf',
+    };
+    const componentProps = ['isDisabled', 'to'];
+
+    expect(getPassThroughProps(props, componentProps)).toEqual({
+      'aria-label': 'help us obi wan',
+      href: 'asdf',
+    });
+  });
+});


### PR DESCRIPTION
#### Summary

Adds new `<Link />` component.

This component is a very thin wrapper over the [react-router link component](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/Link.md)

However, if you pass in the `isExternal` prop as true, instead it will render a regular <a> tag.