### PR TITLE
feat: add accessible-hidden component

### DIFF
--- a/packages/components/accessible-hidden/LICENSE
+++ b/packages/components/accessible-hidden/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 commercetools GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/components/accessible-hidden/README.md
+++ b/packages/components/accessible-hidden/README.md
@@ -1,0 +1,19 @@
+# Accessible Hidden
+
+#### Description
+
+Visually hides a component, while keeping it accessible for screen readers and other assistive technology, as well as for testing purposes with tools such as react-testing-library and cypress.
+
+#### Usage
+
+```js
+import AccessibleHidden from '@commercetools-uikit/accessible-hidden';
+
+<AccessibleHidden>
+  <label htmlFor="sample-input">Sample Input</label>
+</AccessibleHidden>;
+```
+
+#### Properties
+
+This component only accepts the prop `children`, which is the component you want to hide.

--- a/packages/components/accessible-hidden/README.md
+++ b/packages/components/accessible-hidden/README.md
@@ -2,14 +2,14 @@
 
 #### Description
 
-This component is used to hide content offscreen, removing it from sighted users, while keeping the still accessible to screenreaders and other assistive technology.
-It can also be useful for testing with tools like react-testing-library and cypress, which query elements through content which you might not want to be showing explicitly, such as querying for a input by its label while the label is visually hidden.
+This component is used to hide content offscreen, removing it from sighted users, while keeping it still accessible to screenreaders and other assistive technology.
+It can also be useful for testing with tools like react-testing-library and cypress, which requires quering elements through content which might not be intended to be visible on screen, such as querying for a input by its label while the label is visually hidden.
 
 It's the logical opposite of [the `aria-hidden` attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute).
 
 #### Usage
 
-##### Example: A11y
+##### Example: Accessibility (a11y)
 
 In this example, we're showing additional text specifically to be read only by screen readers, to make it more contextualized and easier to understand for non-sighted users (as well "translating" the numeronym which might confuse automatic screen-readers).
 
@@ -23,7 +23,7 @@ import AccessibleHidden from '@commercetools-uikit/accessible-hidden';
 
 ##### Example: Tests
 
-This is an example for when you would want to render an Input without visually displaying a label visually, but still having a label to query by, when testing with RTL, as well as being a11y friendly.
+This is an example for when you would want to render an input without visually displaying a label. You still would want a label to be present so it can be used when testing with RTL as well as supporting a11y.
 
 ```js
 const rendered = render(
@@ -39,7 +39,7 @@ expect(rendered.getByLabelText('Enter your Maiden Name')).toBeInTheDocument();
 // ✓ True
 ```
 
-It is a common use case for inputs inside Tables, where a sighted user understands the context of the input through the column header and a label element taking space inside the cell is undesirable.
+It is a common requirement to show inputs inside tables. In such a case a sighted user should be able to understand the context of the input through the column header. A label element taking space inside the cell is undesirable.
 
 #### Properties
 

--- a/packages/components/accessible-hidden/README.md
+++ b/packages/components/accessible-hidden/README.md
@@ -2,18 +2,49 @@
 
 #### Description
 
-Visually hides a component, while keeping it accessible for screen readers and other assistive technology, as well as for testing purposes with tools such as react-testing-library and cypress.
+This component is used to hide content offscreen, removing it from sighted users, while keeping the still accessible to screenreaders and other assistive technology.
+It can also be useful for testing with tools like react-testing-library and cypress, which query elements through content which you might not want to be showing explicitly, such as querying for a input by its label while the label is visually hidden.
+
+It's the logical opposite of [the `aria-hidden` attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute).
 
 #### Usage
+
+##### Example: A11y
+
+In this example, we're showing additional text specifically to be read only by screen readers, to make it more contextualized and easier to understand for non-sighted users (as well "translating" the numeronym which might confuse automatic screen-readers).
 
 ```js
 import AccessibleHidden from '@commercetools-uikit/accessible-hidden';
 
-<AccessibleHidden>
-  <label htmlFor="sample-input">Sample Input</label>
-</AccessibleHidden>;
+<h3>An Article on A11y</h3>
+<p>A summary of the article</p>
+<button>Read More<AccessibleHidden> from An Article on Accessibility</AccessibleHidden></button>
 ```
