### PR TITLE
fix(date-time-input): Today button not highlighting today's date

### DIFF
--- a/src/components/inputs/date-time-input/date-time-input.js
+++ b/src/components/inputs/date-time-input/date-time-input.js
@@ -13,7 +13,6 @@ import Constraints from '../../constraints';
 import messages from './messages';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import {
-  getDaysInMonth,
   changeTime,
   formatTime,
   getDateInMonth,
@@ -99,7 +98,7 @@ class DateTimeInput extends React.Component {
         calendarDate: today,
         highlightedIndex:
           prevState.suggestedItems.length +
-          getDaysInMonth(today, this.props.timeZone) -
+          getDateInMonth(today, this.props.timeZone) -
           1,
       }),
       () => this.inputRef.current.focus()


### PR DESCRIPTION
We found a bug where the Today button in `DateTimeInput` would not highlight today's date, but the last day of the month instead.

This fixes that, and also for `DateTimeField`, as it is built with the input component.