### PR TITLE
refactor(rich-text-input): remove focusability from buttons

### DIFF
--- a/src/components/internals/rich-text-body/rich-text-body-button.js
+++ b/src/components/internals/rich-text-body/rich-text-body-button.js
@@ -18,6 +18,7 @@ const RichTextBodyButton = props => {
     <button
       {...restOfProps}
       type="button"
+      tabIndex={-1}
       data-button-type="rich-text-button"
       aria-disabled={props.isDisabled}
       disabled={props.isDisabled}


### PR DESCRIPTION
#### Summary

Having "focusable" inputs "inside" of our `RichTextInput` is a nightmare and really hard to deal with. This solves a few bugs, including this one.

![current](https://user-images.githubusercontent.com/2425013/68026175-2a42ad80-fcaf-11e9-9e6c-f1c9914497f4.gif)

