### PR TITLE
fix(collapsible-panel): Accessible panel Header element

### DIFF
--- a/packages/components/buttons/accessible-button/src/accessible-button.js
+++ b/packages/components/buttons/accessible-button/src/accessible-button.js
@@ -9,11 +9,15 @@ import getNormalizedButtonStyles from './accessible-button.styles';
 
 const propsToOmit = ['onClick'];
 
+const getIsEnterOrSpace = e =>
+  e.key === ' ' || e.key === 'Spacebar' || e.which === 13 || e.which === 32;
+
 const Button = styled.button`
   ${getNormalizedButtonStyles}
   display: inline-flex;
-  outline: 0;
   font-size: ${vars.fontSizeDefault};
+
+  ${props => (!props.as || props.as === 'button' ? 'outline: none' : '')}
 
   cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
   &:disabled {
@@ -30,7 +34,9 @@ const AccessibleButton = React.forwardRef((props, ref) => {
         event.preventDefault();
         return false;
       }
-      if (!props.isDisabled && onClick) return onClick(event);
+      if (!props.isDisabled && onClick) {
+        return onClick(event);
+      }
       // eslint-disable-next-line no-useless-return, consistent-return
       return;
     },
@@ -39,9 +45,18 @@ const AccessibleButton = React.forwardRef((props, ref) => {
 
   const isButton = !props.as || props.as === 'button';
 
-  const buttonProps = {
-    type: props.type,
-  };
+  let buttonProps = {};
+  if (isButton) {
+    buttonProps = {
+      type: props.type,
+    };
+  } else if (!props.isDisabled) {
+    buttonProps = {
+      role: 'button',
+      tabIndex: '0',
+      onKeyPress: event => getIsEnterOrSpace(event) && handleClick(event),
+    };
+  }
 
   return (
     <Button
@@ -58,7 +73,7 @@ const AccessibleButton = React.forwardRef((props, ref) => {
       aria-disabled={props.isDisabled}
       {...(props.isToggleButton ? { 'aria-pressed': props.isToggled } : {})}
       {...omit(props.buttonAttributes, propsToOmit)}
-      {...(isButton ? buttonProps : {})}
+      {...buttonProps}
       {...filterAriaAttributes(props)}
     >
       {props.children}

--- a/packages/components/buttons/accessible-button/src/accessible-button.js
+++ b/packages/components/buttons/accessible-button/src/accessible-button.js
@@ -9,8 +9,7 @@ import getNormalizedButtonStyles from './accessible-button.styles';
 
 const propsToOmit = ['onClick'];
 
-const getIsEnterOrSpace = e =>
-  e.key === ' ' || e.key === 'Spacebar' || e.which === 13 || e.which === 32;
+const getIsEnterOrSpace = e => e.key === ' ' || e.key === 'Enter';
 
 const Button = styled.button`
   ${getNormalizedButtonStyles}

--- a/packages/components/buttons/accessible-button/src/accessible-button.spec.js
+++ b/packages/components/buttons/accessible-button/src/accessible-button.spec.js
@@ -70,4 +70,14 @@ describe('rendering', () => {
       expect(getByLabelText('test-button')).toHaveAttribute('type', 'reset');
     });
   });
+
+  describe('rendering as a div', () => {
+    it('should render a div element with accessibility attributes', () => {
+      const { getByLabelText } = render(
+        <AccessibleButton {...props} as="div" />
+      );
+      expect(getByLabelText('test-button')).toHaveAttribute('role', 'button');
+      expect(getByLabelText('test-button')).toHaveAttribute('tabindex', '0');
+    });
+  });
 });

--- a/packages/components/collapsible-panel/src/collapsible-panel.js
+++ b/packages/components/collapsible-panel/src/collapsible-panel.js
@@ -35,9 +35,11 @@ const CollapsiblePanel = props => {
       {({ isOpen, toggle, containerStyles, registerContentNode }) => (
         <Container theme={props.theme} className={props.className}>
           <HeaderContainer
+            as="div"
             id={props.id}
             {...dataProps}
             theme={props.theme}
+            label=""
             isOpen={isOpen}
             onClick={props.isDisabled ? undefined : toggle}
             isSticky={props.isSticky}

--- a/packages/components/collapsible-panel/src/collapsible-panel.spec.js
+++ b/packages/components/collapsible-panel/src/collapsible-panel.spec.js
@@ -170,7 +170,8 @@ describe('aria attributes', () => {
         Children
       </CollapsiblePanel>
     );
-    const getPanelHeader = () => rendered.container.querySelector('button');
+    const getPanelHeader = () =>
+      rendered.container.querySelector('[role=button]');
 
     const panelContentId = CollapsiblePanel.getPanelContentId(
       props.id || 'example'

--- a/packages/components/collapsible-panel/src/collapsible-panel.styles.js
+++ b/packages/components/collapsible-panel/src/collapsible-panel.styles.js
@@ -1,7 +1,7 @@
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { customProperties as vars } from '@commercetools-uikit/design-system';
-import { getNormalizedButtonStyles } from '@commercetools-uikit/accessible-button';
+import AccessibleButton from '@commercetools-uikit/accessible-button';
 
 function getThemeStyle({ theme }) {
   if (theme === 'light') {
@@ -75,14 +75,9 @@ const Container = styled.div`
   font-size: ${vars.fontSizeDefault};
 `;
 
-const HeaderContainer = styled.button`
-  ${getNormalizedButtonStyles}
+const HeaderContainer = styled(AccessibleButton)`
   ${getHeaderContainerStyles}
   ${getThemeStyle}
-
-  &:focus-visible {
-    outline: initial;
-  }
 `;
 
 const HeaderControlsWrapper = styled.div`


### PR DESCRIPTION
#### Summary

This PR addresses this problem: https://github.com/commercetools/merchant-center-frontend/pull/8565#issuecomment-598637568.

It occurs when the `CollapsiblePanel` is passed any child elements for the Header that are buttons, because the Header of the CollapsiblePanel is also a `button` element.

#### Description

* Fix the `AccessibleButton` component to become truly accessible when the `as` prop is used:
  * Add `role` and `tabIndex` attributes.
  * Add `onKeyPress` event for `Enter` and `Space` to trigger the `onClick`, for full keyboard navigation support.
* Use this adjusted `AccessibleButton` as a `div` for the CollapsiblePanel header, instead of a `button` element but keeping the a11y.