### PR TITLE
fix(rich-text-input): do not fire on blur on dropdown open

### DIFF
--- a/src/components/inputs/rich-text-input/rich-text-input.story.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.story.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, boolean, text } from '@storybook/addon-knobs/react';
 import { Value } from 'slate';
+import { action } from '@storybook/addon-actions';
 import withReadme from 'storybook-readme/with-readme';
 import Spacings from '../../spacings';
 import Section from '../../../../.storybook/decorators/section';
@@ -36,6 +37,8 @@ storiesOf('Components|Inputs', module)
               false
             )}
             value={value}
+            onBlur={action('onBlur')}
+            onFocus={action('onFocus')}
             placeholder={text('placeholder', 'Placeholder')}
             hasError={boolean('hasError', false)}
             hasWarning={boolean('hasWarning', false)}

--- a/src/components/internals/rich-text-body/dropdown.js
+++ b/src/components/internals/rich-text-body/dropdown.js
@@ -82,7 +82,7 @@ const Dropdown = props => {
             >
               <AccessibleButton
                 label={props.label}
-                css={getButtonStyles({ isOpen })}
+                css={getButtonStyles({ isOpen, isStyleButton: true })}
                 {...toggleButtonProps}
                 onMouseDown={event => {
                   event.preventDefault();

--- a/src/components/internals/rich-text-body/dropdown.js
+++ b/src/components/internals/rich-text-body/dropdown.js
@@ -82,7 +82,7 @@ const Dropdown = props => {
             >
               <AccessibleButton
                 label={props.label}
-                css={getButtonStyles()}
+                css={getButtonStyles({ isOpen })}
                 {...toggleButtonProps}
                 onMouseDown={event => {
                   event.preventDefault();

--- a/src/components/internals/rich-text-body/dropdown.js
+++ b/src/components/internals/rich-text-body/dropdown.js
@@ -55,7 +55,6 @@ DropdownItem.propTypes = {
 DropdownItem.displayName = 'DropdownItem';
 
 const Dropdown = props => {
-  const buttonRef = React.useRef();
   const intl = useIntl();
 
   return (
@@ -82,15 +81,12 @@ const Dropdown = props => {
               style={{ body: { zIndex: 9999 } }}
             >
               <AccessibleButton
-                ref={buttonRef}
                 label={props.label}
                 css={getButtonStyles()}
                 {...toggleButtonProps}
                 onMouseDown={event => {
                   event.preventDefault();
                   toggleMenu();
-                  // because we can't use onClick, let's fire the focus manually
-                  if (buttonRef.current) buttonRef.current.focus();
                 }}
               >
                 <DropdownLabel>{props.label}</DropdownLabel>

--- a/src/components/internals/rich-text-body/dropdown.styles.js
+++ b/src/components/internals/rich-text-body/dropdown.styles.js
@@ -32,24 +32,21 @@ const getButtonStyles = (props = { isStyleButton: true }) => [
     &:hover {
       background-color: ${vars.colorNeutral90};
     }
-
-    &:focus {
-      outline: none;
-    }
-
-    &:hover:active,
-    &:focus {
-      background-color: ${vars.colorAccent30};
-      color: ${vars.colorSurface};
-
-      * {
-        fill: ${vars.colorSurface};
-      }
-    }
   `,
   props.isIndeterminate &&
     css`
       background-color: ${vars.colorAccent95};
+    `,
+  props.isOpen &&
+    css`
+      &:not(:hover) {
+        background-color: ${vars.colorAccent30};
+        color: ${vars.colorSurface};
+
+        * {
+          fill: ${vars.colorSurface};
+        }
+      }
     `,
 ];
 

--- a/src/components/internals/rich-text-body/multi-dropdown.js
+++ b/src/components/internals/rich-text-body/multi-dropdown.js
@@ -58,7 +58,6 @@ DropdownItem.propTypes = {
 const itemToString = item => item && item.value;
 
 const MultiDownshift = props => {
-  const buttonRef = React.useRef();
   const isIndeterminate = props.selectedItems && props.selectedItems.length > 0;
   const intl = useIntl();
 
@@ -86,16 +85,15 @@ const MultiDownshift = props => {
               <div>
                 <AccessibleButton
                   {...toggleButtonProps}
-                  ref={buttonRef}
                   label={props.label}
                   css={getButtonStyles({
                     isIndeterminate,
                     isStyleButton: false,
+                    isOpen,
                   })}
                   onMouseDown={event => {
                     event.preventDefault();
                     toggleMenu();
-                    if (buttonRef.current) buttonRef.current.focus();
                   }}
                 >
                   <MoreStylesIcon size="medium" />


### PR DESCRIPTION
#### Summary

Fixes a bug with onBlur and onFocus firing when you open / close the dropdowns in the `RichTextInput`