### PR TITLE
fix(data-table): normalize z-index

### DIFF
--- a/packages/components/data-table/src/data-table.styles.js
+++ b/packages/components/data-table/src/data-table.styles.js
@@ -2,6 +2,8 @@ import styled from '@emotion/styled';
 import { customProperties as vars } from '@commercetools-uikit/design-system';
 
 const TableGrid = styled.table`
+  position: relative;
+  z-index: 0;
   display: grid;
   /* stylelint-disable function-whitespace-after */
   grid-template-columns: ${(props) =>


### PR DESCRIPTION
#### Summary

`DataTable`: Because the header cells have a `z-index` higher than the default, other elements that appear above the table might be painted below the header cells.

This PR fixes the problem by giving bringing the `table` element, parent of the header cells, back to `z-index` of `0`, making the table and all the child elements _relative_ to it respect the normal hierarchy.
