### PR TITLE
fix(collapsible-panel): z-index fix when sticky

### DIFF
--- a/src/components/panels/collapsible-panel/collapsible-panel.styles.js
+++ b/src/components/panels/collapsible-panel/collapsible-panel.styles.js
@@ -51,6 +51,7 @@ const getHeaderContainerStyles = ({ isDisabled, isOpen, isSticky, theme }) => {
     isSticky &&
       isOpen &&
       css`
+        z-index: 1;
         position: sticky;
         top: 0;
         border-top-right-radius: ${vars.borderRadius6};


### PR DESCRIPTION
#### Summary

Adds `z-index: 1` when sticky so that the header is visible. 