### PR TITLE
fix(flat-button): icon size and position for multi-line anchors

### DIFF
--- a/src/components/buttons/flat-button/flat-button.js
+++ b/src/components/buttons/flat-button/flat-button.js
@@ -77,11 +77,7 @@ export const FlatButton = props => {
         };
 
         return css`
-          align-items: center;
-          font-size: 1rem;
-          border: none;
-          background: none;
-          padding: 0;
+          display: inline-block;
           min-height: initial;
           ${props.as && props.as !== 'button' ? 'white-space: normal' : ''};
 
@@ -97,39 +93,31 @@ export const FlatButton = props => {
               : getTextColor(props.tone, false, overwrittenVars)};
           }
 
-          &:hover,
-          &:focus {
-            span {
-              color: ${props.isDisabled
-                ? overwrittenVars.colorNeutral
-                : getTextColor(props.tone, true, overwrittenVars)};
-            }
-
-            svg * {
-              fill: ${props.isDisabled
-                ? overwrittenVars.colorNeutral
-                : getTextColor(props.tone, true, overwrittenVars)};
-            }
+          span + span {
+            margin-left: ${vars.spacingXs};
           }
+
+          ${!props.isDisabled
+            ? `
+            &:hover,
+            &:focus {
+              span {
+                color: ${getTextColor(props.tone, true, overwrittenVars)};
+              }
+              svg * {
+                fill: ${getTextColor(props.tone, true, overwrittenVars)};
+              }
+            }`
+            : ''}
         `;
       }}
       buttonAttributes={dataProps}
     >
-      <div
-        css={css`
-          span + span {
-            margin-left: ${vars.spacingXs};
-          }
-        `}
-      >
-        {props.icon && props.iconPosition === 'left' && (
-          <ButtonIcon {...props} />
-        )}
-        <Text.Body as="span">{props.label}</Text.Body>
-        {props.icon && props.iconPosition === 'right' && (
-          <ButtonIcon {...props} />
-        )}
-      </div>
+      {props.icon && props.iconPosition === 'left' && <ButtonIcon {...props} />}
+      <Text.Body as="span">{props.label}</Text.Body>
+      {props.icon && props.iconPosition === 'right' && (
+        <ButtonIcon {...props} />
+      )}
     </AccessibleButton>
   );
 };

