### PR TITLE
fix(data-table): column cells not wrapping

### DIFF
--- a/packages/components/data-table/src/cell.styles.js
+++ b/packages/components/data-table/src/cell.styles.js
@@ -81,10 +81,6 @@ const getCellInnerStyles = (props) => {
     getAlignmentStyle(props),
     getTruncatedStyle(props),
     getOutlineStyles(),
-    !props.shouldWrap &&
-      css`
-        white-space: nowrap;
-      `,
     props.shouldIgnoreRowClick &&
       css`
         cursor: auto;
@@ -145,6 +141,7 @@ const BaseFooterCell = styled.td`
 const HeaderCellInner = styled.div`
   ${(props) => getPaddingStyle(props, true)}
   ${getCellInnerStyles}
+  ${(props) => (props.shouldWrap ? '' : 'white-space: nowrap')}
 `;
 
 const CellInner = styled.div`


### PR DESCRIPTION
#### Summary

The `wrapHeaderLabels` prop was incorrectly affecting non-header cells.
This PR fixes this.

This reminds me that we should have VRTs for the new table: will come in a follow-up PR.