### PR TITLE
refactor(rich-text-input): performance optimisation 

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -7,7 +7,6 @@
 module.exports = {
   launch: {
     args: ['--no-sandbox', '--disable-setuid-sandbox'],
-    headless: false,
   },
   server: {
     command: 'yarn visual-testing-app:serve',

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -7,6 +7,7 @@
 module.exports = {
   launch: {
     args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    headless: false,
   },
   server: {
     command: 'yarn visual-testing-app:serve',

--- a/src/components/inputs/rich-text-input/rich-text-input.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.js
@@ -14,6 +14,14 @@ class RichTextInput extends React.PureComponent {
   internalSlateValue = html.deserialize(this.props.value || '');
 
   componentDidUpdate() {
+    // everytime we call `onChange`, we update `this.serializedValue`
+    // to the new HTML value
+    // this condition only occurs if the parent component takes `control`
+    // and resets the component to a different HTML value that what
+    // we expect
+    // in this case, we need to parse this new value into a value slate
+    // can understand, save this value to our class variable, and forceUpdate
+    // this keeps the component in sync.
     if (this.props.value !== this.serializedValue) {
       this.internalSlateValue = html.deserialize(this.props.value);
       this.serializedValue = this.props.value;

--- a/src/components/inputs/rich-text-input/rich-text-input.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.js
@@ -10,14 +10,8 @@ import html from '../../internals/rich-text-utils/html';
 import isEmpty from '../../internals/rich-text-utils/is-empty';
 
 class RichTextInput extends React.PureComponent {
-  serializedValue;
-  internalSlateValue;
-
-  constructor(props) {
-    super(props);
-    this.serializedValue = props.value || '';
-    this.internalSlateValue = html.deserialize(this.props.value || '');
-  }
+  serializedValue = this.props.value || '';
+  internalSlateValue = html.deserialize(this.props.value || '');
 
   componentDidUpdate() {
     if (this.props.value !== this.serializedValue) {

--- a/src/components/inputs/rich-text-input/rich-text-input.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.js
@@ -9,7 +9,7 @@ import plugins from '../../internals/rich-text-plugins';
 import html from '../../internals/rich-text-utils/html';
 import isEmpty from '../../internals/rich-text-utils/is-empty';
 
-class RichTextInput extends React.Component {
+class RichTextInput extends React.PureComponent {
   serializedValue;
   internalSlateValue;
 
@@ -87,7 +87,6 @@ class RichTextInput extends React.Component {
   };
 
   render() {
-    console.count('render');
     return (
       <Editor
         {...filterDataAttributes(this.props)}

--- a/src/components/inputs/rich-text-input/rich-text-input.story.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.story.js
@@ -24,31 +24,24 @@ const Input = props => {
     [setValue]
   );
 
-  const resetValue = () => {
-    setValue('');
-  };
-
   return (
-    <div>
-      <button onClick={resetValue}>reset</button>
-      <RichTextInput
-        id={props.id}
-        name={props.name}
-        key={`rich-text-input-${props.defaultExpandMultilineText}`}
-        onChange={onChange}
-        value={value}
-        onBlur={props.onBlur}
-        onFocus={props.onFocus}
-        defaultExpandMultilineText={props.defaultExpandMultilineText}
-        placeholder={props.placeholder}
-        onClickExpand={props.onClickExpand}
-        showExpandIcon={props.showExpandIcon}
-        hasError={props.hasError}
-        hasWarning={props.hasWarning}
-        isDisabled={props.isDisabled}
-        isReadOnly={props.isReadOnly}
-      />
-    </div>
+    <RichTextInput
+      id={props.id}
+      name={props.name}
+      key={`rich-text-input-${props.defaultExpandMultilineText}`}
+      onChange={onChange}
+      value={value}
+      onBlur={props.onBlur}
+      onFocus={props.onFocus}
+      defaultExpandMultilineText={props.defaultExpandMultilineText}
+      placeholder={props.placeholder}
+      onClickExpand={props.onClickExpand}
+      showExpandIcon={props.showExpandIcon}
+      hasError={props.hasError}
+      hasWarning={props.hasWarning}
+      isDisabled={props.isDisabled}
+      isReadOnly={props.isReadOnly}
+    />
   );
 };
 

--- a/src/components/inputs/rich-text-input/rich-text-input.story.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.story.js
@@ -23,24 +23,32 @@ const Input = props => {
     },
     [setValue]
   );
+
+  const resetValue = () => {
+    setValue('');
+  };
+
   return (
-    <RichTextInput
-      id={props.id}
-      name={props.name}
-      key={`rich-text-input-${props.defaultExpandMultilineText}`}
-      onChange={onChange}
-      value={value}
-      onBlur={props.onBlur}
-      onFocus={props.onFocus}
-      defaultExpandMultilineText={props.defaultExpandMultilineText}
-      placeholder={props.placeholder}
-      onClickExpand={props.onClickExpand}
-      showExpandIcon={props.showExpandIcon}
-      hasError={props.hasError}
-      hasWarning={props.hasWarning}
-      isDisabled={props.isDisabled}
-      isReadOnly={props.isReadOnly}
-    />
+    <div>
+      <button onClick={resetValue}>reset</button>
+      <RichTextInput
+        id={props.id}
+        name={props.name}
+        key={`rich-text-input-${props.defaultExpandMultilineText}`}
+        onChange={onChange}
+        value={value}
+        onBlur={props.onBlur}
+        onFocus={props.onFocus}
+        defaultExpandMultilineText={props.defaultExpandMultilineText}
+        placeholder={props.placeholder}
+        onClickExpand={props.onClickExpand}
+        showExpandIcon={props.showExpandIcon}
+        hasError={props.hasError}
+        hasWarning={props.hasWarning}
+        isDisabled={props.isDisabled}
+        isReadOnly={props.isReadOnly}
+      />
+    </div>
   );
 };
 

--- a/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
@@ -350,5 +350,16 @@ describe('RichTextInput', () => {
     expect(numOfTags).toEqual(1);
 
     await wait(() => getByText(doc, 'Hello World'));
+
+    // remove bold from text
+    await selectAllText(input);
+    await boldButton.click();
+    await input.press('Backspace');
+
+    numOfTags = await getNumberOfTags('strong');
+    expect(numOfTags).toEqual(1);
+
+    await input.type('Okay dokey');
+    await wait(() => getByText(doc, 'Okay dokey'));
   });
 });

--- a/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
@@ -354,10 +354,11 @@ describe('RichTextInput', () => {
     // remove bold from text
     await selectAllText(input);
     await boldButton.click();
-    await input.press('Backspace');
 
     numOfTags = await getNumberOfTags('strong');
-    expect(numOfTags).toEqual(1);
+    expect(numOfTags).toEqual(0);
+
+    await input.press('Backspace');
 
     await input.type('Okay dokey');
     await wait(() => getByText(doc, 'Okay dokey'));


### PR DESCRIPTION
#### Summary

Currently, the `RichTextInput` is double rendering on every key stroke.

#### Before

![before](https://user-images.githubusercontent.com/2425013/66908937-38849e80-f00c-11e9-9af2-d9db922dbb40.gif)

#### After
![better](https://user-images.githubusercontent.com/2425013/66908938-38849e80-f00c-11e9-97c7-5827c3991479.gif)
