### PR TITLE
refactor(multiline-text-input): move internal

### DIFF
--- a/src/components/inputs/localized-multiline-text-input/translation-input.js
+++ b/src/components/inputs/localized-multiline-text-input/translation-input.js
@@ -91,6 +91,8 @@ const TranslationInput = props => {
           isDisabled={props.isDisabled}
           placeholder={props.placeholder}
           css={theme => getTextareaStyles(props, theme)}
+          hasError={props.hasError}
+          hasWarning={props.hasWarning}
           isReadOnly={props.isReadOnly}
           isAutofocussed={props.isAutofocussed}
           isOpen={!props.isCollapsed}

--- a/src/components/inputs/localized-multiline-text-input/translation-input.js
+++ b/src/components/inputs/localized-multiline-text-input/translation-input.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import TextareaAutosize from 'react-textarea-autosize';
 import requiredIf from 'react-required-if';
 import { css } from '@emotion/core';
+import MultilineInput from '../../internals/multiline-input';
 import FlatButton from '../../buttons/flat-button';
 import { AngleUpIcon } from '../../icons';
 import Spacings from '../../spacings';
@@ -79,28 +79,21 @@ const TranslationInput = props => {
             {props.language.toUpperCase()}
           </Text.Detail>
         </label>
-        <TextareaAutosize
+        <MultilineInput
           id={props.id}
           name={props.name}
           autoComplete={props.autoComplete}
-          type="text"
           value={props.value}
           onChange={handleChange}
           onHeightChange={handleHeightChange}
           onBlur={props.onBlur}
           onFocus={handleFocus}
-          disabled={props.isDisabled}
+          isDisabled={props.isDisabled}
           placeholder={props.placeholder}
           css={theme => getTextareaStyles(props, theme)}
-          readOnly={props.isReadOnly}
-          autoFocus={props.isAutofocussed}
-          /* ARIA */
-          aria-readonly={props.isReadOnly}
-          role="textbox"
-          minRows={TranslationInput.MIN_ROW_COUNT}
-          maxRows={
-            props.isCollapsed ? TranslationInput.MIN_ROW_COUNT : undefined
-          }
+          isReadOnly={props.isReadOnly}
+          isAutofocussed={props.isAutofocussed}
+          isOpen={!props.isCollapsed}
           {...filterDataAttributes(props)}
         />
       </div>

--- a/src/components/inputs/localized-multiline-text-input/translation-input.styles.js
+++ b/src/components/inputs/localized-multiline-text-input/translation-input.styles.js
@@ -1,27 +1,16 @@
 import { css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
 import designTokens from '../../../../materials/design-tokens';
-import { getInputStyles } from '../styles';
-
-/* we need this line-height to achieve 32px height when the component has only one row */
-const sizeInputLineHeight = '22px';
 
 // NOTE: order is important here
 // * a disabled-field currently does not display warning/error-states so it takes precedence
 // * a readonly-field cannot be changed, but it might be relevant for validation, so error and warning are checked first
 // how you can interact with the field is controlled separately by the props, this only influences visuals
-const getTextareaStyles = (props, theme) => {
+const getTextareaStyles = props => {
   const baseStyles = [
-    getInputStyles(props, theme),
     css`
       border-top-left-radius: 0;
       border-bottom-left-radius: 0;
-      flex: auto;
-      line-height: ${sizeInputLineHeight};
-      padding: ${vars.spacingXs} ${vars.spacingS};
-      word-break: break-all;
-      white-space: pre-wrap;
-      resize: vertical;
     `,
     props.isCollapsed &&
       css`

--- a/src/components/inputs/multiline-text-input/multiline-text-input.js
+++ b/src/components/inputs/multiline-text-input/multiline-text-input.js
@@ -52,6 +52,8 @@ const MultilineTextInput = props => {
           onBlur={props.onBlur}
           onFocus={handleFocus}
           isDisabled={props.isDisabled}
+          hasError={props.hasError}
+          hasWarning={props.hasWarning}
           placeholder={props.placeholder}
           isReadOnly={props.isReadOnly}
           isAutofocussed={props.isAutofocussed}

--- a/src/components/inputs/multiline-text-input/multiline-text-input.js
+++ b/src/components/inputs/multiline-text-input/multiline-text-input.js
@@ -10,7 +10,6 @@ import filterDataAttributes from '../../../utils/filter-data-attributes';
 import useToggleState from '../../../hooks/use-toggle-state';
 import Spacings from '../../spacings';
 import Constraints from '../../constraints';
-import { getTextareaStyles } from './multiline-text-input.styles';
 import messages from './messages';
 
 const MultilineTextInput = props => {
@@ -49,7 +48,6 @@ const MultilineTextInput = props => {
           value={props.value}
           onChange={props.onChange}
           onHeightChange={handleHeightChange}
-          css={theme => getTextareaStyles(props, theme)}
           id={props.id}
           onBlur={props.onBlur}
           onFocus={handleFocus}

--- a/src/components/inputs/multiline-text-input/multiline-text-input.js
+++ b/src/components/inputs/multiline-text-input/multiline-text-input.js
@@ -2,16 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import requiredIf from 'react-required-if';
 import { useIntl } from 'react-intl';
-import TextareaAutosize from 'react-textarea-autosize';
 import { css } from '@emotion/core';
+import MultilineInput from '../../internals/multiline-input';
 import FlatButton from '../../buttons/flat-button';
 import { AngleUpIcon, AngleDownIcon } from '../../icons';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import useToggleState from '../../../hooks/use-toggle-state';
 import Spacings from '../../spacings';
 import Constraints from '../../constraints';
-import messages from './messages';
 import { getTextareaStyles } from './multiline-text-input.styles';
+import messages from './messages';
 
 const MultilineTextInput = props => {
   const intl = useIntl();
@@ -43,27 +43,21 @@ const MultilineTextInput = props => {
   return (
     <Constraints.Horizontal constraint={props.horizontalConstraint}>
       <Spacings.Stack scale="xs">
-        <TextareaAutosize
+        <MultilineInput
           name={props.name}
           autoComplete={props.autoComplete}
           value={props.value}
           onChange={props.onChange}
           onHeightChange={handleHeightChange}
+          css={theme => getTextareaStyles(props, theme)}
           id={props.id}
           onBlur={props.onBlur}
           onFocus={handleFocus}
-          disabled={props.isDisabled}
+          isDisabled={props.isDisabled}
           placeholder={props.placeholder}
-          css={theme => getTextareaStyles(props, theme)}
-          readOnly={props.isReadOnly}
-          autoFocus={props.isAutofocussed}
-          /* ARIA */
-          aria-readonly={props.isReadOnly}
-          aria-multiline="true"
-          role="textbox"
-          minRows={MultilineTextInput.MIN_ROW_COUNT}
-          maxRows={isOpen ? undefined : MultilineTextInput.MIN_ROW_COUNT}
-          useCacheForDOMMeasurements={true}
+          isReadOnly={props.isReadOnly}
+          isAutofocussed={props.isAutofocussed}
+          isOpen={isOpen}
           {...filterDataAttributes(props)}
         />
         {shouldRenderToggleButton && (

--- a/src/components/internals/multiline-input/index.js
+++ b/src/components/internals/multiline-input/index.js
@@ -1,0 +1,1 @@
+export { default } from './multiline-input';

--- a/src/components/internals/multiline-input/multiline-input.js
+++ b/src/components/internals/multiline-input/multiline-input.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import requiredIf from 'react-required-if';
+import TextareaAutosize from 'react-textarea-autosize';
+import filterDataAttributes from '../../../utils/filter-data-attributes';
+
+const MIN_ROW_COUNT = 1;
+
+const MultilineInput = props => {
+  return (
+    <TextareaAutosize
+      name={props.name}
+      type="text"
+      autoComplete={props.autoComplete}
+      value={props.value}
+      onChange={props.onChange}
+      onHeightChange={props.onHeightChange}
+      id={props.id}
+      onBlur={props.onBlur}
+      onFocus={props.onFocus}
+      disabled={props.isDisabled}
+      placeholder={props.placeholder}
+      readOnly={props.isReadOnly}
+      autoFocus={props.isAutofocussed}
+      className={props.className}
+      /* ARIA */
+      aria-readonly={props.isReadOnly}
+      aria-multiline="true"
+      role="textbox"
+      minRows={MIN_ROW_COUNT}
+      maxRows={props.isOpen ? undefined : MIN_ROW_COUNT}
+      useCacheForDOMMeasurements={true}
+      {...filterDataAttributes(props)}
+    />
+  );
+};
+
+MultilineInput.displayName = 'MultilineInput';
+
+MultilineInput.propTypes = {
+  name: PropTypes.string,
+  className: PropTypes.string,
+  autoComplete: PropTypes.string,
+  id: PropTypes.string,
+  value: PropTypes.string.isRequired,
+  onChange: requiredIf(PropTypes.func, props => !props.isReadOnly),
+  onBlur: PropTypes.func,
+  onFocus: PropTypes.func,
+  isAutofocussed: PropTypes.bool,
+  isDisabled: PropTypes.bool,
+  isReadOnly: PropTypes.bool,
+  hasError: PropTypes.bool,
+  hasWarning: PropTypes.bool,
+  placeholder: PropTypes.string,
+  isOpen: PropTypes.bool.isRequired,
+  onHeightChange: PropTypes.func,
+};
+
+export default MultilineInput;

--- a/src/components/internals/multiline-input/multiline-input.js
+++ b/src/components/internals/multiline-input/multiline-input.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import requiredIf from 'react-required-if';
 import TextareaAutosize from 'react-textarea-autosize';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
+import { getTextareaStyles } from './multiline-input.styles';
 
 const MIN_ROW_COUNT = 1;
 
@@ -23,6 +24,7 @@ const MultilineInput = props => {
       readOnly={props.isReadOnly}
       autoFocus={props.isAutofocussed}
       className={props.className}
+      css={theme => getTextareaStyles(props, theme)}
       /* ARIA */
       aria-readonly={props.isReadOnly}
       aria-multiline="true"

--- a/src/components/internals/multiline-input/multiline-input.styles.js
+++ b/src/components/internals/multiline-input/multiline-input.styles.js
@@ -1,6 +1,6 @@
 import { css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
-import { getInputStyles } from '../styles';
+import { getInputStyles } from '../../inputs/styles';
 
 /* we need this line-height to achieve 32px height when the component has only one row */
 const sizeInputLineHeight = '22px';


### PR DESCRIPTION
#### Summary

Refactors the `MultilineTextInput` and `LocalizedMultilineTextInput` to use the same internal input.