### PR TITLE
fix(text-detail): proptypes warning when providing an empty string as…

### DIFF
--- a/src/components/typography/text/text.js
+++ b/src/components/typography/text/text.js
@@ -263,7 +263,10 @@ Detail.propTypes = {
   ]),
   title: nonEmptyString,
   truncate: PropTypes.bool,
-  intlMessage: requiredIf(intlMessageShape, props => !props.children),
+  intlMessage: requiredIf(
+    intlMessageShape,
+    props => !React.Children.count(props.children)
+  ),
   children: requiredIf(PropTypes.node, props => !props.intlMessage),
 };
 

--- a/src/components/typography/text/text.js
+++ b/src/components/typography/text/text.js
@@ -88,7 +88,10 @@ Headline.propTypes = {
   },
   title: nonEmptyString,
   truncate: PropTypes.bool,
-  intlMessage: requiredIf(intlMessageShape, props => !props.children),
+  intlMessage: requiredIf(
+    intlMessageShape,
+    props => !React.Children.count(props.children)
+  ),
   children: requiredIf(PropTypes.node, props => !props.intlMessage),
 };
 
@@ -146,7 +149,10 @@ Subheadline.propTypes = {
   ]),
   title: nonEmptyString,
   truncate: PropTypes.bool,
-  intlMessage: requiredIf(intlMessageShape, props => !props.children),
+  intlMessage: requiredIf(
+    intlMessageShape,
+    props => !React.Children.count(props.children)
+  ),
   children: requiredIf(PropTypes.node, props => !props.intlMessage),
 };
 
@@ -163,7 +169,10 @@ const Wrap = props => (
 Wrap.displayName = 'TextWrap';
 Wrap.propTypes = {
   title: nonEmptyString,
-  intlMessage: requiredIf(intlMessageShape, props => !props.children),
+  intlMessage: requiredIf(
+    intlMessageShape,
+    props => !React.Children.count(props.children)
+  ),
   children: requiredIf(PropTypes.node, props => !props.intlMessage),
 };
 
@@ -233,7 +242,10 @@ Body.propTypes = {
   ]),
   title: nonEmptyString,
   truncate: PropTypes.bool,
-  intlMessage: requiredIf(intlMessageShape, props => !props.children),
+  intlMessage: requiredIf(
+    intlMessageShape,
+    props => !React.Children.count(props.children)
+  ),
   children: requiredIf(PropTypes.node, props => !props.intlMessage),
 };
 


### PR DESCRIPTION
… children to TextDetail component

<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

<!-- provide a short summary of your changes -->
A PropTypes warning will be thrown when providing an empty string as the children of `Text.Detail` component.

#### Description

The bug is caused by the empty string being coerced to `false`, this PR fixes it by counting the children instead.

Fixes #1212  
