### PR TITLE
chore(rich-text-input): remove unused props

### DIFF
--- a/src/components/inputs/rich-text-input/editor.js
+++ b/src/components/inputs/rich-text-input/editor.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { useIntl } from 'react-intl';
+import pick from 'lodash/pick';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import CollapsibleMotion from '../../collapsible-motion';
 import usePrevious from '../../../hooks/use-previous';
@@ -112,17 +113,16 @@ const renderEditor = (props, editor, next) => {
   const passedProps = {
     name: props.name,
     id: props.id,
-    isDisabled: props.disabled,
-    onBlur: props.options.onBlur,
-    onFocus: props.options.onFocus,
-    isFocused: props.options.isFocused,
-    horizontalConstraint: props.options.horizontalConstraint,
-    defaultExpandMultilineText: props.options.defaultExpandMultilineText,
-    showExpandIcon: props.options.showExpandIcon,
-    onClickExpand: props.options.onClickExpand,
-    hasError: props.options.hasError,
-    hasWarning: props.options.hasWarning,
     isReadOnly: props.readOnly,
+    isDisabled: props.disabled,
+    ...pick(props.options, [
+      'horizontalConstraint',
+      'defaultExpandMultilineText',
+      'showExpandIcon',
+      'onClickExpand',
+      'hasError',
+      'hasWarning',
+    ]),
     ...filterDataAttributes(props),
   };
 

--- a/src/components/inputs/rich-text-input/rich-text-input.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import requiredIf from 'react-required-if';
 import { Editor } from 'slate-react';
+import pick from 'lodash/pick';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
 import renderEditor from './editor';
 import plugins from '../../internals/rich-text-plugins';
@@ -97,15 +98,15 @@ class RichTextInput extends React.PureComponent {
         // we can only pass this.props to the Editor that Slate understands without getting
         // warning in the console,
         // so instead we pass our extra this.props through this `options` prop.
-        options={{
-          horizontalConstraint: this.props.horizontalConstraint,
-          defaultExpandMultilineText: this.props.defaultExpandMultilineText,
-          hasWarning: this.props.hasWarning,
-          hasError: this.props.hasError,
-          placeholder: this.props.placeholder,
-          showExpandIcon: this.props.showExpandIcon,
-          onClickExpand: this.props.onClickExpand,
-        }}
+        options={pick(this.props, [
+          'horizontalConstraint',
+          'defaultExpandMultilineText',
+          'hasWarning',
+          'hasError',
+          'placeholder',
+          'showExpandIcon',
+          'onClickExpand',
+        ])}
         onChange={this.onValueChange}
         plugins={plugins}
         renderEditor={renderEditor}

--- a/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
@@ -4,12 +4,6 @@ import { getDocument, queries, wait } from 'pptr-testing-library';
 const { getByLabelText, getByText } = queries;
 
 describe('RichTextInput', () => {
-  const delay = timeout => {
-    return new Promise(resolve => {
-      setTimeout(resolve, timeout);
-    });
-  };
-
   const selectAllText = async input => {
     // eslint-disable-next-line no-shadow
     await page.evaluate(input => {
@@ -356,22 +350,5 @@ describe('RichTextInput', () => {
     expect(numOfTags).toEqual(1);
 
     await wait(() => getByText(doc, 'Hello World'));
-
-    await input.click();
-
-    await delay(200);
-
-    await selectAllText(input);
-
-    await boldButton.click();
-    // check there are no strong tags in the document.
-    numOfTags = await getNumberOfTags('strong');
-    expect(numOfTags).toEqual(0);
-
-    await input.press('Backspace');
-
-    await input.type('Goodbye');
-
-    await wait(() => getByText(doc, 'Goodbye'));
   });
 });


### PR DESCRIPTION
#### Summary

Some refactoring to use `pick` and to remove some unused props.