### PR TITLE
chore(localized-rich-text-input): show expand button

### DIFF
--- a/src/components/inputs/localized-multiline-text-input/localized-multiline-text-input.js
+++ b/src/components/inputs/localized-multiline-text-input/localized-multiline-text-input.js
@@ -88,10 +88,6 @@ const LocalizedMultilineTextInput = props => {
     [expandedTranslationsDispatch]
   );
 
-  const expandAllTranslations = React.useCallback(() => {
-    expandedTranslationsDispatch({ type: 'toggleAll' });
-  }, [expandedTranslationsDispatch]);
-
   const languages = sortLanguages(
     props.selectedLanguage,
     Object.keys(props.value)
@@ -161,15 +157,7 @@ const LocalizedMultilineTextInput = props => {
                   return (
                     <LanguagesControl
                       isClosed={true}
-                      onClick={() => {
-                        // expand all multiline language inputs in case the
-                        // first one was expanded when all languages
-                        // are shown
-                        if (expandedTranslationsState[props.selectedLanguage]) {
-                          expandAllTranslations();
-                        }
-                        toggleLanguages();
-                      }}
+                      onClick={toggleLanguages}
                       remainingLanguages={languages.length - 1}
                     />
                   );

--- a/src/components/inputs/localized-rich-text-input/editor.js
+++ b/src/components/inputs/localized-rich-text-input/editor.js
@@ -9,7 +9,7 @@ import filterDataAttributes from '../../../utils/filter-data-attributes';
 import usePrevious from '../../../hooks/use-previous';
 import CollapsibleMotion from '../../collapsible-motion';
 import Spacings from '../../spacings';
-import { AngleUpIcon } from '../../icons';
+import { AngleUpIcon, AngleDownIcon } from '../../icons';
 import Text from '../../typography/text';
 import FlatButton from '../../buttons/flat-button';
 import RichTextBody from '../../internals/rich-text-body';
@@ -146,14 +146,24 @@ const Editor = props => {
                   )
                 );
               })()}
-              {renderToggleButton && isOpen && (
+              {renderToggleButton && (
                 <React.Fragment>
                   <LeftColumn />
                   <RightColumn>
                     <FlatButton
                       onClick={toggle}
-                      label={intl.formatMessage(messages.collapse)}
-                      icon={<AngleUpIcon size="small" />}
+                      label={
+                        isOpen
+                          ? intl.formatMessage(messages.collapse)
+                          : intl.formatMessage(messages.expand)
+                      }
+                      icon={
+                        isOpen ? (
+                          <AngleUpIcon size="small" />
+                        ) : (
+                          <AngleDownIcon size="small" />
+                        )
+                      }
                     />
                   </RightColumn>
                 </React.Fragment>

--- a/src/components/inputs/localized-rich-text-input/editor.js
+++ b/src/components/inputs/localized-rich-text-input/editor.js
@@ -152,11 +152,9 @@ const Editor = props => {
                   <RightColumn>
                     <FlatButton
                       onClick={toggle}
-                      label={
-                        isOpen
-                          ? intl.formatMessage(messages.collapse)
-                          : intl.formatMessage(messages.expand)
-                      }
+                      label={intl.formatMessage(
+                        isOpen ? messages.collapse : messages.expand
+                      )}
                       icon={
                         isOpen ? (
                           <AngleUpIcon size="small" />

--- a/src/components/inputs/localized-rich-text-input/localized-rich-text-input.js
+++ b/src/components/inputs/localized-rich-text-input/localized-rich-text-input.js
@@ -84,10 +84,6 @@ const LocalizedRichTextInput = props => {
     [expandedTranslationsDispatch]
   );
 
-  const expandAllTranslations = React.useCallback(() => {
-    expandedTranslationsDispatch({ type: 'toggleAll' });
-  }, [expandedTranslationsDispatch]);
-
   const languages = sortLanguages(
     props.selectedLanguage,
     Object.keys(props.value)
@@ -160,7 +156,6 @@ const LocalizedRichTextInput = props => {
               isLastLanguage={isLastLanguage}
               hasErrorOnRemainingLanguages={hasErrorOnRemainingLanguages}
               hasWarningOnRemainingLanguages={hasWarningOnRemainingLanguages}
-              expandAllTranslations={expandAllTranslations}
               hasError={Boolean(
                 props.hasError || (props.errors && props.errors[language])
               )}

--- a/src/components/inputs/localized-rich-text-input/localized-rich-text-input.visualroute.js
+++ b/src/components/inputs/localized-rich-text-input/localized-rich-text-input.visualroute.js
@@ -61,7 +61,11 @@ const DefaultRoute = () => (
     <Spec label="minimal" omitPropsList>
       <LocalizedRichTextInput
         onChange={() => {}}
-        value={initialValue}
+        value={{
+          en: emptyValue,
+          de: emptyValue,
+          es: emptyValue,
+        }}
         selectedLanguage="en"
         horizontalConstraint="m"
       />

--- a/src/components/inputs/localized-rich-text-input/rich-text-input.js
+++ b/src/components/inputs/localized-rich-text-input/rich-text-input.js
@@ -113,15 +113,7 @@ class RichTextInput extends React.PureComponent {
       return (
         <LanguagesControlButton
           isClosed={true}
-          onClick={() => {
-            // expand all multiline language inputs in case the
-            // first one was expanded when all languages
-            // are shown
-            if (this.props.isOpen) {
-              this.props.expandAllTranslations();
-            }
-            this.props.toggleLanguages();
-          }}
+          onClick={this.props.toggleLanguages}
           remainingLanguages={this.props.remainingLanguages}
         />
       );


### PR DESCRIPTION
#### Summary

As requested by design, we should show the `expand` button when there is more than 32px of collapsed text.