### PR TITLE
fix(icon-button): hover state fix, and remove HOC

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,15 +1,15 @@
 {
   "dist/ui-kit.esm.js": {
-    "bundled": 879366,
-    "minified": 604150,
-    "gzipped": 123195,
+    "bundled": 879277,
+    "minified": 603873,
+    "gzipped": 123184,
     "treeshaked": {
       "rollup": {
-        "code": 434499,
+        "code": 434486,
         "import_statements": 919
       },
       "webpack": {
-        "code": 458773
+        "code": 458770
       }
     }
   }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,15 +1,15 @@
 {
   "dist/ui-kit.esm.js": {
-    "bundled": 866961,
-    "minified": 596248,
-    "gzipped": 121235,
+    "bundled": 879366,
+    "minified": 604150,
+    "gzipped": 123195,
     "treeshaked": {
       "rollup": {
-        "code": 429763,
+        "code": 434499,
         "import_statements": 919
       },
       "webpack": {
-        "code": 454131
+        "code": 458773
       }
     }
   }

--- a/src/components/buttons/icon-button/icon-button.js
+++ b/src/components/buttons/icon-button/icon-button.js
@@ -73,21 +73,16 @@ export const IconButton = props => {
         css={css`
           width: 100%;
           height: 100%;
+          display: flex;
+          align-items: center;
+          justify-content: center;
         `}
       >
-        <div
-          css={css`
-            display: flex;
-            align-items: center;
-            justify-content: center;
-          `}
-        >
-          {props.icon &&
-            React.cloneElement(props.icon, {
-              size: props.size,
-              theme: getIconThemeColor(props),
-            })}
-        </div>
+        {props.icon &&
+          React.cloneElement(props.icon, {
+            size: props.size,
+            theme: getIconThemeColor(props),
+          })}
       </AccessibleButton>
     </div>
   );

--- a/src/components/buttons/icon-button/icon-button.js
+++ b/src/components/buttons/icon-button/icon-button.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import isNil from 'lodash/isNil';
 import { css } from '@emotion/core';
-import styled from '@emotion/styled';
 import vars from '../../../../materials/custom-properties';
 import filterAriaAttributes from '../../../utils/filter-aria-attributes';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
@@ -12,6 +11,7 @@ import {
   getShapeStyles,
   getSizeStyles,
   getThemeStyles,
+  getHoverStyles,
 } from './icon-button.styles';
 
 // Gets the color which the icon should have based on context of button's state/cursor behavior
@@ -31,22 +31,6 @@ const getIconThemeColor = props => {
   return props.icon.props.theme;
 };
 
-const getIconContainerHoverStyles = props => {
-  if (props.theme === 'default' || props.isDisabled) return css``;
-
-  return css`
-    &:hover {
-      * {
-        fill: ${vars.colorSurface};
-      }
-    }
-  `;
-};
-
-const IconContainer = styled.div`
-  ${getIconContainerHoverStyles}
-`;
-
 export const IconButton = props => {
   const buttonAttributes = {
     'data-track-component': 'IconButton',
@@ -55,7 +39,7 @@ export const IconButton = props => {
   };
   const isActive = props.isToggleButton && props.isToggled;
   return (
-    <IconContainer
+    <div
       isDisabled={props.isDisabled}
       theme={props.theme}
       css={[
@@ -72,6 +56,7 @@ export const IconButton = props => {
         getShapeStyles(props.shape, props.size),
         getSizeStyles(props.size),
         getThemeStyles(props.theme),
+        getHoverStyles(props.isDisabled, props.theme),
       ]}
     >
       <AccessibleButton
@@ -96,7 +81,7 @@ export const IconButton = props => {
             theme: getIconThemeColor(props),
           })}
       </AccessibleButton>
-    </IconContainer>
+    </div>
   );
 };
 

--- a/src/components/buttons/icon-button/icon-button.js
+++ b/src/components/buttons/icon-button/icon-button.js
@@ -39,10 +39,21 @@ export const IconButton = props => {
   };
   const isActive = props.isToggleButton && props.isToggled;
   return (
-    <div
+    <AccessibleButton
+      buttonAttributes={buttonAttributes}
+      type={props.type}
+      label={props.label}
+      onClick={props.onClick}
+      isToggleButton={props.isToggleButton}
+      isToggled={props.isToggled}
+      isDisabled={props.isDisabled}
       css={[
         css`
+          width: 100%;
+          height: 100%;
           display: flex;
+          align-items: center;
+          justify-content: center;
           border: 1px solid ${vars.colorSurface};
           background-color: ${vars.colorSurface};
           box-shadow: ${vars.shadow7};
@@ -57,29 +68,12 @@ export const IconButton = props => {
         getHoverStyles(props.isDisabled, props.theme),
       ]}
     >
-      <AccessibleButton
-        buttonAttributes={buttonAttributes}
-        type={props.type}
-        label={props.label}
-        onClick={props.onClick}
-        isToggleButton={props.isToggleButton}
-        isToggled={props.isToggled}
-        isDisabled={props.isDisabled}
-        css={css`
-          width: 100%;
-          height: 100%;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-        `}
-      >
-        {props.icon &&
-          React.cloneElement(props.icon, {
-            size: props.size,
-            theme: getIconThemeColor(props),
-          })}
-      </AccessibleButton>
-    </div>
+      {props.icon &&
+        React.cloneElement(props.icon, {
+          size: props.size,
+          theme: getIconThemeColor(props),
+        })}
+    </AccessibleButton>
   );
 };
 

--- a/src/components/buttons/icon-button/icon-button.js
+++ b/src/components/buttons/icon-button/icon-button.js
@@ -40,8 +40,6 @@ export const IconButton = props => {
   const isActive = props.isToggleButton && props.isToggled;
   return (
     <div
-      isDisabled={props.isDisabled}
-      theme={props.theme}
       css={[
         css`
           display: flex;

--- a/src/components/buttons/icon-button/icon-button.js
+++ b/src/components/buttons/icon-button/icon-button.js
@@ -1,11 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import flowRight from 'lodash/flowRight';
 import isNil from 'lodash/isNil';
 import { css } from '@emotion/core';
+import styled from '@emotion/styled';
 import vars from '../../../../materials/custom-properties';
-import withMouseDownState from '../../../hocs/with-mouse-down-state';
-import withMouseOverState from '../../../hocs/with-mouse-over-state';
 import filterAriaAttributes from '../../../utils/filter-aria-attributes';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import AccessibleButton from '../accessible-button';
@@ -20,7 +18,7 @@ import {
 const getIconThemeColor = props => {
   const isActive = props.isToggleButton && props.isToggled;
   // if button has a theme, icon should be white when hovering/clicking
-  if (props.theme !== 'default' && (isActive || props.isMouseOver)) {
+  if (props.theme !== 'default' && isActive) {
     if (props.isDisabled) {
       return 'grey';
     }
@@ -33,6 +31,22 @@ const getIconThemeColor = props => {
   return props.icon.props.theme;
 };
 
+const getIconContainerHoverStyles = props => {
+  if (props.theme === 'default' || props.isDisabled) return css``;
+
+  return css`
+    &:hover {
+      * {
+        fill: ${vars.colorSurface};
+      }
+    }
+  `;
+};
+
+const IconContainer = styled.div`
+  ${getIconContainerHoverStyles}
+`;
+
 export const IconButton = props => {
   const buttonAttributes = {
     'data-track-component': 'IconButton',
@@ -41,11 +55,9 @@ export const IconButton = props => {
   };
   const isActive = props.isToggleButton && props.isToggled;
   return (
-    <div
-      onMouseDown={props.handleMouseDown}
-      onMouseUp={props.handleMouseUp}
-      onMouseOver={props.handleMouseOver}
-      onMouseOut={props.handleMouseOut}
+    <IconContainer
+      isDisabled={props.isDisabled}
+      theme={props.theme}
       css={[
         css`
           display: flex;
@@ -84,7 +96,7 @@ export const IconButton = props => {
             theme: getIconThemeColor(props),
           })}
       </AccessibleButton>
-    </div>
+    </IconContainer>
   );
 };
 
@@ -124,14 +136,6 @@ IconButton.propTypes = {
       ...rest
     );
   },
-
-  // HoC
-  isMouseDown: PropTypes.bool.isRequired,
-  isMouseOver: PropTypes.bool.isRequired,
-  handleMouseOver: PropTypes.func.isRequired,
-  handleMouseOut: PropTypes.func.isRequired,
-  handleMouseDown: PropTypes.func.isRequired,
-  handleMouseUp: PropTypes.func.isRequired,
 };
 
 IconButton.defaultProps = {
@@ -144,7 +148,4 @@ IconButton.defaultProps = {
 
 IconButton.displayName = 'IconButton';
 
-export default flowRight(
-  withMouseOverState,
-  withMouseDownState
-)(IconButton);
+export default IconButton;

--- a/src/components/buttons/icon-button/icon-button.spec.js
+++ b/src/components/buttons/icon-button/icon-button.spec.js
@@ -9,14 +9,6 @@ const createTestProps = custom => ({
   onClick: jest.fn(),
   icon: <PlusBoldIcon data-testid="icon" />,
 
-  // HoC
-  isMouseDown: false,
-  isMouseOver: false,
-  handleMouseUp: jest.fn(),
-  handleMouseDown: jest.fn(),
-  handleMouseOver: jest.fn(),
-  handleMouseOut: jest.fn(),
-
   ...custom,
 });
 

--- a/src/components/buttons/icon-button/icon-button.styles.js
+++ b/src/components/buttons/icon-button/icon-button.styles.js
@@ -3,9 +3,9 @@ import { css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
 
 const buttonSizes = {
-  small: '14px',
-  medium: '22px',
-  big: '30px',
+  small: '16px',
+  medium: '24px',
+  big: '32px',
 };
 
 const getStateStyles = (isDisabled, isActive, theme) => {

--- a/src/components/buttons/icon-button/icon-button.styles.js
+++ b/src/components/buttons/icon-button/icon-button.styles.js
@@ -169,8 +169,7 @@ const getThemeStyles = theme => {
   switch (theme) {
     case 'green':
       return css`
-        &:hover,
-        &:active {
+        &:hover {
           background-color: ${vars.colorPrimary};
           border-color: ${vars.colorPrimary};
           color: ${vars.colorSurface};
@@ -178,7 +177,6 @@ const getThemeStyles = theme => {
       `;
     case 'blue':
       return css`
-        &:active,
         &:hover {
           background-color: ${vars.colorInfo};
           border-color: ${vars.colorInfo};

--- a/src/components/buttons/icon-button/icon-button.styles.js
+++ b/src/components/buttons/icon-button/icon-button.styles.js
@@ -166,9 +166,11 @@ const getThemeStyles = theme => {
 
   if (theme === 'default') return css``;
 
+  console.log('here, getThemeStyles');
   switch (theme) {
     case 'green':
       return css`
+        &:hover,
         &:active {
           background-color: ${vars.colorPrimary};
           border-color: ${vars.colorPrimary};
@@ -177,6 +179,7 @@ const getThemeStyles = theme => {
       `;
     case 'blue':
       return css`
+        &:active,
         &:hover {
           background-color: ${vars.colorInfo};
           border-color: ${vars.colorInfo};

--- a/src/components/buttons/icon-button/icon-button.styles.js
+++ b/src/components/buttons/icon-button/icon-button.styles.js
@@ -166,7 +166,6 @@ const getThemeStyles = theme => {
 
   if (theme === 'default') return css``;
 
-  console.log('here, getThemeStyles');
   switch (theme) {
     case 'green':
       return css`
@@ -196,4 +195,22 @@ const getThemeStyles = theme => {
   }
 };
 
-export { getStateStyles, getShapeStyles, getSizeStyles, getThemeStyles };
+const getHoverStyles = (isDisabled, theme) => {
+  if (theme === 'default' || isDisabled) return css``;
+
+  return css`
+    &:hover {
+      * {
+        fill: ${vars.colorSurface};
+      }
+    }
+  `;
+};
+
+export {
+  getStateStyles,
+  getHoverStyles,
+  getShapeStyles,
+  getSizeStyles,
+  getThemeStyles,
+};

--- a/src/components/buttons/icon-button/icon-button.visualroute.js
+++ b/src/components/buttons/icon-button/icon-button.visualroute.js
@@ -123,22 +123,24 @@ export const component = () => (
       />
     </Spec>
 
-    <Spec label="theme - when green">
+    <Spec label="theme - when green - when toggled">
       <IconButton
         icon={<InformationIcon />}
         label="A label text"
         onClick={() => {}}
         isToggleButton={true}
+        isToggled={true}
         theme="green"
       />
     </Spec>
 
-    <Spec label="theme - when blue">
+    <Spec label="theme - when blue - when toggled">
       <IconButton
         icon={<InformationIcon />}
         label="A label text"
         onClick={() => {}}
         isToggleButton={true}
+        isToggled={true}
         theme="blue"
       />
     </Spec>


### PR DESCRIPTION
#### Summary

Fixes a bug with hovering IconButtons with "green" theme. Also, refactors the component to remove the usage of the HOC.

#### Before

![before-green](https://user-images.githubusercontent.com/2425013/59680841-b063c900-91d2-11e9-8280-ce8686fe964d.gif)

#### After
![after-green](https://user-images.githubusercontent.com/2425013/59680830-ab067e80-91d2-11e9-8c91-ed4534cf144e.gif)
