### PR TITLE
fix(typography): fix Text.Body to use intlMessage when 'as' prop is present

### DIFF
--- a/src/components/typography/text/text.js
+++ b/src/components/typography/text/text.js
@@ -180,7 +180,11 @@ const Body = props => {
         title={props.title}
         {...filterDataAttributes(props)}
       >
-        {props.children}
+        {props.intlMessage ? (
+          <FormattedMessage {...props.intlMessage} />
+        ) : (
+          props.children
+        )}
       </BodyElement>
     );
   }

--- a/src/components/typography/text/text.js
+++ b/src/components/typography/text/text.js
@@ -21,6 +21,15 @@ const intlMessageShape = PropTypes.shape({
   defaultMessage: PropTypes.string.isRequired,
 });
 
+const Text = ({ intlMessage, children }) =>
+  intlMessage ? <FormattedMessage {...intlMessage} /> : children;
+
+Text.displayName = 'Text';
+Text.propTypes = {
+  intlMessage: intlMessageShape,
+  children: PropTypes.node,
+};
+
 const nonEmptyString = (props, propName, componentName) => {
   const value = props[propName];
   if (typeof value === 'string' && !value)
@@ -38,11 +47,7 @@ const Headline = props => {
       title={props.title}
       {...filterDataAttributes(props)}
     >
-      {props.intlMessage ? (
-        <FormattedMessage {...props.intlMessage} />
-      ) : (
-        props.children
-      )}
+      <Text intlMessage={props.intlMessage}>{props.children}</Text>
     </HeadlineElement>
   );
 };
@@ -95,11 +100,7 @@ const Subheadline = props => {
       css={theme => subheadlineStyles(props, theme)}
       {...filterDataAttributes(props)}
     >
-      {props.intlMessage ? (
-        <FormattedMessage {...props.intlMessage} />
-      ) : (
-        props.children
-      )}
+      <Text intlMessage={props.intlMessage}>{props.children}</Text>
     </SubheadlineElement>
   );
 };
@@ -155,11 +156,7 @@ const Wrap = props => (
     title={props.title}
     {...filterDataAttributes(props)}
   >
-    {props.intlMessage ? (
-      <FormattedMessage {...props.intlMessage} />
-    ) : (
-      props.children
-    )}
+    <Text intlMessage={props.intlMessage}>{props.children}</Text>
   </div>
 );
 
@@ -180,11 +177,7 @@ const Body = props => {
         title={props.title}
         {...filterDataAttributes(props)}
       >
-        {props.intlMessage ? (
-          <FormattedMessage {...props.intlMessage} />
-        ) : (
-          props.children
-        )}
+        <Text intlMessage={props.intlMessage}>{props.children}</Text>
       </BodyElement>
     );
   }
@@ -195,11 +188,7 @@ const Body = props => {
       title={props.title}
       {...filterDataAttributes(props)}
     >
-      {props.intlMessage ? (
-        <FormattedMessage {...props.intlMessage} />
-      ) : (
-        props.children
-      )}
+      <Text intlMessage={props.intlMessage}>{props.children}</Text>
     </span>
   ) : (
     <p
@@ -207,11 +196,7 @@ const Body = props => {
       title={props.title}
       {...filterDataAttributes(props)}
     >
-      {props.intlMessage ? (
-        <FormattedMessage {...props.intlMessage} />
-      ) : (
-        props.children
-      )}
+      <Text intlMessage={props.intlMessage}>{props.children}</Text>
     </p>
   );
 };
@@ -258,11 +243,7 @@ const Detail = props => (
     title={props.title}
     {...filterDataAttributes(props)}
   >
-    {props.intlMessage ? (
-      <FormattedMessage {...props.intlMessage} />
-    ) : (
-      props.children
-    )}
+    <Text intlMessage={props.intlMessage}>{props.children}</Text>
   </small>
 );
 

--- a/src/components/typography/text/text.spec.js
+++ b/src/components/typography/text/text.spec.js
@@ -192,6 +192,13 @@ describe('<Body>', () => {
       );
       expect(container.querySelector('span')).toBeInTheDocument();
     });
+
+    it('should render given text with react-intl', () => {
+      const { container } = render(
+        <Text.Body title="tooltip text" intlMessage={intlMessage} as="span" />
+      );
+      expect(container).toHaveTextContent('Hello');
+    });
   });
 });
 


### PR DESCRIPTION
Fixes a bug where `intlMessage` prop is being ignored when the `as` prop is present for the `Text.Body` component.