### PR TITLE
refactor(rich-text-input): make rich text only use HTML

### DIFF
--- a/src/components/inputs/rich-text-input/README.md
+++ b/src/components/inputs/rich-text-input/README.md
@@ -11,22 +11,15 @@ Please be aware that this component may be subject to upcoming breaking changes 
 A controlled rich text input component for rich text with validation
 states.
 
-This component uses `slatejs` under the hood. This means that the `value` needs to be kept in slate format.
-The `RichTextInput` exposes two static helper functions to helper with transforming HTML values to and from slate format.
-
-`RichTextInput.deserialize(html)` can be used to turn HTML into slate format.
-`RichTextInput.serialize(value)` can be used to turn slate format into HTML.
-
 ## Usage
 
 ```js
 import { RichTextInput } from '@commercetools-frontend/ui-kit';
 
 const html = '<p>hello world</p>';
-const slateValue = RichTextInput.deserialize(html);
 
 const Input = props => {
-  const [value, setValue] = React.useState(slateValue);
+  const [value, setValue] = React.useState(html);
     return (
       <RichTextInput
       value={value}

--- a/src/components/inputs/rich-text-input/rich-text-input.form.story.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.form.story.js
@@ -15,7 +15,7 @@ import RichTextInput from './rich-text-input';
 import TextInput from '../text-input';
 import TextField from '../../fields/text-field';
 
-const initialValue = RichTextInput.deserialize('');
+const initialValue = '';
 
 storiesOf('Examples|Forms/Inputs', module)
   .addDecorator(withKnobs)

--- a/src/components/inputs/rich-text-input/rich-text-input.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.js
@@ -113,7 +113,6 @@ class RichTextInput extends React.Component {
   };
 
   render() {
-    console.count('rendering here');
     return (
       <Editor
         {...filterDataAttributes(this.props)}

--- a/src/components/inputs/rich-text-input/rich-text-input.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.js
@@ -9,7 +9,7 @@ import plugins from '../../internals/rich-text-plugins';
 import html from '../../internals/rich-text-utils/html';
 import isEmpty from '../../internals/rich-text-utils/is-empty';
 
-const removeProps = ['value'];
+const omittedPropsForRender = ['value'];
 
 class RichTextInput extends React.Component {
   state = {
@@ -19,14 +19,20 @@ class RichTextInput extends React.Component {
   };
 
   shouldComponentUpdate(nextProps, nextState) {
-    // ignore updates for changes to `props.value`
-    const props = omit(this.props, removeProps);
+    // ignore updates for changes to `props.value` because this is
+    // actually an `HTML` value.
+
+    // instead we want to update when the slate `value` changes, which
+    // is stored in state.
+    const props = omit(this.props, omittedPropsForRender);
 
     const havePropsChanged = Object.entries(props).some(
       ([key, val]) => nextProps[key] !== val
     );
 
     if (havePropsChanged) return true;
+
+    if (this.props.value !== this.state.serializedValue) return true;
 
     if (this.state.value !== nextState.value) return true;
 

--- a/src/components/inputs/rich-text-input/rich-text-input.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import omit from 'lodash/omit';
 import requiredIf from 'react-required-if';
 import { Editor } from 'slate-react';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
@@ -8,12 +9,29 @@ import plugins from '../../internals/rich-text-plugins';
 import html from '../../internals/rich-text-utils/html';
 import isEmpty from '../../internals/rich-text-utils/is-empty';
 
-class RichTextInput extends React.PureComponent {
+const removeProps = ['value'];
+
+class RichTextInput extends React.Component {
   state = {
     // we keep track of the serialized (HTML) value
     serializedValue: this.props.value || '',
     value: html.deserialize(this.props.value || ''),
   };
+
+  shouldComponentUpdate(nextProps, nextState) {
+    // ignore updates for changes to `props.value`
+    const props = omit(this.props, removeProps);
+
+    const havePropsChanged = Object.entries(props).some(
+      ([key, val]) => nextProps[key] !== val
+    );
+
+    if (havePropsChanged) return true;
+
+    if (this.state.value !== nextState.value) return true;
+
+    return false;
+  }
 
   componentDidUpdate() {
     // if the value provided is not in sync with the RichTextInput,

--- a/src/components/inputs/rich-text-input/rich-text-input.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.js
@@ -15,7 +15,7 @@ class RichTextInput extends React.Component {
   state = {
     // we keep track of the serialized (HTML) value
     serializedValue: this.props.value || '',
-    value: html.deserialize(this.props.value || ''),
+    internalSlateValue: html.deserialize(this.props.value || ''),
   };
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -34,7 +34,8 @@ class RichTextInput extends React.Component {
 
     if (this.props.value !== this.state.serializedValue) return true;
 
-    if (this.state.value !== nextState.value) return true;
+    if (this.state.internalSlateValue !== nextState.internalSlateValue)
+      return true;
 
     return false;
   }
@@ -44,7 +45,7 @@ class RichTextInput extends React.Component {
     // then reset our value by deserializing this new value
     if (this.props.value !== this.state.serializedValue) {
       this.setState({
-        value: html.deserialize(this.props.value),
+        internalSlateValue: html.deserialize(this.props.value),
         serializedValue: this.props.value,
       });
     }
@@ -64,7 +65,7 @@ class RichTextInput extends React.Component {
     this.props.onChange(fakeEvent);
 
     this.setState({
-      value: event.value,
+      internalSlateValue: event.value,
       serializedValue,
     });
   };
@@ -112,6 +113,7 @@ class RichTextInput extends React.Component {
   };
 
   render() {
+    console.count('rendering here');
     return (
       <Editor
         {...filterDataAttributes(this.props)}
@@ -122,7 +124,7 @@ class RichTextInput extends React.Component {
         onBlur={this.onBlur}
         disabled={this.props.isDisabled}
         readOnly={this.props.isReadOnly}
-        value={this.state.value}
+        value={this.state.internalSlateValue}
         // we can only pass this.props to the Editor that Slate understands without getting
         // warning in the console,
         // so instead we pass our extra this.props through this `options` prop.

--- a/src/components/inputs/rich-text-input/rich-text-input.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import requiredIf from 'react-required-if';
-import Types from 'slate-prop-types';
 import { Editor } from 'slate-react';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import renderEditor from './editor';
@@ -10,16 +9,40 @@ import html from '../../internals/rich-text-utils/html';
 import isEmpty from '../../internals/rich-text-utils/is-empty';
 
 class RichTextInput extends React.PureComponent {
+  state = {
+    // we keep track of the serialized (HTML) value
+    serializedValue: this.props.value || '',
+    value: html.deserialize(this.props.value || ''),
+  };
+
+  componentDidUpdate() {
+    // if the value provided is not in sync with the RichTextInput,
+    // then reset our value by deserializing this new value
+    if (this.props.value !== this.state.serializedValue) {
+      this.setState({
+        value: html.deserialize(this.props.value),
+        serializedValue: this.props.value,
+      });
+    }
+  }
+
   onValueChange = event => {
+    const serializedValue = html.serialize(event.value);
+
     const fakeEvent = {
       target: {
         id: this.props.id,
         name: this.props.name,
-        value: event.value,
+        value: serializedValue,
       },
     };
 
     this.props.onChange(fakeEvent);
+
+    this.setState({
+      value: event.value,
+      serializedValue,
+    });
   };
 
   // this issue explains why we need to use next() + setTimeout
@@ -28,6 +51,7 @@ class RichTextInput extends React.PureComponent {
   onBlur = (event, editor, next) => {
     // we don't call next() if it's a button to stop our input from losing
     // slate focus
+
     if (
       event.relatedTarget &&
       event.relatedTarget.getAttribute('data-button-type') ===
@@ -74,7 +98,7 @@ class RichTextInput extends React.PureComponent {
         onBlur={this.onBlur}
         disabled={this.props.isDisabled}
         readOnly={this.props.isReadOnly}
-        value={this.props.value}
+        value={this.state.value}
         // we can only pass this.props to the Editor that Slate understands without getting
         // warning in the console,
         // so instead we pass our extra this.props through this `options` prop.
@@ -104,9 +128,7 @@ RichTextInput.defaultProps = {
 
 RichTextInput.displayName = 'RichTextInput';
 
-RichTextInput.serialize = html.serialize;
-RichTextInput.deserialize = html.deserialize;
-RichTextInput.isEmpty = isEmpty;
+RichTextInput.isEmpty = value => isEmpty(html.deserialize(value));
 RichTextInput.isTouched = touched => Boolean(touched);
 
 RichTextInput.propTypes = {
@@ -123,7 +145,7 @@ RichTextInput.propTypes = {
   onChange: requiredIf(PropTypes.func, props => !props.isReadOnly),
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
-  value: Types.value.isRequired,
+  value: PropTypes.string,
   showExpandIcon: PropTypes.bool.isRequired,
   onClickExpand: requiredIf(PropTypes.func, props => props.showExpandIcon),
 };

--- a/src/components/inputs/rich-text-input/rich-text-input.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import omit from 'lodash/omit';
 import requiredIf from 'react-required-if';
 import { Editor } from 'slate-react';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
@@ -9,46 +8,17 @@ import plugins from '../../internals/rich-text-plugins';
 import html from '../../internals/rich-text-utils/html';
 import isEmpty from '../../internals/rich-text-utils/is-empty';
 
-const omittedPropsForRender = ['value'];
+const propsToState = props => ({
+  serializedValue: props.value || '',
+  internalSlateValue: html.deserialize(props.value || ''),
+});
 
-class RichTextInput extends React.Component {
-  state = {
-    // we keep track of the serialized (HTML) value
-    serializedValue: this.props.value || '',
-    internalSlateValue: html.deserialize(this.props.value || ''),
-  };
+class RichTextInput extends React.PureComponent {
+  state = propsToState(this.props);
 
-  shouldComponentUpdate(nextProps, nextState) {
-    // ignore updates for changes to `props.value` because this is
-    // actually an `HTML` value.
-
-    // instead we want to update when the slate `value` changes, which
-    // is stored in state.
-    const props = omit(this.props, omittedPropsForRender);
-
-    const havePropsChanged = Object.entries(props).some(
-      ([key, val]) => nextProps[key] !== val
-    );
-
-    if (havePropsChanged) return true;
-
-    if (this.props.value !== this.state.serializedValue) return true;
-
-    if (this.state.internalSlateValue !== nextState.internalSlateValue)
-      return true;
-
-    return false;
-  }
-
-  componentDidUpdate() {
-    // if the value provided is not in sync with the RichTextInput,
-    // then reset our value by deserializing this new value
-    if (this.props.value !== this.state.serializedValue) {
-      this.setState({
-        internalSlateValue: html.deserialize(this.props.value),
-        serializedValue: this.props.value,
-      });
-    }
+  static getDerivedStateFromProps(props, state) {
+    if (props.value === state.serializedValue) return null;
+    return propsToState(props);
   }
 
   onValueChange = event => {

--- a/src/components/inputs/rich-text-input/rich-text-input.spec.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.spec.js
@@ -5,7 +5,7 @@ import RichTextInput from './rich-text-input';
 // mocks
 window.getSelection = () => {};
 
-const initialValue = RichTextInput.deserialize('');
+const initialValue = '';
 
 const baseProps = { value: initialValue, onChange: () => {} };
 
@@ -114,39 +114,13 @@ describe('RichTextInput', () => {
 });
 
 describe('RichTextInput static methods', () => {
-  describe('serialize / deserialize', () => {
-    describe('when called with a simple HTML value', () => {
-      it('should be able to serialize and deserialize back to same value', () => {
-        const html = '<p>hello world</p>';
-        const slateValue = RichTextInput.deserialize(html);
-        expect(RichTextInput.serialize(slateValue)).toEqual(html);
-      });
-    });
-    describe('when called with a more complex HTML value', () => {
-      it('should be able to serialize and deserialize back to same value', () => {
-        const html = `<h1>Hello World</h1><h1></h1><p>This is rich text, <strong>way</strong> better than <u>other</u> kind&#x27;s of text.</p><p></p><ol><li>Numbered list</li><li>Second number</li></ol><ul><li>Bullet list</li></ul>`;
-        const slateValue = RichTextInput.deserialize(html);
-        expect(RichTextInput.serialize(slateValue)).toEqual(html);
-      });
-    });
-    describe('when called with an HTML value that contains tags we do not yet support', () => {
-      it('should be able to serialize and deserialize to the default tag', () => {
-        const html =
-          '<a href="https://google.com">hello world<img src="blah" alt="foobar" /></a>';
-        const slateValue = RichTextInput.deserialize(html);
-        expect(RichTextInput.serialize(slateValue)).toEqual(
-          `<p>hello world</p>`
-        );
-      });
-    });
-  });
   describe('RichTextInput.isEmpty', () => {
     it('should return `false` when used with a non empty value', () => {
-      const value = RichTextInput.deserialize('<p>Foo</p>');
+      const value = '<p>Foo</p>';
       expect(RichTextInput.isEmpty(value)).toBeFalsy();
     });
     it('should return `true` when used with an empty value', () => {
-      const value = RichTextInput.deserialize('');
+      const value = '';
       expect(RichTextInput.isEmpty(value)).toBeTruthy();
     });
   });

