### PR TITLE
feat(storybook): add context add for theme

### DIFF
--- a/.storybook/configs/contexts.js
+++ b/.storybook/configs/contexts.js
@@ -1,6 +1,8 @@
 import intlContext from './intl-context';
+import themeContext from './theme-context';
 
 export const contexts = [
   intlContext,
+  themeContext,
   /* ... */ // multiple contexts setups are supported
 ];

--- a/.storybook/configs/theme-context.js
+++ b/.storybook/configs/theme-context.js
@@ -10,9 +10,9 @@ const darkTheme = {
 
 const defaultTheme = vars;
 
-const ThemeWrapper = props => {
-  return <ThemeProvider theme={props.theme}>{props.children}</ThemeProvider>;
-};
+const ThemeWrapper = props => (
+  <ThemeProvider theme={props.theme}>{props.children}</ThemeProvider>
+);
 
 ThemeWrapper.propTypes = {
   theme: PropTypes.any,

--- a/.storybook/configs/theme-context.js
+++ b/.storybook/configs/theme-context.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import vars from '../../materials/custom-properties';
+import { ThemeProvider } from 'emotion-theming';
+
+const darkTheme = {
+  colorSolid: vars.colorSurface,
+  colorSurface: vars.colorSolid,
+};
+
+const defaultTheme = vars;
+
+const ThemeWrapper = props => {
+  return <ThemeProvider theme={props.theme}>{props.children}</ThemeProvider>;
+};
+
+ThemeWrapper.propTypes = {
+  theme: PropTypes.any,
+};
+
+const themeParams = [
+  {
+    name: 'Default Theme',
+    props: { theme: defaultTheme },
+    default: true,
+  },
+  {
+    name: 'Dark Theme (experimental)',
+    props: { theme: darkTheme },
+  },
+];
+
+const themeContext = {
+  icon: 'box', // a icon displayed in the Storybook toolbar to control contextual props
+  title: 'Themes', // an unique name of a contextual environment
+  components: [ThemeWrapper],
+  params: themeParams,
+  options: {
+    deep: true, // pass the `props` deeply into all wrapping components
+    disable: false, // disable this contextual environment completely
+    cancelable: false, // allow this contextual environment to be opt-out optionally in toolbar
+  },
+};
+
+export default themeContext;

--- a/.storybook/decorators/section/section.js
+++ b/.storybook/decorators/section/section.js
@@ -1,11 +1,19 @@
 import React from 'react';
+import { css } from '@emotion/core';
 import PropTypes from 'prop-types';
 
-const sectionStyles = {
-  padding: 16,
+const Section = props => {
+  return (
+    <div
+      css={theme => css`
+        background-color: ${theme.colorSurface};
+        padding: 16px;
+      `}
+    >
+      {props.children}
+    </div>
+  );
 };
-
-const Section = props => <div style={sectionStyles}>{props.children}</div>;
 
 Section.propTypes = { children: PropTypes.node.isRequired };
 


### PR DESCRIPTION
#### Summary

As theming is still a beta feature, we don't have much documentation about it. Not all components support theming. Most inputs do at the moment. 

This PR adds the ability in storybook to change to a (very basic) dark theme.

```js
const darkTheme = {
  colorSolid: vars.colorSurface,
  colorSurface: vars.colorSolid,
};
```

![dark theme](https://user-images.githubusercontent.com/2425013/59754625-bc10c780-9286-11e9-982d-28a51fb1f80b.gif)
