### PR TITLE
fix(accessible-button): fix no-outline rule for button elements

### DIFF
--- a/packages/components/buttons/accessible-button/src/accessible-button.js
+++ b/packages/components/buttons/accessible-button/src/accessible-button.js
@@ -16,7 +16,7 @@ const Button = styled.button`
   display: inline-flex;
   font-size: ${vars.fontSizeDefault};
 
-  ${props => (!props.as || props.as === 'button' ? 'outline: none' : '')}
+  ${props => (!props.as || props.as === 'button' ? 'outline: none;' : '')}
 
   cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
   &:disabled {


### PR DESCRIPTION
#### Summary

Quick fix: this rule wasn't working because of a missing semicolon 🤦‍♂ 