--- a/src/components/buttons/flat-button/flat-button.js
+++ b/src/components/buttons/flat-button/flat-button.js
@@ -19,18 +19,23 @@ const ButtonIcon = props => {
   else if (props.tone === 'secondary') iconColor = 'solid';
   else if (props.tone === 'inverted') iconColor = 'surface';
 
-  return (
-    <span
-      css={css`
-        vertical-align: middle;
-      `}
-    >
-      {React.cloneElement(props.icon, {
-        size: 'medium',
-        color: iconColor,
-      })}
-    </span>
-  );
+  const Icon = React.cloneElement(props.icon, {
+    size: 'medium',
+    color: iconColor,
+  });
+
+  if (props.as && props.as !== 'button') {
+    return (
+      <span
+        css={css`
+          vertical-align: middle;
+        `}
+      >
+        {Icon}
+      </span>
+    );
+  }
+  return Icon;
 };
 ButtonIcon.displayName = 'ButtonIcon';
 ButtonIcon.propTypes = {
@@ -77,9 +82,12 @@ export const FlatButton = props => {
         };
 
         return css`
-          display: inline-block;
           min-height: initial;
-          ${props.as && props.as !== 'button' ? 'white-space: normal' : ''};
+          align-items: center;
+          ${props.as && props.as !== 'button'
+            ? `white-space: normal;
+               display: inline-block;`
+            : ''};
 
           span {
             color: ${props.isDisabled
@@ -93,7 +101,7 @@ export const FlatButton = props => {
               : getTextColor(props.tone, false, overwrittenVars)};
           }
 
-          span + span {
+          * + span {
             margin-left: ${vars.spacingXs};
           }
 

--- a/src/components/buttons/flat-button/flat-button.js
+++ b/src/components/buttons/flat-button/flat-button.js
@@ -6,25 +6,37 @@ import requiredIf from 'react-required-if';
 import { customProperties as vars } from '@commercetools-uikit/design-system';
 import { filterInvalidAttributes } from '@commercetools-uikit/utils';
 import Text from '@commercetools-uikit/text';
-import Inline from '@commercetools-uikit/spacings-inline';
 import AccessibleButton from '@commercetools-uikit/accessible-button';
 
 const propsToOmit = ['type'];
 
-const getIconElement = props => {
+const ButtonIcon = props => {
   if (!props.icon) return null;
 
   let iconColor = 'solid';
   if (props.isDisabled) iconColor = 'neutral60';
   else if (props.tone === 'primary') iconColor = 'primary';
-  else if (props.tone === 'secondary' && props.isMouseOver)
-    iconColor = 'warning';
+  else if (props.tone === 'secondary') iconColor = 'solid';
   else if (props.tone === 'inverted') iconColor = 'surface';
 
-  return React.cloneElement(props.icon, {
-    size: 'medium',
-    color: iconColor,
-  });
+  return (
+    <span
+      css={css`
+        vertical-align: middle;
+      `}
+    >
+      {React.cloneElement(props.icon, {
+        size: 'medium',
+        color: iconColor,
+      })}
+    </span>
+  );
+};
+ButtonIcon.displayName = 'ButtonIcon';
+ButtonIcon.propTypes = {
+  icon: PropTypes.element,
+  tone: PropTypes.oneOf(['primary', 'secondary', 'inverted']),
+  isDisabled: PropTypes.bool,
 };
 
 const getTextColor = (tone, isHover = false, overwrittenVars) => {
@@ -71,8 +83,9 @@ export const FlatButton = props => {
           background: none;
           padding: 0;
           min-height: initial;
+          ${props.as && props.as !== 'button' ? 'white-space: normal' : ''};
 
-          p {
+          span {
             color: ${props.isDisabled
               ? overwrittenVars.colorNeutral
               : getTextColor(props.tone, false, overwrittenVars)};
@@ -86,7 +99,7 @@ export const FlatButton = props => {
 
           &:hover,
           &:focus {
-            p {
+            span {
               color: ${props.isDisabled
                 ? overwrittenVars.colorNeutral
                 : getTextColor(props.tone, true, overwrittenVars)};
@@ -102,11 +115,21 @@ export const FlatButton = props => {
       }}
       buttonAttributes={dataProps}
     >
-      <Inline scale="xs" alignItems="center">
-        {props.iconPosition === 'left' && getIconElement(props)}
-        <Text.Body>{props.label}</Text.Body>
-        {props.iconPosition === 'right' && getIconElement(props)}
-      </Inline>
+      <div
+        css={css`
+          span + span {
+            margin-left: ${vars.spacingXs};
+          }
+        `}
+      >
+        {props.icon && props.iconPosition === 'left' && (
+          <ButtonIcon {...props} />
+        )}
+        <Text.Body as="span">{props.label}</Text.Body>
+        {props.icon && props.iconPosition === 'right' && (
+          <ButtonIcon {...props} />
+        )}
+      </div>
     </AccessibleButton>
   );
 };

--- a/src/components/buttons/flat-button/flat-button.js
+++ b/src/components/buttons/flat-button/flat-button.js
@@ -101,7 +101,8 @@ export const FlatButton = props => {
               : getTextColor(props.tone, false, overwrittenVars)};
           }
 
-          * + span {
+          * + span,
+          * + svg {
             margin-left: ${vars.spacingXs};
           }
 

--- a/src/components/buttons/flat-button/flat-button.spec.js
+++ b/src/components/buttons/flat-button/flat-button.spec.js
@@ -45,7 +45,7 @@ describe('rendering', () => {
   });
   it('should render label', () => {
     const { getByLabelText } = render(<FlatButton {...props} />);
-    expect(getByLabelText('Add').querySelector('p')).toHaveTextContent('Add');
+    expect(getByLabelText('Add')).toHaveTextContent('Add');
   });
   describe('type variations', () => {
     it('should render a button of type "button"', () => {

--- a/src/components/buttons/flat-button/flat-button.story.js
+++ b/src/components/buttons/flat-button/flat-button.story.js
@@ -28,6 +28,7 @@ storiesOf('Components|Buttons', module)
         iconPosition={select('icon position', ['left', 'right'], 'left')}
         onClick={action('onClick')}
         isDisabled={boolean('isDisabled', false)}
+        as={select('as', ['button', 'a', 'span'], 'button')}
       />
     </Section>
   ));

--- a/src/components/buttons/flat-button/flat-button.visualroute.js
+++ b/src/components/buttons/flat-button/flat-button.visualroute.js
@@ -64,5 +64,34 @@ export const component = ({ themes }) => (
         />
       </Spec>
     </ThemeProvider>
+    <Spec
+      label="as anchor, with a multiline text and icon left"
+      listPropsOfNestedChild
+    >
+      <div style={{ width: 150 }}>
+        <FlatButton
+          tone="primary"
+          label="A label for an anchor which is pretty looooong and doesn't fit its container without breaking"
+          onClick={() => {}}
+          icon={<InformationIcon />}
+          as="a"
+        />
+      </div>
+    </Spec>
+    <Spec
+      label="as anchor, with a multiline text and icon right"
+      listPropsOfNestedChild
+    >
+      <div style={{ width: 150 }}>
+        <FlatButton
+          tone="primary"
+          label="A label for an anchor which is pretty looooong and doesn't fit its container without breaking"
+          onClick={() => {}}
+          icon={<InformationIcon />}
+          iconPosition="right"
+          as="a"
+        />
+      </div>
+    </Spec>
   </Suite>
 );


### PR DESCRIPTION
[UKIT-95](https://jira.commercetools.com/browse/UKIT-95)
#### Summary

This PR adjusts the `FlatButton` to allow breaking the text into multiple lines when the element is not a `button`, and changes the position and size of the icon, not allowing it to shrink and keeping it on the same line as the text.

Before:
![image-2019-12-04-15-33-05-618](https://user-images.githubusercontent.com/2941328/70451377-8f0ad800-1aa5-11ea-9e85-b4a8e8a53bee.png)

After:
![image](https://user-images.githubusercontent.com/2941328/70451364-87e3ca00-1aa5-11ea-9ef3-931c91042a1d.png)
