### PR TITLE
fix(select-input): make the ClearIndicator a button

### DIFF
--- a/packages/components/inputs/select-utils/package.json
+++ b/packages/components/inputs/select-utils/package.json
@@ -29,6 +29,7 @@
     "react-select": "3.0.8"
   },
   "peerDependencies": {
-    "react": ">= 16.8.0"
+    "react": ">= 16.8.0",
+    "react-intl": "3.x"
   }
 }

--- a/packages/i18n/data/core.json
+++ b/packages/i18n/data/core.json
@@ -4,6 +4,7 @@
   "UIKit.CalendarHeader.previousMonthTooltip": "Previous month",
   "UIKit.CalendarHeader.previousYearTooltip": "Previous year",
   "UIKit.CalendarHeader.todayTooltip": "Today",
+  "UIKit.ClearButton.clearButtonLabel": "Clear",
   "UIKit.CreatableSelectInput.createLabel": "Create \"{inputValue}\"",
   "UIKit.DateInput.placeholder": "MM/DD/YYYY",
   "UIKit.DateRangeInput.placeholder": "MM/DD/YYYY - MM/DD/YYYY",

--- a/packages/i18n/data/de.json
+++ b/packages/i18n/data/de.json
@@ -4,6 +4,7 @@
   "UIKit.CalendarHeader.previousMonthTooltip": "letztes Monat",
   "UIKit.CalendarHeader.previousYearTooltip": "letztes Jahr",
   "UIKit.CalendarHeader.todayTooltip": "Heute",
+  "UIKit.ClearButton.clearButtonLabel": "",
   "UIKit.CreatableSelectInput.createLabel": "\"{inputValue}\" erstellen",
   "UIKit.DateInput.placeholder": "TT.MM.JJJJ",
   "UIKit.DateRangeInput.placeholder": "TT.MM.JJJJ - TT.MM.JJJJ",

--- a/packages/i18n/data/en.json
+++ b/packages/i18n/data/en.json
@@ -4,6 +4,7 @@
   "UIKit.CalendarHeader.previousMonthTooltip": "Previous month",
   "UIKit.CalendarHeader.previousYearTooltip": "Previous year",
   "UIKit.CalendarHeader.todayTooltip": "Today",
+  "UIKit.ClearButton.clearButtonLabel": "Clear",
   "UIKit.CreatableSelectInput.createLabel": "Create \"{inputValue}\"",
   "UIKit.DateInput.placeholder": "MM/DD/YYYY",
   "UIKit.DateRangeInput.placeholder": "MM/DD/YYYY - MM/DD/YYYY",

--- a/packages/i18n/data/es.json
+++ b/packages/i18n/data/es.json
@@ -4,6 +4,7 @@
   "UIKit.CalendarHeader.previousMonthTooltip": "Mes anterior",
   "UIKit.CalendarHeader.previousYearTooltip": "Año anterior",
   "UIKit.CalendarHeader.todayTooltip": "Hoy",
+  "UIKit.ClearButton.clearButtonLabel": "",
   "UIKit.CreatableSelectInput.createLabel": "Crear \"{inputValue}\"",
   "UIKit.DateInput.placeholder": "DD/MM/AAAA",
   "UIKit.DateRangeInput.placeholder": "DD/MM/AAAA - DD/MM/AAAA",

--- a/packages/i18n/data/fr-FR.json
+++ b/packages/i18n/data/fr-FR.json
@@ -4,6 +4,7 @@
   "UIKit.CalendarHeader.previousMonthTooltip": "Mois précédent",
   "UIKit.CalendarHeader.previousYearTooltip": "Année précédente",
   "UIKit.CalendarHeader.todayTooltip": "Aujourd'hui",
+  "UIKit.ClearButton.clearButtonLabel": "",
   "UIKit.CreatableSelectInput.createLabel": "Créer \"{inputValue}\"",
   "UIKit.DateInput.placeholder": "JJ/MM/AAAA",
   "UIKit.DateRangeInput.placeholder": "JJ/MM/AAAA - JJ/MM/AAAA",

--- a/packages/i18n/data/ja.json
+++ b/packages/i18n/data/ja.json
@@ -4,6 +4,7 @@
   "UIKit.CalendarHeader.previousMonthTooltip": "",
   "UIKit.CalendarHeader.previousYearTooltip": "",
   "UIKit.CalendarHeader.todayTooltip": "",
+  "UIKit.ClearButton.clearButtonLabel": "",
   "UIKit.CreatableSelectInput.createLabel": "",
   "UIKit.DateInput.placeholder": "",
   "UIKit.DateRangeInput.placeholder": "",

--- a/packages/i18n/data/zh-CN.json
+++ b/packages/i18n/data/zh-CN.json
@@ -4,6 +4,7 @@
   "UIKit.CalendarHeader.previousMonthTooltip": "上个月",
   "UIKit.CalendarHeader.previousYearTooltip": "上一年",
   "UIKit.CalendarHeader.todayTooltip": "今天",
