### PR TITLE
chore(rich-text-input): perf improvement

### DIFF
--- a/src/components/inputs/localized-rich-text-input/localized-rich-text-input.story.js
+++ b/src/components/inputs/localized-rich-text-input/localized-rich-text-input.story.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Value } from 'react-value';
 import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 import {
   withKnobs,
   boolean,
@@ -25,6 +26,7 @@ class StoryWrapper extends React.Component {
       ...this.props.value,
       [event.target.language]: event.target.value,
     });
+    action('onChange')(event);
   };
 
   onClickExpand = () => {

--- a/src/components/inputs/localized-rich-text-input/rich-text-input.js
+++ b/src/components/inputs/localized-rich-text-input/rich-text-input.js
@@ -39,16 +39,20 @@ class RichTextInput extends React.PureComponent {
     this.internalSlateValue = event.value;
     this.serializedValue = serializedValue;
 
-    const fakeEvent = {
-      target: {
-        id: this.props.id,
-        name: this.props.name,
-        language: this.props.language,
-        value: serializedValue,
-      },
-    };
+    // the consumer only cares about the serializedValue, so it doesn't make sense to call
+    // onChange unless this value changes.
+    if (hasSerializedValueChanged) {
+      const fakeEvent = {
+        target: {
+          id: this.props.id,
+          name: this.props.name,
+          language: this.props.language,
+          value: serializedValue,
+        },
+      };
 
-    this.props.onChange(fakeEvent);
+      this.props.onChange(fakeEvent);
+    }
 
     if (hasInternalSlateValueChanged && !hasSerializedValueChanged) {
       // this way we force update if cursor or selection changes

--- a/src/components/inputs/rich-text-input/rich-text-input.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.js
@@ -45,15 +45,19 @@ class RichTextInput extends React.PureComponent {
     this.internalSlateValue = event.value;
     this.serializedValue = serializedValue;
 
-    const fakeEvent = {
-      target: {
-        id: this.props.id,
-        name: this.props.name,
-        value: serializedValue,
-      },
-    };
+    // the consumer only cares about the serializedValue, so it doesn't make sense to call
+    // onChange unless this value changes.
+    if (hasSerializedValueChanged) {
+      const fakeEvent = {
+        target: {
+          id: this.props.id,
+          name: this.props.name,
+          value: serializedValue,
+        },
+      };
 
-    this.props.onChange(fakeEvent);
+      this.props.onChange(fakeEvent);
+    }
 
     if (hasInternalSlateValueChanged && !hasSerializedValueChanged) {
       // this way we force update if cursor or selection changes

--- a/src/components/inputs/rich-text-input/rich-text-input.story.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.story.js
@@ -20,6 +20,7 @@ const Input = props => {
   const onChange = React.useCallback(
     event => {
       setValue(event.target.value);
+      action('onChange')(event);
     },
     [setValue]
   );


### PR DESCRIPTION
#### Summary

Currently we fire `onChange` when there are any changes to the slate internal value of the `RichTextInput`. However, sometimes these changes result in no changes to the HTML consumed by the consumer. In these cases, we should not fire onChange.

An example would be moving the cursor. This results in a change to slate, but no change to the HTML value.