### PR TITLE
refactor(secondary-button): use as

### DIFF
--- a/src/components/buttons/accessible-button/accessible-button.js
+++ b/src/components/buttons/accessible-button/accessible-button.js
@@ -4,9 +4,10 @@ import styled from '@emotion/styled';
 import vars from '../../../../materials/custom-properties';
 
 const Button = styled.button`
+  text-decoration: none;
   border: none;
   background: none;
-  display: inline-block;
+  display: inline-flex;
   outline: 0;
   padding: 0;
   margin: 0;

--- a/src/components/buttons/accessible-button/accessible-button.js
+++ b/src/components/buttons/accessible-button/accessible-button.js
@@ -35,7 +35,7 @@ const AccessibleButton = React.forwardRef((props, ref) => {
     [onClick, props.isDisabled]
   );
 
-  const isButton = !props.as;
+  const isButton = !props.as || props.as === 'button';
 
   const buttonProps = {
     type: props.type,

--- a/src/components/buttons/accessible-button/accessible-button.js
+++ b/src/components/buttons/accessible-button/accessible-button.js
@@ -34,13 +34,18 @@ const AccessibleButton = React.forwardRef((props, ref) => {
     },
     [onClick, props.isDisabled]
   );
+
+  const isButton = !props.as;
+
+  const buttonProps = {
+    type: props.type,
+  };
+
   return (
     <Button
       as={props.as}
-      to={props.to}
       id={props.id}
       ref={ref}
-      type={props.type}
       aria-label={props.label}
       onClick={handleClick}
       // Allow to override the styles by passing a `className` prop.
@@ -51,6 +56,7 @@ const AccessibleButton = React.forwardRef((props, ref) => {
       aria-disabled={props.isDisabled}
       {...(props.isToggleButton ? { 'aria-pressed': props.isToggled } : {})}
       {...props.buttonAttributes}
+      {...(isButton ? buttonProps : {})}
     >
       {props.children}
     </Button>
@@ -60,7 +66,6 @@ AccessibleButton.displayName = 'AccessibleButton';
 AccessibleButton.propTypes = {
   as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
   id: PropTypes.string,
-  to: PropTypes.string,
   type: PropTypes.oneOf(['submit', 'reset', 'button']),
   label: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,

--- a/src/components/buttons/accessible-button/accessible-button.js
+++ b/src/components/buttons/accessible-button/accessible-button.js
@@ -57,7 +57,7 @@ const AccessibleButton = React.forwardRef((props, ref) => {
 });
 AccessibleButton.displayName = 'AccessibleButton';
 AccessibleButton.propTypes = {
-  as: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
   id: PropTypes.string,
   to: PropTypes.string,
   type: PropTypes.oneOf(['submit', 'reset', 'button']),

--- a/src/components/buttons/accessible-button/accessible-button.js
+++ b/src/components/buttons/accessible-button/accessible-button.js
@@ -1,7 +1,26 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { css } from '@emotion/core';
+import styled from '@emotion/styled';
 import vars from '../../../../materials/custom-properties';
+
+const Button = styled.button`
+  border: none;
+  background: none;
+  display: inline-block;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  white-space: nowrap;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  font-size: ${vars.fontSizeDefault};
+  font-family: inherit;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+`;
 
 const AccessibleButton = React.forwardRef((props, ref) => {
   const { onClick } = props;
@@ -15,30 +34,14 @@ const AccessibleButton = React.forwardRef((props, ref) => {
     [onClick, props.isDisabled]
   );
   return (
-    <button
+    <Button
+      as={props.as}
+      to={props.to}
       id={props.id}
       ref={ref}
       type={props.type}
       aria-label={props.label}
       onClick={handleClick}
-      css={css`
-        border: none;
-        background: none;
-        display: inline-block;
-        outline: 0;
-        padding: 0;
-        margin: 0;
-        white-space: nowrap;
-        cursor: pointer;
-        color: inherit;
-        font: inherit;
-        font-size: ${vars.fontSizeDefault};
-        font-family: inherit;
-
-        &:disabled {
-          cursor: not-allowed;
-        }
-      `}
       // Allow to override the styles by passing a `className` prop.
       // Custom styles can also be passed using the `css` prop from emotion.
       // https://emotion.sh/docs/css-prop#style-precedence
@@ -49,12 +52,14 @@ const AccessibleButton = React.forwardRef((props, ref) => {
       {...props.buttonAttributes}
     >
       {props.children}
-    </button>
+    </Button>
   );
 });
 AccessibleButton.displayName = 'AccessibleButton';
 AccessibleButton.propTypes = {
+  as: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   id: PropTypes.string,
+  to: PropTypes.string,
   type: PropTypes.oneOf(['submit', 'reset', 'button']),
   label: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,

--- a/src/components/buttons/secondary-button/secondary-button.js
+++ b/src/components/buttons/secondary-button/secondary-button.js
@@ -35,7 +35,7 @@ export const SecondaryButton = props => {
 
   const containerStyles = [
     css`
