### PR TITLE
fix(localized-rich-text-input): make behaviour match other localized component

### DIFF
--- a/src/components/inputs/localized-rich-text-input/README.md
+++ b/src/components/inputs/localized-rich-text-input/README.md
@@ -20,8 +20,8 @@ const Input = props => {
     return (
       <LocalizedRichTextInput
         value={{
-          en: LocalizedRichTextInput.deserialize(''),
-          de: LocalizedRichTextInput.deserialize('')
+          en: '',
+          de: ''
         }}
         onChange={event => console.log('event.target.value', event.target.value)}
       />;

--- a/src/components/inputs/localized-rich-text-input/localized-rich-text-input.js
+++ b/src/components/inputs/localized-rich-text-input/localized-rich-text-input.js
@@ -225,10 +225,6 @@ LocalizedRichTextInput.propTypes = {
   onClickExpand: requiredIf(PropTypes.func, props => props.showExpandIcon),
 };
 
-LocalizedRichTextInput.serialize = RichTextInput.serialize;
-
-LocalizedRichTextInput.deserialize = RichTextInput.deserialize;
-
 LocalizedRichTextInput.getId = getId;
 
 LocalizedRichTextInput.getName = getName;

--- a/src/components/inputs/localized-rich-text-input/rich-text-input.js
+++ b/src/components/inputs/localized-rich-text-input/rich-text-input.js
@@ -117,7 +117,7 @@ class RichTextInput extends React.PureComponent {
             // expand all multiline language inputs in case the
             // first one was expanded when all languages
             // are shown
-            if (!this.props.isCollapsed) {
+            if (this.props.isOpen) {
               this.props.expandAllTranslations();
             }
             this.props.toggleLanguages();
@@ -165,7 +165,6 @@ class RichTextInput extends React.PureComponent {
             'isOpen',
             'warning',
             'error',
-            'isCollapsed',
             'defaultExpandMultilineText',
             'hasWarning',
             'hasWarningOnRemainingLanguages',
@@ -191,8 +190,6 @@ RichTextInput.defaultProps = {
 
 RichTextInput.displayName = 'RichTextInput';
 
-RichTextInput.serialize = html.serialize;
-RichTextInput.deserialize = html.deserialize;
 RichTextInput.isEmpty = isEmpty;
 
 RichTextInput.propTypes = {


### PR DESCRIPTION
#### Summary

Make behaviour of `LocalizedRichTextInput` match other `LocalizedMutilineTextInput` as per the expand / collapse states.