### PR TITLE
fix(collapsible-panel): height of panel header while disabled

### DIFF
--- a/src/components/panels/collapsible-panel/collapsible-panel.styles.js
+++ b/src/components/panels/collapsible-panel/collapsible-panel.styles.js
@@ -98,6 +98,13 @@ const getHeaderStyles = ({ isDisabled, isCondensed }) => {
       css`
         cursor: default;
       `,
+      !isCondensed &&
+        css`
+          /**
+           We set a min-height of 32px to anticipate use-cases where SecondaryButton or PrimaryButton
+           are rendered in the headerControl */
+          min-height: ${vars.spacingXl};
+        `,
     ];
   }
   return [


### PR DESCRIPTION
#### Summary

When `CollapsiblePanel` is disabled, the header should look the same as when it's not disabled.

Thanks to @adnasa for catching this one 👍 