### PR TITLE
chore(card): fix documentation and small refactor

### DIFF
--- a/packages/components/card/README.md
+++ b/packages/components/card/README.md
@@ -20,5 +20,5 @@ import Card from '@commercetools-uikit/card';
 | ----------- | -------- | :------: | ---------------- | -------- | --------------------------------- |
 | `theme`     | `string` |    -     | `light`, `dark`  | `light`  | background color of the card      |
 | `type`      | `string` |    -     | `raised`, `flat` | `raised` | The type of card                  |
-| `classname` | `string` |    -     | -                | -        | className passed to the container |
+| `className` | `string` |    -     | -                | -        | className passed to the container |
 | `children`  | `node`   |    ✅    | -                | -        | Content rendered within the card  |

--- a/packages/components/card/src/card.js
+++ b/packages/components/card/src/card.js
@@ -8,10 +8,10 @@ const Card = props => (
   <div
     {...filterDataAttributes(props)}
     css={css`
-      display: flex;
-      font-size: 1rem;
-      flex-direction: column;
+      box-sizing: border-box;
       width: 100%;
+      padding: ${vars.spacingM};
+      font-size: 1rem;
       box-shadow: ${props.type === 'raised' ? vars.shadow1 : 'none'};
       border-radius: ${vars.borderRadius6};
       background: ${props.theme === 'dark'
@@ -20,22 +20,16 @@ const Card = props => (
     `}
     className={props.className}
   >
-    <div
-      css={css`
-        padding: ${vars.spacingM};
-      `}
-    >
-      {props.children}
-    </div>
+    {props.children}
   </div>
 );
 
 Card.displayName = 'Card';
 Card.propTypes = {
-  className: PropTypes.string,
   type: PropTypes.oneOf(['raised', 'flat']),
-  children: PropTypes.any,
   theme: PropTypes.oneOf(['light', 'dark']),
+  children: PropTypes.any,
+  className: PropTypes.string,
 };
 
 Card.defaultProps = {


### PR DESCRIPTION
#### Summary

@YahiaElTai raised the fact that the `className` prop was documented with the wrong casing. This is fixed in this PR.

Also took the opportunity to remove one unnecessary wrapper and styles from the component.