-      display: inline-block;
+      display: inline-flex;
       background-color: ${vars.colorSurface};
       border-radius: ${vars.borderRadius6};
       box-shadow: ${vars.shadow7};
@@ -46,10 +46,17 @@ export const SecondaryButton = props => {
     `,
     getStateStyles(props.isDisabled, isActive, props.theme),
     getThemeStyles(props.theme),
+    shouldUseLinkTag &&
+      css`
+        text-decoration: none;
+      `,
   ];
 
-  const containerElements = (
+  const linkProps = shouldUseLinkTag ? { to: props.linkTo, as: Link } : {};
+
+  return (
     <AccessibleButton
+      {...linkProps}
       type={props.type}
       buttonAttributes={dataProps}
       label={props.label}
@@ -85,22 +92,6 @@ export const SecondaryButton = props => {
       </Spacings.Inline>
     </AccessibleButton>
   );
-
-  if (shouldUseLinkTag) {
-    return (
-      <Link
-        css={[
-          css`
-            text-decoration: none;
-          `,
-        ]}
-        to={props.linkTo}
-      >
-        {containerElements}
-      </Link>
-    );
-  }
-  return containerElements;
 };
 
 SecondaryButton.propTypes = {

--- a/src/components/buttons/secondary-button/secondary-button.js
+++ b/src/components/buttons/secondary-button/secondary-button.js
@@ -26,16 +26,17 @@ export const getIconColor = props => {
 };
 
 export const SecondaryButton = props => {
+  const isActive = props.isToggleButton && props.isToggled;
+  const shouldUseLinkTag = !props.isDisabled && Boolean(props.linkTo);
+
+  const asProps = shouldUseLinkTag ? { as: Link } : { as: props.as };
+
   const buttonAttributes = {
     'data-track-component': 'SecondaryButton',
     ...filterAriaAttributes(props),
     ...filterDataAttributes(props),
-    to: props.to,
+    to: props.to || props.linkTo,
   };
-  const isActive = props.isToggleButton && props.isToggled;
-  const shouldUseLinkTag = !props.isDisabled && Boolean(props.linkTo);
-
-  const linkProps = shouldUseLinkTag ? { to: props.linkTo, as: Link } : {};
 
   const containerStyles = [
     css`
@@ -54,9 +55,7 @@ export const SecondaryButton = props => {
 
   return (
     <AccessibleButton
-      {...linkProps}
-      to={props.to}
-      as={props.as}
+      {...asProps}
       type={props.type}
       buttonAttributes={buttonAttributes}
       label={props.label}
@@ -141,16 +140,21 @@ SecondaryButton.propTypes = {
     );
   },
 
-  onClick: requiredIf(PropTypes.func, props => !props.linkTo),
+  onClick: requiredIf(PropTypes.func, props => {
+    return !props.linkTo && !props.to;
+  }),
   as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
-  to(props, propName, componentName) {
-    if (!props.as) {
-      return new Error(oneLine`
-              Invalid prop "${propName}" supplied to "${componentName}".
-              "${propName}" does not have any effect when "as" is not defined`);
+  to(props, propName, componentName, ...rest) {
+    if (props[propName] != null) {
+      if (!props.as) {
+        return new Error(oneLine`
+                Invalid prop "${propName}" supplied to "${componentName}".
+                "${propName}" does not have any effect when "as" is not defined`);
+      }
+      return PropTypes.string(props, propName, componentName, ...rest);
     }
 
-    return PropTypes.string;
+    return PropTypes.string(props, propName, componentName, ...rest);
   },
   linkTo(props, propName, componentName, ...rest) {
     // here

--- a/src/components/buttons/secondary-button/secondary-button.js
+++ b/src/components/buttons/secondary-button/secondary-button.js
@@ -132,6 +132,14 @@ SecondaryButton.propTypes = {
         `
       );
     }
+    if (props.to && props.type !== 'button') {
+      throw new Error(
+        oneLine`
+          ${componentName}: "${propName}" does not have any effect when
+          "to" is set.
+        `
+      );
+    }
     return PropTypes.oneOf(['submit', 'reset', 'button'])(
       props,
       propName,

--- a/src/components/buttons/secondary-button/secondary-button.js
+++ b/src/components/buttons/secondary-button/secondary-button.js
@@ -26,10 +26,11 @@ export const getIconColor = props => {
 };
 
 export const SecondaryButton = props => {
-  const dataProps = {
+  const buttonAttributes = {
     'data-track-component': 'SecondaryButton',
     ...filterAriaAttributes(props),
     ...filterDataAttributes(props),
+    to: props.to,
   };
   const isActive = props.isToggleButton && props.isToggled;
   const shouldUseLinkTag = !props.isDisabled && Boolean(props.linkTo);
@@ -57,7 +58,7 @@ export const SecondaryButton = props => {
       to={props.to}
       as={props.as}
       type={props.type}
-      buttonAttributes={dataProps}
+      buttonAttributes={buttonAttributes}
       label={props.label}
       onClick={props.onClick}
       isToggleButton={props.isToggleButton}

--- a/src/components/buttons/secondary-button/secondary-button.js
+++ b/src/components/buttons/secondary-button/secondary-button.js
@@ -148,8 +148,8 @@ SecondaryButton.propTypes = {
     if (props[propName] != null) {
       if (!props.as) {
         return new Error(oneLine`
-                Invalid prop "${propName}" supplied to "${componentName}".
-                "${propName}" does not have any effect when "as" is not defined`);
+          Invalid prop "${propName}" supplied to "${componentName}".
+          "${propName}" does not have any effect when "as" is not defined`);
       }
       return PropTypes.string(props, propName, componentName, ...rest);
     }

--- a/src/components/buttons/secondary-button/secondary-button.js
+++ b/src/components/buttons/secondary-button/secondary-button.js
@@ -143,7 +143,15 @@ SecondaryButton.propTypes = {
 
   onClick: requiredIf(PropTypes.func, props => !props.linkTo),
   as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
-  to: PropTypes.string,
+  to(props, propName, componentName) {
+    if (!props.as) {
+      return new Error(oneLine`
+              Invalid prop "${propName}" supplied to "${componentName}".
+              "${propName}" does not have any effect when "as" is not defined`);
+    }
+
+    return PropTypes.string;
+  },
   linkTo(props, propName, componentName, ...rest) {
     // here
     if (props[propName] != null) {

--- a/src/components/buttons/secondary-button/secondary-button.spec.js
+++ b/src/components/buttons/secondary-button/secondary-button.spec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { render, fireEvent, wait } from '../../../test-utils';
 import { PlusBoldIcon } from '../../icons';
 import SecondaryButton from './secondary-button';
@@ -71,9 +72,61 @@ describe('rendering', () => {
     });
   });
   describe('when using "linkTo"', () => {
+    /* eslint-disable no-console */
+    let log;
+    beforeEach(() => {
+      log = console.error;
+      console.error = jest.fn();
+    });
+    afterEach(() => {
+      console.error = log;
+    });
+
+    it('should warn', () => {
+      render(<SecondaryButton {...props} onClick={null} linkTo="/foo/bar" />);
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /Warning: "linkTo" property of "SecondaryButton" has been deprecated and will be removed in the next major version\./
+        )
+      );
+    });
+
     it('should navigate to link when clicked', async () => {
       const { getByLabelText, history } = render(
         <SecondaryButton {...props} onClick={null} linkTo="/foo/bar" />
+      );
+      fireEvent.click(getByLabelText('Add'));
+      await wait(() => {
+        expect(history.location.pathname).toBe('/foo/bar');
+      });
+    });
+  });
+  describe('when using `to` without using `as`', () => {
+    /* eslint-disable no-console */
+    let log;
+    beforeEach(() => {
+      log = console.error;
+      console.error = jest.fn();
+    });
+    afterEach(() => {
+      console.error = log;
+    });
+
+    it('should warn', () => {
+      render(<SecondaryButton {...props} onClick={null} to="/foo/bar" />);
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /Warning: Failed prop type: Invalid prop "to" supplied to "SecondaryButton"\./
+        )
+      );
+    });
+  });
+  describe('when using as', () => {
+    it('should navigate to link when clicked', async () => {
+      const { getByLabelText, history } = render(
+        <SecondaryButton {...props} onClick={null} as={Link} to="/foo/bar" />
       );
       fireEvent.click(getByLabelText('Add'));
       await wait(() => {

--- a/src/components/buttons/secondary-button/secondary-button.story.js
+++ b/src/components/buttons/secondary-button/secondary-button.story.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Link } from 'react-router-dom';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, boolean, text, select } from '@storybook/addon-knobs/react';
@@ -18,22 +18,31 @@ storiesOf('Components|Buttons', module)
       sidebar: Readme,
     },
   })
-  .add('SecondaryButton', () => (
-    <Section>
-      <MemoryRouter>
-        <SecondaryButton
-          type={select('type', ['button', 'reset', 'submit'], 'button')}
-          theme={select('theme', ['info', 'default'], 'default')}
-          iconLeft={React.createElement(
-            icons[select('iconLeft', iconNames, iconNames[0])]
-          )}
-          onClick={action('onClick')}
-          label={text('label', 'Accessibility text')}
-          isToggleButton={boolean('isToggleButton', false)}
-          isToggled={boolean('isToggled', false)}
-          isDisabled={boolean('isDisabled', false)}
-          linkTo={text('linkTo')}
-        />
-      </MemoryRouter>
-    </Section>
-  ));
+  .add('SecondaryButton', () => {
+    const linkTo = text('linkTo');
+
+    const isToggled = boolean('isToggled', false);
+    const isToggleButton = boolean('isToggleButton', false);
+    const toggleProps = isToggleButton ? { isToggled } : {};
+    const linkProps = linkTo && linkTo !== '' ? { to: linkTo, as: Link } : {};
+
+    return (
+      <Section>
+        <MemoryRouter>
+          <SecondaryButton
+            type={select('type', ['button', 'reset', 'submit'], 'button')}
+            theme={select('theme', ['info', 'default'], 'default')}
+            iconLeft={React.createElement(
+              icons[select('iconLeft', iconNames, iconNames[0])]
+            )}
+            onClick={action('onClick')}
+            label={text('label', 'Accessibility text')}
+            isToggleButton={boolean('isToggleButton', false)}
+            isDisabled={boolean('isDisabled', false)}
+            {...linkProps}
+            {...toggleProps}
+          />
+        </MemoryRouter>
+      </Section>
+    );
+  });


### PR DESCRIPTION
#### Summary

Refactors `SecondaryButton` to use `as` internally while keeping same API.