### PR TITLE
fix(base-table): onSortChange being called without being passed

### DIFF
--- a/src/components/table/base-table/base-table.js
+++ b/src/components/table/base-table/base-table.js
@@ -196,6 +196,8 @@ export default class BaseTable extends React.Component {
   // from the row index before passing it to the parent
   getBodyRowIndex = rowIndex => rowIndex - 1;
   handleChangeSortDirection = columnKey => {
+    if (!this.props.onSortChange) return;
+
     if (columnKey !== this.props.sortBy) {
       this.props.onSortChange(columnKey, 'ASC');
     } else {

--- a/src/components/table/base-table/base-table.spec.js
+++ b/src/components/table/base-table/base-table.spec.js
@@ -717,44 +717,63 @@ describe('BaseTable', () => {
     let props;
     let wrapper;
     describe('handleChangeSortDirection', () => {
-      beforeEach(() => {
-        props = createTestProps({
-          onSortChange: jest.fn(),
-          sortBy: 'id',
-          sortDirection: 'ASC',
-        });
-        wrapper = shallow(<BaseTable {...props} />);
-      });
-      describe('when previous direction was ASC', () => {
-        beforeEach(() => {
-          wrapper.instance().handleChangeSortDirection('id');
-        });
-        it('should call onSortChange with direction DESC', () => {
-          expect(props.onSortChange).toHaveBeenCalledWith('id', 'DESC');
-        });
-      });
-      describe('when previous direction was DESC', () => {
+      describe('with `onSortChange`', () => {
         beforeEach(() => {
           props = createTestProps({
             onSortChange: jest.fn(),
             sortBy: 'id',
-            sortDirection: 'DESC',
+            sortDirection: 'ASC',
           });
           wrapper = shallow(<BaseTable {...props} />);
         });
-        beforeEach(() => {
-          wrapper.instance().handleChangeSortDirection('id');
+        describe('when previous direction was ASC', () => {
+          beforeEach(() => {
+            wrapper.instance().handleChangeSortDirection('id');
+          });
+          it('should call onSortChange with direction DESC', () => {
+            expect(props.onSortChange).toHaveBeenCalledWith('id', 'DESC');
+          });
         });
-        it('should call onSortChange with direction ASC', () => {
-          expect(props.onSortChange).toHaveBeenCalledWith('id', 'ASC');
+        describe('when previous direction was DESC', () => {
+          beforeEach(() => {
+            props = createTestProps({
+              onSortChange: jest.fn(),
+              sortBy: 'id',
+              sortDirection: 'DESC',
+            });
+            wrapper = shallow(<BaseTable {...props} />);
+          });
+          beforeEach(() => {
+            wrapper.instance().handleChangeSortDirection('id');
+          });
+          it('should call onSortChange with direction ASC', () => {
+            expect(props.onSortChange).toHaveBeenCalledWith('id', 'ASC');
+          });
+        });
+        describe('when the sorted column changes', () => {
+          beforeEach(() => {
+            wrapper.instance().handleChangeSortDirection('foo');
+          });
+          it('should call onSortChange with direction ASC', () => {
+            expect(props.onSortChange).toHaveBeenCalledWith('foo', 'ASC');
+          });
         });
       });
-      describe('when the sorted column changes', () => {
+
+      describe('without `onSortChange`', () => {
         beforeEach(() => {
-          wrapper.instance().handleChangeSortDirection('foo');
+          props = createTestProps({
+            onSortChange: null,
+            sortBy: 'id',
+            sortDirection: 'ASC',
+          });
+          wrapper = shallow(<BaseTable {...props} />);
+
+          wrapper.instance().handleChangeSortDirection('id');
         });
-        it('should call onSortChange with direction ASC', () => {
-          expect(props.onSortChange).toHaveBeenCalledWith('foo', 'ASC');
+
+        it('should not call onSortChange', () => {
+          expect(props.onSortChange).toBe(null);
         });
       });
     });


### PR DESCRIPTION
#### Summary

This fixes `onSortChange` being called even if not passed as a prop (it's not required). As a result the component tree unmounts. This error occured 38 times to 3 users in our error logging.