### PR TITLE
chore(tag): fix storybook example

### DIFF
--- a/src/components/tag/tag.story.js
+++ b/src/components/tag/tag.story.js
@@ -11,7 +11,7 @@ const Story = () => (
   <Section>
     <Tag
       type={select('type', ['normal', 'warning'], 'normal')}
-      linkTo={select('linkTo', ['/foo', null], '/foo')}
+      linkTo={select('linkTo', { '/foo': '/foo', Null: null }, '/foo')}
       isDisabled={boolean('isDisabled', false)}
       onClick={boolean('onClick', false) ? action('onClick') : undefined}
       horizontalConstraint={select(


### PR DESCRIPTION
#### Summary

If you go to: https://uikit.commercetools.com/?path=/story/components-tags--tag
And go to `Knobs`, the page crashes.

This PR fixes the problem.