### PR TITLE
fix(rich-text-input): dropdown focus bug

### DIFF
--- a/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
@@ -4,6 +4,12 @@ import { getDocument, queries, wait } from 'pptr-testing-library';
 const { getByLabelText, getByText } = queries;
 
 describe('RichTextInput', () => {
+  const blur = async element => {
+    // eslint-disable-next-line no-shadow
+    await page.evaluate(element => {
+      element.blur();
+    }, element);
+  };
   const selectAllText = async input => {
     // eslint-disable-next-line no-shadow
     await page.evaluate(input => {
@@ -244,6 +250,9 @@ describe('RichTextInput', () => {
 
     // next, open the Style menu
 
+    // blur input first to test that editor focus works correctly
+    await blur(input);
+
     const styleMenuButton = await getByLabelText(doc, 'Style');
     await styleMenuButton.click();
 
@@ -284,6 +293,9 @@ describe('RichTextInput', () => {
     expect(numOfTags).toEqual(1);
 
     // now change back to paragraph (the default)
+
+    // blur input first to test that editor focus works correctly
+    await blur(input);
 
     // open style menu again
     await styleMenuButton.click();

--- a/src/components/internals/rich-text-body/rich-text-body.js
+++ b/src/components/internals/rich-text-body/rich-text-body.js
@@ -258,7 +258,7 @@ const RichTextEditorBody = React.forwardRef((props, ref) => {
     // if clicking on a dropdown, we need to both focus the RichTextInput
     // and open the dropdown.
     // if we don't use setTimeout, our dropdown opening will be hijacked by the
-    // editors rerendering.
+    // editors rerendering. (a so called `race condition`)
     // the reason we keep this here, is because any onClick from our dropdown or our mark buttons
     // will propogate to here.
     if (!props.editor.value.selection.isFocused) {

--- a/src/components/internals/rich-text-body/rich-text-body.js
+++ b/src/components/internals/rich-text-body/rich-text-body.js
@@ -252,6 +252,20 @@ const RichTextEditorBody = React.forwardRef((props, ref) => {
     );
   }
 
+  const { focus } = props.editor;
+
+  const onToolbarClick = React.useCallback(() => {
+    // if clicking on a dropdown, we need to both focus the RichTextInput
+    // and open the dropdown.
+    // if we don't use setTimeout, our dropdown opening will be hijacked by the
+    // editors rerendering.
+    // the reason we keep this here, is because any onClick from our dropdown or our mark buttons
+    // will propogate to here.
+    if (!props.editor.value.selection.isFocused) {
+      setTimeout(focus, 0);
+    }
+  }, [props.editor.value.selection.isFocused, focus]);
+
   return (
     <Container
       css={props.styles.container}
@@ -260,13 +274,7 @@ const RichTextEditorBody = React.forwardRef((props, ref) => {
       isReadOnly={props.isReadOnly}
       isDisabled={props.isDisabled}
     >
-      <Toolbar
-        onClick={() => {
-          if (!props.editor.value.selection.isFocused) {
-            props.editor.focus();
-          }
-        }}
-      >
+      <Toolbar onClick={onToolbarClick}>
         <ToolbarMainControls>
           <Dropdown
             label={intl.formatMessage(messages.styleDropdownLabel)}


### PR DESCRIPTION
#### Summary

The bug has to do with calling editor.focus() on any event propagated up to the Toolbar. The inline comment should explain the bug and the fix.

#### Before
![before](https://user-images.githubusercontent.com/2425013/67768383-ac826600-fa52-11e9-87a6-ce2702488cad.gif)

#### After

![after](https://user-images.githubusercontent.com/2425013/67768380-a9877580-fa52-11e9-8e34-f2047d44fc77.gif)
