### PR TITLE
fix(select-input): multi select tag borders

### DIFF
--- a/src/components/internals/create-select-styles.js
+++ b/src/components/internals/create-select-styles.js
@@ -339,7 +339,7 @@ const multiValueLabelStyles = (props, theme) => base => {
     padding: `${overwrittenVars.spacingXs} ${overwrittenVars.spacingS}`,
     borderRadius: `${overwrittenVars.borderRadiusForTag} 0 0 ${overwrittenVars.borderRadiusForTag}`,
     border: `1px ${overwrittenVars[designTokens.borderColorForTag]} solid`,
-    borderWidth: '1px 0 1px 1px',
+    borderWidth: '1px',
   };
 };
 
@@ -359,6 +359,8 @@ const multiValueRemoveStyles = (props, theme) => (base, state) => {
     borderStyle: 'solid',
     borderWidth: '1px',
     pointerEvents: state.isDisabled ? 'none' : base.pointerEvents,
+    // This negative margin is for the left border to stay on top of the label's right border
+    marginLeft: '-1px',
 
     '&:hover': {
       borderColor: overwrittenVars.borderColorForTagWarning,

--- a/src/components/internals/create-select-styles.js
+++ b/src/components/internals/create-select-styles.js
@@ -306,10 +306,16 @@ const menuPortalStyles = props => base => ({
   zIndex: props.menuPortalZIndex,
 });
 
-const multiValueStyles = () => base => {
+const multiValueStyles = (props, theme) => base => {
+  const overwrittenVars = {
+    ...vars,
+    ...theme,
+  };
+
   return {
     ...base,
     height: vars.sizeHeightTag,
+    backgroundColor: overwrittenVars[designTokens.backgroundColorForTag],
     padding: '0',
   };
 };
@@ -330,11 +336,15 @@ const multiValueLabelStyles = (props, theme) => base => {
         return overwrittenVars[designTokens.fontColorForInputWhenReadonly];
       return base.color;
     })(),
-    backgroundColor: overwrittenVars[designTokens.backgroundColorForTag],
     padding: `${overwrittenVars.spacingXs} ${overwrittenVars.spacingS}`,
-    borderRadius: overwrittenVars.borderRadiusForTag,
+    borderRadius: `${overwrittenVars.borderRadiusForTag} 0 0 ${overwrittenVars.borderRadiusForTag}`,
     border: `1px ${overwrittenVars[designTokens.borderColorForTag]} solid`,
-    borderWidth: '1px',
+    borderWidth: '1px 0 1px 1px',
+
+    '&:last-child': {
+      borderRadius: overwrittenVars.borderRadiusForTag,
+      borderWidth: '1px',
+    },
   };
 };
 
@@ -346,17 +356,14 @@ const multiValueRemoveStyles = (props, theme) => (base, state) => {
 
   return {
     ...base,
-    backgroundColor: overwrittenVars[designTokens.backgroundColorForTag],
-    padding: `0 ${overwrittenVars.spacingXs}`,
     borderColor: overwrittenVars[designTokens.borderColorForTag],
+    padding: `0 ${overwrittenVars.spacingXs}`,
     borderRadius: `0 ${overwrittenVars[designTokens.borderRadiusForTag]} ${
       overwrittenVars[designTokens.borderRadiusForTag]
     } 0`,
     borderStyle: 'solid',
     borderWidth: '1px',
     pointerEvents: state.isDisabled ? 'none' : base.pointerEvents,
-    // This negative margin is for the left border to stay on top of the label's right border
-    marginLeft: `-${overwrittenVars[designTokens.borderRadiusForTag]}`,
 
     '&:hover': {
       borderColor: overwrittenVars.borderColorForTagWarning,

--- a/src/components/internals/create-select-styles.js
+++ b/src/components/internals/create-select-styles.js
@@ -306,16 +306,10 @@ const menuPortalStyles = props => base => ({
   zIndex: props.menuPortalZIndex,
 });
 
-const multiValueStyles = (props, theme) => base => {
-  const overwrittenVars = {
-    ...vars,
-    ...theme,
-  };
-
+const multiValueStyles = () => base => {
   return {
     ...base,
     height: vars.sizeHeightTag,
-    backgroundColor: overwrittenVars[designTokens.backgroundColorForTag],
     padding: '0',
   };
 };
@@ -336,8 +330,9 @@ const multiValueLabelStyles = (props, theme) => base => {
         return overwrittenVars[designTokens.fontColorForInputWhenReadonly];
       return base.color;
     })(),
+    backgroundColor: overwrittenVars[designTokens.backgroundColorForTag],
     padding: `${overwrittenVars.spacingXs} ${overwrittenVars.spacingS}`,
-    borderRadius: `${overwrittenVars.borderRadiusForTag} 0 0 ${overwrittenVars.borderRadiusForTag}`,
+    borderRadius: overwrittenVars.borderRadiusForTag,
     border: `1px ${overwrittenVars[designTokens.borderColorForTag]} solid`,
     borderWidth: '1px',
   };
@@ -351,8 +346,9 @@ const multiValueRemoveStyles = (props, theme) => (base, state) => {
 
   return {
     ...base,
-    borderColor: overwrittenVars[designTokens.borderColorForTag],
+    backgroundColor: overwrittenVars[designTokens.backgroundColorForTag],
     padding: `0 ${overwrittenVars.spacingXs}`,
+    borderColor: overwrittenVars[designTokens.borderColorForTag],
     borderRadius: `0 ${overwrittenVars[designTokens.borderRadiusForTag]} ${
       overwrittenVars[designTokens.borderRadiusForTag]
     } 0`,
@@ -360,7 +356,7 @@ const multiValueRemoveStyles = (props, theme) => (base, state) => {
     borderWidth: '1px',
     pointerEvents: state.isDisabled ? 'none' : base.pointerEvents,
     // This negative margin is for the left border to stay on top of the label's right border
-    marginLeft: '-1px',
+    marginLeft: `-${overwrittenVars[designTokens.borderRadiusForTag]}`,
 
     '&:hover': {
       borderColor: overwrittenVars.borderColorForTagWarning,


### PR DESCRIPTION
#### Summary

Small adjustment to the `SelectInput` styles, for multi-values: When there is no `multiValueRemove` component being displayed (by passing an empty component to it), the `multiValueLabel` doesn't have a right border.
This PR fixes that, to prevent the need to also override the `multiValueLabel` just for this styling detail, or other "hacky" workarounds.

#### Before:
![image](https://user-images.githubusercontent.com/2941328/72344396-6e035b80-36d1-11ea-9f60-2d32c596c1c5.png)

#### After:
![image](https://user-images.githubusercontent.com/2941328/72344479-9db26380-36d1-11ea-98a9-e1a66afb9574.png)
