### PR TITLE
fix(rich-text-input): fix regression

### DIFF
--- a/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
@@ -351,6 +351,7 @@ describe('RichTextInput', () => {
 
     await wait(() => getByText(doc, 'Hello World'));
 
+    await input.click();
     // remove bold from text
     await selectAllText(input);
     await boldButton.click();


### PR DESCRIPTION
Fixes two regressions.

1. onFocus was being called when we interacted with the toolbar butters.
2. We weren't rerendering when you changed the cursor.