### PR TITLE
feat(messages): to add intlMessage prop to error and warning message components

### DIFF
--- a/packages/components/messages/README.md
+++ b/packages/components/messages/README.md
@@ -14,9 +14,12 @@ import { WarningMessage } from '@commercetools-frontend/ui-kit';
 
 #### Properties
 
-| Props      | Type   | Required | Values | Default | Description                               |
-| ---------- | ------ | :------: | ------ | ------- | ----------------------------------------- |
-| `children` | `node` |    ✅    | -      | -       | Warning message, either as string or node |
+| Props         | Type           | Required | Values | Default | Description                                                          |
+| ------------- | -------------- | :------: | ------ | ------- | -------------------------------------------------------------------- |
+| `children`    | `node`         | ✅ (\*)  | -      | -       | - Warning message, either as string or node                          |
+| `intlMessage` | `intl message` | ✅ (\*)  | -      | -       | An intl message object that will be rendered with `FormattedMessage` |
+
+> `*`: `children` is required only if `intlMessage` is not provided
 
 Main functions and use cases are:
 
@@ -38,9 +41,12 @@ import { ErrorMessage } from '@commercetools-frontend/ui-kit';
 
 #### Properties
 
-| Props      | Type   | Required | Values | Default | Description                             |
-| ---------- | ------ | :------: | ------ | ------- | --------------------------------------- |
-| `children` | `node` |    ✅    | -      | -       | Error message, either as string or node |
+| Props         | Type           | Required | Values | Default | Description                                                          |
+| ------------- | -------------- | :------: | ------ | ------- | -------------------------------------------------------------------- |
+| `children`    | `node`         | ✅ (\*)  | -      | -       | - Error message, either as string or node                            |
+| `intlMessage` | `intl message` | ✅ (\*)  | -      | -       | An intl message object that will be rendered with `FormattedMessage` |
+
+> `*`: `children` is required only if `intlMessage` is not provided
 
 Main functions and use cases are:
 

--- a/packages/components/messages/README.md
+++ b/packages/components/messages/README.md
@@ -16,7 +16,7 @@ import { WarningMessage } from '@commercetools-frontend/ui-kit';
 
 | Props         | Type           | Required | Values | Default | Description                                                          |
 | ------------- | -------------- | :------: | ------ | ------- | -------------------------------------------------------------------- |
-| `children`    | `node`         | ✅ (\*)  | -      | -       | - Warning message, either as string or node                          |
+| `children`    | `node`         | ✅ (\*)  | -      | -       | Warning message, either as string or node                          |
 | `intlMessage` | `intl message` | ✅ (\*)  | -      | -       | An intl message object that will be rendered with `FormattedMessage` |
 
 > `*`: `children` is required only if `intlMessage` is not provided
@@ -43,7 +43,7 @@ import { ErrorMessage } from '@commercetools-frontend/ui-kit';
 
 | Props         | Type           | Required | Values | Default | Description                                                          |
 | ------------- | -------------- | :------: | ------ | ------- | -------------------------------------------------------------------- |
-| `children`    | `node`         | ✅ (\*)  | -      | -       | - Error message, either as string or node                            |
+| `children`    | `node`         | ✅ (\*)  | -      | -       | Error message, either as string or node                            |
 | `intlMessage` | `intl message` | ✅ (\*)  | -      | -       | An intl message object that will be rendered with `FormattedMessage` |
 
 > `*`: `children` is required only if `intlMessage` is not provided

--- a/packages/components/messages/package.json
+++ b/packages/components/messages/package.json
@@ -23,7 +23,8 @@
     "@commercetools-uikit/utils": "10.14.1",
     "@emotion/core": "10.0.27",
     "@emotion/styled": "10.0.27",
