### PR TITLE
refactor(flat-button): add as, deprecate linkbutton

### DIFF
--- a/src/components/buttons/accessible-button/accessible-button.js
+++ b/src/components/buttons/accessible-button/accessible-button.js
@@ -14,7 +14,7 @@ const Button = styled.button`
   padding: 0;
   margin: 0;
   white-space: nowrap;
-  cursor: pointer;
+  cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
   color: inherit;
   font: inherit;
   font-size: ${vars.fontSizeDefault};
@@ -30,6 +30,10 @@ const AccessibleButton = React.forwardRef((props, ref) => {
 
   const handleClick = React.useCallback(
     event => {
+      if (props.isDisabled) {
+        event.preventDefault();
+        return false;
+      }
       if (!props.isDisabled && onClick) return onClick(event);
       // eslint-disable-next-line no-useless-return, consistent-return
       return;
@@ -45,6 +49,9 @@ const AccessibleButton = React.forwardRef((props, ref) => {
 
   return (
     <Button
+      {...(props.isToggleButton ? { 'aria-pressed': props.isToggled } : {})}
+      {...props.buttonAttributes}
+      {...(isButton ? buttonProps : {})}
       as={props.as}
       id={props.id}
       ref={ref}
@@ -56,9 +63,6 @@ const AccessibleButton = React.forwardRef((props, ref) => {
       className={props.className}
       disabled={props.isDisabled}
       aria-disabled={props.isDisabled}
-      {...(props.isToggleButton ? { 'aria-pressed': props.isToggled } : {})}
-      {...props.buttonAttributes}
-      {...(isButton ? buttonProps : {})}
     >
       {props.children}
     </Button>

--- a/src/components/buttons/accessible-button/accessible-button.js
+++ b/src/components/buttons/accessible-button/accessible-button.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import omit from 'lodash/omit';
 import { oneLine } from 'common-tags';
 import styled from '@emotion/styled';
 import vars from '../../../../materials/custom-properties';
+
+const propsToOmit = ['onClick'];
 
 const Button = styled.button`
   text-decoration: none;
