### PR TITLE
refactor(tag): simplify code by using `as` internally

### DIFF
--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -10,6 +10,8 @@ import AccessibleButton from '../buttons/accessible-button';
 import Text from '../typography/text';
 import { CloseBoldIcon } from '../icons';
 
+const Body = styled.div``;
+
 const getTextDetailColor = (isDisabled, theme) => {
   const overwrittenVars = {
     ...vars,
@@ -82,9 +84,7 @@ const getClickableContentWrapperStyles = ({ type, theme }) => {
       ];
 };
 
-const Body = styled.div``;
-
-export const TagNormalBody = props => (
+const TagBody = props => (
   <Body
     to={props.to}
     as={props.as}
@@ -126,8 +126,8 @@ export const TagNormalBody = props => (
   </Body>
 );
 
-TagNormalBody.displayName = 'TagNormalBody';
-TagNormalBody.propTypes = {
+TagBody.displayName = 'TagBody';
+TagBody.propTypes = {
   as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
   to: PropTypes.string,
   type: PropTypes.string.isRequired,
@@ -162,7 +162,7 @@ const Tag = props => {
           `
         }
       >
-        <TagNormalBody
+        <TagBody
           {...linkProps}
           styles={props.styles}
           type={props.type}
@@ -171,7 +171,7 @@ const Tag = props => {
           isDisabled={props.isDisabled}
         >
           {props.children}
-        </TagNormalBody>
+        </TagBody>
 
         {Boolean(props.onRemove) && (
           <AccessibleButton

--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -175,7 +175,7 @@ const Tag = props => {
           <AccessibleButton
             label="Remove"
             isDisabled={props.isDisabled}
-            onClick={props.isDisabled ? undefined : props.onRemove}
+            onClick={props.onRemove}
             css={theme => {
               const overwrittenVars = {
                 ...vars,

--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -120,7 +120,7 @@ const TagBody = props => (
         `,
       props.styles.body,
     ]}
-    onClick={props.isDisabled ? undefined : props.onClick}
+    onClick={props.onClick}
   >
     <Text.Detail>{props.children}</Text.Detail>
   </Body>

--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -120,7 +120,7 @@ const TagBody = props => (
         `,
       props.styles.body,
     ]}
-    onClick={props.onClick}
+    onClick={props.isDisabled ? undefined : props.onClick}
   >
     <Text.Detail>{props.children}</Text.Detail>
   </Body>

--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import vars from '../../../materials/custom-properties';
 import designTokens from '../../../materials/design-tokens';
@@ -32,7 +33,6 @@ const getContentWrapperStyles = (props, theme) => {
     align-items: center;
     border-radius: ${overwrittenVars[designTokens.borderRadiusForTag]};
     padding: 5px ${vars.spacingS};
-    cursor: default;
     white-space: normal;
     text-align: left;
     min-width: 0;
@@ -82,77 +82,12 @@ const getClickableContentWrapperStyles = ({ type, theme }) => {
       ];
 };
 
-export const TagLinkBody = props => {
-  const isRemoveable = Boolean(props.onRemove);
-  return (
-    <div
-      css={theme => [
-        getContentWrapperStyles(props, theme),
-        !props.isDisabled &&
-          css`
-            cursor: pointer;
-          `,
-        !props.isDisabled &&
-          isRemoveable &&
-          css`
-            padding-right: ${vars.spacingS};
-            &:hover {
-              &::after {
-                position: absolute;
-                right: -1px;
-                content: '';
-                background-color: ${vars.borderColorForTagWhenFocused};
-                width: 1px;
-                height: 100%;
-              }
-            }
-          `,
-        !props.isDisabled &&
-          getClickableContentWrapperStyles({
-            type: props.type,
-            theme,
-          }),
-        isRemoveable &&
-          css`
-            border-right: 0;
-            border-top-right-radius: 0;
-            border-bottom-right-radius: 0;
-          `,
-        props.styles.body,
-      ]}
-    >
-      {!props.isDisabled ? (
-        <Link
-          onClick={props.onClick}
-          to={props.linkTo}
-          css={css`
-            text-decoration: none;
-          `}
-        >
-          <Text.Detail>{props.children}</Text.Detail>
-        </Link>
-      ) : (
-        <Text.Detail>{props.children}</Text.Detail>
-      )}
-    </div>
-  );
-};
-
-TagLinkBody.displayName = 'TagLinkBody';
-TagLinkBody.propTypes = {
-  type: PropTypes.string.isRequired,
-  onClick: PropTypes.func,
-  onRemove: PropTypes.func,
-  linkTo: PropTypes.string,
-  isDisabled: PropTypes.bool.isRequired,
-  children: PropTypes.node.isRequired,
-  styles: PropTypes.shape({
-    body: PropTypes.object,
-  }).isRequired,
-};
+const Body = styled.div``;
 
 export const TagNormalBody = props => (
-  <div
+  <Body
+    to={props.to}
+    as={props.as}
     css={theme => [
       getContentWrapperStyles(props, theme),
       Boolean(props.onRemove) &&
@@ -188,10 +123,13 @@ export const TagNormalBody = props => (
     onClick={props.isDisabled ? undefined : props.onClick}
   >
     <Text.Detail>{props.children}</Text.Detail>
-  </div>
+  </Body>
 );
+
 TagNormalBody.displayName = 'TagNormalBody';
 TagNormalBody.propTypes = {
+  as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
+  to: PropTypes.string,
   type: PropTypes.string.isRequired,
   onClick: PropTypes.func,
   onRemove: PropTypes.func,
@@ -202,30 +140,30 @@ TagNormalBody.propTypes = {
   }).isRequired,
 };
 
-const Tag = props => (
-  <Constraints.Horizontal constraint={props.horizontalConstraint}>
-    <div
-      css={theme => [
-        css`
-          min-width: 0;
-          display: flex;
-          background-color: ${getWrapperBackgroundColor(props.type, theme)};
-        `,
-      ]}
-    >
-      {props.linkTo ? (
-        <TagLinkBody
-          styles={props.styles}
-          type={props.type}
-          onClick={props.onClick}
-          onRemove={props.onRemove}
-          linkTo={props.linkTo}
-          isDisabled={props.isDisabled}
-        >
-          {props.children}
-        </TagLinkBody>
-      ) : (
+const Tag = props => {
+  const linkProps =
+    props.linkTo && !props.isDisabled
+      ? { as: Link, to: props.linkTo }
+      : { as: 'div' };
+
+  return (
+    <Constraints.Horizontal constraint={props.horizontalConstraint}>
+      <div
+        css={theme =>
+          css`
+            a {
+              cursor: pointer;
+              text-decoration: none;
+            }
+            cursor: default;
+            min-width: 0;
+            display: flex;
+            background-color: ${getWrapperBackgroundColor(props.type, theme)};
+          `
+        }
+      >
         <TagNormalBody
+          {...linkProps}
           styles={props.styles}
           type={props.type}
           onClick={props.onClick}
@@ -234,65 +172,66 @@ const Tag = props => (
         >
           {props.children}
         </TagNormalBody>
-      )}
-      {Boolean(props.onRemove) && (
-        <AccessibleButton
-          label="Remove"
-          isDisabled={props.isDisabled}
-          onClick={props.isDisabled ? undefined : props.onRemove}
-          css={theme => {
-            const overwrittenVars = {
-              ...vars,
-              ...theme,
-            };
 
-            return [
-              css`
-                border-color: ${props.type === 'warning'
-                  ? overwrittenVars[designTokens.borderColorForTagWarning]
-                  : overwrittenVars[designTokens.borderColorForTag]};
-                padding: 0 ${vars.spacingXs};
-                border-radius: 0
-                  ${overwrittenVars[designTokens.borderRadiusForTag]}
-                  ${overwrittenVars[designTokens.borderRadiusForTag]} 0;
-                display: flex;
-                align-items: center;
-                background: inherit;
-                border-style: solid;
-                border-width: 1px 1px 1px 1px;
-                &:hover,
-                &:focus {
-                  border-color: ${overwrittenVars[
-                    designTokens.borderColorForTagWarning
-                  ]};
+        {Boolean(props.onRemove) && (
+          <AccessibleButton
+            label="Remove"
+            isDisabled={props.isDisabled}
+            onClick={props.isDisabled ? undefined : props.onRemove}
+            css={theme => {
+              const overwrittenVars = {
+                ...vars,
+                ...theme,
+              };
 
-                  > svg * {
-                    fill: ${overwrittenVars[
+              return [
+                css`
+                  border-color: ${props.type === 'warning'
+                    ? overwrittenVars[designTokens.borderColorForTagWarning]
+                    : overwrittenVars[designTokens.borderColorForTag]};
+                  padding: 0 ${vars.spacingXs};
+                  border-radius: 0
+                    ${overwrittenVars[designTokens.borderRadiusForTag]}
+                    ${overwrittenVars[designTokens.borderRadiusForTag]} 0;
+                  display: flex;
+                  align-items: center;
+                  background: inherit;
+                  border-style: solid;
+                  border-width: 1px 1px 1px 1px;
+                  &:hover,
+                  &:focus {
+                    border-color: ${overwrittenVars[
                       designTokens.borderColorForTagWarning
                     ]};
+
+                    > svg * {
+                      fill: ${overwrittenVars[
+                        designTokens.borderColorForTagWarning
+                      ]};
+                    }
                   }
-                }
-                > svg * {
-                  fill: ${overwrittenVars[designTokens.fontColorForTag]};
-                }
-              `,
-              props.isDisabled &&
-                css`
                   > svg * {
-                    fill: ${overwrittenVars[
-                      designTokens.fontColorForTagWhenDisabled
-                    ]};
+                    fill: ${overwrittenVars[designTokens.fontColorForTag]};
                   }
                 `,
-            ];
-          }}
-        >
-          <CloseBoldIcon size="medium" />
-        </AccessibleButton>
-      )}
-    </div>
-  </Constraints.Horizontal>
-);
+                props.isDisabled &&
+                  css`
+                    > svg * {
+                      fill: ${overwrittenVars[
+                        designTokens.fontColorForTagWhenDisabled
+                      ]};
+                    }
+                  `,
+              ];
+            }}
+          >
+            <CloseBoldIcon size="medium" />
+          </AccessibleButton>
+        )}
+      </div>
+    </Constraints.Horizontal>
+  );
+};
 
 Tag.propTypes = {
   type: PropTypes.oneOf(['normal', 'warning']),

--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -142,9 +142,7 @@ TagBody.propTypes = {
 
 const Tag = props => {
   const linkProps =
-    props.linkTo && !props.isDisabled
-      ? { as: Link, to: props.linkTo }
-      : { as: 'div' };
+    props.linkTo && !props.isDisabled ? { as: Link, to: props.linkTo } : {};
 
   return (
     <Constraints.Horizontal constraint={props.horizontalConstraint}>


### PR DESCRIPTION
#### Summary

The `Tag` code was needlessly complicated as we rendered different internal "containers" based on whether or not it was a `Link`. This simplifies it quite a bit while preserving the same API.