### PR TITLE
chore: simplify localized text input

### DIFF
--- a/src/components/inputs/localized-text-input/localized-text-input.js
+++ b/src/components/inputs/localized-text-input/localized-text-input.js
@@ -7,7 +7,6 @@ import { css } from '@emotion/core';
 import useToggleState from '../../../hooks/use-toggle-state';
 import useFieldId from '../../../hooks/use-field-id';
 import ErrorMessage from '../../messages/error-message';
-import filterDataAttributes from '../../../utils/filter-data-attributes';
 import Spacings from '../../spacings';
 import Constraints from '../../constraints';
 import Text from '../../typography/text';
@@ -74,24 +73,9 @@ const LocalizedInput = props => {
         </Text.Detail>
       </label>
       <TextInput
-        id={props.id}
-        name={props.name}
-        autoComplete={props.autoComplete}
-        type="text"
-        value={props.value}
+        {...props}
         onChange={handleChange}
-        onBlur={props.onBlur}
-        onFocus={props.onFocus}
-        disabled={props.isDisabled}
-        placeholder={props.placeholder}
-        css={theme => getLocalizedInputStyles(props, theme)}
-        readOnly={props.isReadOnly}
-        autoFocus={props.isAutofocussed}
-        /* ARIA */
-        aria-readonly={props.isReadOnly}
-        role="textbox"
-        contentEditable={!props.isReadOnly}
-        {...filterDataAttributes(props)}
+        css={getLocalizedInputStyles}
       />
     </div>
   );

--- a/src/components/inputs/localized-text-input/localized-text-input.js
+++ b/src/components/inputs/localized-text-input/localized-text-input.js
@@ -24,6 +24,7 @@ import {
 } from '../../../utils/localized';
 import createSequentialId from '../../../utils/create-sequential-id';
 import LanguagesButton from './languages-button';
+import TextInput from '../text-input';
 import messages from './messages';
 import {
   getLocalizedInputStyles,
@@ -72,7 +73,7 @@ const LocalizedInput = props => {
           {props.language.toUpperCase()}
         </Text.Detail>
       </label>
-      <input
+      <TextInput
         id={props.id}
         name={props.name}
         autoComplete={props.autoComplete}

--- a/src/components/inputs/localized-text-input/localized-text-input.styles.js
+++ b/src/components/inputs/localized-text-input/localized-text-input.styles.js
@@ -1,14 +1,12 @@
 import { css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
 import designTokens from '../../../../materials/design-tokens';
-import { getInputStyles } from '../styles';
 
 // NOTE: order is important here
 // * a disabled-field currently does not display warning/error-states so it takes precedence
 // * a readonly-field cannot be changed, but it might be relevant for validation, so error and warning are checked first
 // how you can interact with the field is controlled separately by the props, this only influences visuals
-const getLocalizedInputStyles = (props, theme) => [
-  getInputStyles(props, theme),
+const getLocalizedInputStyles = () => [
   css`
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;

--- a/src/components/inputs/text-input/README.md
+++ b/src/components/inputs/text-input/README.md
@@ -19,6 +19,7 @@ import { TextInput } from '@commercetools-frontend/ui-kit';
 | ---------------------- | -------- | :------: | ---------------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
 | `id`                   | `string` |    -     | -                            | -       | Used as HTML `id` property                                                                             |
 | `name`                 | `string` |    -     | -                            | -       | Used as HTML `name` property                                                                           |
+| `className`            | `string` |    -     | -                            | -       | Used as HTML `className` property                                                                      |
 | `value`                | `string` |    ✅    | -                            | -       | Value of the input                                                                                     |
 | `autoComplete`         | `string` |    -     | -                            | -       | Used as HTML `autocomplete` property                                                                   |
 | `onChange`             | `func`   |    -     | -                            | -       | Called with the new value. Required when input is not read only. Parent should pass it back as `value` |

--- a/src/components/inputs/text-input/README.md
+++ b/src/components/inputs/text-input/README.md
@@ -19,7 +19,6 @@ import { TextInput } from '@commercetools-frontend/ui-kit';
 | ---------------------- | -------- | :------: | ---------------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
 | `id`                   | `string` |    -     | -                            | -       | Used as HTML `id` property                                                                             |
 | `name`                 | `string` |    -     | -                            | -       | Used as HTML `name` property                                                                           |
-| `className`            | `string` |    -     | -                            | -       | Used as HTML `className` property                                                                      |
 | `value`                | `string` |    ✅    | -                            | -       | Value of the input                                                                                     |
 | `autoComplete`         | `string` |    -     | -                            | -       | Used as HTML `autocomplete` property                                                                   |
 | `onChange`             | `func`   |    -     | -                            | -       | Called with the new value. Required when input is not read only. Parent should pass it back as `value` |

--- a/src/components/inputs/text-input/text-input.js
+++ b/src/components/inputs/text-input/text-input.js
@@ -5,35 +5,39 @@ import filterDataAttributes from '../../../utils/filter-data-attributes';
 import Constraints from '../../constraints';
 import { getInputStyles } from '../styles';
 
-const TextInput = props => (
-  <Constraints.Horizontal constraint={props.horizontalConstraint}>
-    <input
-      id={props.id}
-      name={props.name}
-      type="text"
-      value={props.value}
-      onChange={props.onChange}
-      onBlur={props.onBlur}
-      onFocus={props.onFocus}
-      disabled={props.isDisabled}
-      placeholder={props.placeholder}
-      readOnly={props.isReadOnly}
-      autoFocus={props.isAutofocussed}
-      autoComplete={props.autoComplete}
-      css={theme => getInputStyles(props, theme)}
-      {...filterDataAttributes(props)}
-      /* ARIA */
-      aria-readonly={props.isReadOnly}
-      role="textbox"
-      contentEditable={!props.isReadOnly}
-    />
-  </Constraints.Horizontal>
-);
+const TextInput = props => {
+  return (
+    <Constraints.Horizontal constraint={props.horizontalConstraint}>
+      <input
+        id={props.id}
+        name={props.name}
+        type="text"
+        value={props.value}
+        onChange={props.onChange}
+        className={props.className}
+        onBlur={props.onBlur}
+        onFocus={props.onFocus}
+        disabled={props.isDisabled}
+        placeholder={props.placeholder}
+        readOnly={props.isReadOnly}
+        autoFocus={props.isAutofocussed}
+        autoComplete={props.autoComplete}
+        css={theme => getInputStyles(props, theme)}
+        {...filterDataAttributes(props)}
+        /* ARIA */
+        aria-readonly={props.isReadOnly}
+        role="textbox"
+        contentEditable={!props.isReadOnly}
+      />
+    </Constraints.Horizontal>
+  );
+};
 
 TextInput.displayName = 'TextInput';
 
 TextInput.propTypes = {
   autoComplete: PropTypes.string,
+  className: PropTypes.string,
   id: PropTypes.string,
   name: PropTypes.string,
   value: PropTypes.string.isRequired,


### PR DESCRIPTION
#### Summary

Uses `TextInput` in our `LocalizedTextInput`, instead of our current approach of copy pasting the component.

Adds the `className` field to `TextInput`