+  "UIKit.ClearButton.clearButtonLabel": "",
   "UIKit.CreatableSelectInput.createLabel": "创建 \"{inputValue}\"",
   "UIKit.DateInput.placeholder": "年/月/日",
   "UIKit.DateRangeInput.placeholder": "年/月/日 - 年/月/日",

--- a/src/components/inputs/select-input/select-input.spec.js
+++ b/src/components/inputs/select-input/select-input.spec.js
@@ -215,20 +215,13 @@ describe('in multi mode', () => {
         expect(onChange).not.toHaveBeenCalled();
         expect(queryByText('Mango')).toBeInTheDocument();
       });
-      it('should call not call onChange when value is cleared by clicking delete button ', () => {
-        const onChange = jest.fn();
-        const { getByLabelText, getByText, queryByText } = renderInput({
-          onChange,
+      it('should not render the clear button', () => {
+        const { queryByTitle } = renderInput({
           isMulti: true,
           value: ['mango'],
           isDisabled: true,
         });
-        const input = getByLabelText('Fruit');
-        fireEvent.focus(input);
-        const deleteButton = getByText('Mango').nextSibling;
-        deleteButton.click();
-        expect(onChange).not.toHaveBeenCalled();
-        expect(queryByText('Mango')).toBeInTheDocument();
+        expect(queryByTitle('Clear')).not.toBeInTheDocument();
       });
     });
     it('should open the list and all options should be visible', () => {
@@ -317,17 +310,17 @@ describe('in multi mode', () => {
       });
       expect(queryByText('Mango')).not.toBeInTheDocument();
     });
-    it('should call onChange when value is cleared by clicking delete button ', () => {
+    it('should call onChange when value is cleared by clicking the clear button ', () => {
       const onChange = jest.fn();
-      const { getByLabelText, getByText, queryByText } = renderInput({
+      const { getByLabelText, getByTitle, queryByText } = renderInput({
         onChange,
         isMulti: true,
         value: ['mango'],
       });
       const input = getByLabelText('Fruit');
       fireEvent.focus(input);
-      const deleteButton = getByText('Mango').nextSibling;
-      deleteButton.click();
+      const deleteButton = getByTitle('Clear');
+      fireEvent.mouseDown(deleteButton);
       expect(onChange).toHaveBeenCalledWith({
         persist: expect.any(Function),
         target: {
@@ -352,20 +345,13 @@ describe('in multi mode', () => {
         expect(onChange).not.toHaveBeenCalled();
         expect(queryByText('Mango')).toBeInTheDocument();
       });
-      it('should call not call onChange when value is cleared by clicking delete button ', () => {
-        const onChange = jest.fn();
-        const { getByLabelText, getByText, queryByText } = renderInput({
-          onChange,
+      it('should not render the clear button ', () => {
+        const { queryByTitle } = renderInput({
           isMulti: true,
           value: ['mango'],
           isReadOnly: true,
         });
-        const input = getByLabelText('Fruit');
-        fireEvent.focus(input);
-        const deleteButton = getByText('Mango').nextSibling;
-        deleteButton.click();
-        expect(onChange).not.toHaveBeenCalled();
-        expect(queryByText('Mango')).toBeInTheDocument();
+        expect(queryByTitle('Clear')).not.toBeInTheDocument();
       });
     });
   });

--- a/src/components/internals/clear-indicator/clear-indicator.js
+++ b/src/components/internals/clear-indicator/clear-indicator.js
@@ -1,28 +1,39 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+import { useIntl } from 'react-intl';
 import { CloseIcon } from '@commercetools-uikit/icons';
+import messages from './messages';
 
 const ClearIndicator = props => {
+  const intl = useIntl();
   const {
     getStyles,
     innerProps: { ref, ...restInnerProps },
   } = props;
   return (
-    <div
+    <button
       {...restInnerProps}
       ref={ref}
+      css={css`
+        border: none;
+        cursor: pointer;
+        background: none;
+        box-sizing: border-box;
+        text-decoration: none;
+      `}
       style={getStyles('clearIndicator', props)}
+      title={intl.formatMessage(messages.clearButtonLabel)}
+      aria-label={intl.formatMessage(messages.clearButtonLabel)}
     >
-      <CloseIcon color={props.isDisabled && 'neutral60'} size="medium" />
-    </div>
+      <CloseIcon color="solid" size="medium" />
+    </button>
   );
 };
 
 ClearIndicator.displayName = 'ClearIndicator';
-
 ClearIndicator.propTypes = {
   innerProps: PropTypes.object,
-  isDisabled: PropTypes.bool,
   getStyles: PropTypes.func.isRequired,
 };
 

--- a/src/components/internals/clear-indicator/messages.js
+++ b/src/components/internals/clear-indicator/messages.js
@@ -1,0 +1,9 @@
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  clearButtonLabel: {
+    id: 'UIKit.ClearButton.clearButtonLabel',
+    description: 'Label for the clear button',
+    defaultMessage: 'Clear',
+  },
+});


### PR DESCRIPTION
Related to #1210 

#### Summary

This PR changes the `ClearIndicator`, used by `SelectInput`, to be a button and have a title and label, becoming screen-readable and easier to select (e.g. for tests).

Some tests for this element were fixed, because they were giving false positives.