### PR TITLE
Fix MoneyInput's parsing

### DIFF
--- a/src/components/inputs/money-input/money-input.js
+++ b/src/components/inputs/money-input/money-input.js
@@ -185,26 +185,23 @@ const createCurrencySelectStyles = ({
 // position of `.` and `,`. Whatever occurs later is used as the decimal
 // separator.
 export const parseRawAmountToNumber = (rawAmount, locale) => {
-  let throwaway;
-  let separator;
+  let fractionsSeparator;
 
   if (locale) {
-    [throwaway, separator] = (9999.999) // we need any number that has more than 3 digits to show the thousand sepirator, and has fractions
-      .toLocaleString(locale) // after this step (localizing it) it'll be either 9,999.999 or 9.999,999 based in the locale
-      .replace(/9/g, '') // then we remove the number `9` to endup with `,.` or `.,`
-      .split('')
-      .map(symbol => (symbol === '.' ? '\\.' : symbol)); // here we escape the '.' to use it as regex
+    fractionsSeparator = (2.5) // we need any number with fractions, so that we know what is the fraction
+      .toLocaleString(locale) // "symbol" for the provided locale
+      .replace(/\d/g, ''); // then we remove the numbers and keep the "symbol"
   } else {
     const lastDot = String(rawAmount).lastIndexOf('.');
     const lastComma = String(rawAmount).lastIndexOf(',');
-
-    separator = lastComma > lastDot ? ',' : '.';
-    throwaway = separator === '.' ? ',' : '\\.';
+    fractionsSeparator = lastComma > lastDot ? ',' : '.';
   }
+
+  fractionsSeparator = fractionsSeparator === '.' ? '\\.' : fractionsSeparator; // here we escape the '.' to use it as regex
   // The raw amount with only one sparator
   const normalizedAmount = String(rawAmount)
-    .replace(new RegExp(`${throwaway}`, 'g'), '')
-    .replace(separator, '.');
+    .replace(new RegExp(`[^0-9${fractionsSeparator}]`, 'g'), '') // we just keep the numbers and the fraction symbol
+    .replace(fractionsSeparator, '.'); // then we change whatever `fractionsSeparator` was to `.` so we can parse it as float
 
   return parseFloat(normalizedAmount, 10);
 };

--- a/src/components/inputs/money-input/money-input.spec.js
+++ b/src/components/inputs/money-input/money-input.spec.js
@@ -304,6 +304,21 @@ describe('MoneyInput.parseMoneyValue', () => {
       );
     });
   });
+  describe('when called with a locale that uses comma as fraction separator', () => {
+    it('should parse the value according to the passed locale', () => {
+      expect(
+        MoneyInput.parseMoneyValue(
+          {
+            type: 'highPrecision',
+            currencyCode: 'EUR',
+            fractionDigits: 3,
+            preciseAmount: 1234567,
+          },
+          'es'
+        )
+      ).toEqual({ amount: '1.234,567', currencyCode: 'EUR' });
+    });
+  });
 
   describe('when called with a minimal, valid centPrecision price', () => {
     it('should turn it into a value', () => {


### PR DESCRIPTION

<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

In this PR we fix the issue explained thoroughly in  #1017 
which causes wrong parsing in `es` locale
The issue only happens to my knowledge in the `es` locale, and that's because in `es` there is no thousands separator for 4 digits numbers and the number that we used for figuring out the separation symbol was 4 digits number.
The issue could've been solved easily by making the number 5 or 6 digits, but the new implementation which uses the fractions separator only made more sense to me.

Currently, our test env can only provide `en` locale, that's why we can't add unit tests for this issue