### PR TITLE
fix(collapsible-panel): to forward data-attributes

### DIFF
--- a/packages/components/collapsible-panel/src/collapsible-panel.js
+++ b/packages/components/collapsible-panel/src/collapsible-panel.js
@@ -37,7 +37,6 @@ const CollapsiblePanel = props => {
           <HeaderContainer
             as="div"
             id={props.id}
-            {...dataProps}
             theme={props.theme}
             label=""
             isOpen={isOpen}
@@ -45,6 +44,7 @@ const CollapsiblePanel = props => {
             isSticky={props.isSticky}
             isDisabled={props.isDisabled}
             isCondensed={props.condensed}
+            buttonAttributes={dataProps}
             headerControlsAlignment={props.headerControlsAlignment}
             aria-controls={panelContentId}
             aria-expanded={isOpen ? 'true' : 'false'}

--- a/packages/components/collapsible-panel/src/collapsible-panel.spec.js
+++ b/packages/components/collapsible-panel/src/collapsible-panel.spec.js
@@ -150,6 +150,16 @@ it('should not call "onToggle" when header is clicked while disabled', () => {
   expect(onToggle).not.toHaveBeenCalled();
 });
 
+it('should forward data-attributes ', () => {
+  const { container } = render(
+    <CollapsiblePanel header="Header" data-foo="bar">
+      Children
+    </CollapsiblePanel>
+  );
+
+  expect(container.querySelector("[data-foo='bar']")).toBeInTheDocument();
+});
+
 describe('getPanelContentId', () => {
   it('should return a string containing the given id', () => {
     const panelContentId = CollapsiblePanel.getPanelContentId('example');


### PR DESCRIPTION
### Summary

I broke the forwarding of `data-` attributes on the last changes for `CollapsiblePanel`.

This PR fixes it and adds a test so it won't happen again 🙃 

