### PR TITLE
fix(rich-text-input): use `output` instead of `div` for contenteditable

### DIFF
--- a/src/components/inputs/rich-text-input/editor.js
+++ b/src/components/inputs/rich-text-input/editor.js
@@ -103,15 +103,9 @@ const Editor = props => {
 
 // eslint-disable-next-line react/display-name
 const renderEditor = (props, editor, next) => {
-  const children = next();
-
-  const transformedChildren = {
-    ...children,
-    props: {
-      ...children.props,
-      tagName: 'output',
-    },
-  };
+  const children = React.cloneElement(next(), {
+    tagName: 'output',
+  });
 
   const passedProps = {
     name: props.name,
@@ -130,7 +124,7 @@ const renderEditor = (props, editor, next) => {
 
   return (
     <Editor editor={editor} {...passedProps}>
-      {transformedChildren}
+      {children}
     </Editor>
   );
 };

--- a/src/components/inputs/rich-text-input/editor.js
+++ b/src/components/inputs/rich-text-input/editor.js
@@ -52,7 +52,6 @@ const Editor = props => {
         ) {
           toggle();
         }
-
         return (
           <Constraints.Horizontal constraint={props.horizontalConstraint}>
             <Spacings.Stack scale="xs">
@@ -106,6 +105,14 @@ const Editor = props => {
 const renderEditor = (props, editor, next) => {
   const children = next();
 
+  const transformedChildren = {
+    ...children,
+    props: {
+      ...children.props,
+      tagName: 'output',
+    },
+  };
+
   const passedProps = {
     name: props.name,
     id: props.id,
@@ -122,8 +129,8 @@ const renderEditor = (props, editor, next) => {
   };
 
   return (
-    <Editor editor={editor} {...passedProps}>
-      {children}
+    <Editor id={props.id} editor={editor} {...passedProps}>
+      {transformedChildren}
     </Editor>
   );
 };

--- a/src/components/inputs/rich-text-input/editor.js
+++ b/src/components/inputs/rich-text-input/editor.js
@@ -129,7 +129,7 @@ const renderEditor = (props, editor, next) => {
   };
 
   return (
-    <Editor id={props.id} editor={editor} {...passedProps}>
+    <Editor editor={editor} {...passedProps}>
       {transformedChildren}
     </Editor>
   );

--- a/src/components/inputs/rich-text-input/rich-text-input.form.story.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.form.story.js
@@ -98,7 +98,10 @@ storiesOf('Examples|Forms/Inputs', module)
               />
             </Spacings.Stack>
             <Spacings.Stack scale="s">
-              <label htmlFor="coverLetter">cover letter</label>
+              <FieldLabel
+                title="Enter your cover letter"
+                htmlFor="coverLetter"
+              />
               <RichTextInput
                 id="coverLetter"
                 name="coverLetter"

--- a/src/components/inputs/rich-text-input/rich-text-input.form.story.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.form.story.js
@@ -83,7 +83,7 @@ storiesOf('Examples|Forms/Inputs', module)
               errors={formik.errors.lastName}
             />
             <Spacings.Stack scale="s">
-              <FieldLabel title="Enter your cv" />
+              <FieldLabel title="Enter your cv" htmlFor="cv" />
               <RichTextInput
                 id="cv"
                 name="cv"
@@ -98,7 +98,7 @@ storiesOf('Examples|Forms/Inputs', module)
               />
             </Spacings.Stack>
             <Spacings.Stack scale="s">
-              <FieldLabel title="Enter your cover letter" />
+              <label htmlFor="coverLetter">cover letter</label>
               <RichTextInput
                 id="coverLetter"
                 name="coverLetter"
@@ -113,7 +113,7 @@ storiesOf('Examples|Forms/Inputs', module)
               />
             </Spacings.Stack>
             <Spacings.Stack scale="s">
-              <FieldLabel title="Tell us about yourself" />
+              <FieldLabel title="Tell us about yourself" htmlFor="aboutMe" />
               <RichTextInput
                 id="aboutMe"
                 name="aboutMe"


### PR DESCRIPTION
#### Summary

This way we can use `<label>` elements to refer to our `RichTextInput`.

Big thanks to @islam3zzat 