### PR TITLE
fix: primary button active and toggle state

### DIFF
--- a/src/components/buttons/primary-button/primary-button.styles.js
+++ b/src/components/buttons/primary-button/primary-button.styles.js
@@ -50,7 +50,7 @@ const getButtonStyles = (isDisabled, isActive, tone, size) => {
     const baseActiveStyles = [
       baseStyles,
       css`
-        box-shadow: inset ${vars.shadow7First}, inset ${vars.shadow7Second};
+        box-shadow: ${vars.shadow9};
         &:hover,
         &:focus {
           box-shadow: ${vars.shadow8};
@@ -97,7 +97,7 @@ const getButtonStyles = (isDisabled, isActive, tone, size) => {
         box-shadow: ${vars.shadow8};
       }
       &:active {
-        box-shadow: inset ${vars.shadow7First}, inset ${vars.shadow7Second};
+        box-shadow: ${vars.shadow9};
       }
     `,
   ];


### PR DESCRIPTION
## Summary

Fixes the `active` and `toggled` state of `PrimaryButton`, because of some leftover deprecated design tokens we forgot to update on version 10.0.0 😅

**Before**: (the button remains the same when clicked or toggled)
**After**:
![image](https://user-images.githubusercontent.com/2941328/68666288-ed46a880-0543-11ea-8335-604813baf920.png)
