### PR TITLE
fix(tooltip): do not use native title when tooltip is off

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -140,18 +140,24 @@ const Tooltip = props => {
   }, [props.off, closeAfter, handleClose, toggle, isOpen]);
 
   const childrenProps = {
-    'aria-describedby': tooltipIsOpen ? id : null,
-    // for seo and accessibility, we add the tooltip's title
-    // as a native title when the title is hidden
-    title:
-      !tooltipIsOpen && typeof props.title === 'string' ? props.title : null,
-    ...props.children.props,
     // don't pass event listeners to children
     onFocus: null,
     onMouseOver: null,
     onMouseLeave: null,
     onBlur: null,
   };
+
+  const tooltipProps = !props.off
+    ? {
+        'aria-describedby': tooltipIsOpen ? id : null,
+        // for seo and accessibility, we add the tooltip's title
+        // as a native title when the title is hidden
+        title:
+          !tooltipIsOpen && typeof props.title === 'string'
+            ? props.title
+            : null,
+      }
+    : {};
 
   const eventListeners = !props.off
     ? {
@@ -170,7 +176,10 @@ const Tooltip = props => {
   return (
     <React.Fragment>
       <WrapperComponent {...eventListeners} ref={reference.ref}>
-        {React.cloneElement(props.children, { ...childrenProps })}
+        {React.cloneElement(props.children, {
+          ...childrenProps,
+          ...tooltipProps,
+        })}
       </WrapperComponent>
       {tooltipIsOpen && (
         <TooltipWrapperComponent>

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -448,7 +448,7 @@ describe('when off is true', () => {
     // should not be visible
     expect(queryByText('What kind of bear is best?')).not.toBeInTheDocument();
     // should not have title
-    expect(button).not.toHaveProperty('title', 'What kind of bear is best?');
+    expect(button).not.toHaveAttribute('title');
 
     fireEvent.mouseLeave(button);
 

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -431,7 +431,7 @@ describe('when off is true', () => {
     // should not be visible
     expect(queryByText('What kind of bear is best?')).not.toBeInTheDocument();
     // should not have title
-    expect(button).not.toHaveProperty('title', 'What kind of bear is best?');
+    expect(button).not.toHaveAttribute('title');
 
     fireEvent.blur(button);
 

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -430,8 +430,8 @@ describe('when off is true', () => {
 
     // should not be visible
     expect(queryByText('What kind of bear is best?')).not.toBeInTheDocument();
-    // should not remove title
-    expect(button).toHaveProperty('title', 'What kind of bear is best?');
+    // should not have title
+    expect(button).not.toHaveProperty('title', 'What kind of bear is best?');
 
     fireEvent.blur(button);
 
@@ -447,8 +447,8 @@ describe('when off is true', () => {
 
     // should not be visible
     expect(queryByText('What kind of bear is best?')).not.toBeInTheDocument();
-    // should not remove title
-    expect(button).toHaveProperty('title', 'What kind of bear is best?');
+    // should not have title
+    expect(button).not.toHaveProperty('title', 'What kind of bear is best?');
 
     fireEvent.mouseLeave(button);
 


### PR DESCRIPTION
#### Summary

When `Tooltip` is set to off, we should not add `aria-describedby` or `title`. 