### PR TITLE
fix: Localized Rich Text Input containment

### DIFF
--- a/src/components/inputs/localized-rich-text-input/editor.js
+++ b/src/components/inputs/localized-rich-text-input/editor.js
@@ -114,6 +114,7 @@ const Editor = props => {
                   container: css`
                     flex: auto;
                     width: 100%;
+                    overflow: auto;
                     border-top-left-radius: 0;
                     border-bottom-left-radius: 0;
                   `,


### PR DESCRIPTION
#### Summary

This PR fixes an edge case where the width of the Localized Rich Text Input might outgrow the size of its container in case there is a very long word (or the container is narrow), such as the name of a very specific tool in the Icelandic language:
![image](https://user-images.githubusercontent.com/2941328/68849826-121d5600-06d3-11ea-93e7-5c0ce1c908e3.png)

#### Description

This occurs because the Rich Text input container grows until 100% of its parent width and only then it starts breaking the text, but it doesn't take into account the space taken from the language label on the left (which is variable).

The added one-liner fixes this, as the text is broken to different lines before the input outgrows its parent, with no side-effects.