### PR TITLE
chore: enable percy for renovate prs

### DIFF
--- a/scripts/run-percy.sh
+++ b/scripts/run-percy.sh
@@ -3,17 +3,7 @@
 # skip percy builds when this is not a pull request or when it's not master
 if [[ -n $CIRCLE_PULL_REQUEST || ${CIRCLE_BRANCH} == 'master' ]]
   then
-  # skip percy builds when pull request is opened by a renovate
-  # if renovate opens an average of 6 PRs per week, that means, 24 PRs per month.
-  # 24 * ~50 snapshots = 1200, or almost 25% of our current percy snapshot allowances.
-  # if in the future, we drop more 💸 on percy, we can remove this.
-  regexp='^renovate\/'
-  if ! [[ ${CIRCLE_BRANCH} =~ ${regexp} ]]
-    then
-      yarn visual-testing-app:build && yarn percy --reporters jest-silent-reporter
-    else
-      echo 'Skipping percy - PR opened by `renovate`'
-  fi
+    yarn visual-testing-app:build && yarn percy --reporters jest-silent-reporter
 else
   echo 'Skipping percy build'
 fi


### PR DESCRIPTION
#### Summary

Now that renovate creates less PRs, we should make it more useful by reenabling Percy.