### PR TITLE
feat(icon-button): support `as` 

### DIFF
--- a/src/components/buttons/accessible-button/accessible-button.js
+++ b/src/components/buttons/accessible-button/accessible-button.js
@@ -7,6 +7,7 @@ const Button = styled.button`
   text-decoration: none;
   border: none;
   background: none;
+  box-sizing: border-box;
   display: inline-flex;
   outline: 0;
   padding: 0;

--- a/src/components/buttons/icon-button/README.md
+++ b/src/components/buttons/icon-button/README.md
@@ -23,20 +23,21 @@ Icon Buttons are "icon-only" buttons. They trigger an action when clicked
 
 #### Properties
 
-| Props            | Type     | Required | Values                      | Default           | Description                                                                                                                                      |
-| ---------------- | -------- | :------: | --------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `type`           | `string` |    -     | `submit`, `reset`, `button` | `button`          | Used as the HTML `type` attribute.                                                                                                               |
-| `label`          | `string` |    ✅    | -                           | -                 | Should describe what the button does, for accessibility purposes (screen-reader users)                                                           |
-| `icon`           | `node`   |    -     | -                           | -                 | Likely an `Icon` component                                                                                                                       |
-| `isToggleButton` | `bool`   |    -     | -                           | `false`           | If this is active, it means the button will persist in an "active" state when toggled (see `isToggled`), and back to normal state when untoggled |
-| `isToggled`      | `bool`   |    -     | -                           | -                 | Tells when the button should present a toggled state. It does not have any effect when `isToggleButton` is false                                 |
-| `isDisabled`     | `bool`   |    -     | -                           | -                 | Tells when the button should present a disabled state                                                                                            |
-| `onClick`        | `func`   |    ✅    | -                           | -                 | What the button will trigger when clicked                                                                                                        |
-| `shape`          | `oneOf`  |    -     | `round`, `square`           | `round`           | The container shape of the button                                                                                                                |
-| `size`           | `oneOf`  |    -     | `big`, `medium`, `small`    | `big`             | -                                                                                                                                                |
-| `theme`          | `oneOf`  |    -     | `default`                   | `info`, `primary` | The component may have a theme only if `isToggleButton` is true                                                                                  |
+| Props            | Type                  | Required | Values                      | Default           | Description                                                                                                                                      |
+| ---------------- | --------------------- | :------: | --------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `type`           | `string`              |    -     | `submit`, `reset`, `button` | `button`          | Used as the HTML `type` attribute.                                                                                                               |
+| `label`          | `string`              |    ✅    | -                           | -                 | Should describe what the button does, for accessibility purposes (screen-reader users)                                                           |
+| `icon`           | `node`                |    -     | -                           | -                 | Likely an `Icon` component                                                                                                                       |
+| `isToggleButton` | `bool`                |    -     | -                           | `false`           | If this is active, it means the button will persist in an "active" state when toggled (see `isToggled`), and back to normal state when untoggled |
+| `isToggled`      | `bool`                |    -     | -                           | -                 | Tells when the button should present a toggled state. It does not have any effect when `isToggleButton` is false                                 |
+| `isDisabled`     | `bool`                |    -     | -                           | -                 | Tells when the button should present a disabled state                                                                                            |
+| `onClick`        | `func`                |    ✅    | -                           | -                 | What the button will trigger when clicked                                                                                                        |
+| `shape`          | `oneOf`               |    -     | `round`, `square`           | `round`           | The container shape of the button                                                                                                                |
+| `size`           | `oneOf`               |    -     | `big`, `medium`, `small`    | `big`             | -                                                                                                                                                |
+| `theme`          | `oneOf`               |    -     | `default`                   | `info`, `primary` | The component may have a theme only if `isToggleButton` is true                                                                                  |
+| `as`             | `string` or `element` |    -     | -                           | -                 | You may pass in a string like "a" to have the button render as an anchor tag instead. Or you could pass in a React Component, like a `Link`.     |
 
-The component further forwards all `data-` and `aria-` attributes to the underlying `button` component.
+The component further forwards all valid HTML attributes to the underlying `button` component.
 
 #### Where to use
 

--- a/src/components/buttons/icon-button/icon-button.js
+++ b/src/components/buttons/icon-button/icon-button.js
@@ -81,18 +81,6 @@ export const IconButton = props => {
 };
 
 IconButton.propTypes = {
-  to(props, propName, componentName, ...rest) {
-    if (props[propName] != null) {
-      if (!props.as) {
-        return new Error(oneLine`
-          Invalid prop "${propName}" supplied to "${componentName}".
-          "${propName}" does not have any effect when "as" is not defined`);
-      }
-      return PropTypes.string(props, propName, componentName, ...rest);
-    }
-
-    return PropTypes.string(props, propName, componentName, ...rest);
-  },
   as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
   type: (props, propName, componentName, ...rest) => {
     // the type defaults to `button`, so we don't need to handle undefined

--- a/src/components/buttons/icon-button/icon-button.js
+++ b/src/components/buttons/icon-button/icon-button.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { oneLine } from 'common-tags';
 import isNil from 'lodash/isNil';
 import { css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
-import filterAriaAttributes from '../../../utils/filter-aria-attributes';
-import filterDataAttributes from '../../../utils/filter-data-attributes';
+import filterInvalidAttributes from '../../../utils/filter-invalid-attributes';
 import AccessibleButton from '../accessible-button';
 import {
   getStateStyles,
@@ -33,15 +33,17 @@ const getIconThemeColor = props => {
 };
 
 export const IconButton = props => {
-  const buttonAttributes = {
+  const attributes = {
     'data-track-component': 'IconButton',
-    ...filterAriaAttributes(props),
-    ...filterDataAttributes(props),
+    ...filterInvalidAttributes(props),
   };
+
   const isActive = props.isToggleButton && props.isToggled;
+
   return (
     <AccessibleButton
-      buttonAttributes={buttonAttributes}
+      as={props.as}
+      buttonAttributes={attributes}
       type={props.type}
       label={props.label}
       onClick={props.onClick}
@@ -79,7 +81,36 @@ export const IconButton = props => {
 };
 
 IconButton.propTypes = {
-  type: PropTypes.oneOf(['submit', 'reset', 'button']),
+  to(props, propName, componentName, ...rest) {
+    if (props[propName] != null) {
+      if (!props.as) {
+        return new Error(oneLine`
+          Invalid prop "${propName}" supplied to "${componentName}".
+          "${propName}" does not have any effect when "as" is not defined`);
+      }
+      return PropTypes.string(props, propName, componentName, ...rest);
+    }
+
+    return PropTypes.string(props, propName, componentName, ...rest);
+  },
+  as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
+  type: (props, propName, componentName, ...rest) => {
+    // the type defaults to `button`, so we don't need to handle undefined
+    if (props.as && props.type !== 'button') {
+      throw new Error(
+        oneLine`
+          ${componentName}: "${propName}" does not have any effect when
+          "as" is set.
+        `
+      );
+    }
+    return PropTypes.oneOf(['submit', 'reset', 'button'])(
+      props,
+      propName,
+      componentName,
+      ...rest
+    );
+  },
   label: PropTypes.string.isRequired,
   icon: PropTypes.node,
   isToggleButton: PropTypes.bool.isRequired,

--- a/src/components/buttons/icon-button/icon-button.spec.js
+++ b/src/components/buttons/icon-button/icon-button.spec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { render } from '../../../test-utils';
 import { PlusBoldIcon } from '../../icons';
 import IconButton from './icon-button';
@@ -44,5 +45,35 @@ describe('rendering', () => {
   it('should render icon', () => {
     const { getByTestId } = render(<IconButton {...props} />);
     expect(getByTestId('icon')).toBeInTheDocument();
+  });
+  describe('when used with `as`', () => {
+    describe('when as is a valid HTML element', () => {
+      it('should render as that HTML element', () => {
+        const { container } = render(
+          <IconButton
+            {...props}
+            as="a"
+            href="https://www.kanyetothe.com"
+            target="_BLANK"
+          />
+        );
+        const linkButton = container.querySelector('a');
+        expect(linkButton).toHaveAttribute(
+          'href',
+          'https://www.kanyetothe.com'
+        );
+        expect(linkButton).toHaveAttribute('target', '_BLANK');
+      });
+    });
+    describe('when as is a React component', () => {
+      it('should render as that component', () => {
+        const { getByLabelText } = render(
+          <IconButton {...props} as={Link} to="foo/bar" target="_BLANK" />
+        );
+
+        const linkButton = getByLabelText('test-button');
+        expect(linkButton).toHaveAttribute('href', '/foo/bar');
+      });
+    });
   });
 });

--- a/src/components/buttons/icon-button/icon-button.story.js
+++ b/src/components/buttons/icon-button/icon-button.story.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { MemoryRouter, Link } from 'react-router-dom';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, boolean, select, text } from '@storybook/addon-knobs/react';
@@ -17,21 +18,29 @@ storiesOf('Components|Buttons', module)
       sidebar: Readme,
     },
   })
-  .add('IconButton', () => (
-    <Section>
-      <IconButton
-        type={select('type', ['submit', 'reset', 'button'], 'button')}
-        shape={select('shape', ['round', 'square'], 'round')}
-        size={select('size', ['big', 'medium', 'small'], 'big')}
-        theme={select('theme', ['primary', 'info', 'default'], 'default')}
-        icon={React.createElement(
-          icons[select('icon', iconNames, iconNames[0])]
-        )}
-        onClick={action('onClick')}
-        label={text('label', 'Accessibility text')}
-        isToggleButton={boolean('isToggleButton', false)}
-        isToggled={boolean('isToggled', false)}
-        isDisabled={boolean('isDisabled?', false)}
-      />
-    </Section>
-  ));
+  .add('IconButton', () => {
+    const to = text('to', '');
+
+    return (
+      <Section>
+        <MemoryRouter>
+          <IconButton
+            as={to ? Link : null}
+            to={to}
+            type={select('type', ['submit', 'reset', 'button'], 'button')}
+            shape={select('shape', ['round', 'square'], 'round')}
+            size={select('size', ['big', 'medium', 'small'], 'big')}
+            theme={select('theme', ['primary', 'info', 'default'], 'default')}
+            icon={React.createElement(
+              icons[select('icon', iconNames, iconNames[0])]
+            )}
+            onClick={action('onClick')}
+            label={text('label', 'Accessibility text')}
+            isToggleButton={boolean('isToggleButton', false)}
+            isToggled={boolean('isToggled', false)}
+            isDisabled={boolean('isDisabled?', false)}
+          />
+        </MemoryRouter>
+      </Section>
+    );
+  });

--- a/src/components/buttons/secondary-button/README.md
+++ b/src/components/buttons/secondary-button/README.md
@@ -24,20 +24,21 @@ accessibility reasons.
 
 #### Properties
 
-| Props              | Type                 | Required | Values                      | Default   | Description                                                                                                                                      |
-| ------------------ | -------------------- | :------: | --------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `label`            | `string`             |    ✅    | -                           | -         | Should describe what the button does, for accessibility purposes (screen-reader users)                                                           |
-| `iconLeft`         | `node`               |    ✅    | -                           | -         | The left icon displayed within the button                                                                                                        |
-| `isToggleButton`   | `bool`               |    ✅    | -                           | `false`   | If this is active, it means the button will persist in an "active" state when toggled (see `isToggled`), and back to normal state when untoggled |
-| `isToggled`        | `bool`               |    -     | -                           | -         | Tells when the button should present a toggled state. It does not have any effect when `isToggleButton` is false                                 |
-| `theme`            | `string`             |    -     | `default`, `info`           | `default` | The component may have a theme only if `isToggleButton` is true                                                                                  |
-| `isDisabled`       | `bool`               |    -     | -                           | -         | Tells when the button should present a disabled state                                                                                            |
-| `buttonAttributes` | `object`             |    -     | -                           | -         | Allows setting custom attributes on the underlying button html element                                                                           |
-| `type`             | `string`             |    -     | `submit`, `reset`, `button` | `button`  | Used as the HTML `type` attribute.                                                                                                               |
-| `onClick`          | `func`               |          | -                           | -         | What the button will trigger when clicked                                                                                                        |
-| `linkTo`           | `string` or `object` |    -     | -                           | -         | Where the button should redirect when clicked                                                                                                    |
+| Props              | Type                  | Required | Values                      | Default   | Description                                                                                                                                      |
+| ------------------ | --------------------- | :------: | --------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `label`            | `string`              |    ✅    | -                           | -         | Should describe what the button does, for accessibility purposes (screen-reader users)                                                           |
+| `iconLeft`         | `node`                |    ✅    | -                           | -         | The left icon displayed within the button                                                                                                        |
+| `isToggleButton`   | `bool`                |    ✅    | -                           | `false`   | If this is active, it means the button will persist in an "active" state when toggled (see `isToggled`), and back to normal state when untoggled |
+| `isToggled`        | `bool`                |    -     | -                           | -         | Tells when the button should present a toggled state. It does not have any effect when `isToggleButton` is false                                 |
+| `theme`            | `string`              |    -     | `default`, `info`           | `default` | The component may have a theme only if `isToggleButton` is true                                                                                  |
+| `isDisabled`       | `bool`                |    -     | -                           | -         | Tells when the button should present a disabled state                                                                                            |
+| `buttonAttributes` | `object`              |    -     | -                           | -         | Allows setting custom attributes on the underlying button html element                                                                           |
+| `type`             | `string`              |    -     | `submit`, `reset`, `button` | `button`  | Used as the HTML `type` attribute.                                                                                                               |
+| `onClick`          | `func`                |          | -                           | -         | What the button will trigger when clicked                                                                                                        |
+| `linkTo`           | `string` or `object`  |    -     | -                           | -         | Where the button should redirect when clicked                                                                                                    |
+| `as`               | `string` or `element` |    -     | -                           | -         | You may pass in a string like "a" to have the button render as an anchor tag instead. Or you could pass in a React Component, like a `Link`.     |
 
-The component further forwards all `data-` and `aria-` attributes to the underlying `button` component.
+The component further forwards all valid HTML attributes to the underlying `button` component.
 
 Main Functions and use cases are:
 

--- a/src/components/buttons/secondary-button/secondary-button.js
+++ b/src/components/buttons/secondary-button/secondary-button.js
@@ -8,8 +8,7 @@ import { css } from '@emotion/core';
 import vars from '../../../../materials/custom-properties';
 import Spacings from '../../spacings';
 import AccessibleButton from '../accessible-button';
-import filterAriaAttributes from '../../../utils/filter-aria-attributes';
-import filterDataAttributes from '../../../utils/filter-data-attributes';
+import filterInvalidAttributes from '../../../utils/filter-invalid-attributes';
 import { getStateStyles, getThemeStyles } from './secondary-button.styles';
 import throwDeprecationWarning from '../../../utils/warn-deprecated-prop';
 
@@ -33,9 +32,8 @@ export const SecondaryButton = props => {
 
   const buttonAttributes = {
     'data-track-component': 'SecondaryButton',
-    ...filterAriaAttributes(props),
-    ...filterDataAttributes(props),
-    to: props.to || props.linkTo,
+    ...filterInvalidAttributes(props),
+    ...(shouldUseLinkTag ? { to: props.linkTo } : {}),
   };
 
   const containerStyles = [
@@ -132,11 +130,11 @@ SecondaryButton.propTypes = {
         `
       );
     }
