### PR TITLE
fix(rich-text-input): fixes undo / redo button problem

### DIFF
--- a/src/components/internals/rich-text-body/rich-text-body-button.js
+++ b/src/components/internals/rich-text-body/rich-text-body-button.js
@@ -43,13 +43,13 @@ const RichTextBodyButton = props => {
             : vars.colorNeutral90};
         }
 
-        * {
+        svg {
           fill: ${getFillColor(props)};
         }
 
         &:disabled {
           pointer-events: none;
-          * {
+          svg {
             fill: ${vars.colorNeutral60};
           }
         }


### PR DESCRIPTION
#### Summary

Using the following css
```
* {
  fill: color
}
```

Was resulting in some flakey behaviour when the SVG contained a shadow DOM. It's weird behaviour that results in things like this.

![Screen Shot 2019-10-07 at 4 38 29 PM](https://user-images.githubusercontent.com/2425013/66379913-ae5a8b80-e9b6-11e9-9aa5-717fddfbdf75.png)

You probably are asking yourself WHERE IS THE GRAY COMING FROM? Yeah. 

More reading

https://stackoverflow.com/questions/27866893/svg-fill-not-being-applied-in-firefox