-    "prop-types": "15.7.2"
+    "prop-types": "15.7.2",
+    "react-required-if": "1.0.3"
   },
   "peerDependencies": {
     "react": ">= 16.8.0"

--- a/packages/components/messages/src/error-message/error-message.js
+++ b/packages/components/messages/src/error-message/error-message.js
@@ -1,16 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import requiredIf from 'react-required-if';
 import Text from '@commercetools-uikit/text';
 import { filterDataAttributes } from '@commercetools-uikit/utils';
 
+const intlMessageShape = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  defaultMessage: PropTypes.string.isRequired,
+});
+
 const ErrorMessage = props => (
-  <Text.Detail tone="negative" {...filterDataAttributes(props)}>
+  <Text.Detail
+    intlMessage={props.intlMessage}
+    tone="negative"
+    {...filterDataAttributes(props)}
+  >
     {props.children}
   </Text.Detail>
 );
 ErrorMessage.displayName = 'ErrorMessage';
 ErrorMessage.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: requiredIf(PropTypes.node, props => !props.intlMessage),
+  intlMessage: requiredIf(
+    intlMessageShape,
+    props => !React.Children.count(props.children)
+  ),
 };
 
 export default ErrorMessage;

--- a/packages/components/messages/src/error-message/error-message.spec.js
+++ b/packages/components/messages/src/error-message/error-message.spec.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { render } from '../../../../../src/test-utils';
 import ErrorMessage from './error-message';
 
+const intlMessage = { id: 'Title', defaultMessage: 'Hello' };
+
 describe('ErrorMessage', () => {
   it('should render children', () => {
     const { container } = render(
@@ -9,6 +11,11 @@ describe('ErrorMessage', () => {
     );
 
     expect(container).toHaveTextContent('Some error message');
+  });
+
+  it('should render given text with react-intl', () => {
+    const { container } = render(<ErrorMessage intlMessage={intlMessage} />);
+    expect(container).toHaveTextContent('Hello');
   });
 
   it('should forward data-attributes', () => {

--- a/packages/components/messages/src/warning-message/warning-message.js
+++ b/packages/components/messages/src/warning-message/warning-message.js
@@ -1,14 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import requiredIf from 'react-required-if';
 import Text from '@commercetools-uikit/text';
 
+const intlMessageShape = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  defaultMessage: PropTypes.string.isRequired,
+});
+
 const WarningMessage = props => (
-  <Text.Detail tone="warning">{props.children}</Text.Detail>
+  <Text.Detail intlMessage={props.intlMessage} tone="warning">
+    {props.children}
+  </Text.Detail>
 );
 
 WarningMessage.displayName = 'WarningMessage';
 WarningMessage.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: requiredIf(PropTypes.node, props => !props.intlMessage),
+  intlMessage: requiredIf(
+    intlMessageShape,
+    props => !React.Children.count(props.children)
+  ),
 };
 
 export default WarningMessage;

--- a/packages/components/messages/src/warning-message/warning-message.spec.js
+++ b/packages/components/messages/src/warning-message/warning-message.spec.js
@@ -1,11 +1,20 @@
 import React from 'react';
 import { render } from '../../../../../src/test-utils';
-import ErrorMessage from './warning-message';
+import WarningMessage from './warning-message';
 
-it('should render children', () => {
-  const { container } = render(
-    <ErrorMessage>Some warning message</ErrorMessage>
-  );
+const intlMessage = { id: 'Title', defaultMessage: 'Hello' };
 
-  expect(container).toHaveTextContent('Some warning message');
+describe('WarningMessage', () => {
+  it('should render children', () => {
+    const { container } = render(
+      <WarningMessage>Some warning message</WarningMessage>
+    );
+
+    expect(container).toHaveTextContent('Some warning message');
+  });
+
+  it('should render given text with react-intl', () => {
+    const { container } = render(<WarningMessage intlMessage={intlMessage} />);
+    expect(container).toHaveTextContent('Hello');
+  });
 });


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary
Adding `intlMessage` prop to `ErrorMessage` and `WarningMessage` components similair to `Text` component
<!-- provide a short summary of your changes -->

#### Description
current usage of `ErrorMessage` or `WarningMessage`:
```javascript
    <ErrorMessage>
       <FormattedMessage {...validationMessages.required} />
    </ErrorMessage>
```
adding `intlMessage` prop will help reduce code and nesting of components inside one another.

desired usage of `ErrorMessage` or `WarningMessage`:
```javascript
    <ErrorMessage intlMessage={validationMessages.required} />
```
<!-- provide some context -->
This feature implemetation doesn't change the API of the components.