### PR TITLE
feat(rich-text-input): support admin center rich text

### DIFF
--- a/src/components/internals/rich-text-utils/html/html.js
+++ b/src/components/internals/rich-text-utils/html/html.js
@@ -1,6 +1,7 @@
 /* eslint-disable consistent-return */
 import React from 'react';
 import Html from 'slate-html-serializer';
+import flatMap from 'lodash/flatMap';
 import { MARK_TAGS, BLOCK_TAGS } from '../tags';
 
 const mapper = {
@@ -82,18 +83,18 @@ const rules = [
         const childNode = el.childNodes[0];
 
         if (styleAttribute) {
-          const marks = styleAttribute
-            .split(';')
-            .flatMap(val => {
-              const split = val.trim().split(' ');
+          const styles = styleAttribute.split(';');
 
-              const [key, ...values] = split;
+          const marks = flatMap(styles, val => {
+            const split = val.trim().split(' ');
 
-              return values.map(value => ({
-                // always remove the : from the key
-                [key.slice(0, -1)]: value,
-              }));
-            })
+            const [key, ...values] = split;
+
+            return values.map(value => ({
+              // always remove the : from the key
+              [key.slice(0, -1)]: value,
+            }));
+          })
             .map(val => {
               const [key, value] = Object.entries(val)[0];
               return mapper[key] && mapper[key][value];

--- a/src/components/internals/rich-text-utils/html/html.js
+++ b/src/components/internals/rich-text-utils/html/html.js
@@ -83,9 +83,7 @@ const rules = [
         const childNode = el.childNodes[0];
 
         if (styleAttribute) {
-          const styles = styleAttribute.split(';');
-
-          const marks = flatMap(styles, val => {
+          const marks = flatMap(styleAttribute.split(';'), val => {
             const split = val.trim().split(' ');
 
             const [key, ...values] = split;

--- a/src/components/internals/rich-text-utils/html/html.js
+++ b/src/components/internals/rich-text-utils/html/html.js
@@ -1,7 +1,27 @@
 /* eslint-disable consistent-return */
 import React from 'react';
 import Html from 'slate-html-serializer';
-import { MARK_TAGS, BLOCK_TAGS } from './tags';
+import { MARK_TAGS, BLOCK_TAGS } from '../tags';
+
+const mapper = {
+  'font-weight': {
+    bold: 'strong',
+  },
+  'text-decoration-line': {
+    underline: 'u',
+    'line-through': 'del',
+  },
+  'text-decoration': {
+    underline: 'u',
+  },
+  'font-style': {
+    italic: 'em',
+  },
+  'vertical-align': {
+    sub: 'sub',
+    super: 'sup',
+  },
+};
 
 const rules = [
   {
@@ -52,6 +72,58 @@ const rules = [
       }
     },
   },
+
+  {
+    // Special case for code blocks, which need to grab the nested childNodes.
+    deserialize(el, next) {
+      if (el.tagName.toLowerCase() === 'span') {
+        const styleAttribute = el.getAttribute('style');
+        let tagName = 'span';
+        const childNode = el.childNodes[0];
+
+        if (styleAttribute) {
+          const marks = styleAttribute
+            .split(';')
+            .flatMap(val => {
+              const split = val.trim().split(' ');
+
+              const [key, ...values] = split;
+
+              return values.map(value => ({
+                // always remove the : from the key
+                [key.slice(0, -1)]: value,
+              }));
+            })
+            .map(val => {
+              const [key, value] = Object.entries(val)[0];
+              return mapper[key] && mapper[key][value];
+            })
+            .filter(val => Boolean(val));
+
+          let deepestNode = el;
+
+          if (marks && marks.length > 0) {
+            tagName = marks[0];
+
+            marks.forEach(mark => {
+              deepestNode.removeChild(childNode);
+              const newNode = document.createElement(mark);
+              newNode.appendChild(childNode);
+              deepestNode.appendChild(newNode);
+              deepestNode = newNode;
+            });
+          }
+        }
+
+        return {
+          object: 'mark',
+          type: MARK_TAGS[tagName],
+          nodes: next(el.childNodes),
+        };
+      }
+    },
+  },
+
   // Add a new rule that handles marks...
   {
     deserialize(el, next) {
@@ -68,6 +140,8 @@ const rules = [
       if (obj.object === 'mark') {
         // eslint-disable-next-line default-case
         switch (obj.type) {
+          case 'span':
+            return <span>{children}</span>;
           case 'bold':
             return <strong>{children}</strong>;
           case 'italic':

--- a/src/components/internals/rich-text-utils/html/html.spec.js
+++ b/src/components/internals/rich-text-utils/html/html.spec.js
@@ -1,0 +1,77 @@
+import { JSDOM } from 'jsdom';
+import html from './html';
+
+const dom = new JSDOM();
+global.document = dom.window.document;
+global.window = dom.window;
+
+describe('html', () => {
+  describe('deserialize', () => {
+    describe('with empty value', () => {
+      it('should return same value', () => {
+        const htmlValue = '<p></p>';
+        expect(html.serialize(html.deserialize(htmlValue))).toEqual(htmlValue);
+      });
+    });
+    describe('with inline span styles', () => {
+      describe('with one known value', () => {
+        it('should properly serialize', () => {
+          const htmlValue = '<span style="font-weight: bold;">hello</span>';
+
+          expect(html.serialize(html.deserialize(htmlValue))).toEqual(
+            '<p><strong>hello</strong></p>'
+          );
+        });
+      });
+      describe('with one unknown value', () => {
+        it('should properly serialize', () => {
+          const htmlValue = '<span style="display: block;">hello</span>';
+
+          expect(html.serialize(html.deserialize(htmlValue))).toEqual(
+            '<p><span>hello</span></p>'
+          );
+        });
+      });
+      describe('with one unknown value and one known value', () => {
+        it('should properly serialize', () => {
+          const htmlValue =
+            '<span style="display: block; text-decoration: underline;">hello</span>';
+
+          expect(html.serialize(html.deserialize(htmlValue))).toEqual(
+            '<p><u>hello</u></p>'
+          );
+        });
+      });
+      describe('with two known values', () => {
+        it('should properly serialize', () => {
+          const htmlValue =
+            '<span style="font-weight: bold; text-decoration: underline;">hello</span>';
+
+          expect(html.serialize(html.deserialize(htmlValue))).toEqual(
+            '<p><strong><u>hello</u></strong></p>'
+          );
+        });
+      });
+      describe('with three known values', () => {
+        it('should properly serialize', () => {
+          const htmlValue =
+            '<span style="font-weight: bold; font-style: italic; text-decoration: underline;">hello</span>';
+
+          expect(html.serialize(html.deserialize(htmlValue))).toEqual(
+            '<p><strong><em><u>hello</u></em></strong></p>'
+          );
+        });
+      });
+      describe('with four known values', () => {
+        it('should properly serialize', () => {
+          const htmlValue =
+            '<span style="font-weight: bold; font-style: italic; text-decoration-line: underline line-through;">hello</span>';
+
+          expect(html.serialize(html.deserialize(htmlValue))).toEqual(
+            '<p><strong><em><u><del>hello</del></u></em></strong></p>'
+          );
+        });
+      });
+    });
+  });
+});

--- a/src/components/internals/rich-text-utils/html/html.spec.js
+++ b/src/components/internals/rich-text-utils/html/html.spec.js
@@ -81,6 +81,15 @@ describe('html', () => {
           );
         });
       });
+      describe('with line breaks', () => {
+        it('should properly serialize', () => {
+          const htmlValue =
+            '<p><span style="text-decoration-line: underline;">Underline</span></p><p><span style="text-decoration-line: line-through;">Strikethrough</span></p>';
+          expect(html.serialize(html.deserialize(htmlValue))).toEqual(
+            '<p><u>Underline</u></p><p><del>Strikethrough</del></p>'
+          );
+        });
+      });
       describe('mixed', () => {
         it('should properly serialize', () => {
           const htmlValue =

--- a/src/components/internals/rich-text-utils/html/html.spec.js
+++ b/src/components/internals/rich-text-utils/html/html.spec.js
@@ -14,6 +14,15 @@ describe('html', () => {
       });
     });
     describe('with inline span styles', () => {
+      describe('with no styles', () => {
+        it('should properly serialize', () => {
+          const htmlValue = '<span>hello</span>';
+
+          expect(html.serialize(html.deserialize(htmlValue))).toEqual(
+            '<p><span>hello</span></p>'
+          );
+        });
+      });
       describe('with one known value', () => {
         it('should properly serialize', () => {
           const htmlValue = '<span style="font-weight: bold;">hello</span>';
@@ -69,6 +78,16 @@ describe('html', () => {
 
           expect(html.serialize(html.deserialize(htmlValue))).toEqual(
             '<p><strong><em><u><del>hello</del></u></em></strong></p>'
+          );
+        });
+      });
+      describe('mixed', () => {
+        it('should properly serialize', () => {
+          const htmlValue =
+            '<span style="font-weight: bold"><span style="font-style: italic;">hello</span></span>';
+
+          expect(html.serialize(html.deserialize(htmlValue))).toEqual(
+            '<p><strong><em>hello</em></strong></p>'
           );
         });
       });

--- a/src/components/internals/rich-text-utils/html/index.js
+++ b/src/components/internals/rich-text-utils/html/index.js
@@ -1,0 +1,1 @@
+export { default } from './html';

--- a/src/components/internals/rich-text-utils/tags.js
+++ b/src/components/internals/rich-text-utils/tags.js
@@ -20,4 +20,5 @@ export const MARK_TAGS = {
   sup: 'superscript',
   sub: 'subscript',
   del: 'strikethrough',
+  span: 'span',
 };


### PR DESCRIPTION
#### Summary

The admin centre uses inline style instead of HTML elements.

![Screen Shot 2019-10-18 at 5 06 49 PM](https://user-images.githubusercontent.com/2425013/67105830-cb1e6c80-f1c9-11e9-8afc-82714e04a33d.png)

This results in the following HTML

```
<p>
  <span style="text-decoration-line: underline;">Underline</span>
</p>
<p>
  <span style="text-decoration-line: line-through;">Strikethrough</span>
</p>
```

We need to translate this to HTML that our `RichTextInput` can understand.

So it should look like this

```
<p><u>Underline</u></p><p><del>Strikethrough</del></p>
```

This is how the Admin Center deals with text that is underlined and strikethrough

```<span style="text-decoration-line: underline line-through" />```
