### PR TITLE
fix(multiline-input): Expand behaviour not working

### DIFF
--- a/src/components/inputs/localized-multiline-text-input/translation-input.styles.js
+++ b/src/components/inputs/localized-multiline-text-input/translation-input.styles.js
@@ -26,7 +26,6 @@ const getTextareaStyles = (props, theme) => {
     props.isCollapsed &&
       css`
         overflow: hidden;
-        word-break: break-all;
       `,
   ];
   return baseStyles;

--- a/src/components/inputs/multiline-text-input/multiline-text-input.styles.js
+++ b/src/components/inputs/multiline-text-input/multiline-text-input.styles.js
@@ -15,6 +15,7 @@ const getTextareaStyles = (props, theme) => {
     css`
       padding: ${vars.spacingXs} ${vars.spacingS};
       line-height: ${sizeInputLineHeight};
+      flex: auto;
       word-break: break-all;
       white-space: pre-wrap;
       resize: vertical;


### PR DESCRIPTION
#### Summary

The `MultilineTextInput` expand behaviour is currently broken. This PR restores the functionality.