### PR TITLE
fix(toggle-input): allow to pass value prop

### DIFF
--- a/src/components/inputs/toggle-input/toggle-input.js
+++ b/src/components/inputs/toggle-input/toggle-input.js
@@ -119,6 +119,7 @@ const ToggleInput = props => {
         onChange={props.onChange}
         disabled={props.isDisabled}
         checked={props.isChecked}
+        value={props.value}
         type="checkbox"
         size={props.size}
         {...filterDataAttributes(props)}
@@ -136,6 +137,7 @@ ToggleInput.propTypes = {
   size: PropTypes.oneOf(['small', 'big']).isRequired,
   isDisabled: PropTypes.bool,
   isChecked: PropTypes.bool.isRequired,
+  value: PropTypes.string,
   onChange: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
TL;DR: in Formik v2 they changed a bit how checkbox and radio inputs deal with values

> Formik 2 "fixes" React checkboxes and multi-selects with built-in array binding and boolean behavior

https://github.com/jaredpalmer/formik/releases/tag/v2.0.1

As we are upgrading our apps to formik v2, we started bumping into weird test failures and we narrowed the issue down to checkbox input types. It seems that if no `value` is provided, the default value is `on`, [as described in the MDN <input type="checkbox">](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#Value).

You can also see in the following codesandbox how the behavior differs:

<img width="1232" alt="image" src="https://user-images.githubusercontent.com/1110551/69086793-c35f1b80-0a46-11ea-83d0-296285ebb472.png">

https://codesandbox.io/s/formik-checkbox-value-i40kv

## The fix

It appears that by passing both `value` and `checked` to the input, Formik handles the boolean value correctly.