### PR TITLE
feat(link-button): support isExternal prop

### DIFF
--- a/src/components/buttons/link-button/README.md
+++ b/src/components/buttons/link-button/README.md
@@ -9,7 +9,8 @@ import { LinkButton } from '@commercetools-frontend/ui-kit';
 #### Description
 
 Link buttons are similar to Flat buttons, however they are constructed as a
-`<Link>` and they do not have types.
+`<Link>` and they do not have types. They also support an `isExternal` prop. When passed,
+the Link button is then constructed with a `<a>` instead of the default `<Link>` tag.
 
 > Requires `react-router`.
 
@@ -24,16 +25,27 @@ Link buttons are similar to Flat buttons, however they are constructed as a
 />
 ```
 
+```js
+<LinkButton
+  to={'https://kanyetothe.com'}
+  iconLeft={<SupportIcon />}
+  label="A label text"
+  isDisabled={false}
+  isExternal={true}
+/>
+```
+
 #### Properties
 
-| Props        | Type                                                              | Required | Values | Default | Description                                           |
-| ------------ | ----------------------------------------------------------------- | :------: | ------ | ------- | ----------------------------------------------------- |
-| `label`      | `string`                                                          |    ✅    | -      | -       | Should describe what the button is for                |
-| `to`         | `string` or `{ pathname: String, search: String, query: Object }` |    ✅    | -      | -       | The URL that the Link should point to                 |
-| `iconLeft`   | `element`                                                         |    -     | -      | -       | The icon of the button                                |
-| `isDisabled` | `boolean`                                                         |    -     | -      | -       | Tells when the button should present a disabled state |
+| Props        | Type                                                              | Required | Values | Default | Description                                                                 |
+| ------------ | ----------------------------------------------------------------- | :------: | ------ | ------- | --------------------------------------------------------------------------- |
+| `label`      | `string`                                                          |    ✅    | -      | -       | Should describe what the button is for                                      |
+| `to`         | `string` or `{ pathname: String, search: String, query: Object }` |    ✅    | -      | -       | The URL that the Link should point to                                       |
+| `iconLeft`   | `element`                                                         |    -     | -      | -       | The icon of the button                                                      |
+| `isDisabled` | `boolean`                                                         |    -     | -      | false   | Tells when the button should present a disabled state                       |
+| `isExternal` | `boolean`                                                         |    -     | -      | false   | If true, a regular <a> is rendered instead of the default React Router Link |
 
-The component further forwards all `data-` and `aria-` attributes to the underlying `button` component.
+The component further forwards all remaining props to the underlying component.
 
 Main Functions and use cases are:
 

--- a/src/components/buttons/link-button/link-button.js
+++ b/src/components/buttons/link-button/link-button.js
@@ -44,8 +44,6 @@ const createStyledComponent = component => styled(component)`
 const StyledReactRouterLink = createStyledComponent(ReactRouterLink);
 const StyledExternalLink = createStyledComponent('a');
 
