### PR TITLE
fix(data-table): Allow table to have scrollbar when too wide for its container

### DIFF
--- a/.changeset/seven-adults-turn.md
+++ b/.changeset/seven-adults-turn.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table': patch
+---
+
+fix to prevent table from overflowing if it's too wide for its container, adding a horizontal scrollbar if needed

--- a/packages/components/data-table/src/data-table.styles.js
+++ b/packages/components/data-table/src/data-table.styles.js
@@ -24,18 +24,11 @@ const TableGrid = styled.table`
     props.columns.map((column) => column.width || 'auto').join(' ')};
   /* stylelint-enable function-whitespace-after */
 
+  ${(props) => (props.maxHeight ? `max-height: ${props.maxHeight}px;` : '')}
   ${(props) =>
-    props.maxHeight
-      ? `
-    max-height: ${props.maxHeight}px;
-    overflow-y: auto;`
-      : ''}
-  ${(props) =>
-    props.maxWidth
-      ? `
-    max-width: ${props.maxWidth}px;
-    overflow-x: auto;`
-      : ''}
+    props.maxWidth ? `max-width: ${props.maxWidth}px;` : ''}
+
+  overflow: auto;
 `;
 
 const Header = styled.thead`


### PR DESCRIPTION
#### Summary

* `DataTable`

This PR complements the last one (https://github.com/commercetools/ui-kit/pull/1341) to prevent the table from overflowing if it's too wide for its container, adding a horizontal scrollbar if needed, even if there's no `maxWidth` defined.

This is a common case if the window is too narrow for the columns, and the table is inside a `Card`, `CollapsiblePanel`, or any other container which doesn't necessarily have a specified width.

A possible follow-up might be excluding the footer part from the containment, but this is still being considered by the design team.