--- a/src/components/inputs/rich-text-input/rich-text-input.story.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.story.js
@@ -16,30 +16,30 @@ import Readme from './README.md';
 const initialValue = '<h1>H1 heading</h1>';
 
 const Input = props => {
+  const [value, setValue] = React.useState(initialValue);
+  const onChange = React.useCallback(
+    event => {
+      setValue(event.target.value);
+    },
+    [setValue]
+  );
   return (
-    <Value
-      defaultValue={initialValue}
-      render={(value, onChange) => (
-        <RichTextInput
-          id={props.id}
-          name={props.name}
-          key={`rich-text-input-${props.defaultExpandMultilineText}`}
-          onChange={event => {
-            onChange(event.target.value);
-          }}
-          value={value}
-          onBlur={props.onBlur}
-          onFocus={props.onFocus}
-          defaultExpandMultilineText={props.defaultExpandMultilineText}
-          placeholder={props.placeholder}
-          onClickExpand={props.onClickExpand}
-          showExpandIcon={props.showExpandIcon}
-          hasError={props.hasError}
-          hasWarning={props.hasWarning}
-          isDisabled={props.isDisabled}
-          isReadOnly={props.isReadOnly}
-        />
-      )}
+    <RichTextInput
+      id={props.id}
+      name={props.name}
+      key={`rich-text-input-${props.defaultExpandMultilineText}`}
+      onChange={onChange}
+      value={value}
+      onBlur={props.onBlur}
+      onFocus={props.onFocus}
+      defaultExpandMultilineText={props.defaultExpandMultilineText}
+      placeholder={props.placeholder}
+      onClickExpand={props.onClickExpand}
+      showExpandIcon={props.showExpandIcon}
+      hasError={props.hasError}
+      hasWarning={props.hasWarning}
+      isDisabled={props.isDisabled}
+      isReadOnly={props.isReadOnly}
     />
   );
 };

