### PR TITLE
fix(rich-text-input): fix for safari

### DIFF
--- a/src/components/inputs/localized-rich-text-input/editor.js
+++ b/src/components/inputs/localized-rich-text-input/editor.js
@@ -9,6 +9,7 @@ import filterDataAttributes from '../../../utils/filter-data-attributes';
 import usePrevious from '../../../hooks/use-previous';
 import CollapsibleMotion from '../../collapsible-motion';
 import Spacings from '../../spacings';
+import accessibleHiddenInputStyles from '../../internals/accessible-hidden-input.styles';
 import { AngleUpIcon, AngleDownIcon } from '../../icons';
 import Text from '../../typography/text';
 import FlatButton from '../../buttons/flat-button';
@@ -177,12 +178,14 @@ const Editor = props => {
 
 // eslint-disable-next-line react/display-name
 const renderEditor = (props, editor, next) => {
+  const internalId = `${props.id}__internal__id`;
+
   const children = React.cloneElement(next(), {
-    tagName: 'output',
+    id: internalId,
   });
 
   const passedProps = {
-    id: props.id,
+    id: internalId,
     isDisabled: props.disabled,
     isReadOnly: props.readOnly,
     ...pick(props.options, [
@@ -201,9 +204,25 @@ const renderEditor = (props, editor, next) => {
     ...filterDataAttributes(props),
   };
 
+  const isFocused = props.editor.value.selection.isFocused;
+
   return (
     <Editor editor={editor} {...passedProps}>
       {children}
+      <input
+        css={accessibleHiddenInputStyles}
+        id={props.id}
+        name={props.name}
+        onFocus={event => {
+          event.preventDefault();
+          if (!isFocused) {
+            editor.focus();
+          }
+        }}
+        onBlur={event => {
+          event.preventDefault();
+        }}
+      />
     </Editor>
   );
 };
@@ -233,6 +252,7 @@ renderEditor.propTypes = {
   name: PropTypes.string,
   disabled: PropTypes.bool,
   readOnly: PropTypes.bool,
+  editor: PropTypes.any,
   options: PropTypes.shape({
     language: PropTypes.string.isRequired,
     error: PropTypes.node,

--- a/src/components/inputs/localized-rich-text-input/editor.js
+++ b/src/components/inputs/localized-rich-text-input/editor.js
@@ -185,7 +185,7 @@ const renderEditor = (props, editor, next) => {
   });
 
   const passedProps = {
-    id: internalId,
+    id: props.id,
     isDisabled: props.disabled,
     isReadOnly: props.readOnly,
     ...pick(props.options, [

--- a/src/components/inputs/localized-rich-text-input/editor.js
+++ b/src/components/inputs/localized-rich-text-input/editor.js
@@ -9,11 +9,11 @@ import filterDataAttributes from '../../../utils/filter-data-attributes';
 import usePrevious from '../../../hooks/use-previous';
 import CollapsibleMotion from '../../collapsible-motion';
 import Spacings from '../../spacings';
-import accessibleHiddenInputStyles from '../../internals/accessible-hidden-input.styles';
 import { AngleUpIcon, AngleDownIcon } from '../../icons';
 import Text from '../../typography/text';
 import FlatButton from '../../buttons/flat-button';
 import RichTextBody from '../../internals/rich-text-body';
+import HiddenInput from '../../internals/rich-text-body/hidden-input';
 import { getLanguageLabelStyles } from './editor.styles';
 import messages from '../../internals/messages/multiline-input';
 
@@ -209,19 +209,10 @@ const renderEditor = (props, editor, next) => {
   return (
     <Editor editor={editor} {...passedProps}>
       {children}
-      <input
-        css={accessibleHiddenInputStyles}
+      <HiddenInput
+        isFocused={isFocused}
+        handleFocus={editor.focus}
         id={props.id}
-        name={props.name}
-        onFocus={event => {
-          event.preventDefault();
-          if (!isFocused) {
-            editor.focus();
-          }
-        }}
-        onBlur={event => {
-          event.preventDefault();
-        }}
       />
     </Editor>
   );

--- a/src/components/inputs/localized-rich-text-input/localized-rich-text-input.spec.js
+++ b/src/components/inputs/localized-rich-text-input/localized-rich-text-input.spec.js
@@ -10,50 +10,56 @@ const initialValue = '';
 const baseProps = {
   value: { en: initialValue, de: initialValue },
   id: 'rich-text-input',
+  'data-testid': 'rich-text-data-test',
   onChange: () => {},
 };
 
 describe('LocalizedRichTextInput', () => {
   it('should have an HTML name', () => {
-    const { getByLabelText } = render(
+    const { getByTestId } = render(
       <LocalizedRichTextInput {...baseProps} name="foo" selectedLanguage="en" />
     );
-    expect(getByLabelText('EN')).toHaveAttribute('name', 'foo.en');
+    expect(getByTestId('rich-text-data-test-en')).toHaveAttribute(
+      'name',
+      'foo.en'
+    );
   });
   describe('when collapsed', () => {
     it('should render input the selected languages (en)', () => {
-      const { getByLabelText, queryByLabelText } = render(
+      const { getByTestId, queryByLabelText } = render(
         <LocalizedRichTextInput {...baseProps} selectedLanguage="en" />
       );
-      expect(getByLabelText('EN')).toBeInTheDocument();
-      expect(queryByLabelText('DE')).not.toBeInTheDocument();
+      expect(getByTestId('rich-text-data-test-en')).toBeInTheDocument();
+      expect(
+        queryByLabelText('rich-text-data-test-de')
+      ).not.toBeInTheDocument();
     });
   });
 
   describe('when expanded', () => {
     it('should render inputs for all the languages (en, de)', () => {
-      const { getByLabelText } = render(
+      const { getByTestId } = render(
         <LocalizedRichTextInput
           {...baseProps}
           selectedLanguage="en"
           defaultExpandLanguages={true}
         />
       );
-      expect(getByLabelText('EN')).toBeInTheDocument();
-      expect(getByLabelText('DE')).toBeInTheDocument();
+      expect(getByTestId('rich-text-data-test-en')).toBeInTheDocument();
+      expect(getByTestId('rich-text-data-test-de')).toBeInTheDocument();
     });
   });
   describe('when expansion controls are hidden', () => {
     it('should render one input per language and no hide button', () => {
-      const { getByLabelText, queryByLabelText } = render(
+      const { getByTestId, queryByLabelText } = render(
         <LocalizedRichTextInput
           {...baseProps}
           selectedLanguage="en"
           hideLanguageExpansionControls={true}
         />
       );
-      expect(getByLabelText('EN')).toBeInTheDocument();
-      expect(getByLabelText('DE')).toBeInTheDocument();
+      expect(getByTestId('rich-text-data-test-en')).toBeInTheDocument();
+      expect(getByTestId('rich-text-data-test-de')).toBeInTheDocument();
       expect(queryByLabelText(/hide languages/i)).not.toBeInTheDocument();
     });
   });
@@ -61,7 +67,7 @@ describe('LocalizedRichTextInput', () => {
   describe('when disabled', () => {
     describe('when expanded', () => {
       it('should render a disabled input for each language (en, de)', () => {
-        const { getByLabelText } = render(
+        const { getByLabelText, getByTestId } = render(
           <LocalizedRichTextInput
             {...baseProps}
             selectedLanguage="en"
@@ -69,27 +75,33 @@ describe('LocalizedRichTextInput', () => {
           />
         );
         getByLabelText(/show all languages/i).click();
-        expect(getByLabelText('EN')).toHaveAttribute('disabled');
-        expect(getByLabelText('DE')).toHaveAttribute('disabled');
+        expect(getByTestId('rich-text-data-test-en')).toHaveAttribute(
+          'disabled'
+        );
+        expect(getByTestId('rich-text-data-test-de')).toHaveAttribute(
+          'disabled'
+        );
       });
     });
     describe('when not expanded', () => {
       it('should render a disabled input', () => {
-        const { getByLabelText } = render(
+        const { getByTestId } = render(
           <LocalizedRichTextInput
             {...baseProps}
             selectedLanguage="en"
             isDisabled={true}
           />
         );
-        expect(getByLabelText('EN')).toHaveAttribute('disabled');
+        expect(getByTestId('rich-text-data-test-en')).toHaveAttribute(
+          'disabled'
+        );
       });
     });
   });
   describe('when readonly', () => {
     describe('when expanded', () => {
       it('should render a readonly input for each language (en, de)', () => {
-        const { getByLabelText } = render(
+        const { getByLabelText, getByTestId } = render(
           <LocalizedRichTextInput
             {...baseProps}
             selectedLanguage="en"
@@ -97,20 +109,26 @@ describe('LocalizedRichTextInput', () => {
           />
         );
         getByLabelText(/show all languages/i).click();
-        expect(getByLabelText('EN')).not.toHaveAttribute('contenteditable');
-        expect(getByLabelText('DE')).not.toHaveAttribute('contenteditable');
+        expect(getByTestId('rich-text-data-test-en')).not.toHaveAttribute(
+          'contenteditable'
+        );
+        expect(getByTestId('rich-text-data-test-de')).not.toHaveAttribute(
+          'contenteditable'
+        );
       });
     });
     describe('when not expanded', () => {
       it('should render a disabled input', () => {
-        const { getByLabelText } = render(
+        const { getByTestId } = render(
           <LocalizedRichTextInput
             {...baseProps}
             selectedLanguage="en"
             isReadOnly={true}
           />
         );
-        expect(getByLabelText('EN')).not.toHaveAttribute('contenteditable');
+        expect(getByTestId('rich-text-data-test-en')).not.toHaveAttribute(
+          'contenteditable'
+        );
       });
     });
   });
@@ -120,15 +138,15 @@ describe('LocalizedRichTextInput', () => {
       de: 'Another error',
     };
     it('should be open all fields and render errors', () => {
-      const { getByLabelText, getByText } = render(
+      const { getByText, getByTestId } = render(
         <LocalizedRichTextInput
           {...baseProps}
           selectedLanguage="en"
           errors={errors}
         />
       );
-      expect(getByLabelText('EN')).toBeInTheDocument();
-      expect(getByLabelText('DE')).toBeInTheDocument();
+      expect(getByTestId('rich-text-data-test-en')).toBeInTheDocument();
+      expect(getByTestId('rich-text-data-test-de')).toBeInTheDocument();
       expect(getByText(errors.en)).toBeInTheDocument();
       expect(getByText(errors.de)).toBeInTheDocument();
     });
@@ -139,15 +157,15 @@ describe('LocalizedRichTextInput', () => {
       de: 'An error',
     };
     it('should be open all fields and render errors', () => {
-      const { getByLabelText, getByText } = render(
+      const { getByText, getByTestId } = render(
         <LocalizedRichTextInput
           {...baseProps}
           selectedLanguage="en"
           errors={errors}
         />
       );
-      expect(getByLabelText('EN')).toBeInTheDocument();
-      expect(getByLabelText('DE')).toBeInTheDocument();
+      expect(getByTestId('rich-text-data-test-en')).toBeInTheDocument();
+      expect(getByTestId('rich-text-data-test-de')).toBeInTheDocument();
       expect(getByText(errors.de)).toBeInTheDocument();
     });
   });
@@ -156,16 +174,18 @@ describe('LocalizedRichTextInput', () => {
       const errors = {
         en: 'A value required',
       };
-      const { getByLabelText, getByText, queryByLabelText } = render(
+      const { getByText, getByTestId, queryByLabelText } = render(
         <LocalizedRichTextInput
           {...baseProps}
           selectedLanguage="en"
           errors={errors}
         />
       );
-      expect(getByLabelText('EN')).toBeInTheDocument();
+      expect(getByTestId('rich-text-data-test-en')).toBeInTheDocument();
       expect(getByText(errors.en)).toBeInTheDocument();
-      expect(queryByLabelText('DE')).not.toBeInTheDocument();
+      expect(
+        queryByLabelText('rich-text-data-test-de')
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/inputs/localized-rich-text-input/localized-rich-text-input.visualroute.js
+++ b/src/components/inputs/localized-rich-text-input/localized-rich-text-input.visualroute.js
@@ -29,6 +29,8 @@ const WrappedComponent = ({ onChange, value }) => {
   return (
     <LocalizedRichTextInput
       id="rich-text"
+      name="rich-text"
+      data-testid="rich-text-data-test"
       onChange={handleChange}
       value={value}
       selectedLanguage="en"

--- a/src/components/inputs/localized-rich-text-input/localized-rich-text-input.visualspec.js
+++ b/src/components/inputs/localized-rich-text-input/localized-rich-text-input.visualspec.js
@@ -1,7 +1,7 @@
 import { percySnapshot } from '@percy/puppeteer';
 import { getDocument, queries, wait } from 'pptr-testing-library';
 
-const { getByLabelText, getAllByLabelText, getByText } = queries;
+const { getByLabelText, getByTestId, getAllByLabelText, getByText } = queries;
 
 describe('LocalizedRichTextInput', () => {
   const selectAllText = async input => {
@@ -33,7 +33,7 @@ describe('LocalizedRichTextInput', () => {
   it('Interactive', async () => {
     await page.goto(`${HOST}/localized-rich-text-input/interactive`);
     const doc = await getDocument(page);
-    let input = await getByLabelText(doc, 'EN');
+    let input = await getByTestId(doc, 'rich-text-data-test-en');
 
     // make the text bold
     let boldButton = await getByLabelText(doc, 'Bold');
@@ -66,7 +66,7 @@ describe('LocalizedRichTextInput', () => {
     expect(boldButtons.length).toBe(3);
 
     // switch to german input
-    input = await getByLabelText(doc, 'DE');
+    input = await getByTestId(doc, 'rich-text-data-test-de');
 
     boldButton = boldButtons[1];
 

--- a/src/components/inputs/rich-text-input/editor.js
+++ b/src/components/inputs/rich-text-input/editor.js
@@ -110,7 +110,6 @@ const renderEditor = (props, editor, next) => {
   const internalId = `${props.id}__internal__id`;
 
   const children = React.cloneElement(next(), {
-    // tagName: 'output',
     id: internalId,
   });
 

--- a/src/components/inputs/rich-text-input/editor.js
+++ b/src/components/inputs/rich-text-input/editor.js
@@ -117,7 +117,7 @@ const renderEditor = (props, editor, next) => {
 
   const passedProps = {
     name: props.name,
-    id: internalId,
+    id: props.id,
     isReadOnly: props.readOnly,
     isDisabled: props.disabled,
     ...pick(props.options, [

--- a/src/components/inputs/rich-text-input/editor.js
+++ b/src/components/inputs/rich-text-input/editor.js
@@ -4,6 +4,7 @@ import { css } from '@emotion/core';
 import { useIntl } from 'react-intl';
 import pick from 'lodash/pick';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
+import accessibleHiddenInputStyles from '../../internals/accessible-hidden-input.styles';
 import CollapsibleMotion from '../../collapsible-motion';
 import usePrevious from '../../../hooks/use-previous';
 import Spacings from '../../spacings';
@@ -106,13 +107,18 @@ const Editor = props => {
 
 // eslint-disable-next-line react/display-name
 const renderEditor = (props, editor, next) => {
+  const internalId = `${props.id}__internal__id`;
+
   const children = React.cloneElement(next(), {
-    tagName: 'output',
+    // tagName: 'output',
+    id: internalId,
   });
+
+  const isFocused = props.editor.value.selection.isFocused;
 
   const passedProps = {
     name: props.name,
-    id: props.id,
+    id: internalId,
     isReadOnly: props.readOnly,
     isDisabled: props.disabled,
     ...pick(props.options, [
@@ -129,6 +135,20 @@ const renderEditor = (props, editor, next) => {
   return (
     <Editor editor={editor} {...passedProps}>
       {children}
+      <input
+        css={accessibleHiddenInputStyles}
+        id={props.id}
+        name={props.name}
+        onFocus={event => {
+          event.preventDefault();
+          if (!isFocused) {
+            editor.focus();
+          }
+        }}
+        onBlur={event => {
+          event.preventDefault();
+        }}
+      />
     </Editor>
   );
 };

--- a/src/components/inputs/rich-text-input/editor.js
+++ b/src/components/inputs/rich-text-input/editor.js
@@ -4,7 +4,6 @@ import { css } from '@emotion/core';
 import { useIntl } from 'react-intl';
 import pick from 'lodash/pick';
 import filterDataAttributes from '../../../utils/filter-data-attributes';
-import accessibleHiddenInputStyles from '../../internals/accessible-hidden-input.styles';
 import CollapsibleMotion from '../../collapsible-motion';
 import usePrevious from '../../../hooks/use-previous';
 import Spacings from '../../spacings';
@@ -12,6 +11,7 @@ import { AngleUpIcon, AngleDownIcon } from '../../icons';
 import Constraints from '../../constraints';
 import FlatButton from '../../buttons/flat-button';
 import RichTextBody from '../../internals/rich-text-body';
+import HiddenInput from '../../internals/rich-text-body/hidden-input';
 import messages from '../../internals/messages/multiline-input';
 
 const COLLAPSED_HEIGHT = 32;
@@ -135,19 +135,10 @@ const renderEditor = (props, editor, next) => {
   return (
     <Editor editor={editor} {...passedProps}>
       {children}
-      <input
-        css={accessibleHiddenInputStyles}
+      <HiddenInput
+        isFocused={isFocused}
+        handleFocus={editor.focus}
         id={props.id}
-        name={props.name}
-        onFocus={event => {
-          event.preventDefault();
-          if (!isFocused) {
-            editor.focus();
-          }
-        }}
-        onBlur={event => {
-          event.preventDefault();
-        }}
       />
     </Editor>
   );

--- a/src/components/inputs/rich-text-input/rich-text-input.story.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.story.js
@@ -75,7 +75,7 @@ storiesOf('Components|Inputs', module)
           <label htmlFor={id}>Rich Text</label>
           <Input
             id={text('id', 'test-id')}
-            name={id}
+            name={text('name', 'test-name')}
             onBlur={onBlur}
             onFocus={onFocus}
             defaultExpandMultilineText={boolean(

--- a/src/components/inputs/rich-text-input/rich-text-input.story.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.story.js
@@ -57,7 +57,7 @@ storiesOf('Components|Inputs', module)
 
     const onBlur = React.useCallback(action('onBlur'), []);
     const onFocus = React.useCallback(action('onFocus'), []);
-
+    const id = text('id', 'test-id');
     return (
       <Section>
         <Spacings.Stack scale="l">
@@ -72,9 +72,10 @@ storiesOf('Components|Inputs', module)
               />
             )}
           />
+          <label htmlFor={id}>Rich Text</label>
           <Input
             id={text('id', 'test-id')}
-            name={text('name', 'test-name')}
+            name={id}
             onBlur={onBlur}
             onFocus={onFocus}
             defaultExpandMultilineText={boolean(

--- a/src/components/inputs/rich-text-input/rich-text-input.visualroute.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.visualroute.js
@@ -41,6 +41,7 @@ const InteractiveRoute = () => {
         </div>
         <label htmlFor="rich-text">Rich text</label>
         <RichTextInput
+          data-testid="rich-text"
           id="rich-text"
           onChange={onChange}
           value={value}

--- a/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.visualspec.js
@@ -1,7 +1,7 @@
 import { percySnapshot } from '@percy/puppeteer';
 import { getDocument, queries, wait } from 'pptr-testing-library';
 
-const { getByLabelText, getByText } = queries;
+const { getByLabelText, getByTestId, getByText } = queries;
 
 describe('RichTextInput', () => {
   const blur = async element => {
@@ -39,7 +39,7 @@ describe('RichTextInput', () => {
   it('Interactive', async () => {
     await page.goto(`${HOST}/rich-text-input/interactive`);
     const doc = await getDocument(page);
-    const input = await getByLabelText(doc, 'Rich text');
+    const input = await getByTestId(doc, 'rich-text');
 
     // make the text bold
     const boldButton = await getByLabelText(doc, 'Bold');

--- a/src/components/internals/rich-text-body/hidden-input.js
+++ b/src/components/internals/rich-text-body/hidden-input.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import accessibleHiddenInputStyles from '../accessible-hidden-input.styles';
+
+const HiddenInput = props => {
+  const { handleFocus } = props;
+  const onFocus = React.useCallback(
+    event => {
+      event.preventDefault();
+      if (!props.isFocused) {
+        handleFocus();
+      }
+    },
+    [props.isFocused, handleFocus]
+  );
+
+  const onBlur = React.useCallback(event => {
+    event.preventDefault();
+  }, []);
+
+  return (
+    <input
+      css={accessibleHiddenInputStyles}
+      id={props.id}
+      onFocus={onFocus}
+      onBlur={onBlur}
+    />
+  );
+};
+
+HiddenInput.displayName = 'HiddenInput';
+
+HiddenInput.propTypes = {
+  handleFocus: PropTypes.func,
+  id: PropTypes.string,
+  isFocused: PropTypes.bool.isRequired,
+};
+
+export default HiddenInput;

--- a/src/components/internals/rich-text-body/hidden-input.js
+++ b/src/components/internals/rich-text-body/hidden-input.js
@@ -24,6 +24,7 @@ const HiddenInput = props => {
       id={props.id}
       onFocus={onFocus}
       onBlur={onBlur}
+      tabIndex={-1}
     />
   );
 };

--- a/src/utils/localized.js
+++ b/src/utils/localized.js
@@ -45,6 +45,7 @@ export const createLocalizedDataAttributes = (props, language) =>
   Object.entries(filterDataAttributes(props)).reduce((acc, [key, value]) => {
     switch (key) {
       case 'data-track-component':
+      case 'data-testid':
       case 'data-test':
         acc[key] = `${value}-${language}`;
         break;


### PR DESCRIPTION
#### Summary

Currently the `RichTextInput` and the `LocalizedRichTextInput` are completely broken in Safari.

After a lot of debugging, I figured out that combining `slate` + `contenteditable` + `<output>` lead to this problem.

![bug](https://user-images.githubusercontent.com/2425013/67967102-47bb3d00-fc05-11e9-9447-9cf8daecca15.gif)

In case anyone has forgotten, the reason why we wanted to use `output` in the first place, is because it natively supports working with `label`s and `htmlFor`.

Instead, I added a hidden input and I manually focus the `RichTextInput` based on that.