### PR TITLE
fix(rich-text-input): disabled fix

### DIFF
--- a/src/components/inputs/localized-rich-text-input/rich-text-input.js
+++ b/src/components/inputs/localized-rich-text-input/rich-text-input.js
@@ -141,7 +141,7 @@ class RichTextInput extends React.PureComponent {
         id={this.props.id}
         name={this.props.name}
         disabled={this.props.isDisabled}
-        readOnly={this.props.isReadOnly}
+        readOnly={this.props.isReadOnly || this.props.isDisabled}
         value={this.internalSlateValue}
         onFocus={this.onFocus}
         onBlur={this.onBlur}

--- a/src/components/inputs/rich-text-input/rich-text-input.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.js
@@ -127,7 +127,7 @@ class RichTextInput extends React.PureComponent {
         onFocus={this.onFocus}
         onBlur={this.onBlur}
         disabled={this.props.isDisabled}
-        readOnly={this.props.isReadOnly}
+        readOnly={this.props.isReadOnly || this.props.isDisabled}
         value={this.internalSlateValue}
         // we can only pass this.props to the Editor that Slate understands without getting
         // warning in the console,


### PR DESCRIPTION
#### Summary

Slate does not seem to respect `disabled`. So instead we pass `readOnly` 

[ref](https://docs.slatejs.org/slate-core/editor#readonly)