### PR TITLE
Fix MoneyInput.parseMoneyValue to respect the fraction digits

### DIFF
--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -355,7 +355,9 @@ class MoneyInput extends React.Component {
     );
 
     const amount = formatAmount(
-      getAmountAsNumberFromMoneyValue(moneyValue).toLocaleString(locale),
+      getAmountAsNumberFromMoneyValue(moneyValue).toLocaleString(locale, {
+        minimumFractionDigits: moneyValue.fractionDigits,
+      }),
       moneyValue.currencyCode,
       locale
     );

--- a/src/components/inputs/money-input/money-input.spec.js
+++ b/src/components/inputs/money-input/money-input.spec.js
@@ -356,12 +356,12 @@ describe('MoneyInput.parseMoneyValue', () => {
             type: 'highPrecision',
             centAmount: 1234,
             currencyCode: 'EUR',
-            fractionDigits: 3,
-            preciseAmount: 12345,
+            fractionDigits: 5,
+            preciseAmount: 1234527,
           },
           'en'
         )
-      ).toEqual({ amount: '12.345', currencyCode: 'EUR' });
+      ).toEqual({ amount: '12.34527', currencyCode: 'EUR' });
     });
   });
 });


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary
In this PR we set the `minimumFractionDigits` to the value's `fractionDigits` when converting to string in `MoneyInput.parseMoneyValue`

Fixes #793 
#### Description

More details on the issue, and reproduce steps can be found on the issue https://github.com/commercetools/ui-kit/issues/793
