### PR TITLE
[UKIT-110] fix(password-field): show password button alignment

### DIFF
--- a/src/components/fields/password-field/password-field.js
+++ b/src/components/fields/password-field/password-field.js
@@ -30,7 +30,7 @@ const PasswordField = (props) => {
   return (
     <Constraints.Horizontal constraint={props.horizontalConstraint}>
       <Stack scale="xs">
-        <Inline alignItems="center" justifyContent="space-between">
+        <Inline alignItems="flex-end" justifyContent="space-between">
           <FieldLabel
             hint={props.hint}
             title={props.title}

--- a/src/components/fields/password-field/password-field.visualroute.js
+++ b/src/components/fields/password-field/password-field.visualroute.js
@@ -72,5 +72,15 @@ export const component = () => (
         touched={true}
       />
     </Spec>
+    <Spec label="with description and hint">
+      <PasswordField
+        title="Welcome Text"
+        value={value}
+        onChange={() => {}}
+        horizontalConstraint="m"
+        hint="Make sure the Caps Lock is disabled"
+        description="Your secret password"
+      />
+    </Spec>
   </Suite>
 );


### PR DESCRIPTION
#### Summary

A follow-up to https://github.com/commercetools/ui-kit/pull/1292

Fixes the alignment of the `show` password button in `PasswordField`.