### PR TITLE
feat(collapsible-panel): add prop to set alignment of header controls

### DIFF
--- a/src/components/panels/collapsible-panel/collapsible-panel.js
+++ b/src/components/panels/collapsible-panel/collapsible-panel.js
@@ -25,13 +25,14 @@ export default class CollapsiblePanel extends React.PureComponent {
     description: PropTypes.string,
     className: PropTypes.string,
     isSticky: PropTypes.bool,
-    headerControls: PropTypes.node,
     isDisabled: PropTypes.bool,
     children: PropTypes.node,
     tone: PropTypes.oneOf(['urgent', 'primary']),
     theme: PropTypes.oneOf(['dark', 'light']),
     condensed: PropTypes.bool,
     hideExpansionControls: PropTypes.bool,
+    headerControls: PropTypes.node,
+    headerControlsAlignment: PropTypes.string,
 
     // props when uncontrolled
     isDefaultClosed(props, propName, componentName, ...rest) {
@@ -73,6 +74,7 @@ export default class CollapsiblePanel extends React.PureComponent {
     theme: 'dark',
     condensed: false,
     isDisabled: false,
+    headerControlsAlignment: 'right',
   };
 
   render() {
@@ -109,6 +111,7 @@ export default class CollapsiblePanel extends React.PureComponent {
                   css={getHeaderStyles({
                     isCondensed: this.props.condensed,
                     isDisabled: this.props.isDisabled,
+                    headerControlsAlignment: this.props.headerControlsAlignment,
                   })}
                 >
                   <div

--- a/src/components/panels/collapsible-panel/collapsible-panel.story.js
+++ b/src/components/panels/collapsible-panel/collapsible-panel.story.js
@@ -37,6 +37,7 @@ storiesOf('Components|Panels', module)
           theme={select('theme', ['dark', 'light'])}
           condensed={condensed}
           secondaryHeader={text('secondaryHeader', 'Subtitle')}
+          headerControlsAlignment={select('size', ['left', 'right'], 'right')}
         >
           {text('Text', 'Sample text')}
         </CollapsiblePanel>

--- a/src/components/panels/collapsible-panel/collapsible-panel.styles.js
+++ b/src/components/panels/collapsible-panel/collapsible-panel.styles.js
@@ -64,13 +64,19 @@ const getHeaderContainerStyles = ({ isDisabled, isOpen, isSticky, theme }) => {
   ];
 };
 
-const getHeaderStyles = ({ isDisabled, isCondensed }) => {
+const getHeaderStyles = ({
+  isDisabled,
+  isCondensed,
+  headerControlsAlignment,
+}) => {
   const baseStyles = css`
     display: flex;
     flex: 1;
     align-items: center;
     list-style-type: none;
-    justify-content: space-between;
+    justify-content: ${headerControlsAlignment === 'left'
+      ? 'flex-start'
+      : 'space-between'};
 
     /*
       Two resource that explain why we need the min-width: 0; here


### PR DESCRIPTION
### Summary


We have a bunch of these `CollapsiblePanel` components in our MC which have a input/control on the left side of header. Currently, our component allows setting a `headerControls` but it’s always aligned to the right and there is no way to override that positioning. 
![image](https://user-images.githubusercontent.com/2941328/66848996-65867200-ef76-11e9-8a85-d1dc74ff7700.png)
This example in the image is achieved by setting the input in the `header` prop, and we need to add a wrapper to make sure clicking on the input/control doesn’t trigger the collapsing of the panel. This seems unnecessary because the `headerControls` prop already does this for you, but we can’t use it because of the inflexible alignment.