### PR TITLE
chore(vrts): define new spec `listPropsOfChild` prop

### DIFF
--- a/src/components/label/label.visualroute.js
+++ b/src/components/label/label.visualroute.js
@@ -19,7 +19,7 @@ export const component = ({ themes }) => (
       </Label>
     </Spec>
     <ThemeProvider theme={{ ...themes.darkTheme, colorSurface: 'purple' }}>
-      <Spec label="when inverted" omitPropsList={true}>
+      <Spec label="when inverted" listPropsOfChild={true}>
         <ThemeProvider theme={themes.darkTheme}>
           <Label tone="inverted">Hello</Label>
         </ThemeProvider>

--- a/src/components/label/label.visualroute.js
+++ b/src/components/label/label.visualroute.js
@@ -19,7 +19,7 @@ export const component = ({ themes }) => (
       </Label>
     </Spec>
     <ThemeProvider theme={{ ...themes.darkTheme, colorSurface: 'purple' }}>
-      <Spec label="when inverted" listPropsOfChild={true}>
+      <Spec label="when inverted" listPropsOfNestedChild={true}>
         <ThemeProvider theme={themes.darkTheme}>
           <Label tone="inverted">Hello</Label>
         </ThemeProvider>

--- a/src/components/tooltip/tooltip.visualroute.js
+++ b/src/components/tooltip/tooltip.visualroute.js
@@ -16,12 +16,12 @@ export const routePath = '/tooltip';
 
 export const component = () => (
   <Suite>
-    <Spec label="Closed" listPropsOfChild={true}>
+    <Spec label="Closed" listPropsOfNestedChild={true}>
       <Tooltip title={title}>
         <PrimaryButton onClick={noop} label="Hello" />
       </Tooltip>
     </Spec>
-    <Spec label="Open" listPropsOfChild={true}>
+    <Spec label="Open" listPropsOfNestedChild={true}>
       <div
         css={css`
           margin-top: 50px;
@@ -31,7 +31,7 @@ export const component = () => (
         <PrimaryButton onClick={noop} label="Hello" />
       </Tooltip>
     </Spec>
-    <Spec label="Open with custom body component" listPropsOfChild={true}>
+    <Spec label="Open with custom body component" listPropsOfNestedChild={true}>
       <div
         css={css`
           margin-top: 50px;

--- a/src/components/tooltip/tooltip.visualroute.js
+++ b/src/components/tooltip/tooltip.visualroute.js
@@ -16,12 +16,12 @@ export const routePath = '/tooltip';
 
 export const component = () => (
   <Suite>
-    <Spec label="Closed" omitPropsList>
+    <Spec label="Closed" listPropsOfChild={true}>
       <Tooltip title={title}>
         <PrimaryButton onClick={noop} label="Hello" />
       </Tooltip>
     </Spec>
-    <Spec label="Open" omitPropsList>
+    <Spec label="Open" listPropsOfChild={true}>
       <div
         css={css`
           margin-top: 50px;
@@ -31,7 +31,7 @@ export const component = () => (
         <PrimaryButton onClick={noop} label="Hello" />
       </Tooltip>
     </Spec>
-    <Spec label="Open with custom body component" omitPropsList>
+    <Spec label="Open with custom body component" listPropsOfChild={true}>
       <div
         css={css`
           margin-top: 50px;

--- a/src/components/tooltip/tooltip.visualroute.js
+++ b/src/components/tooltip/tooltip.visualroute.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { PrimaryButton, Tooltip } from 'ui-kit';
 import { Suite, Spec } from '../../../test/percy';
@@ -12,34 +11,43 @@ const Body = styled.div`
   margin-top: 12px;
 `;
 
+const ContainerWithPadding = styled.div`
+  padding-top: 50px;
+`;
+
 export const routePath = '/tooltip';
 
-export const component = () => (
-  <Suite>
-    <Spec label="Closed" listPropsOfNestedChild={true}>
-      <Tooltip title={title}>
-        <PrimaryButton onClick={noop} label="Hello" />
-      </Tooltip>
-    </Spec>
-    <Spec label="Open" listPropsOfNestedChild={true}>
-      <div
-        css={css`
-          margin-top: 50px;
-        `}
-      />
-      <Tooltip title={title} isOpen={true}>
-        <PrimaryButton onClick={noop} label="Hello" />
-      </Tooltip>
-    </Spec>
-    <Spec label="Open with custom body component" listPropsOfNestedChild={true}>
-      <div
-        css={css`
-          margin-top: 50px;
-        `}
-      />
-      <Tooltip title={title} isOpen={true} components={{ BodyComponent: Body }}>
-        <PrimaryButton onClick={noop} label="Hello" />
-      </Tooltip>
-    </Spec>
-  </Suite>
-);
+export const component = () => {
+  return (
+    <Suite>
+      <Spec label="Closed">
+        <Tooltip title={title}>
+          <PrimaryButton onClick={noop} label="Hello" />
+        </Tooltip>
+      </Spec>
+      <Spec label="Open" listPropsOfNestedChild={true}>
+        <ContainerWithPadding>
+          <Tooltip title={title} isOpen={true}>
+            <PrimaryButton onClick={noop} label="Hello" />
+          </Tooltip>
+        </ContainerWithPadding>
+      </Spec>
+      <Spec
+        label="Open with custom body component"
+        listPropsOfNestedChild={true}
+      >
+        <ContainerWithPadding>
+          <Tooltip
+            title={title}
+            isOpen={true}
+            components={{ BodyComponent: Body }}
+          >
+            <PrimaryButton onClick={noop} label="Hello" />
+          </Tooltip>
+        </ContainerWithPadding>
+      </Spec>
+    </Suite>
+  );
+};
+/*
+ */

--- a/test/percy/README.md
+++ b/test/percy/README.md
@@ -191,5 +191,6 @@ A `Spec` should render your component in a specific state.
 
 You may use the prop `propsToList` to specify which props you want to display within the snapshot. Ideally, these should be the ones which you are testing. If `propsToList` is not defined, every prop will be displayed.
 If don't want to display any props at all, use `omitPropsList`.
+If you want to display of the child of the children you pass it, use `listPropsOfChild`. This can be useful if you need to wrap your component in a `ThemeProvider`.
 
 You can use multiple specs within a `Suite`.

--- a/test/percy/README.md
+++ b/test/percy/README.md
@@ -191,6 +191,7 @@ A `Spec` should render your component in a specific state.
 
 You may use the prop `propsToList` to specify which props you want to display within the snapshot. Ideally, these should be the ones which you are testing. If `propsToList` is not defined, every prop will be displayed.
 If don't want to display any props at all, use `omitPropsList`.
-If you want to display of the child of the children you pass it, use `listPropsOfChild`. This can be useful if you need to wrap your component in a `ThemeProvider`.
+
+If you want to display the props of a nested component which is wrapped by the direct child of your `Spec`, use `listPropsOfChild`. This can be useful if you need to wrap your component in a `ThemeProvider`.
 
 You can use multiple specs within a `Suite`.

--- a/test/percy/spec.js
+++ b/test/percy/spec.js
@@ -81,7 +81,10 @@ Pill.propTypes = {
 };
 
 const Props = props => {
-  const node = React.Children.only(props.children);
+  const node = props.listPropsOfChild
+    ? React.Children.only(props.children.props.children)
+    : React.Children.only(props.children);
+
   const propEntries = Object.entries(
     props.propsToList ? pick(node.props, props.propsToList) : node.props
   );
@@ -100,6 +103,7 @@ const Props = props => {
 Props.displayName = 'Props';
 Props.propTypes = {
   children: PropTypes.node.isRequired,
+  listPropsOfChild: PropTypes.bool.isRequired,
   propsToList: PropTypes.arrayOf(PropTypes.string),
 };
 
@@ -107,7 +111,12 @@ const Spec = props => (
   <SpecContainer>
     <Label>{props.label}</Label>
     {!props.omitPropsList && (
-      <Props propsToList={props.propsToList}>{props.children}</Props>
+      <Props
+        propsToList={props.propsToList}
+        listPropsOfChild={props.listPropsOfChild}
+      >
+        {props.children}
+      </Props>
     )}
     <Box>{props.children}</Box>
   </SpecContainer>
@@ -116,12 +125,14 @@ const Spec = props => (
 Spec.propTypes = {
   label: PropTypes.string.isRequired,
   children: PropTypes.node,
+  listPropsOfChild: PropTypes.bool,
   propsToList: PropTypes.arrayOf(PropTypes.string),
   omitPropsList: PropTypes.bool,
 };
 
 Spec.defaultProps = {
   omitPropsList: false,
+  listPropsOfChild: false,
 };
 
 Spec.displayName = 'Spec';

--- a/test/percy/spec.js
+++ b/test/percy/spec.js
@@ -81,7 +81,7 @@ Pill.propTypes = {
 };
 
 const Props = props => {
-  const node = props.listPropsOfChild
+  const node = props.listPropsOfNestedChild
     ? React.Children.only(props.children.props.children)
     : React.Children.only(props.children);
 
@@ -103,7 +103,7 @@ const Props = props => {
 Props.displayName = 'Props';
 Props.propTypes = {
   children: PropTypes.node.isRequired,
-  listPropsOfChild: PropTypes.bool.isRequired,
+  listPropsOfNestedChild: PropTypes.bool.isRequired,
   propsToList: PropTypes.arrayOf(PropTypes.string),
 };
 
@@ -113,7 +113,7 @@ const Spec = props => (
     {!props.omitPropsList && (
       <Props
         propsToList={props.propsToList}
-        listPropsOfChild={props.listPropsOfChild}
+        listPropsOfNestedChild={props.listPropsOfNestedChild}
       >
         {props.children}
       </Props>
@@ -125,14 +125,14 @@ const Spec = props => (
 Spec.propTypes = {
   label: PropTypes.string.isRequired,
   children: PropTypes.node,
-  listPropsOfChild: PropTypes.bool,
+  listPropsOfNestedChild: PropTypes.bool,
   propsToList: PropTypes.arrayOf(PropTypes.string),
   omitPropsList: PropTypes.bool,
 };
 
 Spec.defaultProps = {
   omitPropsList: false,
-  listPropsOfChild: false,
+  listPropsOfNestedChild: false,
 };
 
 Spec.displayName = 'Spec';


### PR DESCRIPTION
#### Summary

We sometimes have Specs that look like this.

```js
      <Spec label="when inverted" omitPropsList={true}>
        <ThemeProvider theme={themes.darkTheme}>
          <Label tone="inverted">Hello</Label>
        </ThemeProvider>
      </Spec>
```

In these cases, we would usually use `omitPropsList`, because otherwise, our props list will come from `ThemeProvider`, instead of from the component that we are testing.

By adding this prop, we can tell our `Spec` to use the child, and therefore display the correct props.
