### PR TITLE
chore: remove classnames

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
   "dependencies": {
     "@emotion/core": "10.0.10",
     "@emotion/styled": "10.0.12",
-    "classnames": "2.2.6",
     "common-tags": "1.8.0",
     "dom-helpers": "3.4.0",
     "downshift": "3.2.10",

--- a/src/components/table/base-table/base-table.js
+++ b/src/components/table/base-table/base-table.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { CellMeasurer, CellMeasurerCache, MultiGrid } from 'react-virtualized';
 import sortBy from 'lodash/sortBy';
 import getScrollbarSize from 'dom-helpers/util/scrollbarSize';
-import classnames from 'classnames';
 import { Global, ClassNames, css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
 import Spacings from '../../spacings';
@@ -348,13 +347,13 @@ export default class BaseTable extends React.Component {
     if (renderParams.rowIndex === 0) {
       return (
         <ClassNames>
-          {({ css: makeClassName }) => (
+          {({ css: makeClassName, cx }) => (
             <div
               style={{
                 ...(renderParams.style || {}),
                 ...(columnDefinition.headerStyle || {}),
               }}
-              className={classnames(
+              className={cx(
                 makeClassName({
                   background: vars.colorAccent,
                   color: vars.colorSurface,
@@ -371,9 +370,9 @@ export default class BaseTable extends React.Component {
     }
     return (
       <ClassNames>
-        {({ css: makeClassName }) => (
+        {({ css: makeClassName, cx }) => (
           <div
-            className={classnames(
+            className={cx(
               makeClassName({
                 textAlign: columnDefinition.align || 'left',
                 ...(renderParams.rowIndex === this.state.hoveredRowIndex &&
@@ -494,9 +493,9 @@ export default class BaseTable extends React.Component {
           `}
         />
         <ClassNames>
-          {({ css: makeClassName }) => (
+          {({ css: makeClassName, cx }) => (
             <div
-              className={classnames(
+              className={cx(
                 makeClassName({
                   outline: `1px solid ${vars.colorNeutral90}`,
                 }),

--- a/src/components/table/base-table/base-table.spec.js
+++ b/src/components/table/base-table/base-table.spec.js
@@ -31,7 +31,10 @@ describe('BaseTable', () => {
       props = createTestProps();
       wrapper = shallow(<BaseTable {...props} />);
       gridWrapper = shallow(
-        wrapper.find(ClassNames).prop('children')({ css: jest.fn() })
+        wrapper.find(ClassNames).prop('children')({
+          css: jest.fn(),
+          cx: jest.fn(),
+        })
       );
     });
     it('should render <MultiGrid>', () => {
@@ -56,7 +59,10 @@ describe('BaseTable', () => {
         });
         wrapper = shallow(<BaseTable {...props} />);
         gridWrapper = shallow(
-          wrapper.find(ClassNames).prop('children')({ css: jest.fn() })
+          wrapper.find(ClassNames).prop('children')({
+            css: jest.fn(),
+            cx: jest.fn(),
+          })
         );
       });
       it('should not pass fixedColumnCount prop to <MultiGrid>', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4278,7 +4278,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@2.2.6, classnames@^2.2.5:
+classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==


### PR DESCRIPTION
#### Summary

We were only using the `classnames` dep in one file. Here I remove that package, and replace it with the usage of `cx` from `@emotion`.

See the [emotion docs](https://emotion.sh/docs/class-names) for more info.