### PR TITLE
chore(storybook): fix deprecation warning

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -33,7 +33,7 @@ module.exports = ({ config }) => {
     // add story source
     {
       test: /\.story\.js$/,
-      loaders: [require.resolve('@storybook/addon-storysource/loader')],
+      loaders: [require.resolve('@storybook/source-loader')],
       enforce: 'pre',
     },
     // Process JS with Babel.


### PR DESCRIPTION
#### Summary

Just removes this annoying warning from building storybook.

DeprecationWarning: @storybook/addon-storysource/loader is deprecated, please use @storybook/source-loader instead.