+
+##### Example: Tests
+
+This is an example for when you would want to render an Input without visually displaying a label visually, but still having a label to query by, when testing with RTL, as well as being a11y friendly.
+
+```js
+const rendered = render(
+  <>
+    <AccessibleHidden>
+      <label htmlFor="maiden-name-input">Enter your Maiden Name</label>
+    </AccessibleHidden>
+    <input id="maiden-name-input" type="text"></input>
+  </>
+);
+
+expect(rendered.getByLabelText('Enter your Maiden Name')).toBeInTheDocument();
+// ✓ True
+```
+
+It is a common use case for inputs inside Tables, where a sighted user understands the context of the input through the column header and a label element taking space inside the cell is undesirable.
 
 #### Properties
 
-This component only accepts the prop `children`, which is the component you want to hide.
+This component only accepts the prop `children`, which is the element you want to visually hide.
+
+#### References:
+
+- [The A11Y Project - How-to: Hide Content](https://a11yproject.com/posts/how-to-hide-content/)

--- a/packages/components/accessible-hidden/index.js
+++ b/packages/components/accessible-hidden/index.js
@@ -1,0 +1,6 @@
+// This file exists  because we want jest to use our non-compiled code to run tests
+// if this file is missing, and you have a `module` or `main` that points to a non-existing file
+// (ie, a bundle that hasn't been built yet) then jest will fail if the bundle is not yet built.
+// all apps should export all their named exports from their root index.js
+export { default } from './src';
+export * from './src';

--- a/packages/components/accessible-hidden/package.json
+++ b/packages/components/accessible-hidden/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@commercetools-uikit/accessible-hidden",
+  "version": "10.16.0",
+  "description": "",
+  "main": "dist/accessible-hidden.cjs.js",
+  "module": "dist/accessible-hidden.esm.js",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "prepare": "../../../scripts/version.js replace",
+    "prebuild": "rimraf dist",
+    "build": "cross-env NODE_ENV=production rollup -c ../../../rollup.config.js -i ./src/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "license": "MIT",
+  "dependencies": {
+    "@emotion/core": "10.0.27",
+    "prop-types": "15.7.2"
+  },
+  "peerDependencies": {
+    "react": ">= 16.8.0"
+  }
+}

--- a/packages/components/accessible-hidden/src/accessible-hidden.js
+++ b/packages/components/accessible-hidden/src/accessible-hidden.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+
+const AccessibleHidden = props => {
+  return (
+    <div
+      css={css`
+        clip: rect(0 0 0 0);
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        border: 0;
+        padding: 0;
+        overflow: hidden;
+        position: absolute;
+        white-space: nowrap;
+      `}
+    >
+      {props.children}
+    </div>
+  );
+};
+AccessibleHidden.displayName = 'AccessibleHidden';
+AccessibleHidden.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default AccessibleHidden;

--- a/packages/components/accessible-hidden/src/accessible-hidden.spec.js
+++ b/packages/components/accessible-hidden/src/accessible-hidden.spec.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render } from '../../../../src/test-utils';
+import AccessibleHidden from './accessible-hidden';
+
+it('should find text inside AccessibleHidden', () => {
+  const rendered = render(<AccessibleHidden>Spies!</AccessibleHidden>);
+
+  expect(rendered.getByText('Spies!')).toBeInTheDocument();
+});
+
+it('should find the input of a label inside AccessibleHidden', () => {
+  const rendered = render(
+    <>
+      <AccessibleHidden>
+        <label htmlFor="maiden-name-input">Enter your Maiden Name</label>
+      </AccessibleHidden>
+      <input id="maiden-name-input" type="text"></input>
+    </>
+  );
+
+  expect(rendered.getByLabelText('Enter your Maiden Name')).toBeInTheDocument();
+});

--- a/packages/components/accessible-hidden/src/index.js
+++ b/packages/components/accessible-hidden/src/index.js
@@ -1,0 +1,3 @@
+export { default } from './accessible-hidden';
+
+export { default as version } from './version';

--- a/packages/components/accessible-hidden/src/version.js
+++ b/packages/components/accessible-hidden/src/version.js
@@ -1,0 +1,2 @@
+// NOTE: This string will be replaced in the `prepare` script by the `scripts/version.js` file.
+export default '__@UI_KIT_PACKAGE/VERSION_OF_RELEASE__';


### PR DESCRIPTION
#### Summary

This is a new component proposal for addressing #1269 

The idea is providing an easy way to [render invisible, but machine-readable content](https://webaim.org/techniques/css/invisiblecontent/).

#### Usage

```js
import AccessibleHidden from '@commercetools-uikit/accessible-hidden';

<AccessibleHidden>
  <label htmlFor="sample-input">Sample Input</label>
</AccessibleHidden>;
```

##### Follow-up:
 Add a prop to Field components to allow hiding the `label` using this component.