### PR TITLE
fix(toggle-input): toggle input disabled styles

### DIFF
--- a/src/components/inputs/toggle-input/toggle-input.js
+++ b/src/components/inputs/toggle-input/toggle-input.js
@@ -66,23 +66,39 @@ const Span = styled.span`
 `;
 
 const Input = styled.input`
-  &:checked + ${Span}::before {
-    background: ${vars.colorPrimary};
+  /* when checked */
+  &:checked {
+    + ${Span}::before {
+      background: ${vars.colorPrimary};
+    }
+    & + ${Span}::after {
+      transform: ${props =>
+        props.size === 'small'
+          ? 'translate(117%, -50%)'
+          : 'translate(127%, -50%)'};
+    }
   }
 
-  &:disabled + ${Span}::before {
-    background: ${vars.colorNeutral};
+  /* when disabled */
+  &:disabled {
+    & + ${Span}::before {
+      background: ${vars.colorNeutral};
+      box-shadow: none;
+    }
+    & + ${Span}::after {
+      background: ${vars.colorNavy95};
+      box-shadow: none;
+    }
   }
 
-  &:disabled&:checked + ${Span}::before {
-    background: ${vars.colorPrimary25};
-  }
-
-  &:checked + ${Span}::after {
-    transform: ${props =>
-      props.size === 'small'
-        ? 'translate(117%, -50%)'
-        : 'translate(127%, -50%)'};
+  /* when disabled and checked */
+  &:disabled&:checked {
+    & + ${Span}::before {
+      background: ${vars.colorPrimary25};
+    }
+    & + ${Span}::after {
+      background: ${vars.colorGray};
+    }
   }
 
   :not(:disabled)&:hover


### PR DESCRIPTION
Fixes the following reported bugs on the ToggleInput component for when it is `disabled`:

> - The handler (thumb-color) should be grey instead of white 
> - The track shadow (the inner part) should be NONE. Right now there is a shadow.

Also fixes the styles for when the input is `disabled` and `checked`.