### PR TITLE
fix(rich-text-input): fix onBlur and onFocus

### DIFF
--- a/src/components/inputs/rich-text-input/rich-text-input.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.js
@@ -40,14 +40,26 @@ class RichTextInput extends React.PureComponent {
     next();
 
     if (this.props.onBlur) {
-      setTimeout(() => this.props.onBlur(event), 0);
+      const fakeEvent = {
+        target: {
+          id: this.props.id,
+          name: this.props.name,
+        },
+      };
+      setTimeout(() => this.props.onBlur(fakeEvent), 0);
     }
   };
 
   onFocus = (event, editor, next) => {
     next();
     if (this.props.onFocus) {
-      setTimeout(() => this.props.onFocus(event), 0);
+      const fakeEvent = {
+        target: {
+          id: this.props.id,
+          name: this.props.name,
+        },
+      };
+      setTimeout(() => this.props.onFocus(fakeEvent), 0);
     }
   };
 


### PR DESCRIPTION
#### Summary

Regression caused by #1088 

I imagine that because we are using setTimeout, our synthetic event is gone and by not calling `persist()`, we no longer have access to `name` and `id` inside of the onBlur.

When I debug it in storybook I also get `null` as event.target for a non persisted event.

