### PR TITLE
chore: check npm authentication on prerelease

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:visual": "jest --config jest.visual.config.js",
     "bundlesize": "bundlesize",
     "test:bundle:watch": "jest --config jest.bundle.config.js --watch",
-    "prerelease": "yarn build",
+    "prerelease": "npm_config_registry=https://registry.npmjs.org npm whoami && yarn build",
     "release": "lerna publish --exact --dist-tag next",
     "release:alpha": "lerna publish --exact --dist-tag alpha --no-git-tag-version --no-push",
     "release:canary": "lerna publish --exact --dist-tag canary --canary --preid canary --yes",


### PR DESCRIPTION
#### Summary

When doing a `yarn release`, if you forgot to log in to the `npm` CLI, lerna will still perform some of the steps but then fail on the `npm publish` process, resulting in dirty state (see https://github.com/lerna/lerna/issues/455).

This PR prevents this problem by checking if the user is logged in to npm on the `prerelease` step.