### PR TITLE
chore: update react-select, remove ci silencing

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "prop-types": "15.7.2",
     "react-is": "16.10.1",
     "react-required-if": "1.0.3",
-    "react-select": "3.0.5",
+    "react-select": "3.0.8",
     "react-textarea-autosize": "7.1.0",
     "react-virtualized": "9.21.1",
     "slate": "0.47.8",

--- a/test/setup-tests.js
+++ b/test/setup-tests.js
@@ -2,11 +2,6 @@ import fs from 'fs';
 import path from 'path';
 import colors from 'colors/safe';
 
-const shouldSilenceWarnings = (...messages) =>
-  [/Warning: componentWillReceiveProps has been renamed/].some(msgRegex =>
-    messages.some(msg => msgRegex.test(msg))
-  );
-
 global.window.app = {
   mcApiUrl: 'http://localhost:8080',
 };
@@ -15,10 +10,6 @@ global.window.app = {
 const logOrThrow = (log, method, messages) => {
   const warning = `console.${method} calls not allowed in tests`;
   if (process.env.CI) {
-    if (shouldSilenceWarnings(messages)) {
-      return;
-    }
-
     log(warning, '\n', ...messages);
     throw new Error(warning);
   } else {

--- a/vendors/package-lock.json
+++ b/vendors/package-lock.json
@@ -7,7 +7,15 @@
     "full-icu": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.0.tgz",
-      "integrity": "sha512-LGLpSsbkHUT0T+EKrIJltYoejYzUqg1eW+n6wm/FTte1pDiYjeKTxO0uJvrE3jgv6V9eBzMAjF6A8jH16C0+eQ=="
+      "integrity": "sha512-LGLpSsbkHUT0T+EKrIJltYoejYzUqg1eW+n6wm/FTte1pDiYjeKTxO0uJvrE3jgv6V9eBzMAjF6A8jH16C0+eQ==",
+      "requires": {
+        "icu4c-data": "^0.63.2"
+      }
+    },
+    "icu4c-data": {
+      "version": "0.63.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.63.2.tgz",
+      "integrity": "sha512-vT6/47CcBzDemlhRzkL7dZLoNvuUWjjiuKZHMt5T4dbkKAqLBh7ZQ33GU13ecC/aIcMlIdBOqtF4uIYTgWML4Q=="
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11943,6 +11943,13 @@ react-input-autosize@^2.2.1:
   dependencies:
     prop-types "^15.5.8"
 
+react-input-autosize@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.2.tgz#fcaa7020568ec206bc04be36f4eb68e647c4d8c2"
+  integrity sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==
+  dependencies:
+    prop-types "^15.5.8"
+
 react-inspector@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-3.0.2.tgz#c530a06101f562475537e47df428e1d7aff16ed8"
@@ -12045,7 +12052,21 @@ react-router@5.1.1:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-select@3.0.5, react-select@^3.0.0:
+react-select@3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.0.8.tgz#06ff764e29db843bcec439ef13e196865242e0c1"
+  integrity sha512-v9LpOhckLlRmXN5A6/mGGEft4FMrfaBFTGAnuPHcUgVId7Je42kTq9y0Z+Ye5z8/j0XDT3zUqza8gaRaI1PZIg==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@emotion/cache" "^10.0.9"
+    "@emotion/core" "^10.0.9"
+    "@emotion/css" "^10.0.9"
+    memoize-one "^5.0.0"
+    prop-types "^15.6.0"
+    react-input-autosize "^2.2.2"
+    react-transition-group "^2.2.1"
+
+react-select@^3.0.0:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.0.5.tgz#f2810e63fa8a6be375b3fa6f390284e9e33c9573"
   integrity sha512-2tBXZ1XSqbk2boMUzSmKXwGl/6W46VkSMSLMy+ShccOVyD1kDTLPwLX7lugISkRMmL0v5BcLtriXOLfYwO0otw==


### PR DESCRIPTION
#### Summary

With the latest version of `react-select`, it no longer spits out warnings about deprecated lifestyle methods.