### PR TITLE
feat(data-table/cell): Improve data table's sortable columns

### DIFF
--- a/.changeset/tidy-hounds-repeat.md
+++ b/.changeset/tidy-hounds-repeat.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table': patch
+---
+
+Indicate sortable columns of a data table clearly in the UI

--- a/packages/components/data-table/package.json
+++ b/packages/components/data-table/package.json
@@ -20,7 +20,7 @@
     "@commercetools-uikit/accessible-button": "10.16.0",
     "@commercetools-uikit/design-system": "10.13.0",
     "@commercetools-uikit/hooks": "10.18.0",
-    "@commercetools-uikit/icons": "10.15.1",
+    "@commercetools-uikit/icons": "10.19.0",
     "@commercetools-uikit/utils": "10.14.1",
     "@emotion/core": "10.0.28",
     "@emotion/styled": "10.0.27",

--- a/packages/components/data-table/src/cell.js
+++ b/packages/components/data-table/src/cell.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import requiredIf from 'react-required-if';
-import { AngleDownIcon, AngleUpIcon } from '@commercetools-uikit/icons';
+import {
+  AngleUpIcon,
+  AngleDownIcon,
+  AngleUpDownIcon,
+} from '@commercetools-uikit/icons';
+
 import {
   BaseCell,
   BaseFooterCell,
@@ -16,8 +21,7 @@ const HeaderCell = (props) => {
     const isActive = props.sortedBy === props.columnKey;
     const nextSortDirection =
       !isActive || props.sortDirection === 'desc' ? 'asc' : 'desc';
-    const Icon =
-      isActive && props.sortDirection === 'desc' ? AngleDownIcon : AngleUpIcon;
+    const Icon = props.sortDirection === 'desc' ? AngleDownIcon : AngleUpIcon;
 
     return (
       <BaseHeaderCell disableHeaderStickiness={props.disableHeaderStickiness}>
@@ -29,6 +33,8 @@ const HeaderCell = (props) => {
           isCondensed={props.isCondensed}
         >
           {props.children}
+          {/** conditional rendering of one of the icons at a time is handled by CSS. Checkout cell.styles */}
+          <AngleUpDownIcon size="medium" color="surface" />
           <Icon size="medium" color="surface" />
         </SortableHeaderInner>
       </BaseHeaderCell>

--- a/packages/components/data-table/src/cell.js
+++ b/packages/components/data-table/src/cell.js
@@ -34,8 +34,12 @@ const HeaderCell = (props) => {
         >
           {props.children}
           {/** conditional rendering of one of the icons at a time is handled by CSS. Checkout cell.styles */}
-          <AngleUpDownIcon size="medium" color="surface" />
-          <Icon size="medium" color="surface" />
+          <AngleUpDownIcon
+            size="medium"
+            color="surface"
+            id="nonActiveSortingIcon"
+          />
+          <Icon size="medium" color="surface" id="activeSortingIcon" />
         </SortableHeaderInner>
       </BaseHeaderCell>
     );

--- a/packages/components/data-table/src/cell.styles.js
+++ b/packages/components/data-table/src/cell.styles.js
@@ -103,21 +103,21 @@ const getSortableHeaderStyles = (props) => css`
   * THEN AngleUpDown icon is hidden
   * AND AngleUp or AngleDown icon is shown
   */
-  svg:nth-last-of-type(2) {
+  svg[id='nonActiveSortingIcon'] {
     display: ${props.isActive ? 'none' : 'inline-block'};
     margin-left: ${vars.spacingS};
   }
-  svg:last-of-type {
+  svg[id='activeSortingIcon'] {
     display: ${props.isActive ? 'inline-block' : 'none'};
     margin-left: ${vars.spacingS};
   }
 
   :hover,
   :focus {
-    svg:first-of-type {
+    svg[id='nonActiveSortingIcon'] {
       display: none;
     }
-    svg:last-of-type {
+    svg[id='activeSortingIcon'] {
       display: inline-block;
       * {
         fill: ${vars.colorNeutral};

--- a/packages/components/data-table/src/cell.styles.js
+++ b/packages/components/data-table/src/cell.styles.js
@@ -94,15 +94,31 @@ const getSortableHeaderStyles = (props) => css`
   justify-content: space-between;
   align-items: center;
 
-  /* A sortable header has the arrow svg icon as the last child */
-  svg:last-of-type {
-    visibility: ${props.isActive ? 'visible' : 'hidden'};
+  /* A sortable header has the two arrow svg icons
+  * GIVEN column is sortable and is not focused
+  * THEN AngleUpDown icon is shown (default behaviour)
+  * AND AngleUp or AngleDown icon is not shown
+  * 
+  * GIVEN column is sortable and foucsed
+  * THEN AngleUpDown icon is hidden
+  * AND AngleUp or AngleDown icon is shown
+  */
+  svg:nth-last-of-type(2) {
+    display: ${props.isActive ? 'none' : 'inline-block'};
     margin-left: ${vars.spacingS};
   }
+  svg:last-of-type {
+    display: ${props.isActive ? 'inline-block' : 'none'};
+    margin-left: ${vars.spacingS};
+  }
+
   :hover,
   :focus {
+    svg:first-of-type {
+      display: none;
+    }
     svg:last-of-type {
-      visibility: visible;
+      display: inline-block;
       * {
         fill: ${vars.colorNeutral};
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,17 +1193,6 @@
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/design-system/-/design-system-10.15.1.tgz#87f1c1d4acfd3d6da1cf59db5c951402b204a00f"
   integrity sha512-RuwNY3SvT2YkSgAWnv1XxFw7BHsnahaM61070MjPE2Lg8lHZm8+tevkd4QSxFBZWBAc8gWfMA48/ujgcg9Rtug==
 
-"@commercetools-uikit/icons@10.15.1":
-  version "10.15.1"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/icons/-/icons-10.15.1.tgz#853dcd9f101c277b849abff2c74fa6aeef630cfc"
-  integrity sha512-wquQwny4EEaceWLKFrkrDFT14CoDjhhjUynR4wBGOGOfu6EmrlhcwLcTE+dfBuHzVI77g4QGKqPnzUzhjjKMrQ==
-  dependencies:
-    "@commercetools-uikit/design-system" "10.15.1"
-    "@emotion/core" "10.0.27"
-    "@emotion/styled" "10.0.27"
-    prop-types "15.7.2"
-    tiny-invariant "1.1.0"
-
 "@commercetools-uikit/utils@10.14.1":
   version "10.14.1"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/utils/-/utils-10.14.1.tgz#a24420e7c68fccdf12f56081fbf252694724c360"


### PR DESCRIPTION
#### Summary

- `DataTable` => Sortable columns should be clearly indicated (showing `AngleUpDown` icon in the header cell) so that user can see it without hover on each column and finding it out that way. If a column is focused/active, either `AngleUp` or `AngleDown` icon is shown, depending on its current sort direction.
