### PR TITLE
fix(circleci): glob for workspace because of golang glob limitations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,13 @@ commands:
           root: *working_directory
           paths:
             - design-system/dist/
-            - packages/**/dist/
-            - presets/**/dist/
+            - packages/*/dist/
+            - packages/components/*/dist/
+            - packages/components/buttons/*/dist/
+            - packages/components/fields/*/dist/
+            - packages/components/inputs/*/dist/
+            - packages/components/spacings/*/dist/
+            - presets/*/dist/
   restore_package_bundles:
     steps:
       - attach_workspace:


### PR DESCRIPTION
The [persist_to_workspace](https://circleci.com/docs/2.0/configuration-reference/#persist_to_workspace) step uses golang `filepath.Match` for glob patterns which unfortunately has some limitations (e.g. the double stars `**` is not supported).
This causes nested packages to not be matched.

For now, until we have moved the source code into the related packages and flattened the list of packages, we need to be explicit on the glob matches.
Once we have a flat list, we can simply use `packages/*/dist/`.