### PR TITLE
[UKIT-97] fix(tag): on remove button hover when disabled

### DIFF
--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -198,8 +198,8 @@ const Tag = props => {
                   background: inherit;
                   border-style: solid;
                   border-width: 1px 1px 1px 1px;
-                  &:hover,
-                  &:focus {
+                  :not(:disabled)&:hover,
+                  :not(:disabled)&:focus {
                     border-color: ${overwrittenVars[
                       designTokens.borderColorForTagWarning
                     ]};
@@ -213,15 +213,12 @@ const Tag = props => {
                   > svg * {
                     fill: ${overwrittenVars[designTokens.fontColorForTag]};
                   }
+                  &:disabled > svg * {
+                    fill: ${overwrittenVars[
+                      designTokens.fontColorForTagWhenDisabled
+                    ]};
+                  }
                 `,
-                props.isDisabled &&
-                  css`
-                    > svg * {
-                      fill: ${overwrittenVars[
-                        designTokens.fontColorForTagWhenDisabled
-                      ]};
-                    }
-                  `,
               ];
             }}
           >


### PR DESCRIPTION
#### Summary

Fix for [UKIT-97](https://jira.commercetools.com/browse/UKIT-97)

> When the user hovers the removable area on a disabled label, the button still displays the orange hover effect that indicates the label is removable. There should not display any hover effect when disabled.