### PR TITLE
feat: require react 16.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,8 +201,8 @@
   "peerDependencies": {
     "moment": "2.x",
     "moment-timezone": "0.5.x",
-    "react": "16.x",
-    "react-dom": "16.x",
+    "react": ">= 16.8.0",
+    "react-dom": ">= 16.8.0",
     "react-intl": "2.x",
     "react-router-dom": "5.x"
   },


### PR DESCRIPTION
#### Summary

Since App Kit will be requiring React 16.8 in it's next major release, we should do the same. [ref](https://github.com/commercetools/merchant-center-application-kit/issues/748)

