### PR TITLE
fix(localized-rich-text-input): fix omit empty translations, add readme

### DIFF
--- a/src/components/inputs/localized-multiline-text-input/README.md
+++ b/src/components/inputs/localized-multiline-text-input/README.md
@@ -60,7 +60,7 @@ LocalizedMultilineTextInput.createLocalizedString(languages);
 // -> { en: '', de: '' }
 ```
 
-In case existingTranslations is passed, it will merge an empty localized field with the exisiting translations. Usually this is used to ensure that a localized string contains at least the project's languages.
+In case existingTranslations is passed, it will merge an empty localized field with the existing translations. Usually this is used to ensure that a localized string contains at least the project's languages.
 
 ```js
 const languages = ['en', 'de'];

--- a/src/components/inputs/localized-rich-text-input/README.md
+++ b/src/components/inputs/localized-rich-text-input/README.md
@@ -28,3 +28,112 @@ const Input = props => {
   )
 }
 ```
+
+#### Properties
+
+| Props                           | Type             | Required | Values                  | Default | Description                                                                                                                                                    |
+| ------------------------------- | ---------------- | :------: | ----------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                            | `string`         |    -     | -                       | -       | Used as prefix of HTML `id` property. Each input field id will have the language as a suffix (`${idPrefix}.${lang}`), e.g. `foo.en`                            |
+| `name`                          | `string`         |    -     | -                       | -       | Used as HTML `name` property for each input field. Each input field name will have the language as a suffix (`${namePrefix}.${lang}`), e.g. `foo.en`           |
+| `value`                         | `object`         |    ✅    | -                       | -       | Values to use. Keyed by language, the values are the actual values, e.g. `{ en: '<p>Horse</p>', de: '<p>Pferd</p>' }`                                          |
+| `autoComplete`                  | `string`         |    -     | -                       | -       | Used as HTML `autocomplete` property                                                                                                                           |
+| `onChange`                      | `function`       |    ✅    | -                       | -       | Gets called when any input is changed. Is called with the change event of the changed input.                                                                   |
+| `selectedLanguage`              | `string`         |    ✅    | -                       | -       | Specifies which language will be shown in case the `LocalizedRichTextInput` is collapsed.                                                                      |
+| `onBlur`                        | `function`       |    -     | -                       | -       | Called when any field is blurred. Is called with the `event` of that field.                                                                                    |
+| `onFocus`                       | `function`       |    -     | -                       | -       | Called when any field is focussed. Is called with the `event` of that field.                                                                                   |
+| `defaultExpandMultilineText`    | `bool`           |    -     | -                       | `false` | Expands input components holding multiline values instead of collpasing them by default.                                                                       |
+| `hideLanguageExpansionControls` | `bool`           |    -     | -                       | `false` | Will hide the language expansion controls when set to `true`. All languages will be shown when set to `true`.                                                  |
+| `defaultExpandLanguages`        | `bool`           |    -     | -                       | `false` | Controls whether one or all languages are visible by default. Pass `true` to show all languages by default.                                                    |
+| `isAutofocussed`                | `bool`           |    -     | -                       | `false` | Sets the focus on the first input when `true` is passed.                                                                                                       |
+| `isDisabled`                    | `bool`           |    -     | -                       | `false` | Disables all input fields.                                                                                                                                     |
+| `isReadOnly`                    | `bool`           |    -     | -                       | `false` | Disables all input fields and shows them in read-only mode.                                                                                                    |
+| `placeholder`                   | `object`         |    -     | -                       | -       | Placeholders for each language. Object of the same shape as `value`.                                                                                           |
+| `horizontalConstraint`          | `object`         |    -     | `m`, `l`, `xl`, `scale` | `scale` | Horizontal size limit of the input fields.                                                                                                                     |
+| `hasError`                      | `bool`           |    -     | -                       | -       | Will apply the error state to each input without showing any error message.                                                                                    |
+| `hasWarning`                    | `bool`           |    -     | -                       | -       | Will apply the warning state to each input without showing any warning message.                                                                                |
+| `errors`                        | `objectOf(node)` |    -     | -                       | -       | Used to show errors underneath the inputs of specific languages. Pass an object whose key is a language and whose value is the error to show for that key.     |
+| `warnings`                      | `objectOf(node)` |    -     | -                       | -       | Used to show warnings underneath the inputs of specific languages. Pass an object whose key is a language and whose value is the warning to show for that key. |
+
+The component forwards all `data` attribute props. It further adds a `-${language}` suffix to the values of the `data-test` and `data-track-component` attributes, e.g `data-test="foo"` will get added to the input for `en` as `data-test="foo-en"`.
+
+Main Functions and use cases are:
+
+- Receiving localized HTML input from user
+
+#### Static Properties
+
+##### `createLocalizedString(languages, existingTranslations)`
+
+This function creates a [localized string](https://docs.commercetools.com/http-api-types.html#localizedstring). It merges the `languages` and the language keys of existing translations to form a localized string holding all languages.
+The `existingTranslations` argument is optional. If it is not passed, an empty localized field will be created.
+
+```js
+const languages = ['en', 'de'];
+LocalizedRichTextInput.createLocalizedString(languages);
+// -> { en: '<p></p>', de: '<p></p>' }
+```
+
+In case existingTranslations is passed, it will merge an empty localized field with the existing translations. Usually this is used to ensure that a localized string contains at least the project's languages.
+
+```js
+const languages = ['en', 'de'];
+const existingTranslations = { en: '<p>Tree</p>', ar: '<p>شجرة</p>' };
+LocalizedRichTextInput.createLocalizedString(languages, existingTranslations);
+// -> { en: 'Tree', de: '', ar: '<p>شجرة</p>' }
+```
+
+##### `isEmpty(localizedField)`
+
+Returns `true` when all values in a localized field are empty.
+
+```js
+LocalizedRichTextInput.isEmpty({});
+// -> true
+```
+
+```js
+LocalizedRichTextInput.isEmpty({ en: '', de: '<p></p>' });
+// -> true
+```
+
+```js
+LocalizedRichTextInput.isEmpty({ en: '<p>Tree</p>', de: '<p></p>' });
+// -> false
+```
+
+##### `omitEmptyTranslations(localizedField)`
+
+Omits translations with empty values.
+
+```js
+LocalizedRichTextInput.omitEmptyTranslations({ en: '', de: '  ' });
+// -> {}
+```
+
+```js
+LocalizedRichTextInput.omitEmptyTranslations({ en: '<p>Tree</p>', de: '' });
+// -> { en: '<p>Tree</p>' }
+```
+
+##### `isTouched(touched)`
+
+Expects to be called with an object or `undefined`.
+Returns `true` when at least one value is truthy.
+
+##### `RequiredValueErrorMessage`
+
+This field exports a default error message which can be used when the field is
+required, but the user provided no value. You can use it as
+
+```js
+render (
+  return (
+    <div>
+      <LocalizedRichTextInput hasError={isMissing} />
+      {
+        isMissing && <LocalizedRichTextInput.RequiredValueErrorMessage />
+      }
+    </div>
+  )
+)
+```

--- a/src/components/inputs/localized-rich-text-input/localized-rich-text-input.js
+++ b/src/components/inputs/localized-rich-text-input/localized-rich-text-input.js
@@ -11,7 +11,6 @@ import {
   getHasErrorOnRemainingLanguages,
   getHasWarningOnRemainingLanguages,
   isTouched,
-  omitEmptyTranslations,
   getId,
   getName,
 } from '../../../utils/localized';
@@ -19,6 +18,7 @@ import RichTextInput from './rich-text-input';
 import {
   isEmpty,
   createLocalizedString,
+  omitEmptyTranslations,
 } from '../../internals/rich-text-utils/localized';
 import RequiredValueErrorMessage from './required-value-error-message';
 

--- a/src/components/internals/rich-text-utils/localized/index.js
+++ b/src/components/internals/rich-text-utils/localized/index.js
@@ -1,1 +1,5 @@
-export { createLocalizedString, isEmpty } from './localized';
+export {
+  createLocalizedString,
+  isEmpty,
+  omitEmptyTranslations,
+} from './localized';

--- a/src/components/internals/rich-text-utils/localized/localized.js
+++ b/src/components/internals/rich-text-utils/localized/localized.js
@@ -1,13 +1,31 @@
+import invariant from 'tiny-invariant';
 import uniq from 'lodash/uniq';
 import html from '../html';
 import isRichTextEmpty from '../is-empty';
 
 const initializeValue = value => html.serialize(html.deserialize(value));
 
-export const isEmpty = localizedString => {
-  if (!localizedString) return true;
-  return Object.values(localizedString).every(
-    value => !value || isRichTextEmpty(value)
+const isLocalizedHtmlValueEmpty = value => !value || isRichTextEmpty(value);
+
+export const isEmpty = localizedHtmlValue => {
+  if (!localizedHtmlValue) return true;
+  return Object.values(localizedHtmlValue).every(isLocalizedHtmlValueEmpty);
+};
+
+export const omitEmptyTranslations = localizedString => {
+  invariant(
+    typeof localizedString === 'object',
+    'omitEmptyTranslations must be called with an object'
+  );
+  return Object.entries(localizedString).reduce(
+    (localizedStringWithoutEmptyTranslations, [language, value]) => {
+      if (!isLocalizedHtmlValueEmpty(value)) {
+        // eslint-disable-next-line no-param-reassign
+        localizedStringWithoutEmptyTranslations[language] = value;
+      }
+      return localizedStringWithoutEmptyTranslations;
+    },
+    {}
   );
 };
 

--- a/src/components/internals/rich-text-utils/localized/localized.spec.js
+++ b/src/components/internals/rich-text-utils/localized/localized.spec.js
@@ -1,4 +1,8 @@
-import { createLocalizedString, isEmpty } from './localized';
+import {
+  createLocalizedString,
+  isEmpty,
+  omitEmptyTranslations,
+} from './localized';
 
 const emptyValue = '<p></p>';
 
@@ -57,6 +61,36 @@ describe('isEmpty', () => {
   describe('when calling with one undefined value and one truthy value', () => {
     it('should indicate that the value is not empty', () => {
       expect(isEmpty({ en: emptyValue, de: '<p>Okay</p>' })).toBeFalsy();
+    });
+  });
+});
+
+describe('omitEmptyTranslations', () => {
+  describe('when called with an empty object', () => {
+    it('should indicate that there are no defined translations', () => {
+      expect(omitEmptyTranslations({})).toEqual({});
+    });
+  });
+  describe('when called with all undefined values', () => {
+    it('should indicate that there are no defined translations', () => {
+      expect(omitEmptyTranslations({ en: null, de: null })).toEqual({});
+    });
+  });
+  describe('when called with one defined value', () => {
+    it('should indiciate that there is one defined translations', () => {
+      expect(
+        omitEmptyTranslations({ en: emptyValue, de: '<p>Hallo</p>' })
+      ).toEqual({ de: '<p>Hallo</p>' });
+    });
+  });
+  describe('when called with all defined values', () => {
+    it('should indiciate that there are two defined translations', () => {
+      expect(
+        omitEmptyTranslations({
+          en: '<h1>Poutine</h1>',
+          de: '<p>Hello World</p>',
+        })
+      ).toEqual({ en: '<h1>Poutine</h1>', de: '<p>Hello World</p>' });
     });
   });
 });


### PR DESCRIPTION
#### Summary

Defines an HTML centric `omitEmptyTranslations` for `LocalizedRichTextInput`.

Finishes up the README for `LocalizedRichTextInput`.