-    if (props.to && props.type !== 'button') {
+    if (props.as && props.type !== 'button') {
       throw new Error(
         oneLine`
           ${componentName}: "${propName}" does not have any effect when
-          "to" is set.
+          "as" is set.
         `
       );
     }
@@ -149,7 +147,7 @@ SecondaryButton.propTypes = {
   },
 
   onClick: requiredIf(PropTypes.func, props => {
-    return !props.linkTo && !props.to;
+    return !props.linkTo && !props.as;
   }),
   as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
   to(props, propName, componentName, ...rest) {
@@ -174,12 +172,6 @@ SecondaryButton.propTypes = {
       );
 
       if (props.as) {
-        return new Error(oneLine`
-          Invalid prop "${propName}" supplied to "${componentName}".
-          "${propName}" does not have any effect when "as" is defined`);
-      }
-
-      if (props.to) {
         return new Error(oneLine`
           Invalid prop "${propName}" supplied to "${componentName}".
           "${propName}" does not have any effect when "as" is defined`);

--- a/src/utils/filter-invalid-attributes.js
+++ b/src/utils/filter-invalid-attributes.js
@@ -1,0 +1,11 @@
+import isPropValid from '@emotion/is-prop-valid';
+
+export default function filterProps(obj) {
+  return Object.keys(obj)
+    .filter(prop => isPropValid(prop))
+    .reduce((acc, prop) => {
+      // eslint-disable-next-line no-param-reassign
+      acc[prop] = obj[prop];
+      return acc;
+    }, {});
+}

--- a/src/utils/filter-invalid-attributes.spec.js
+++ b/src/utils/filter-invalid-attributes.spec.js
@@ -1,0 +1,22 @@
+import filterInvalidAttributes from './filter-invalid-attributes';
+
+describe('fitlerInvalidAttributes', () => {
+  it('filters invalid attributes', () => {
+    const dataAttrs = {
+      'aria-label': 'hello world',
+      'aria-disabled': 'true',
+      disabled: false,
+      'data-testid': 'hello-test',
+    };
+    const nonDataAttrs = {
+      two: 2,
+      four: 4,
+    };
+    const dataObject = {
+      ...dataAttrs,
+      ...nonDataAttrs,
+    };
+
+    expect(filterInvalidAttributes(dataObject)).toEqual(dataAttrs);
+  });
+});


### PR DESCRIPTION
#### Summary

Adds support for `as` to the `IconButton`.

Also supports prop forwarding to `IconButton` and `SecondaryButton`. Without this, it would not be possible to use `anchor` tags.

Closes #1162 