### PR TITLE
chore: use prod in vrt

### DIFF
--- a/visual-testing-app/webpack.config.js
+++ b/visual-testing-app/webpack.config.js
@@ -25,9 +25,7 @@ if (!info) {
 
 module.exports = {
   target: 'web',
-  // note: we have to use 'development' for now, because when we use production
-  // our emotion styles aren't displayed in our percy snapshots.
-  mode: 'development',
+  mode: 'production',
   stats: 'minimal',
   entry: './visual-testing-app/src/index.js',
   output: {


### PR DESCRIPTION
#### Summary

Thanks to first class CSS in JS support in @percy/agent, we can remove this webpack workaround. 