### PR TITLE
fix(data-table): add footer prop

### DIFF
--- a/packages/components/data-table/README.md
+++ b/packages/components/data-table/README.md
@@ -58,6 +58,7 @@ return <DataTable rows={rows} columns={columns} />;
 | `sortedBy`         | `string`          | -        | -                                    | The key of the column for which the data is currently sorted by.                                                                                                                                                                                                                        |
 | `sortDirection`    | [`desc`, `asc`]   | -        | -                                    | The direction towards which the sorting is applied.                                                                                                                                                                                                                                     |
 | `onSortChange`     | `func`            | -        | -                                    | Function called when a sortable column's header is clicked. Required if you set `isSortable` on at least on column. Should implement the following interface: (columnKey: string, sortDirection: string).                                                                               |
+| `footer`           | `node`            | -        | -                                    | Element to render within the `tfoot` (footer) element of the table.                                                                                                                                                                                                                     |
 
 ### Columns
 

--- a/packages/components/data-table/src/cell.js
+++ b/packages/components/data-table/src/cell.js
@@ -4,6 +4,7 @@ import requiredIf from 'react-required-if';
 import { AngleDownIcon, AngleUpIcon } from '@commercetools-uikit/icons';
 import {
   BaseCell,
+  BaseFooterCell,
   BaseHeaderCell,
   CellInner,
   HeaderCellInner,
@@ -90,9 +91,10 @@ const DataCell = (props) => {
 };
 DataCell.displayName = 'DataCell';
 DataCell.propTypes = {
-  align: PropTypes.oneOf(['left', 'center', 'right']),
   onClick: PropTypes.func,
   children: PropTypes.node.isRequired,
+  alignment: PropTypes.oneOf(['left', 'center', 'right']),
+  isCondensed: PropTypes.bool,
   isTruncated: PropTypes.bool,
   shouldIgnoreRowClick: PropTypes.bool,
 };
@@ -101,4 +103,19 @@ DataCell.defaultProps = {
   shouldIgnoreRowClick: false,
 };
 
-export { HeaderCell, DataCell };
+const FooterCell = (props) => (
+  <BaseFooterCell numberOfColumns={props.numberOfColumns}>
+    <CellInner alignment={props.alignment} isCondensed={props.isCondensed}>
+      {props.children}
+    </CellInner>
+  </BaseFooterCell>
+);
+FooterCell.displayName = 'FooterCell';
+FooterCell.propTypes = {
+  children: PropTypes.node.isRequired,
+  alignment: PropTypes.oneOf(['left', 'center', 'right']),
+  isCondensed: PropTypes.bool,
+  numberOfColumns: PropTypes.number.isRequired,
+};
+
+export { HeaderCell, DataCell, FooterCell };

--- a/packages/components/data-table/src/cell.styles.js
+++ b/packages/components/data-table/src/cell.styles.js
@@ -137,6 +137,11 @@ const BaseCell = styled.td`
   ${(props) => (props.isTruncated ? 'overflow: hidden;' : '')}
 `;
 
+const BaseFooterCell = styled.td`
+  grid-column: 1 / ${(props) => props.numberOfColumns};
+  border-bottom: 1px solid ${vars.colorNeutral90};
+`;
+
 const HeaderCellInner = styled.div`
   ${(props) => getPaddingStyle(props, true)}
   ${getCellInnerStyles}
@@ -162,6 +167,7 @@ const SortableHeaderInner = styled.button`
 
 export {
   BaseCell,
+  BaseFooterCell,
   BaseHeaderCell,
   CellInner,
   HeaderCellInner,

--- a/packages/components/data-table/src/data-table.js
+++ b/packages/components/data-table/src/data-table.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { filterDataAttributes } from '@commercetools-uikit/utils';
-import { TableGrid, Header, Body, Row } from './data-table.styles';
-import { HeaderCell, DataCell } from './cell';
+import { TableGrid, Header, Body, Row, Footer } from './data-table.styles';
+import { HeaderCell, DataCell, FooterCell } from './cell';
 
 const DataTable = (props) => (
   <TableGrid
@@ -57,6 +57,19 @@ const DataTable = (props) => (
         </Row>
       ))}
     </Body>
+    {props.footer && (
+      <Footer>
+        <Row>
+          <FooterCell
+            isCondensed={props.isCondensed}
+            cellAlignment={props.cellAlignment}
+            numberOfColumns={props.columns.length + 1}
+          >
+            {props.footer}
+          </FooterCell>
+        </Row>
+      </Footer>
+    )}
   </TableGrid>
 );
 DataTable.propTypes = {
@@ -80,6 +93,7 @@ DataTable.propTypes = {
       shouldIgnoreRowClick: PropTypes.bool,
     })
   ).isRequired,
+  footer: PropTypes.node,
   maxWidth: PropTypes.number,
   maxHeight: PropTypes.number,
   onRowClick: PropTypes.func,

--- a/packages/components/data-table/src/data-table.spec.js
+++ b/packages/components/data-table/src/data-table.spec.js
@@ -63,6 +63,16 @@ describe('DataTable', () => {
     });
   });
 
+  it('should allow rendering a footer', () => {
+    const rendered = render(
+      <DataTable {...baseProps} footer="This is in the footer" />
+    );
+
+    const footerElement = rendered.container.querySelector('tfoot');
+
+    expect(footerElement.textContent).toBe('This is in the footer');
+  });
+
   describe('when setting an action for onRowClick', () => {
     // we will be expecting this mock function to be called with (row: object, rowIndex: number)
     const rowClickEvent = jest.fn();

--- a/packages/components/data-table/src/data-table.story.js
+++ b/packages/components/data-table/src/data-table.story.js
@@ -1,7 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, number, boolean, select } from '@storybook/addon-knobs';
+import {
+  text,
+  select,
+  number,
+  boolean,
+  withKnobs,
+} from '@storybook/addon-knobs';
 import withReadme from 'storybook-readme/with-readme';
 import { Value } from 'react-value';
 import { useFormik } from 'formik';
@@ -335,6 +341,7 @@ storiesOf('Components|Table (NEW)', module)
 
     const onRowClick = boolean('onRowClick', true);
     const withRowSelection = boolean('withRowSelection', true);
+    const footer = text('footer', 'This is a Footer');
 
     const {
       rows: rowsWithSelection,
@@ -401,6 +408,7 @@ storiesOf('Components|Table (NEW)', module)
           sortedBy={sortedBy}
           onSortChange={onSortChange}
           sortDirection={sortDirection}
+          footer={footer}
         />
         <br />
         <hr />

--- a/packages/components/data-table/src/data-table.styles.js
+++ b/packages/components/data-table/src/data-table.styles.js
@@ -46,4 +46,8 @@ const Row = styled.tr`
   ${getClickableRowStyle}
 `;
 
-export { TableGrid, Header, Body, Row };
+const Footer = styled.tfoot`
+  display: contents;
+`;
+
+export { TableGrid, Header, Body, Row, Footer };


### PR DESCRIPTION
#### Summary

Adds a `footer` prop to `DataTable` to allow placing content on the `tfoot`  element.