--- a/src/components/inputs/rich-text-input/rich-text-input.story.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.story.js
@@ -8,11 +8,12 @@ import withReadme from 'storybook-readme/with-readme';
 import Spacings from '../../spacings';
 import Section from '../../../../.storybook/decorators/section';
 import RichTextInput from './rich-text-input';
+import TextInput from '../text-input';
 import Readme from './README.md';
 
 // Create our initial value...
 
-const initialValue = RichTextInput.deserialize('');
+const initialValue = '<h1>H1 heading</h1>';
 
 const Input = props => {
   return (
@@ -23,8 +24,10 @@ const Input = props => {
           id={props.id}
           name={props.name}
           key={`rich-text-input-${props.defaultExpandMultilineText}`}
-          onChange={event => onChange(event.target.value)}
-          value={value}
+          onChange={event => {
+            onChange(event.target.value);
+          }}
+          value={props.showBlah ? initialValue : value}
           onBlur={props.onBlur}
           onFocus={props.onFocus}
           defaultExpandMultilineText={props.defaultExpandMultilineText}
@@ -56,6 +59,17 @@ storiesOf('Components|Inputs', module)
     return (
       <Section>
         <Spacings.Stack scale="l">
+          <Value
+            defaultValue={''}
+            render={(value, onChange) => (
+              <TextInput
+                id="text-input"
+                name="text-input"
+                value={value}
+                onChange={event => onChange(event.target.value)}
+              />
+            )}
+          />
           <Input
             id={text('id', 'test-id')}
             name={text('name', 'test-name')}
@@ -63,8 +77,9 @@ storiesOf('Components|Inputs', module)
             onFocus={onFocus}
             defaultExpandMultilineText={boolean(
               'defaultExpandMultilineText',
-              false
+              true
             )}
+            showBlah={boolean('yes', false)}
             placeholder={text('placeholder', 'Placeholder')}
             showExpandIcon={boolean('showExpandIcon', false)}
             onClickExpand={onClickExpand}

--- a/src/components/inputs/rich-text-input/rich-text-input.story.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.story.js
@@ -27,7 +27,7 @@ const Input = props => {
           onChange={event => {
             onChange(event.target.value);
           }}
-          value={props.showBlah ? initialValue : value}
+          value={value}
           onBlur={props.onBlur}
           onFocus={props.onFocus}
           defaultExpandMultilineText={props.defaultExpandMultilineText}
@@ -79,7 +79,6 @@ storiesOf('Components|Inputs', module)
               'defaultExpandMultilineText',
               true
             )}
-            showBlah={boolean('yes', false)}
             placeholder={text('placeholder', 'Placeholder')}
             showExpandIcon={boolean('showExpandIcon', false)}
             onClickExpand={onClickExpand}

--- a/src/components/inputs/rich-text-input/rich-text-input.visualroute.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.visualroute.js
@@ -3,11 +3,12 @@ import { Switch, Route } from 'react-router';
 import { RichTextInput } from 'ui-kit';
 import { Suite, Spec } from '../../../../test/percy';
 
-const minimalValue = RichTextInput.deserialize('Hello World');
-const largeValue = RichTextInput.deserialize(
-  '<h1>Hello world</h1><p>This is a longer text</p><ul><li>One</li><li>Two</li></ul>'
-);
-const emptyValue = RichTextInput.deserialize('');
+const minimalValue = 'Hello World';
+
+const largeValue =
+  '<h1>Hello world</h1><p>This is a longer text</p><ul><li>One</li><li>Two</li></ul>';
+
+const emptyValue = '';
 
 export const routePath = '/rich-text-input';
 

--- a/src/components/inputs/rich-text-input/rich-text-input.visualroute.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.visualroute.js
@@ -16,6 +16,10 @@ export const routePath = '/rich-text-input';
 const InteractiveRoute = () => {
   const [value, setValue] = React.useState(emptyValue);
 
+  const handleReset = React.useCallback(() => {
+    setValue('<p><strong>Hello World</strong></p>');
+  }, [setValue]);
+
   const onChange = event => {
     setValue(event.target.value);
   };
@@ -23,6 +27,12 @@ const InteractiveRoute = () => {
   return (
     <Suite>
       <Spec label="minimal" omitPropsList>
+        <div>
+          <label htmlFor="reset-button">Reset value to Hello World</label>
+          <button onClick={handleReset} id="reset-button">
+            Reset
+          </button>
+        </div>
         <label htmlFor="rich-text">Rich text</label>
         <RichTextInput
           id="rich-text"

--- a/src/components/inputs/rich-text-input/rich-text-input.visualroute.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.visualroute.js
@@ -29,7 +29,13 @@ const InteractiveRoute = () => {
       <Spec label="minimal" omitPropsList>
         <div>
           <label htmlFor="reset-button">Reset value to Hello World</label>
-          <button onClick={handleReset} id="reset-button">
+          <button
+            onMouseDown={event => {
+              event.preventDefault();
+              handleReset();
+            }}
+            id="reset-button"
+          >
             Reset
           </button>
         </div>

--- a/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
@@ -351,14 +351,14 @@ describe('RichTextInput', () => {
 
     await wait(() => getByText(doc, 'Hello World'));
 
-    await input.focus();
-
+    await input.click();
     await selectAllText(input);
-    // make the text bold
+
     await boldButton.click();
     // check there are no strong tags in the document.
     numOfTags = await getNumberOfTags('strong');
     expect(numOfTags).toEqual(0);
+
     await input.press('Backspace');
 
     await input.type('Goodbye');

--- a/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
@@ -4,6 +4,12 @@ import { getDocument, queries, wait } from 'pptr-testing-library';
 const { getByLabelText, getByText } = queries;
 
 describe('RichTextInput', () => {
+  const delay = timeout => {
+    return new Promise(resolve => {
+      setTimeout(resolve, timeout);
+    });
+  };
+
   const selectAllText = async input => {
     // eslint-disable-next-line no-shadow
     await page.evaluate(input => {
@@ -352,6 +358,9 @@ describe('RichTextInput', () => {
     await wait(() => getByText(doc, 'Hello World'));
 
     await input.click();
+
+    await delay(200);
+
     await selectAllText(input);
 
     await boldButton.click();

--- a/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
@@ -336,5 +336,19 @@ describe('RichTextInput', () => {
 
     numOfTags = await getNumberOfTags('li');
     expect(numOfTags).toEqual(2);
+
+    // remove all the text
+    await selectAllText(input);
+    await input.press('Backspace');
+
+    const resetButton = await getByLabelText(doc, 'Reset value to Hello World');
+    await resetButton.click();
+
+    // 1 strong tag should be in the document
+
+    numOfTags = await getNumberOfTags('strong');
+    expect(numOfTags).toEqual(1);
+
+    await wait(() => getByText(doc, 'Hello World'));
   });
 });

--- a/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
@@ -350,5 +350,15 @@ describe('RichTextInput', () => {
     expect(numOfTags).toEqual(1);
 
     await wait(() => getByText(doc, 'Hello World'));
+
+    // check we can still type afterwards
+
+    // remove all the text
+    await selectAllText(input);
+    await input.press('Backspace');
+
+    await input.type('Typing still works!');
+
+    await wait(() => getByText(doc, 'Typing still works!'));
   });
 });

--- a/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
@@ -351,14 +351,18 @@ describe('RichTextInput', () => {
 
     await wait(() => getByText(doc, 'Hello World'));
 
-    // check we can still type afterwards
+    await input.focus();
 
-    // remove all the text
     await selectAllText(input);
+    // make the text bold
+    await boldButton.click();
+    // check there are no strong tags in the document.
+    numOfTags = await getNumberOfTags('strong');
+    expect(numOfTags).toEqual(0);
     await input.press('Backspace');
 
-    await input.type('Typing still works!');
+    await input.type('Goodbye');
 
-    await wait(() => getByText(doc, 'Typing still works!'));
+    await wait(() => getByText(doc, 'Goodbye'));
   });
 });

--- a/vendors/package-lock.json
+++ b/vendors/package-lock.json
@@ -7,7 +7,15 @@
     "full-icu": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.0.tgz",
-      "integrity": "sha512-LGLpSsbkHUT0T+EKrIJltYoejYzUqg1eW+n6wm/FTte1pDiYjeKTxO0uJvrE3jgv6V9eBzMAjF6A8jH16C0+eQ=="
+      "integrity": "sha512-LGLpSsbkHUT0T+EKrIJltYoejYzUqg1eW+n6wm/FTte1pDiYjeKTxO0uJvrE3jgv6V9eBzMAjF6A8jH16C0+eQ==",
+      "requires": {
+        "icu4c-data": "^0.63.2"
+      }
+    },
+    "icu4c-data": {
+      "version": "0.63.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.63.2.tgz",
+      "integrity": "sha512-vT6/47CcBzDemlhRzkL7dZLoNvuUWjjiuKZHMt5T4dbkKAqLBh7ZQ33GU13ecC/aIcMlIdBOqtF4uIYTgWML4Q=="
     }
   }
 }


### PR DESCRIPTION
#### Summary

I started playing around with using the `RichTextInput` in the MC and I found that forcing our users to use Slate values made it a lot more complicated to integrate.

This PR refactors the `RichTextInput` to still be a `controlled` component, but to not expose slate values to the consumer.

Thanks to @pa3 for questioning why we were using slate values in the first place...