-const componentProps = ['isExternal', 'to', 'label', 'isDisabled', 'iconLeft'];
-
 const LinkBody = props => (
   <Spacings.Inline scale="xs" alignItems="center">
     {Boolean(props.iconLeft) &&
@@ -65,7 +63,10 @@ LinkBody.propTypes = {
 };
 
 const LinkButton = props => {
-  const remainingProps = getPassThroughProps(props, componentProps);
+  const remainingProps = getPassThroughProps(
+    props,
+    Object.keys(LinkButton.propTypes)
+  );
 
   if (props.isExternal) {
     return (

--- a/src/components/buttons/link-button/link-button.js
+++ b/src/components/buttons/link-button/link-button.js
@@ -1,64 +1,109 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link as ReactRouterLink } from 'react-router-dom';
 import { css } from '@emotion/core';
+import styled from '@emotion/styled';
 import vars from '../../../../materials/custom-properties';
-import filterAriaAttributes from '../../../utils/filter-aria-attributes';
-import filterDataAttributes from '../../../utils/filter-data-attributes';
+import getPassThroughProps from '../../../utils/get-pass-through-props';
 import Text from '../../typography/text';
 import Spacings from '../../spacings';
 
-const LinkButton = props => (
-  <Link
-    to={props.to}
-    css={[
-      css`
-        display: inline-flex;
-        align-items: center;
-        font-size: 1rem;
-        border: none;
-        background: none;
-        padding: 0;
-        min-height: initial;
-        cursor: pointer;
-        text-decoration: none;
-        span {
-          color: ${props.isDisabled ? vars.colorNeutral : vars.colorPrimary};
-        }
-      `,
-      props.isDisabled &&
-        css`
-          cursor: not-allowed;
-        `,
-      !props.isDisabled &&
-        css`
-          &:hover {
-            span {
-              color: ${vars.colorPrimary25};
-            }
+const hoverStyles = () => css`
+  &:hover,
+  &:focus,
+  &:active {
+    span {
+      color: ${vars.colorPrimary25};
+    }
 
-            * {
-              fill: ${vars.colorPrimary25};
-            }
-          }
-        `,
-    ]}
-    onClick={props.isDisabled ? event => event.preventDefault() : undefined}
-    data-track-component="LinkButton"
-    {...filterAriaAttributes(props)}
-    {...filterDataAttributes(props)}
-    aria-label={props.label}
-  >
-    <Spacings.Inline scale="xs" alignItems="center">
-      {Boolean(props.iconLeft) &&
-        React.cloneElement(props.iconLeft, {
-          size: 'medium',
-          theme: props.isDisabled ? 'grey' : 'green',
-        })}
-      <Text.Body isInline={true}>{props.label}</Text.Body>
-    </Spacings.Inline>
-  </Link>
+    svg * {
+      fill: ${vars.colorPrimary25};
+    }
+  }
+`;
+
+const createStyledComponent = component => styled(component)`
+  display: inline-flex;
+  align-items: center;
+  font-size: 1rem;
+  border: none;
+  background: none;
+  padding: 0;
+  min-height: initial;
+  text-decoration: none;
+
+  span {
+    color: ${props =>
+      props.isDisabled ? vars.colorNeutral : vars.colorPrimary};
+  }
+
+  cursor: ${props => (props.isDisabled ? 'not-allowed' : 'pointer')};
+
+  ${props => !props.isDisabled && hoverStyles}
+`;
+
+const StyledReactRouterLink = createStyledComponent(ReactRouterLink);
+const StyledExternalLink = createStyledComponent('a');
+
+const componentProps = ['isExternal', 'to', 'label', 'isDisabled', 'iconLeft'];
+
+const LinkBody = props => (
+  <Spacings.Inline scale="xs" alignItems="center">
+    {Boolean(props.iconLeft) &&
+      React.cloneElement(props.iconLeft, {
+        size: 'medium',
+        theme: props.isDisabled ? 'grey' : 'green',
+      })}
+    <Text.Body isInline={true}>{props.label}</Text.Body>
+  </Spacings.Inline>
 );
+
+LinkBody.displayName = 'LinkBody';
+LinkBody.propTypes = {
+  iconLeft: PropTypes.element,
+  label: PropTypes.string,
+  isDisabled: PropTypes.bool,
+};
+
+const LinkButton = props => {
+  const remainingProps = getPassThroughProps(props, componentProps);
+
+  if (props.isExternal) {
+    return (
+      <StyledExternalLink
+        href={props.to}
+        onClick={props.isDisabled ? event => event.preventDefault() : undefined}
+        isDisabled={props.isDisabled}
+        data-track-component="LinkButton"
+        aria-label={props.label}
+        {...remainingProps}
+      >
+        <LinkBody
+          iconLeft={props.iconLeft}
+          isDisabled={props.isDisabled}
+          label={props.label}
+        />
+      </StyledExternalLink>
+    );
+  }
+
+  return (
+    <StyledReactRouterLink
+      to={props.to}
+      isDisabled={props.isDisabled}
+      onClick={props.isDisabled ? event => event.preventDefault() : undefined}
+      data-track-component="LinkButton"
+      aria-label={props.label}
+      {...remainingProps}
+    >
+      <LinkBody
+        iconLeft={props.iconLeft}
+        isDisabled={props.isDisabled}
+        label={props.label}
+      />
+    </StyledReactRouterLink>
+  );
+};
 
 LinkButton.displayName = 'LinkButton';
 LinkButton.propTypes = {
@@ -73,10 +118,12 @@ LinkButton.propTypes = {
   ]).isRequired,
   iconLeft: PropTypes.element,
   isDisabled: PropTypes.bool,
+  isExternal: PropTypes.bool,
 };
 
 LinkButton.defaultProps = {
   isDisabled: false,
+  isExternal: false,
 };
 
 export default LinkButton;

--- a/src/components/buttons/link-button/link-button.js
+++ b/src/components/buttons/link-button/link-button.js
@@ -33,13 +33,12 @@ const createStyledComponent = component => styled(component)`
   text-decoration: none;
 
   span {
-    color: ${props =>
-      props.isDisabled ? vars.colorNeutral : vars.colorPrimary};
+    color: ${props => (props.disabled ? vars.colorNeutral : vars.colorPrimary)};
   }
 
-  cursor: ${props => (props.isDisabled ? 'not-allowed' : 'pointer')};
+  cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
 
-  ${props => !props.isDisabled && hoverStyles}
+  ${props => !props.disabled && hoverStyles}
 `;
 
 const StyledReactRouterLink = createStyledComponent(ReactRouterLink);
@@ -73,7 +72,7 @@ const LinkButton = props => {
       <StyledExternalLink
         href={props.to}
         onClick={props.isDisabled ? event => event.preventDefault() : undefined}
-        isDisabled={props.isDisabled}
+        disabled={props.isDisabled}
         data-track-component="LinkButton"
         aria-label={props.label}
         {...remainingProps}
@@ -90,7 +89,7 @@ const LinkButton = props => {
   return (
     <StyledReactRouterLink
       to={props.to}
-      isDisabled={props.isDisabled}
+      disabled={props.isDisabled}
       onClick={props.isDisabled ? event => event.preventDefault() : undefined}
       data-track-component="LinkButton"
       aria-label={props.label}

--- a/src/components/buttons/link-button/link-button.story.js
+++ b/src/components/buttons/link-button/link-button.story.js
@@ -23,6 +23,7 @@ storiesOf('Components|Buttons', module)
             icons[select('iconLeft', iconNames, iconNames[0])]
           )}
           isDisabled={boolean('isDisabled', false)}
+          isExternal={boolean('isExternal', false)}
         />
       </Section>
     </Router>

--- a/src/components/links/link/link.js
+++ b/src/components/links/link/link.js
@@ -19,10 +19,11 @@ const createStyledComponent = component => Styled(component)`
 const StyledReactRouterLink = createStyledComponent(ReactRouterLink);
 const StyledExternalLink = createStyledComponent('a');
 
-const componentProps = ['isExternal', 'to'];
-
 const Link = props => {
-  const remainingProps = getPassThroughProps(props, componentProps);
+  const remainingProps = getPassThroughProps(
+    props,
+    Object.keys(Link.propTypes)
+  );
 
   if (props.isExternal) {
     return <StyledExternalLink href={props.to} {...remainingProps} />;

--- a/src/components/links/link/link.js
+++ b/src/components/links/link/link.js
@@ -19,10 +19,11 @@ const createStyledComponent = component => Styled(component)`
 const StyledReactRouterLink = createStyledComponent(ReactRouterLink);
 const StyledExternalLink = createStyledComponent('a');
 
-const componentProps = ['isExternal', 'to'];
-
 const Link = props => {
-  const remainingProps = getPassThroughProps(props, componentProps);
+  const remainingProps = getPassThroughProps(
+    props,
+    Object.keys(Link.propTypes)
+  );
 
   if (props.isExternal) {
     return <StyledExternalLink href={props.to} {...remainingProps} />;
@@ -46,7 +47,6 @@ Link.propTypes = {
     ]),
     props => !props.isExternal
   ),
-  children: PropTypes.node.isRequired,
 };
 
 Link.defaultProps = {

--- a/src/components/links/link/link.js
+++ b/src/components/links/link/link.js
@@ -19,11 +19,10 @@ const createStyledComponent = component => Styled(component)`
 const StyledReactRouterLink = createStyledComponent(ReactRouterLink);
 const StyledExternalLink = createStyledComponent('a');
 
+const componentProps = ['isExternal', 'to'];
+
 const Link = props => {
-  const remainingProps = getPassThroughProps(
-    props,
-    Object.keys(Link.propTypes)
-  );
+  const remainingProps = getPassThroughProps(props, componentProps);
 
   if (props.isExternal) {
     return <StyledExternalLink href={props.to} {...remainingProps} />;


### PR DESCRIPTION
#### Summary

Adds `isExternal` prop to `LinkButton`

#### Motivation

Some use cases in the MC (discount predicates for one) have this sort of external link, and this would make their code cleaner.