### PR TITLE
[UIKIT-879] feat(buttons): Add color prop to SecondaryIconButton

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,15 +1,15 @@
 {
   "dist/ui-kit.esm.js": {
-    "bundled": 881431,
-    "minified": 604254,
-    "gzipped": 123431,
+    "bundled": 874809,
+    "minified": 600844,
+    "gzipped": 122315,
     "treeshaked": {
       "rollup": {
-        "code": 431523,
+        "code": 428635,
         "import_statements": 893
       },
       "webpack": {
-        "code": 458249
+        "code": 455406
       }
     }
   }

--- a/src/components/buttons/secondary-icon-button/README.md
+++ b/src/components/buttons/secondary-icon-button/README.md
@@ -31,8 +31,11 @@ also pass a label for accessibility reasons.
 | `icon`       | `node`   |    ✅    | -                           | -        | An `Icon` component                                                                    |
 | `isDisabled` | `bool`   |    -     | -                           | `false`  | Tells when the button should present a disabled state                                  |
 | `onClick`    | `func`   |    ✅    | -                           | -        | What the button will trigger when clicked                                              |
-| `size`       | `oneOf`  |    -     | `big`, `medium`, `small`    | `big`    | Sets the size of the icon                                                              |
 | `color`      | `oneOf`  |    -     | `solid`, `primary`          | `solid`  | Sets the color of the icon                                                             |
+
+#### Note
+
+The size of the button should be adjusted directly on the passed `Icon` component.
 
 #### Where to use
 

--- a/src/components/buttons/secondary-icon-button/README.md
+++ b/src/components/buttons/secondary-icon-button/README.md
@@ -35,7 +35,15 @@ also pass a label for accessibility reasons.
 
 #### Note
 
-The size of the button should be adjusted directly on the passed `Icon` component.
+The size of the button should be adjusted directly on the passed `Icon` component. Example:
+
+```js
+<SecondaryIconButton
+  icon={<ArrowRightIcon size="small" />}
+  label="Next"
+  onClick={() => alert('Button clicked')}
+/>
+```
 
 #### Where to use
 

--- a/src/components/buttons/secondary-icon-button/README.md
+++ b/src/components/buttons/secondary-icon-button/README.md
@@ -31,6 +31,8 @@ also pass a label for accessibility reasons.
 | `icon`       | `node`   |    ✅    | -                           | -        | An `Icon` component                                                                    |
 | `isDisabled` | `bool`   |    -     | -                           | `false`  | Tells when the button should present a disabled state                                  |
 | `onClick`    | `func`   |    ✅    | -                           | -        | What the button will trigger when clicked                                              |
+| `size`       | `oneOf`  |    -     | `big`, `medium`, `small`    | `big`    | Sets the size of the icon                                                              |
+| `color`      | `oneOf`  |    -     | `solid`, `primary`          | `solid`  | Sets the color of the icon                                                             |
 
 #### Where to use
 

--- a/src/components/buttons/secondary-icon-button/secondary-icon-button.js
+++ b/src/components/buttons/secondary-icon-button/secondary-icon-button.js
@@ -20,10 +20,7 @@ export const SecondaryIconButton = props => {
       isDisabled={props.isDisabled}
       css={theme => getBaseStyles(theme, props)}
     >
-      {props.icon &&
-        React.cloneElement(props.icon, {
-          size: props.size,
-        })}
+      {props.icon}
     </AccessibleButton>
   );
 };
