### PR TITLE
fix: tooltip z-index fix

### DIFF
--- a/src/components/tooltip/tooltip.styles.js
+++ b/src/components/tooltip/tooltip.styles.js
@@ -53,5 +53,6 @@ export const getBodyStyles = ({ constraint, placement, customStyles }) => ({
   maxWidth: getMaxWidth({ constraint }),
   // so hovering over the tooltip when the tooltip overlaps the component
   pointerEvents: 'none',
+  zIndex: 1,
   ...customStyles,
 });


### PR DESCRIPTION
* Closes #763 

I tested it in the MC locally with @islam3zzat's reproduction case and now the tooltip is no longer hidden by the card. 