### PR TITLE
feat(tooltip): expose Popper.js modifiers

### DIFF
--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -100,17 +100,44 @@ In the following example, the tooltip text only appears on hover when the button
 </Tooltip>
 ```
 
+### Fine-tuning underlying Popper.js behavior
+
+This component uses [Popper.js](https://popper.js.org/) under the hood. Popper provides a way to adjust how tooltip element should behave, by providing a [set of `modifiers`][modifiers-doc].
+
+For instance, forcing tooltip to stay in the original placement and not to try flipping when it's getting out of boundaries, can be implemented as follows:
+
+```js
+<Tooltip
+  placement="left"
+  title="I will always be on the left side"
+  modifiers={{
+    preventOverflow: {
+      enabled: false,
+      }
+    flip: {
+      enabled: false,
+    },
+  }}
+>
+  <button disabled={props.isDisabled}>Submit</button>
+</Tooltip>
+```
+
 #### Properties
 
-| Props                  | Type     | Required | Values                                                                                                                                       | Default | Description                                                                                     |
-| ---------------------- | -------- | :------: | -------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------- |
-| `off`                  | `bool`   |    -     | -                                                                                                                                            | false   | Whether or not the tooltip opens and closes as a result of event listeners.                     |
-| `isOpen`               | `bool`   |    -     | -                                                                                                                                            | -       | If passed, the tooltip's open and closed states are controlled by this prop                     |
-| `closeAfter`           | `number` |    -     | -                                                                                                                                            | 0       | Delay (in milliseconds) between the end of the user interaction, and the closing of the tooltip |
-| `onOpen`               | `func`   |    -     | -                                                                                                                                            | -       | Called when the tooltip is opened                                                               |
-| `onClose`              | `func`   |    -     | -                                                                                                                                            | -       | Called after the tooltip is closed                                                              |
-| `position`             | `object` |    -     | `top`, `top-start`, `top-end`, `right`, `right-start`, `right-end`, `bottom`, `bottom-end`, `bottom-start`, `left`, `left-start`, `left-end` | `top`   | How the tooltip is positioned relative to the child element                                     |
-| `horizontalConstraint` | `object` |    -     | `xs`, `s`, `m`, `l`, `xl`, `scale`                                                                                                           | `scale` | Horizontal size limit of the tooltip                                                            |
-| `children`             | `node`   |    ✅    | -                                                                                                                                            | -       | Content rendered within the tooltip                                                             |
-| `components`           | `object` |    -     | `WrapperComponent`, `BodyComponent`                                                                                                          | -       | If passed, the tooltip will wrap your component with this element                               |
-| `styles.body`          | `object` |    -     | -                                                                                                                                            | -       | If passed, these styles will be spread onto the div surrounding the tooltip body                |
+| Props                  | Type     | Required | Values                                                                                                                                       | Default | Description                                                                                                                                                 |
+| ---------------------- | -------- | :------: | -------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `off`                  | `bool`   |    -     | -                                                                                                                                            | false   | Whether or not the tooltip opens and closes as a result of event listeners.                                                                                 |
+| `isOpen`               | `bool`   |    -     | -                                                                                                                                            | -       | If passed, the tooltip's open and closed states are controlled by this prop                                                                                 |
+| `closeAfter`           | `number` |    -     | -                                                                                                                                            | 0       | Delay (in milliseconds) between the end of the user interaction, and the closing of the tooltip                                                             |
+| `onOpen`               | `func`   |    -     | -                                                                                                                                            | -       | Called when the tooltip is opened                                                                                                                           |
+| `onClose`              | `func`   |    -     | -                                                                                                                                            | -       | Called after the tooltip is closed                                                                                                                          |
+| `position`             | `object` |    -     | `top`, `top-start`, `top-end`, `right`, `right-start`, `right-end`, `bottom`, `bottom-end`, `bottom-start`, `left`, `left-start`, `left-end` | `top`   | How the tooltip is positioned relative to the child element                                                                                                 |
+| `horizontalConstraint` | `object` |    -     | `xs`, `s`, `m`, `l`, `xl`, `scale`                                                                                                           | `scale` | Horizontal size limit of the tooltip                                                                                                                        |
+| `children`             | `node`   |    ✅    | -                                                                                                                                            | -       | Content rendered within the tooltip                                                                                                                         |
+| `components`           | `object` |    -     | `WrapperComponent`, `BodyComponent`                                                                                                          | -       | If passed, the tooltip will wrap your component with this element                                                                                           |
+| `styles.body`          | `object` |    -     | -                                                                                                                                            | -       | If passed, these styles will be spread onto the div surrounding the tooltip body                                                                            |
+| `modifiers`            | `object` |    -     | -                                                                                                                                            | -       | Provides a way to fine-tune an appearance of underlying Popper tooltip element. For more information, please check [Popper.js documentation][modifiers-doc] |
+|                        |          |          |                                                                                                                                              |         |                                                                                                                                                             |
+
+[modifiers-doc]: https://popper.js.org/popper-documentation.html#modifiers

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -36,7 +36,10 @@ const Tooltip = props => {
     };
   }, []);
 
-  const { reference, popper } = usePopper({ placement: props.placement });
+  const { reference, popper } = usePopper({
+    placement: props.placement,
+    modifiers: props.modifiers,
+  });
   const [isOpen, toggle] = useToggleState(false);
   const closeTooltip = React.useCallback(() => {
     toggle(false);
@@ -245,6 +248,82 @@ Tooltip.propTypes = {
       }
       return null;
     },
+  }),
+  modifiers: PropTypes.shape({
+    shift: PropTypes.shape({
+      order: PropTypes.number,
+      enabled: PropTypes.bool,
+      fn: PropTypes.func,
+    }),
+    offset: PropTypes.shape({
+      order: PropTypes.number,
+      enabled: PropTypes.bool,
+      fn: PropTypes.func,
+      offset: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    }),
+    preventOverflow: PropTypes.shape({
+      order: PropTypes.number,
+      enabled: PropTypes.bool,
+      fn: PropTypes.func,
+      priority: PropTypes.arrayOf(['left', 'right', 'top', 'bottom']),
+      padding: PropTypes.number,
+      boundariesElement: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.instanceOf(HTMLElement),
+      ]),
+    }),
+    keepTogether: PropTypes.shape({
+      order: PropTypes.number,
+      enabled: PropTypes.bool,
+      fn: PropTypes.func,
+    }),
+    arrow: PropTypes.shape({
+      order: PropTypes.number,
+      enabled: PropTypes.bool,
+      fn: PropTypes.func,
+      element: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.instanceOf(HTMLElement),
+      ]),
+    }),
+    flip: PropTypes.shape({
+      order: PropTypes.number,
+      enabled: PropTypes.bool,
+      fn: PropTypes.func,
+      behavior: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.string),
+      ]),
+      padding: PropTypes.number,
+      boundariesElement: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.instanceOf(HTMLElement),
+      ]),
+    }),
+    inner: PropTypes.shape({
+      order: PropTypes.number,
+      enabled: PropTypes.bool,
+      fn: PropTypes.func,
+    }),
+    hide: PropTypes.shape({
+      order: PropTypes.number,
+      enabled: PropTypes.bool,
+      fn: PropTypes.func,
+    }),
+    computeStyle: PropTypes.shape({
+      order: PropTypes.number,
+      enabled: PropTypes.bool,
+      fn: PropTypes.func,
+      gpuAcceleration: PropTypes.bool,
+      x: PropTypes.number,
+      y: PropTypes.number,
+    }),
+    applyStyle: PropTypes.shape({
+      order: PropTypes.number,
+      enabled: PropTypes.bool,
+      fn: PropTypes.func,
+      onLoad: PropTypes.func,
+    }),
   }),
 };
 

--- a/vendors/package-lock.json
+++ b/vendors/package-lock.json
@@ -9,7 +9,7 @@
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.0.tgz",
       "integrity": "sha512-LGLpSsbkHUT0T+EKrIJltYoejYzUqg1eW+n6wm/FTte1pDiYjeKTxO0uJvrE3jgv6V9eBzMAjF6A8jH16C0+eQ==",
       "requires": {
-        "icu4c-data": "^0.63.2"
+        "icu4c-data": "^0.64.2"
       }
     },
     "icu4c-data": {


### PR DESCRIPTION
Popper.js, which our Tooltip relies on, provides a powerful way of altering tooltip behaviour by using so called modifiers: https://popper.js.org/popper-documentation.html#modifiers

In some tricky cases they can really help properly place your tooltip. Instead of extending Tooltip's API case-by-case when facing them (at the moment I need a way to provide `preventOverflow` modifier to achieve proper positioning of a tooltip in MC), I suggest just expose all of them at once.

By doing this, we are paying a price of leaking internal implementation details of Tooltip component, but on the other hand leveraging lot of power of the underlying lib.