### PR TITLE
feat(spacings.inline): support flex wrap

### DIFF
--- a/src/components/spacings/inline/inline.js
+++ b/src/components/spacings/inline/inline.js
@@ -22,6 +22,13 @@ Inline.propTypes = {
     'flexStart',
     'flexEnd',
   ]),
+  flexWrap: PropTypes.oneOf([
+    'nowrap',
+    'wrap',
+    'wrap-reverse',
+    'initial',
+    'inherit',
+  ]),
   justifyContent: PropTypes.oneOf([
     'flex-start',
     'flex-end',
@@ -36,6 +43,7 @@ Inline.propTypes = {
 Inline.defaultProps = {
   scale: 's',
   alignItems: 'flex-start',
+  flexWrap: 'nowrap',
   justifyContent: 'flex-start',
 };
 

--- a/src/components/spacings/inline/inline.styles.js
+++ b/src/components/spacings/inline/inline.styles.js
@@ -39,6 +39,7 @@ export default props => css`
   display: flex;
   align-items: ${getAlignItem(props.alignItems)};
   justify-content: ${props.justifyContent};
+  flex-wrap: ${props.flexWrap};
 
   > * + * {
     margin: 0 0 0 ${getMargin(props.scale)} !important;


### PR DESCRIPTION
#### Summary

Sometimes when we want to make things "flex-wrap". IMHO this is a nice addition to this component, which means we can make more UI elements with needing custom css

[more info](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap)
Fixes #898 