### PR TITLE
refactor(flat-button): simplify code, remove mouseover

### DIFF
--- a/src/components/buttons/flat-button/flat-button.js
+++ b/src/components/buttons/flat-button/flat-button.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
-import withMouseOverState from '../../../hocs/with-mouse-over-state';
 import filterAriaAttributes from '../../../utils/filter-aria-attributes';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import Text from '../../typography/text';
@@ -12,15 +11,8 @@ import AccessibleButton from '../accessible-button';
 const getIconElement = props => {
   if (!props.icon) return null;
 
-  let iconTheme = 'black';
-  if (props.isDisabled) iconTheme = 'grey';
-  else if (props.tone === 'primary') iconTheme = 'green';
-  else if (props.tone === 'secondary' && props.isMouseOver)
-    iconTheme = 'orange';
-
   return React.cloneElement(props.icon, {
     size: 'medium',
-    theme: iconTheme,
   });
 };
 
@@ -43,13 +35,12 @@ export const FlatButton = props => {
   };
 
   return (
-    <div onMouseOver={props.handleMouseOver} onMouseOut={props.handleMouseOut}>
-      <AccessibleButton
-        type={props.type}
-        label={props.label}
-        onClick={props.onClick}
-        isDisabled={props.isDisabled}
-        css={css`
+    <AccessibleButton
+      type={props.type}
+      label={props.label}
+      onClick={props.onClick}
+      isDisabled={props.isDisabled}
+      css={css`
           display: flex;
           align-items: center;
           font-size: 1rem;
@@ -62,6 +53,16 @@ export const FlatButton = props => {
               props.isDisabled ? vars.colorNeutral : getTextColor(props.tone)
             };
           }
+
+          svg * {
+              fill: ${
+                props.isDisabled
+                  ? vars.colorNeutral
+                  : getTextColor(props.tone, false)
+              };
+            }
+          }
+
           &:hover,
           &:focus {
             p {
@@ -82,15 +83,14 @@ export const FlatButton = props => {
             }
           }
         `}
-        buttonAttributes={dataProps}
-      >
-        <Spacings.Inline scale="xs" alignItems="center">
-          {props.iconPosition === 'left' && getIconElement(props)}
-          <Text.Body>{props.label}</Text.Body>
-          {props.iconPosition === 'right' && getIconElement(props)}
-        </Spacings.Inline>
-      </AccessibleButton>
-    </div>
+      buttonAttributes={dataProps}
+    >
+      <Spacings.Inline scale="xs" alignItems="center">
+        {props.iconPosition === 'left' && getIconElement(props)}
+        <Text.Body>{props.label}</Text.Body>
+        {props.iconPosition === 'right' && getIconElement(props)}
+      </Spacings.Inline>
+    </AccessibleButton>
   );
 };
 
@@ -103,11 +103,6 @@ FlatButton.propTypes = {
   icon: PropTypes.element,
   iconPosition: PropTypes.oneOf(['left', 'right']),
   isDisabled: PropTypes.bool,
-
-  // HoC
-  isMouseOver: PropTypes.bool.isRequired,
-  handleMouseOver: PropTypes.func.isRequired,
-  handleMouseOut: PropTypes.func.isRequired,
 };
 FlatButton.defaultProps = {
   tone: 'primary',
@@ -116,4 +111,4 @@ FlatButton.defaultProps = {
   isDisabled: false,
 };
 
-export default withMouseOverState(FlatButton);
+export default FlatButton;

--- a/src/components/buttons/flat-button/flat-button.spec.js
+++ b/src/components/buttons/flat-button/flat-button.spec.js
@@ -9,10 +9,6 @@ const createTestProps = props => ({
   onClick: jest.fn(),
   icon: <PlusThinIcon size="medium" data-testid="icon" />,
   isDisabled: false,
-  // HOC
-  isMouseOver: false,
-  handleMouseOver: jest.fn(),
-  handleMouseOut: jest.fn(),
   ...props,
 });
 


### PR DESCRIPTION
#### Summary

I believe that the use of the `withMouseOverState` HOC is unnecessary. We can achieve the same effect with pure css, with better performance, and (marginally) more readable code.

If this is acceptable to yall, I'll make PRs to remove from the other components as well.