### PR TITLE
fix(icon-button): misaligned icon fix

### DIFF
--- a/src/components/buttons/icon-button/icon-button.js
+++ b/src/components/buttons/icon-button/icon-button.js
@@ -70,17 +70,17 @@ export const IconButton = props => {
         isToggleButton={props.isToggleButton}
         isToggled={props.isToggled}
         isDisabled={props.isDisabled}
-        css={getSizeStyles(props.size)}
+        css={css`
+          width: 100%;
+          height: 100%;
+        `}
       >
         <div
-          css={[
-            css`
-              display: flex;
-              align-items: center;
-              justify-content: center;
-            `,
-            getSizeStyles(props.size),
-          ]}
+          css={css`
+            display: flex;
+            align-items: center;
+            justify-content: center;
+          `}
         >
           {props.icon &&
             React.cloneElement(props.icon, {


### PR DESCRIPTION
#### Summary

@franzi-t reported this bug in the MC. It's weird because our VRTs don't catch it, and I can't recreate the bug in storybook or in our visual testing app 🤔 

However, I manually tested the MC with this fix (by building the library, and then copy pasting it into `node_modules` in the MC, and it worked.

🤷‍♂ CSS is weird sometimes I guess 🤔 

#### Before

(screenshot from MC)

![Screen Shot 2019-05-20 at 1 51 31 PM](https://user-images.githubusercontent.com/2425013/58019705-708fc000-7b06-11e9-97f6-e1c6612b634f.png)


#### After

![Screen Shot 2019-05-20 at 1 50 25 PM](https://user-images.githubusercontent.com/2425013/58019684-67065800-7b06-11e9-8136-f321f018d47c.png)
