### PR TITLE
fix(collapsible-panel): disabled state fix

### DIFF
--- a/src/components/panels/collapsible-panel/header-icon.js
+++ b/src/components/panels/collapsible-panel/header-icon.js
@@ -13,52 +13,56 @@ const getArrowTheme = ({ tone, isDisabled }) => {
   return 'black';
 };
 
-const HeaderIcon = props => (
-  <div
-    css={[
-      css`
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        height: ${props.size === 'small'
-          ? sizeIconContainerSmall
-          : sizeIconContainer};
-        width: ${props.size === 'small'
-          ? sizeIconContainerSmall
-          : sizeIconContainer};
-        border-radius: 50%;
-        flex-shrink: 0;
-        box-shadow: ${vars.shadow7};
-        background-color: ${props.tone === 'urgent'
-          ? vars.colorWarning
-          : vars.colorSurface};
-      `,
-      props.isDisabled &&
+const HeaderIcon = props => {
+  const backgroundColor =
+    props.tone === 'urgent' ? vars.colorWarning : vars.colorSurface;
+  return (
+    <div
+      css={[
         css`
-          box-shadow: none;
-          background-color: ${vars.colorAccent98};
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          height: ${props.size === 'small'
+            ? sizeIconContainerSmall
+            : sizeIconContainer};
+          width: ${props.size === 'small'
+            ? sizeIconContainerSmall
+            : sizeIconContainer};
+          border-radius: 50%;
+          flex-shrink: 0;
+          box-shadow: ${vars.shadow7};
+          background-color: ${backgroundColor};
+          border: 1px solid ${backgroundColor};
         `,
-    ]}
-  >
-    {props.isClosed ? (
-      <AngleRightIcon
-        theme={getArrowTheme({
-          tone: props.tone,
-          isDisabled: props.isDisabled,
-        })}
-        size={props.size}
-      />
-    ) : (
-      <AngleDownIcon
-        theme={getArrowTheme({
-          tone: props.tone,
-          isDisabled: props.isDisabled,
-        })}
-        size={props.size}
-      />
-    )}
-  </div>
-);
+        props.isDisabled &&
+          css`
+            box-shadow: none;
+            border: 1px solid ${vars.colorNeutral};
+            background-color: ${vars.colorAccent98};
+          `,
+      ]}
+    >
+      {props.isClosed ? (
+        <AngleRightIcon
+          theme={getArrowTheme({
+            tone: props.tone,
+            isDisabled: props.isDisabled,
+          })}
+          size={props.size}
+        />
+      ) : (
+        <AngleDownIcon
+          theme={getArrowTheme({
+            tone: props.tone,
+            isDisabled: props.isDisabled,
+          })}
+          size={props.size}
+        />
+      )}
+    </div>
+  );
+};
 
 HeaderIcon.displayName = 'HeaderIcon';
 HeaderIcon.propTypes = {

--- a/src/components/panels/collapsible-panel/header-icon.js
+++ b/src/components/panels/collapsible-panel/header-icon.js
@@ -37,6 +37,11 @@ const HeaderIcon = props => (
         css`
           box-shadow: none;
         `,
+      props.isDisabled &&
+        props.tone !== 'urgent' &&
+        css`
+          background-color: ${vars.colorAccent98};
+        `,
     ]}
   >
     {props.isClosed ? (

--- a/src/components/panels/collapsible-panel/header-icon.js
+++ b/src/components/panels/collapsible-panel/header-icon.js
@@ -36,10 +36,6 @@ const HeaderIcon = props => (
       props.isDisabled &&
         css`
           box-shadow: none;
-        `,
-      props.isDisabled &&
-        props.tone !== 'urgent' &&
-        css`
           background-color: ${vars.colorAccent98};
         `,
     ]}

--- a/src/components/panels/collapsible-panel/header-icon.js
+++ b/src/components/panels/collapsible-panel/header-icon.js
@@ -4,8 +4,8 @@ import { css } from '@emotion/core';
 import { AngleDownIcon, AngleRightIcon } from '../../icons';
 import vars from '../../../../materials/custom-properties';
 
-const sizeIconContainer = '24px';
-const sizeIconContainerSmall = '16px';
+const sizeIconContainer = '22px';
+const sizeIconContainerSmall = '14px';
 
 const getArrowTheme = ({ tone, isDisabled }) => {
   if (isDisabled) return 'grey';


### PR DESCRIPTION
#### Summary

When `CollapsiblePanel` is disabled, we should have the proper background colour for the icon button.

Should just be able to review the Percy diff.