### PR TITLE
refactor: improve `useToggleState` and use it across our components

### DIFF
--- a/src/components/dropdowns/primary-action-dropdown/primary-action-dropdown.js
+++ b/src/components/dropdowns/primary-action-dropdown/primary-action-dropdown.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import invariant from 'tiny-invariant';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
+import useToggleState from '../../../hooks/use-toggle-state';
 import vars from '../../../../materials/custom-properties';
 import Text from '../../typography/text';
 import { CaretDownIcon, CaretUpIcon } from '../../icons';
@@ -210,7 +211,7 @@ Option.defaultProps = {
  */
 const PrimaryActionDropdown = props => {
   const ref = React.useRef();
-  const [isOpen, setIsOpen] = React.useState(false);
+  const [isOpen, toggle, setOn, setOff] = useToggleState(false);
 
   const handleGlobalClick = React.useCallback(
     event => {
@@ -220,10 +221,10 @@ const PrimaryActionDropdown = props => {
         event.target !== dropdownButton &&
         !dropdownButton.contains(event.target)
       ) {
-        setIsOpen(false);
+        setOff();
       }
     },
-    [ref]
+    [ref, setOff]
   );
   React.useEffect(() => {
     window.addEventListener('click', handleGlobalClick);
@@ -241,16 +242,16 @@ const PrimaryActionDropdown = props => {
   const handleClickOnHead = React.useCallback(
     event => {
       if (isOpen) {
-        setIsOpen(false);
+        setOn();
       } else {
         onClick(event);
       }
     },
-    [isOpen, onClick]
+    [isOpen, onClick, setOn]
   );
   const handleClickOnChevron = React.useCallback(() => {
-    setIsOpen(!isOpen);
-  }, [isOpen]);
+    toggle();
+  }, [toggle]);
 
   invariant(
     childrenAsArray.length > 1,

--- a/src/components/dropdowns/primary-action-dropdown/primary-action-dropdown.js
+++ b/src/components/dropdowns/primary-action-dropdown/primary-action-dropdown.js
@@ -211,7 +211,7 @@ Option.defaultProps = {
  */
 const PrimaryActionDropdown = props => {
   const ref = React.useRef();
-  const [isOpen, toggle, setOn, setOff] = useToggleState(false);
+  const [isOpen, toggle] = useToggleState(false);
 
   const handleGlobalClick = React.useCallback(
     event => {
@@ -221,10 +221,10 @@ const PrimaryActionDropdown = props => {
         event.target !== dropdownButton &&
         !dropdownButton.contains(event.target)
       ) {
-        setOff();
+        toggle(false);
       }
     },
-    [ref, setOff]
+    [ref, toggle]
   );
   React.useEffect(() => {
     window.addEventListener('click', handleGlobalClick);
@@ -242,12 +242,12 @@ const PrimaryActionDropdown = props => {
   const handleClickOnHead = React.useCallback(
     event => {
       if (isOpen) {
-        setOn();
+        toggle(true);
       } else {
         onClick(event);
       }
     },
-    [isOpen, onClick, setOn]
+    [isOpen, onClick, toggle]
   );
   const handleClickOnChevron = React.useCallback(() => {
     toggle();

--- a/src/components/fields/password-field/password-field.js
+++ b/src/components/fields/password-field/password-field.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import requiredIf from 'react-required-if';
+import useToggleState from '../../../hooks/use-toggle-state';
 import Constraints from '../../constraints';
 import Spacings from '../../spacings';
 import FieldLabel from '../../field-label';
@@ -20,13 +21,9 @@ const hasErrors = errors => errors && Object.values(errors).some(Boolean);
 
 const PasswordField = props => {
   const intl = useIntl();
-  const [isPasswordVisible, setIsPasswordVisible] = React.useState(false);
+  const [isPasswordVisible, togglePasswordVisibility] = useToggleState(false);
   const id = getFieldId(props, {}, sequentialId);
   const hasError = props.touched && hasErrors(props.errors);
-
-  const togglePasswordVisibility = React.useCallback(() => {
-    setIsPasswordVisible(!isPasswordVisible);
-  }, [isPasswordVisible]);
 
   return (
     <Constraints.Horizontal constraint={props.horizontalConstraint}>

--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -312,20 +312,8 @@ const getCurrencyDropdownName = name =>
 
 const MoneyInput = props => {
   const intl = useIntl();
-  const [
-    currencyHasFocus,
-    // eslint-disable-next-line no-unused-vars
-    toggleCurrencyHasFocus,
-    setCurrencyHasFocusOn,
-    setCurrencyHasFocusOff,
-  ] = useToggleState(false);
-  const [
-    amountHasFocus,
-    // eslint-disable-next-line no-unused-vars
-    toggleAmountHasFocus,
-    setAmountHasFocusOn,
-    setAmountHasFocusOff,
-  ] = useToggleState(false);
+  const [currencyHasFocus, toggleCurrencyHasFocus] = useToggleState(false);
+  const [amountHasFocus, toggleAmountHasFocus] = useToggleState(false);
 
   const containerRef = React.useRef();
   const amountInputRef = React.useRef();
@@ -339,13 +327,13 @@ const MoneyInput = props => {
           name: getAmountInputName(props.name),
         },
       });
-    setAmountHasFocusOn();
-  }, [setAmountHasFocusOn, onFocus, props.id, props.name]);
+    toggleAmountHasFocus(true);
+  }, [toggleAmountHasFocus, onFocus, props.id, props.name]);
 
   const { onChange } = props;
   const handleAmountBlur = React.useCallback(() => {
     const amount = props.value.amount.trim();
-    setAmountHasFocusOff();
+    toggleAmountHasFocus(false);
     // Skip formatting for empty value or when the input is used with an
     // unknown currency.
     if (amount.length > 0 && currencies[props.value.currencyCode]) {
@@ -377,7 +365,7 @@ const MoneyInput = props => {
     props.name,
     props.value.amount,
     props.value.currencyCode,
-    setAmountHasFocusOff,
+    toggleAmountHasFocus,
   ]);
 
   const handleAmountChange = React.useCallback(
@@ -463,12 +451,12 @@ const MoneyInput = props => {
         },
       });
 
-    setCurrencyHasFocusOn();
-  }, [onFocus, setCurrencyHasFocusOn, props.name, props.id]);
+    toggleCurrencyHasFocus(true);
+  }, [onFocus, toggleCurrencyHasFocus, props.name, props.id]);
 
   const handleCurrencyBlur = React.useCallback(() => {
-    setCurrencyHasFocusOff();
-  }, [setCurrencyHasFocusOff]);
+    toggleCurrencyHasFocus(false);
+  }, [toggleCurrencyHasFocus]);
 
   const hasNoCurrencies = props.currencies.length === 0;
   const hasFocus = currencyHasFocus || amountHasFocus;

--- a/src/components/internals/calendar-body/calendar-body.js
+++ b/src/components/internals/calendar-body/calendar-body.js
@@ -32,52 +32,46 @@ ClearSection.propTypes = {
 };
 
 export const CalendarBody = props => {
-  const [
-    isFocused,
-    // eslint-disable-next-line no-unused-vars
-    toggleIsFocused,
-    setIsFocusedOn,
-    setIsFocusedOff,
-  ] = useToggleState(false);
+  const [isFocused, toggleIsFocused] = useToggleState(false);
 
   const { onFocus: onInputFocus } = props.inputProps;
 
   const handleInputFocus = React.useCallback(
     event => {
-      setIsFocusedOn();
+      toggleIsFocused(true);
       if (onInputFocus) onInputFocus(event);
     },
-    [onInputFocus, setIsFocusedOn]
+    [onInputFocus, toggleIsFocused]
   );
 
   const { onBlur: onInputBlur } = props.inputProps;
 
   const handleInputBlur = React.useCallback(
     event => {
-      setIsFocusedOff();
+      toggleIsFocused(false);
       if (onInputBlur) onInputBlur(event);
     },
-    [onInputBlur, setIsFocusedOff]
+    [onInputBlur, toggleIsFocused]
   );
 
   const { onFocus: onToggleFocus } = props.toggleButtonProps;
 
   const handleToggleFocus = React.useCallback(
     event => {
-      setIsFocusedOn();
+      toggleIsFocused(true);
       if (onToggleFocus) onToggleFocus(event);
     },
-    [onToggleFocus, setIsFocusedOn]
+    [onToggleFocus, toggleIsFocused]
   );
 
   const { onBlur: onToggleBlur } = props.toggleButtonProps;
 
   const handleToggleBlur = React.useCallback(
     event => {
-      setIsFocusedOff();
+      toggleIsFocused(false);
       if (onToggleBlur) onToggleBlur(event);
     },
-    [onToggleBlur, setIsFocusedOff]
+    [onToggleBlur, toggleIsFocused]
   );
 
   return (

--- a/src/components/internals/calendar-body/calendar-body.js
+++ b/src/components/internals/calendar-body/calendar-body.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { CalendarIcon, ClockIcon, CloseIcon } from '../../icons';
 import Spacings from '../../spacings';
+import useToggleState from '../../../hooks/use-toggle-state';
 import {
   getClearSectionStyles,
   getCalendarIconContainerStyles,
@@ -31,46 +32,52 @@ ClearSection.propTypes = {
 };
 
 export const CalendarBody = props => {
-  const [isFocused, setIsFocused] = React.useState(false);
+  const [
+    isFocused,
+    // eslint-disable-next-line no-unused-vars
+    toggleIsFocused,
+    setIsFocusedOn,
+    setIsFocusedOff,
+  ] = useToggleState(false);
 
   const { onFocus: onInputFocus } = props.inputProps;
 
   const handleInputFocus = React.useCallback(
     event => {
-      setIsFocused(true);
+      setIsFocusedOn();
       if (onInputFocus) onInputFocus(event);
     },
-    [onInputFocus]
+    [onInputFocus, setIsFocusedOn]
   );
 
   const { onBlur: onInputBlur } = props.inputProps;
 
   const handleInputBlur = React.useCallback(
     event => {
-      setIsFocused(false);
+      setIsFocusedOff();
       if (onInputBlur) onInputBlur(event);
     },
-    [onInputBlur]
+    [onInputBlur, setIsFocusedOff]
   );
 
   const { onFocus: onToggleFocus } = props.toggleButtonProps;
 
   const handleToggleFocus = React.useCallback(
     event => {
-      setIsFocused(true);
+      setIsFocusedOn();
       if (onToggleFocus) onToggleFocus(event);
     },
-    [onToggleFocus]
+    [onToggleFocus, setIsFocusedOn]
   );
 
   const { onBlur: onToggleBlur } = props.toggleButtonProps;
 
   const handleToggleBlur = React.useCallback(
     event => {
-      setIsFocused(false);
+      setIsFocusedOff();
       if (onToggleBlur) onToggleBlur(event);
     },
-    [onToggleBlur]
+    [onToggleBlur, setIsFocusedOff]
   );
 
   return (

--- a/src/hooks/use-toggle-state/use-toggle-state.js
+++ b/src/hooks/use-toggle-state/use-toggle-state.js
@@ -1,12 +1,21 @@
-import React from 'react';
+import { useCallback, useState } from 'react';
 
 const useToggleState = (defaultValue = true) => {
-  const [isToggled, setIsToggled] = React.useState(defaultValue);
-  const toggle = React.useCallback(() => {
-    setIsToggled(!isToggled);
-  }, [isToggled]);
+  const [isToggled, setIsToggled] = useState(defaultValue);
 
-  return [isToggled, toggle];
+  const setOn = useCallback(() => {
+    setIsToggled(true);
+  }, [setIsToggled]);
+
+  const setOff = useCallback(() => {
+    setIsToggled(false);
+  }, [setIsToggled]);
+
+  const toggle = useCallback(() => {
+    setIsToggled(!isToggled);
+  }, [isToggled, setIsToggled]);
+
+  return [isToggled, toggle, setOn, setOff];
 };
 
 export default useToggleState;

--- a/src/hooks/use-toggle-state/use-toggle-state.js
+++ b/src/hooks/use-toggle-state/use-toggle-state.js
@@ -11,9 +11,14 @@ const useToggleState = (defaultValue = true) => {
     setIsToggled(false);
   }, [setIsToggled]);
 
-  const toggle = useCallback(() => {
-    setIsToggled(!isToggled);
-  }, [isToggled, setIsToggled]);
+  const toggle = useCallback(
+    forceIsToggled => {
+      setIsToggled(
+        typeof forceIsToggled === 'boolean' ? forceIsToggled : !isToggled
+      );
+    },
+    [isToggled]
+  );
 
   return [isToggled, toggle, setOn, setOff];
 };

--- a/src/hooks/use-toggle-state/use-toggle-state.js
+++ b/src/hooks/use-toggle-state/use-toggle-state.js
@@ -3,14 +3,6 @@ import { useCallback, useState } from 'react';
 const useToggleState = (defaultValue = true) => {
   const [isToggled, setIsToggled] = useState(defaultValue);
 
-  const setOn = useCallback(() => {
-    setIsToggled(true);
-  }, [setIsToggled]);
-
-  const setOff = useCallback(() => {
-    setIsToggled(false);
-  }, [setIsToggled]);
-
   const toggle = useCallback(
     forceIsToggled => {
       setIsToggled(
@@ -20,7 +12,7 @@ const useToggleState = (defaultValue = true) => {
     [isToggled]
   );
 
-  return [isToggled, toggle, setOn, setOff];
+  return [isToggled, toggle];
 };
 
 export default useToggleState;

--- a/src/hooks/use-toggle-state/use-toggle-state.spec.js
+++ b/src/hooks/use-toggle-state/use-toggle-state.spec.js
@@ -5,11 +5,25 @@ import useToggleState from './use-toggle-state';
 const TestComponent = props => {
   // eslint-disable-next-line react/prop-types
   const [isOpen, toggle] = useToggleState(props.isDefaultOpen);
+  const setOff = React.useCallback(() => {
+    toggle(false);
+  }, [toggle]);
+
+  const setOn = React.useCallback(() => {
+    toggle(true);
+  }, [toggle]);
+
   return (
     <div>
       <div data-testid="openState">{isOpen ? 'open' : 'closed'}</div>
       <button data-testid="toggle" onClick={toggle}>
         Toggle
+      </button>
+      <button data-testid="setOff" onClick={setOff}>
+        setOff
+      </button>
+      <button data-testid="setOn" onClick={setOn}>
+        setOn
       </button>
     </div>
   );
@@ -25,6 +39,15 @@ it('should be possible to toggle the open state', () => {
   expect(getByTestId('openState')).toHaveTextContent('open');
   getByTestId('toggle').click();
   expect(getByTestId('openState')).toHaveTextContent('closed');
+});
+
+it('should be possible to set the state on and off', () => {
+  const { getByTestId } = render(<TestComponent />);
+  expect(getByTestId('openState')).toHaveTextContent('open');
+  getByTestId('setOff').click();
+  expect(getByTestId('openState')).toHaveTextContent('closed');
+  getByTestId('setOn').click();
+  expect(getByTestId('openState')).toHaveTextContent('open');
 });
 
 it('should respect the default closed state', () => {


### PR DESCRIPTION
#### Summary

Updates `useToggleState` hook's `toggle` function to accept an option arg that can be used to force the state.

Refactors various components (`MoneyInput`, `PrimaryActionDropdown`, `PasswordField` and `CalendarBody`) to use this hook instead of custom toggle logic.