@@ -32,7 +29,6 @@ SecondaryIconButton.displayName = 'SecondaryIconButton';
 SecondaryIconButton.propTypes = {
   type: PropTypes.oneOf(['submit', 'reset', 'button']),
   icon: PropTypes.element.isRequired,
-  size: PropTypes.oneOf(['small', 'medium', 'big']),
   color: PropTypes.oneOf(['solid', 'primary']),
   label: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
@@ -40,7 +36,6 @@ SecondaryIconButton.propTypes = {
 };
 
 SecondaryIconButton.defaultProps = {
-  size: 'big',
   color: 'solid',
   type: 'button',
   isDisabled: false,

--- a/src/components/buttons/secondary-icon-button/secondary-icon-button.js
+++ b/src/components/buttons/secondary-icon-button/secondary-icon-button.js
@@ -18,7 +18,7 @@ export const SecondaryIconButton = props => {
       label={props.label}
       onClick={props.onClick}
       isDisabled={props.isDisabled}
-      css={getBaseStyles(props)}
+      css={theme => getBaseStyles(theme, props)}
     >
       {props.icon &&
         React.cloneElement(props.icon, {

--- a/src/components/buttons/secondary-icon-button/secondary-icon-button.js
+++ b/src/components/buttons/secondary-icon-button/secondary-icon-button.js
@@ -1,50 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { css } from '@emotion/core';
-import styled from '@emotion/styled';
 import filterAriaAttributes from '../../../utils/filter-aria-attributes';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
-import vars from '../../../../materials/custom-properties';
 import AccessibleButton from '../accessible-button';
-
-const hoverStyle = props => {
-  const overwrittenVars = {
-    ...vars,
-    ...props.theme,
-  };
-
-  return css`
-    &:hover {
-      svg * {
-        fill: ${overwrittenVars.colorPrimary};
-      }
-    }
-  `;
-};
-
-const fillStyle = props => {
-  const overwrittenVars = {
-    ...vars,
-    ...props.theme,
-  };
-  return css`
-    svg * {
-      fill: ${props.isDisabled
-        ? overwrittenVars.colorNeutral60
-        : overwrittenVars.colorSolid};
-    }
-  `;
-};
-
-const IconContainer = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  ${fillStyle}
-
-  ${props => !props.isDisabled && hoverStyle}
-`;
+import { getBaseStyles } from './secondary-icon-button.styles';
 
 export const SecondaryIconButton = props => {
   const buttonAttributes = {
@@ -59,10 +18,12 @@ export const SecondaryIconButton = props => {
       label={props.label}
       onClick={props.onClick}
       isDisabled={props.isDisabled}
+      css={getBaseStyles(props)}
     >
-      <IconContainer isDisabled={props.isDisabled}>
-        {React.cloneElement(props.icon)}
-      </IconContainer>
+      {props.icon &&
+        React.cloneElement(props.icon, {
+          size: props.size,
+        })}
     </AccessibleButton>
   );
 };
@@ -70,13 +31,17 @@ export const SecondaryIconButton = props => {
 SecondaryIconButton.displayName = 'SecondaryIconButton';
 SecondaryIconButton.propTypes = {
   type: PropTypes.oneOf(['submit', 'reset', 'button']),
-  label: PropTypes.string.isRequired,
   icon: PropTypes.element.isRequired,
-  isDisabled: PropTypes.bool,
+  size: PropTypes.oneOf(['small', 'medium', 'big']),
+  color: PropTypes.oneOf(['solid', 'primary']),
+  label: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
+  isDisabled: PropTypes.bool,
 };
 
 SecondaryIconButton.defaultProps = {
+  size: 'big',
+  color: 'solid',
   type: 'button',
   isDisabled: false,
 };

--- a/src/components/buttons/secondary-icon-button/secondary-icon-button.story.js
+++ b/src/components/buttons/secondary-icon-button/secondary-icon-button.story.js
@@ -23,7 +23,6 @@ storiesOf('Components|Buttons', module)
         icon={React.createElement(
           icons[select('icon', iconNames, iconNames[0])]
         )}
-        size={select('size', ['big', 'medium', 'small'], 'big')}
         label={text('label', 'Accessibility text')}
         color={select('color', ['solid', 'primary'], 'solid')}
         onClick={action('onClick')}

--- a/src/components/buttons/secondary-icon-button/secondary-icon-button.story.js
+++ b/src/components/buttons/secondary-icon-button/secondary-icon-button.story.js
@@ -23,8 +23,10 @@ storiesOf('Components|Buttons', module)
         icon={React.createElement(
           icons[select('icon', iconNames, iconNames[0])]
         )}
-        onClick={action('onClick')}
+        size={select('size', ['big', 'medium', 'small'], 'big')}
         label={text('label', 'Accessibility text')}
+        color={select('color', ['solid', 'primary'], 'solid')}
+        onClick={action('onClick')}
         isDisabled={boolean('isDisabled', false)}
       />
     </Section>

--- a/src/components/buttons/secondary-icon-button/secondary-icon-button.styles.js
+++ b/src/components/buttons/secondary-icon-button/secondary-icon-button.styles.js
@@ -1,0 +1,56 @@
+import { css } from '@emotion/core';
+import vars from '../../../../materials/custom-properties';
+
+const getDisabledStyle = overwrittenVars => {
+  /* By using the css 'disabled' selector directly, we don't need additional logic to check the isDisabled prop */
+  return css`
+    &:disabled svg * {
+      fill: ${overwrittenVars.colorNeutral60};
+    }
+  `;
+};
+
+const getColorStyle = (props, overwrittenVars) => {
+  switch (props.color) {
+    case 'solid':
+      return css`
+        & svg * {
+          fill: ${overwrittenVars.colorSolid};
+        }
+        &:hover svg * {
+          fill: ${overwrittenVars.colorPrimary};
+        }
+      `;
+    case 'primary':
+      return css`
+        & svg * {
+          fill: ${overwrittenVars.colorPrimary};
+        }
+        &:hover svg * {
+          fill: ${overwrittenVars.colorPrimary25};
+        }
+      `;
+    default:
+      return '';
+  }
+};
+
+const getBaseStyles = props => {
+  const overwrittenVars = {
+    ...vars,
+    ...props.theme,
+  };
+
+  return [
+    css`
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    `,
+    getColorStyle(props, overwrittenVars),
+    getDisabledStyle(overwrittenVars),
+  ];
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export { getBaseStyles };

--- a/src/components/buttons/secondary-icon-button/secondary-icon-button.styles.js
+++ b/src/components/buttons/secondary-icon-button/secondary-icon-button.styles.js
@@ -31,14 +31,18 @@ const getColorStyle = (props, overwrittenVars) => {
         }
       `;
     default:
-      return '';
+      return css`
+        svg * {
+          fill: ${overwrittenVars.colorSolid};
+        }
+      `;
   }
 };
 
-const getBaseStyles = props => {
+const getBaseStyles = (theme, props) => {
   const overwrittenVars = {
     ...vars,
-    ...props.theme,
+    ...theme,
   };
 
   return [

--- a/src/components/buttons/secondary-icon-button/secondary-icon-button.visualroute.js
+++ b/src/components/buttons/secondary-icon-button/secondary-icon-button.visualroute.js
@@ -47,5 +47,12 @@ export const component = ({ themes }) => (
         color="primary"
       />
     </Spec>
+    <Spec label="with small Icon">
+      <SecondaryIconButton
+        icon={<InformationIcon size="small" />}
+        label="A label text"
+        onClick={() => {}}
+      />
+    </Spec>
   </Suite>
 );

--- a/src/components/buttons/secondary-icon-button/secondary-icon-button.visualroute.js
+++ b/src/components/buttons/secondary-icon-button/secondary-icon-button.visualroute.js
@@ -22,6 +22,46 @@ export const component = ({ themes }) => (
         isDisabled={true}
       />
     </Spec>
+    <Spec label="size - small">
+      <SecondaryIconButton
+        icon={<InformationIcon />}
+        label="A label text"
+        onClick={() => {}}
+        size="small"
+      />
+    </Spec>
+    <Spec label="size - medium">
+      <SecondaryIconButton
+        icon={<InformationIcon />}
+        label="A label text"
+        onClick={() => {}}
+        size="medium"
+      />
+    </Spec>
+    <Spec label="size - big">
+      <SecondaryIconButton
+        icon={<InformationIcon />}
+        label="A label text"
+        onClick={() => {}}
+        size="big"
+      />
+    </Spec>
+    <Spec label="color - solid">
+      <SecondaryIconButton
+        icon={<InformationIcon />}
+        label="A label text"
+        onClick={() => {}}
+        color="solid"
+      />
+    </Spec>
+    <Spec label="color - primary">
+      <SecondaryIconButton
+        icon={<InformationIcon />}
+        label="A label text"
+        onClick={() => {}}
+        color="primary"
+      />
+    </Spec>
     <ThemeProvider theme={themes.darkTheme}>
       <Spec label="with custom (dark) theme">
         <SecondaryIconButton

--- a/src/components/buttons/secondary-icon-button/secondary-icon-button.visualroute.js
+++ b/src/components/buttons/secondary-icon-button/secondary-icon-button.visualroute.js
@@ -31,30 +31,6 @@ export const component = ({ themes }) => (
         />
       </Spec>
     </ThemeProvider>
-    <Spec label="size - small">
-      <SecondaryIconButton
-        icon={<InformationIcon />}
-        label="A label text"
-        onClick={() => {}}
-        size="small"
-      />
-    </Spec>
-    <Spec label="size - medium">
-      <SecondaryIconButton
-        icon={<InformationIcon />}
-        label="A label text"
-        onClick={() => {}}
-        size="medium"
-      />
-    </Spec>
-    <Spec label="size - big">
-      <SecondaryIconButton
-        icon={<InformationIcon />}
-        label="A label text"
-        onClick={() => {}}
-        size="big"
-      />
-    </Spec>
     <Spec label="color - solid">
       <SecondaryIconButton
         icon={<InformationIcon />}

--- a/src/components/buttons/secondary-icon-button/secondary-icon-button.visualroute.js
+++ b/src/components/buttons/secondary-icon-button/secondary-icon-button.visualroute.js
@@ -22,6 +22,15 @@ export const component = ({ themes }) => (
         isDisabled={true}
       />
     </Spec>
+    <ThemeProvider theme={themes.darkTheme}>
+      <Spec label="with custom (dark) theme">
+        <SecondaryIconButton
+          icon={<InformationIcon />}
+          label="A label text"
+          onClick={() => {}}
+        />
+      </Spec>
+    </ThemeProvider>
     <Spec label="size - small">
       <SecondaryIconButton
         icon={<InformationIcon />}
@@ -62,14 +71,5 @@ export const component = ({ themes }) => (
         color="primary"
       />
     </Spec>
-    <ThemeProvider theme={themes.darkTheme}>
-      <Spec label="with custom (dark) theme">
-        <SecondaryIconButton
-          icon={<InformationIcon />}
-          label="A label text"
-          onClick={() => {}}
-        />
-      </Spec>
-    </ThemeProvider>
   </Suite>
 );


### PR DESCRIPTION
#### Summary

Adds new `color` props to the SecondaryIconButton. The defaults are the same as before, to avoid breaking changes.

The size can be adjusted directly by the `Icon` element prop that is passed to the button.

Fixes #879