### PR TITLE
fix(collapsible-panel): remove z-index

### DIFF
--- a/src/components/panels/collapsible-panel/collapsible-panel.styles.js
+++ b/src/components/panels/collapsible-panel/collapsible-panel.styles.js
@@ -53,7 +53,6 @@ const getHeaderContainerStyles = ({ isDisabled, isOpen, isSticky, theme }) => {
       css`
         position: sticky;
         top: 0;
-        z-index: 1;
         border-top-right-radius: ${vars.borderRadius6};
         border-top-left-radius: ${vars.borderRadius6};
       `,


### PR DESCRIPTION
#### Summary

Currently when you have a <SelectInput> above a CollapsiblePanel, the menu list is hidden by the CollapsiblePanel due to z-index setting. I don't believe we need to set a z-index here.

![Screen Shot 2019-05-23 at 12 01 14 PM](https://user-images.githubusercontent.com/2425013/58244243-842f6680-7d52-11e9-8e0c-95ae96cf2994.png)


![Screen Shot 2019-05-23 at 11 44 42 AM](https://user-images.githubusercontent.com/2425013/58244218-7bd72b80-7d52-11e9-9455-00045afd8d01.png)
