### PR TITLE
fix(rich-text-input): performance fix

### DIFF
--- a/src/components/inputs/rich-text-input/rich-text-input.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.js
@@ -40,7 +40,6 @@ class RichTextInput extends React.PureComponent {
     next();
 
     if (this.props.onBlur) {
-      event.persist();
       setTimeout(() => this.props.onBlur(event), 0);
     }
   };
@@ -48,7 +47,6 @@ class RichTextInput extends React.PureComponent {
   onFocus = (event, editor, next) => {
     next();
     if (this.props.onFocus) {
-      event.persist();
       setTimeout(() => this.props.onFocus(event), 0);
     }
   };


### PR DESCRIPTION
#### Summary

We were getting performance warnings about setTimeout taking N ms. Removing event.persist fixed it.