### PR TITLE
fix: use first-of-type instead of first-child

### DIFF
--- a/src/components/internals/create-select-styles.js
+++ b/src/components/internals/create-select-styles.js
@@ -228,7 +228,7 @@ const groupStyles = (props, theme) => base => {
   return {
     ...base,
     padding: 0,
-    '&:not(:first-child)': {
+    '&:not(:first-of-type)': {
       borderTop: props.showOptionGroupDivider
         ? `1px solid ${overwrittenVars.colorNeutral}`
         : base.borderTop,


### PR DESCRIPTION
#### Summary

Hopefully this fixes the warning that was failing CI