@@ -49,9 +52,6 @@ const AccessibleButton = React.forwardRef((props, ref) => {
 
   return (
     <Button
-      {...(props.isToggleButton ? { 'aria-pressed': props.isToggled } : {})}
-      {...props.buttonAttributes}
-      {...(isButton ? buttonProps : {})}
       as={props.as}
       id={props.id}
       ref={ref}
@@ -63,6 +63,9 @@ const AccessibleButton = React.forwardRef((props, ref) => {
       className={props.className}
       disabled={props.isDisabled}
       aria-disabled={props.isDisabled}
+      {...(props.isToggleButton ? { 'aria-pressed': props.isToggled } : {})}
+      {...omit(props.buttonAttributes, propsToOmit)}
+      {...(isButton ? buttonProps : {})}
     >
       {props.children}
     </Button>

--- a/src/components/buttons/flat-button/README.md
+++ b/src/components/buttons/flat-button/README.md
@@ -26,17 +26,18 @@ iconClass label url onClick
 
 #### Properties
 
-| Props          | Type      | Required | Values                      | Default   | Description                                           |
-| -------------- | --------- | :------: | --------------------------- | --------- | ----------------------------------------------------- |
-| `tone`         | `oneOf`   |    -     | `primary`, `secondary`      | `primary` | -                                                     |
-| `type`         | `string`  |    -     | `submit`, `reset`, `button` | `button`  | Used as the HTML `type` attribute.                    |
-| `label`        | `string`  |    ✅    | -                           | -         | Should describe what the button is for                |
-| `onClick`      | `func`    |    ✅    | -                           | -         | What the button will trigger when clicked             |
-| `icon`         | `element` |    -     | -                           | -         | The icon of the button                                |
-| `iconPosition` | `oneOf`   |    -     | `left`, `right`             | `left`    | The position of the icon                              |
-| `isDisabled`   | `boolean` |    -     | -                           | -         | Tells when the button should present a disabled state |
+| Props          | Type                  | Required | Values                      | Default   | Description                                                                                                                                  |
+| -------------- | --------------------- | :------: | --------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tone`         | `oneOf`               |    -     | `primary`, `secondary`      | `primary` | -                                                                                                                                            |
+| `type`         | `string`              |    -     | `submit`, `reset`, `button` | `button`  | Used as the HTML `type` attribute.                                                                                                           |
+| `label`        | `string`              |    ✅    | -                           | -         | Should describe what the button is for                                                                                                       |
+| `onClick`      | `func`                |    ✅    | -                           | -         | What the button will trigger when clicked                                                                                                    |
+| `icon`         | `element`             |    -     | -                           | -         | The icon of the button                                                                                                                       |
+| `iconPosition` | `oneOf`               |    -     | `left`, `right`             | `left`    | The position of the icon                                                                                                                     |
+| `isDisabled`   | `boolean`             |    -     | -                           | -         | Tells when the button should present a disabled state                                                                                        |
+| `as`           | `string` or `element` |    -     | -                           | -         | You may pass in a string like "a" to have the button render as an anchor tag instead. Or you could pass in a React Component, like a `Link`. |
 
-The component further forwards all `data-` and `aria-` attributes to the underlying `button` component.
+The component further forwards all valid HTML attributes to the underlying `button` component.
 
 #### Where to use
 

--- a/src/components/buttons/flat-button/flat-button.js
+++ b/src/components/buttons/flat-button/flat-button.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
+import omit from 'lodash/omit';
 import vars from '../../../../materials/custom-properties';
-import filterAriaAttributes from '../../../utils/filter-aria-attributes';
-import filterDataAttributes from '../../../utils/filter-data-attributes';
+import filterInvalidAttributes from '../../../utils/filter-invalid-attributes';
 import Text from '../../typography/text';
 import Spacings from '../../spacings';
 import AccessibleButton from '../accessible-button';
+
+const propsToOmit = ['type'];
 
 const getIconElement = props => {
   if (!props.icon) return null;
@@ -39,12 +41,15 @@ const getTextColor = (tone, isHover = false, overwrittenVars) => {
 export const FlatButton = props => {
   const dataProps = {
     'data-track-component': 'FlatButton',
-    ...filterAriaAttributes(props),
-    ...filterDataAttributes(props),
+    ...filterInvalidAttributes(omit(props, propsToOmit)),
+    // if there is a divergence between `isDisabled` and `disabled`,
+    // we fall back to `isDisabled`
+    disabled: props.isDisabled,
   };
 
   return (
     <AccessibleButton
+      as={props.as}
       type={props.type}
       label={props.label}
       onClick={props.onClick}
@@ -56,7 +61,6 @@ export const FlatButton = props => {
         };
 
         return css`
-          display: flex;
           align-items: center;
           font-size: 1rem;
           border: none;
@@ -105,6 +109,7 @@ export const FlatButton = props => {
 
 FlatButton.displayName = 'FlatButton';
 FlatButton.propTypes = {
+  as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
   tone: PropTypes.oneOf(['primary', 'secondary']),
   type: PropTypes.oneOf(['submit', 'reset', 'button']),
   label: PropTypes.string.isRequired,

--- a/src/components/buttons/flat-button/flat-button.spec.js
+++ b/src/components/buttons/flat-button/flat-button.spec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { render } from '../../../test-utils';
 import { PlusThinIcon } from '../../icons';
 import FlatButton from './flat-button';
@@ -60,6 +61,39 @@ describe('rendering', () => {
     it('should render a button of type "reset"', () => {
       const { getByLabelText } = render(<FlatButton {...props} type="reset" />);
       expect(getByLabelText('Add')).toHaveAttribute('type', 'reset');
+    });
+  });
+  describe('when used with `as`', () => {
+    describe('when as is a valid HTML element', () => {
+      it('should render as that HTML element', () => {
+        const { getByLabelText } = render(
+          <FlatButton
+            {...props}
+            as="a"
+            href="https://www.kanyetothe.com"
+            target="_BLANK"
+          />
+        );
+        const linkButton = getByLabelText('Add');
+        expect(linkButton).toHaveAttribute(
+          'href',
+          'https://www.kanyetothe.com'
+        );
+        expect(linkButton).not.toHaveAttribute('type', 'button');
+        expect(linkButton).toHaveAttribute('target', '_BLANK');
+      });
+    });
+    describe('when as is a React component', () => {
+      it('should render as that component', () => {
+        const { getByLabelText } = render(
+          <FlatButton {...props} as={Link} to="foo/bar" target="_BLANK" />
+        );
+
+        const linkButton = getByLabelText('Add');
+        expect(linkButton).toHaveAttribute('href', '/foo/bar');
+        expect(linkButton).toHaveAttribute('target', '_BLANK');
+        expect(linkButton).not.toHaveAttribute('type', 'button');
+      });
     });
   });
 });

--- a/src/components/buttons/link-button/link-button.js
+++ b/src/components/buttons/link-button/link-button.js
@@ -4,6 +4,7 @@ import { Link as ReactRouterLink } from 'react-router-dom';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import vars from '../../../../materials/custom-properties';
+import warnDeprecatedComponent from '../../../utils/warn-deprecated-component';
 import getPassThroughProps from '../../../utils/get-pass-through-props';
 import Text from '../../typography/text';
 import Spacings from '../../spacings';
@@ -63,6 +64,9 @@ LinkBody.propTypes = {
 };
 
 const LinkButton = props => {
+  React.useEffect(() => {
+    warnDeprecatedComponent('LinkButton');
+  }, []);
   const remainingProps = getPassThroughProps(
     props,
     Object.keys(LinkButton.propTypes)

--- a/src/components/buttons/link-button/link-button.spec.js
+++ b/src/components/buttons/link-button/link-button.spec.js
@@ -11,10 +11,29 @@ const createTestProps = custom => ({
 });
 
 describe('rendering', () => {
+  /* eslint-disable no-console */
   let props;
+  let log;
   beforeEach(() => {
     props = createTestProps();
+    log = console.error;
+    console.error = jest.fn();
   });
+
+  afterEach(() => {
+    console.error = log;
+  });
+
+  it('should warn', () => {
+    render(<LinkButton {...props} />);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringMatching(
+        'Warning: "LinkButton" has been deprecated and will be removed in the next major version.'
+      )
+    );
+  });
+
   it('should render', () => {
     const { getByLabelText } = render(<LinkButton {...props} />);
     expect(getByLabelText('test-button')).toBeInTheDocument();

--- a/src/components/inputs/localized-multiline-text-input/translation-input.js
+++ b/src/components/inputs/localized-multiline-text-input/translation-input.js
@@ -22,6 +22,7 @@ const LeftColumn = styled.div`
 const RightColumn = styled.div`
   flex: 0;
   display: flex;
+  align-items: flex-start;
 `;
 
 const Row = styled.div`

--- a/src/components/inputs/localized-multiline-text-input/translation-input.js
+++ b/src/components/inputs/localized-multiline-text-input/translation-input.js
@@ -21,6 +21,7 @@ const LeftColumn = styled.div`
 
 const RightColumn = styled.div`
   flex: 0;
+  display: flex;
 `;
 
 const Row = styled.div`

--- a/src/components/inputs/localized-rich-text-input/editor.js
+++ b/src/components/inputs/localized-rich-text-input/editor.js
@@ -25,6 +25,7 @@ const LeftColumn = styled.div`
 
 const RightColumn = styled.div`
   flex: 0;
+  display: flex;
 `;
 
 const Row = styled.div`

--- a/src/components/inputs/localized-rich-text-input/editor.js
+++ b/src/components/inputs/localized-rich-text-input/editor.js
@@ -21,6 +21,8 @@ const COLLAPSED_HEIGHT = 32;
 
 const LeftColumn = styled.div`
   flex: 1;
+  display: flex;
+  align-items: flex-start;
 `;
 
 const RightColumn = styled.div`

--- a/src/components/inputs/localized-rich-text-input/editor.js
+++ b/src/components/inputs/localized-rich-text-input/editor.js
@@ -26,6 +26,7 @@ const LeftColumn = styled.div`
 const RightColumn = styled.div`
   flex: 0;
   display: flex;
+  align-items: flex-start;
 `;
 
 const Row = styled.div`

--- a/src/utils/warn-deprecated-component.js
+++ b/src/utils/warn-deprecated-component.js
@@ -1,0 +1,7 @@
+import warning from 'warning';
+
+export default (componentName, additionalMessage = '') => {
+  const message = `"${componentName}" has been deprecated and will be removed in the next major version.${additionalMessage}`;
+
+  warning(false, message);
+};


### PR DESCRIPTION
#### Summary

* Deprecates `LinkButton`
* Adds `as` prop to `FlatButton`.
* Fixes a bug in `AccessibleButton` where `handleClick` was being overwritten by the passed in `onClick`