### PR TITLE
chore(select-input): add test for when autoFocussed is true

### DIFF
--- a/src/components/inputs/select-input/select-input.spec.js
+++ b/src/components/inputs/select-input/select-input.spec.js
@@ -116,6 +116,26 @@ describe('in single mode', () => {
     });
   });
   describe('interacting', () => {
+    describe('when isAutofocussed is `true`', () => {
+      it('should open the list and all options should be visible', () => {
+        const { getByLabelText, getByText } = renderInput({
+          isAutofocussed: true,
+        });
+
+        const input = getByLabelText('Fruit');
+
+        fireEvent.blur(input);
+
+        fireEvent.keyDown(input, {
+          key: 'ArrowDown',
+          keyCode: 40,
+        });
+
+        expect(getByText('Mango')).toBeInTheDocument();
+        expect(getByText('Lichi')).toBeInTheDocument();
+        expect(getByText('Raspberry')).toBeInTheDocument();
+      });
+    });
     it('should open the list and all options should be visible', () => {
       const { getByLabelText, getByText } = renderInput();
       const input = getByLabelText('Fruit');

--- a/src/components/inputs/select-input/select-input.spec.js
+++ b/src/components/inputs/select-input/select-input.spec.js
@@ -128,7 +128,6 @@ describe('in single mode', () => {
 
         fireEvent.keyDown(input, {
           key: 'ArrowDown',
-          keyCode: 40,
         });
 
         expect(getByText('Mango')).toBeInTheDocument();


### PR DESCRIPTION
#### Summary

Adds test case with `isAutofocussed` to `SelectInput` 

Closes #897 

Big thanks to @iamchanii and the help in https://github.com/JedWatson/react-select/issues/3655#issuecomment-518158533