### PR TITLE
feat(data-table): Enable rows to expand and collapse in case they have truncated columns

### DIFF
--- a/.changeset/little-tomatoes-brush.md
+++ b/.changeset/little-tomatoes-brush.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table': minor
+---
+
+Enable rows to expand and collapse in case they have truncated columns

--- a/packages/components/data-table/package.json
+++ b/packages/components/data-table/package.json
@@ -22,6 +22,7 @@
     "@commercetools-uikit/hooks": "10.21.0",
     "@commercetools-uikit/icons": "10.20.0",
     "@commercetools-uikit/utils": "10.21.0",
+    "@commercetools-uikit/secondary-icon-button": "10.18.4",
     "@emotion/core": "10.0.28",
     "@emotion/styled": "10.0.27",
     "lodash": "4.17.15",

--- a/packages/components/data-table/src/cell.js
+++ b/packages/components/data-table/src/cell.js
@@ -5,6 +5,8 @@ import {
   AngleUpIcon,
   AngleDownIcon,
   AngleUpDownIcon,
+  RightTriangleFilledIcon,
+  RightTriangleLinearIcon,
 } from '@commercetools-uikit/icons';
 import {
   BaseCell,
@@ -13,7 +15,7 @@ import {
   CellInner,
   HeaderCellInner,
   SortableHeaderInner,
-  CellCollapseButtonWrapper,
+  RowExpandCollapseButton,
 } from './cell.styles';
 
 const HeaderCell = (props) => {
@@ -81,7 +83,9 @@ const DataCell = (props) => {
     [shouldIgnoreRowClick]
   );
 
-  const Icon = props.isRowCollapsed ? AngleDownIcon : AngleUpIcon;
+  const Icon = props.isRowCollapsed
+    ? RightTriangleFilledIcon
+    : RightTriangleLinearIcon;
   return (
     <BaseCell isTruncated={props.isTruncated}>
       <CellInner
@@ -89,16 +93,15 @@ const DataCell = (props) => {
         onClick={props.shouldIgnoreRowClick ? onClickHandler : undefined}
       />
       {props.shouldRenderCollapseButton && (
-        <CellCollapseButtonWrapper>
-          <Icon
-            id="rowExpandCollapseButton"
-            size="medium"
-            onClick={(event) => {
-              props.handleRowCollapseClick();
-              event.stopPropagation();
-            }}
-          />
-        </CellCollapseButtonWrapper>
+        <RowExpandCollapseButton
+          icon={<Icon size="small" />}
+          id="rowExpandCollapseButton"
+          label="Expand/Collapse"
+          onClick={(event) => {
+            props.handleRowCollapseClick();
+            event.stopPropagation();
+          }}
+        />
       )}
     </BaseCell>
   );

--- a/packages/components/data-table/src/cell.js
+++ b/packages/components/data-table/src/cell.js
@@ -95,7 +95,6 @@ const DataCell = (props) => {
       {props.shouldRenderCollapseButton && (
         <RowExpandCollapseButton
           icon={<Icon size="small" />}
-          id="rowExpandCollapseButton"
           isRowCollapsed={props.isRowCollapsed}
           label="Expand/Collapse Row"
           onClick={(event) => {
@@ -114,13 +113,13 @@ DataCell.propTypes = {
   isCondensed: PropTypes.bool,
   isTruncated: PropTypes.bool,
   shouldIgnoreRowClick: PropTypes.bool,
-  handleRowCollapseClick: requiredIf(
-    PropTypes.func,
-    (props) => props.isTruncated
-  ),
   shouldRenderCollapseButton: requiredIf(
     PropTypes.bool,
     (props) => props.isTruncated
+  ),
+  handleRowCollapseClick: requiredIf(
+    PropTypes.func,
+    (props) => props.shouldRenderCollapseButton
   ),
   isRowCollapsed: requiredIf(PropTypes.bool, (props) => props.isTruncated),
 };

--- a/packages/components/data-table/src/cell.js
+++ b/packages/components/data-table/src/cell.js
@@ -113,15 +113,15 @@ DataCell.propTypes = {
   isCondensed: PropTypes.bool,
   isTruncated: PropTypes.bool,
   shouldIgnoreRowClick: PropTypes.bool,
-  shouldRenderCollapseButton: requiredIf(
-    PropTypes.bool,
-    (props) => props.isTruncated
-  ),
+  shouldRenderCollapseButton: PropTypes.bool.isRequired,
   handleRowCollapseClick: requiredIf(
     PropTypes.func,
     (props) => props.shouldRenderCollapseButton
   ),
-  isRowCollapsed: requiredIf(PropTypes.bool, (props) => props.isTruncated),
+  isRowCollapsed: requiredIf(
+    PropTypes.bool,
+    (props) => props.shouldRenderCollapseButton
+  ),
 };
 DataCell.defaultProps = {
   isTruncated: false,

--- a/packages/components/data-table/src/cell.js
+++ b/packages/components/data-table/src/cell.js
@@ -6,7 +6,6 @@ import {
   AngleDownIcon,
   AngleUpDownIcon,
 } from '@commercetools-uikit/icons';
-
 import {
   BaseCell,
   BaseFooterCell,
@@ -14,6 +13,7 @@ import {
   CellInner,
   HeaderCellInner,
   SortableHeaderInner,
+  CellCollapseButtonWrapper,
 } from './cell.styles';
 
 const HeaderCell = (props) => {
@@ -81,12 +81,25 @@ const DataCell = (props) => {
     [shouldIgnoreRowClick]
   );
 
+  const Icon = props.isRowCollapsed ? AngleDownIcon : AngleUpIcon;
   return (
     <BaseCell isTruncated={props.isTruncated}>
       <CellInner
         {...props}
         onClick={props.shouldIgnoreRowClick ? onClickHandler : undefined}
       />
+      {props.shouldRenderCollapseButton && (
+        <CellCollapseButtonWrapper>
+          <Icon
+            id="rowExpandCollapseButton"
+            size="medium"
+            onClick={(event) => {
+              props.handleRowCollapseClick();
+              event.stopPropagation();
+            }}
+          />
+        </CellCollapseButtonWrapper>
+      )}
     </BaseCell>
   );
 };
@@ -97,6 +110,15 @@ DataCell.propTypes = {
   isCondensed: PropTypes.bool,
   isTruncated: PropTypes.bool,
   shouldIgnoreRowClick: PropTypes.bool,
+  handleRowCollapseClick: requiredIf(
+    PropTypes.func,
+    (props) => props.isTruncated
+  ),
+  shouldRenderCollapseButton: requiredIf(
+    PropTypes.bool,
+    (props) => props.isTruncated
+  ),
+  isRowCollapsed: requiredIf(PropTypes.bool, (props) => props.isTruncated),
 };
 DataCell.defaultProps = {
   isTruncated: false,

--- a/packages/components/data-table/src/cell.js
+++ b/packages/components/data-table/src/cell.js
@@ -96,7 +96,8 @@ const DataCell = (props) => {
         <RowExpandCollapseButton
           icon={<Icon size="small" />}
           id="rowExpandCollapseButton"
-          label="Expand/Collapse"
+          isRowCollapsed={props.isRowCollapsed}
+          label="Expand/Collapse Row"
           onClick={(event) => {
             props.handleRowCollapseClick();
             event.stopPropagation();

--- a/packages/components/data-table/src/cell.styles.js
+++ b/packages/components/data-table/src/cell.styles.js
@@ -146,6 +146,7 @@ const BaseHeaderCell = styled.th`
 
 const BaseCell = styled.td`
   border-bottom: 1px solid ${vars.colorNeutral90};
+  position: relative;
   ${(props) => (props.isTruncated ? 'overflow: hidden;' : '')}
 `;
 
@@ -172,6 +173,12 @@ const SortableHeaderInner = styled.button`
   ${getSortableHeaderStyles}
 `;
 
+const CellCollapseButtonWrapper = styled.div`
+  position: absolute;
+  bottom: 0;
+  right: 0;
+`;
+
 export {
   BaseCell,
   BaseFooterCell,
@@ -179,4 +186,5 @@ export {
   CellInner,
   HeaderCellInner,
   SortableHeaderInner,
+  CellCollapseButtonWrapper,
 };

--- a/packages/components/data-table/src/cell.styles.js
+++ b/packages/components/data-table/src/cell.styles.js
@@ -175,6 +175,7 @@ const SortableHeaderInner = styled.button`
 `;
 
 const RowExpandCollapseButton = styled(SecondaryIconButton)`
+  cursor: ${(props) => (props.isRowCollapsed ? 's-resize' : 'n-resize')};
   position: absolute;
   bottom: 0;
   right: 0;

--- a/packages/components/data-table/src/cell.styles.js
+++ b/packages/components/data-table/src/cell.styles.js
@@ -1,6 +1,7 @@
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { customProperties as vars } from '@commercetools-uikit/design-system';
+import SecondaryIconButton from '@commercetools-uikit/secondary-icon-button';
 
 const getPaddingStyle = (props, isHeader) => {
   if (props.isCondensed)
@@ -173,10 +174,11 @@ const SortableHeaderInner = styled.button`
   ${getSortableHeaderStyles}
 `;
 
-const CellCollapseButtonWrapper = styled.div`
+const RowExpandCollapseButton = styled(SecondaryIconButton)`
   position: absolute;
   bottom: 0;
   right: 0;
+  visibility: hidden;
 `;
 
 export {
@@ -186,5 +188,5 @@ export {
   CellInner,
   HeaderCellInner,
   SortableHeaderInner,
-  CellCollapseButtonWrapper,
+  RowExpandCollapseButton,
 };

--- a/packages/components/data-table/src/data-row.js
+++ b/packages/components/data-table/src/data-row.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Row } from './data-table.styles';
+import { DataCell } from './cell';
+
+const DataRow = (props) => {
+  const rowHasTruncatedColumn = props.columns.some(
+    (column) => column.isTruncated
+  );
+  const [isRowCollapsed, collapseRow] = React.useState(rowHasTruncatedColumn);
+  const handleRowCollapseClick = () => {
+    collapseRow(!isRowCollapsed);
+  };
+  const shouldRenderCollapseButton = (totalColumnsLength, currentColumnIndex) =>
+    totalColumnsLength - 1 === currentColumnIndex &&
+    ((isRowCollapsed && rowHasTruncatedColumn) ||
+      (rowHasTruncatedColumn && !isRowCollapsed));
+  return (
+    <Row
+      key={props.row.id}
+      onClick={
+        props.onRowClick
+          ? () => props.onRowClick(props.row, props.rowIndex)
+          : undefined
+      }
+    >
+      {props.columns.map((column, columnIndex) => (
+        <DataCell
+          key={`${props.row.id}-${column.key}`}
+          alignment={column.align ? column.align : props.cellAlignment}
+          isTruncated={column.isTruncated && isRowCollapsed}
+          isRowCollapsed={isRowCollapsed}
+          isCondensed={props.isCondensed}
+          shouldIgnoreRowClick={column.shouldIgnoreRowClick}
+          handleRowCollapseClick={handleRowCollapseClick}
+          shouldRenderCollapseButton={shouldRenderCollapseButton(
+            props.columns.length,
+            columnIndex
+          )}
+        >
+          {column.renderItem
+            ? column.renderItem(props.row)
+            : props.itemRenderer(props.row, column)}
+        </DataCell>
+      ))}
+    </Row>
+  );
+};
+DataRow.propTypes = {
+  row: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired,
+  rowIndex: PropTypes.number.isRequired,
+  columns: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      align: PropTypes.oneOf(['left', 'center', 'right']),
+      onClick: PropTypes.func,
+      /* custom item renderer, specific for items of this column */
+      renderItem: PropTypes.func,
+      isTruncated: PropTypes.bool,
+      shouldIgnoreRowClick: PropTypes.bool,
+    })
+  ).isRequired,
+  onRowClick: PropTypes.func,
+  isCondensed: PropTypes.bool,
+  /* the default item (cell) renderer.
+    an existing per-column `renderItem` func takes precedence over this */
+  itemRenderer: PropTypes.func.isRequired,
+  /* the default cell alignment
+    an existing per-column `align` property takes precedence over this */
+  cellAlignment: PropTypes.oneOf(['left', 'center', 'right']),
+};
+DataRow.defaultProps = {
+  isCondensed: false,
+  cellAlignment: 'left',
+  itemRenderer: (row, column) => row[column.key],
+};
+DataRow.displayName = 'DataRow';
+
+export default DataRow;

--- a/packages/components/data-table/src/data-table.js
+++ b/packages/components/data-table/src/data-table.js
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { filterDataAttributes } from '@commercetools-uikit/utils';
 import { TableGrid, Header, Body, Row, Footer } from './data-table.styles';
-import { HeaderCell, DataCell, FooterCell } from './cell';
+import { HeaderCell, FooterCell } from './cell';
+import DataRow from './data-row';
 
 const DataTable = (props) => (
   <TableGrid
@@ -33,26 +34,7 @@ const DataTable = (props) => (
     </Header>
     <Body>
       {props.rows.map((row, rowIndex) => (
-        <Row
-          key={row.id}
-          onClick={
-            props.onRowClick ? () => props.onRowClick(row, rowIndex) : undefined
-          }
-        >
-          {props.columns.map((column) => (
-            <DataCell
-              key={`${row.id}-${column.key}`}
-              alignment={column.align ? column.align : props.cellAlignment}
-              isTruncated={column.isTruncated}
-              isCondensed={props.isCondensed}
-              shouldIgnoreRowClick={column.shouldIgnoreRowClick}
-            >
-              {column.renderItem
-                ? column.renderItem(row)
-                : props.itemRenderer(row, column)}
-            </DataCell>
-          ))}
-        </Row>
+        <DataRow {...props} row={row} key={rowIndex} rowIndex={rowIndex} />
       ))}
     </Body>
     {props.footer && (

--- a/packages/components/data-table/src/data-table.spec.js
+++ b/packages/components/data-table/src/data-table.spec.js
@@ -54,7 +54,7 @@ describe('DataTable', () => {
      * Since we have only three rows, it should render only three row expand-collapse buttons
      */
     const rowExpandCollapseButtons = rendered.container.querySelectorAll(
-      "svg[id='rowExpandCollapseButton']"
+      "button[id='rowExpandCollapseButton']"
     );
     expect(rowExpandCollapseButtons).toHaveLength(3);
   });

--- a/packages/components/data-table/src/data-table.spec.js
+++ b/packages/components/data-table/src/data-table.spec.js
@@ -49,12 +49,12 @@ describe('DataTable', () => {
   it('should render only one expand-collapse button per row', () => {
     const rendered = render(<DataTable {...baseProps} />);
     /**
-     * Even though two columns are marked as truncatable in each row, but only button should be shown
-     * in each row that will control the expand and collapse of the whole row.
+     * Even though two columns are marked as truncatable in each row, only one button should be shown
+     * per row, which controls the expand and collapse of its whole row.
      * Since we have only three rows, it should render only three row expand-collapse buttons
      */
-    const rowExpandCollapseButtons = rendered.container.querySelectorAll(
-      "button[id='rowExpandCollapseButton']"
+    const rowExpandCollapseButtons = rendered.queryAllByLabelText(
+      /Expand\/Collapse Row/i
     );
     expect(rowExpandCollapseButtons).toHaveLength(3);
   });

--- a/packages/components/data-table/src/data-table.spec.js
+++ b/packages/components/data-table/src/data-table.spec.js
@@ -12,10 +12,12 @@ const testColumns = [
   {
     key: 'title',
     label: 'Title',
+    isTruncated: true,
   },
   {
     key: 'year',
     label: 'Year',
+    isTruncated: true,
   },
 ];
 
@@ -42,6 +44,19 @@ describe('DataTable', () => {
     expect(rendered.queryByText('Woman At War')).toBeInTheDocument();
     expect(rendered.queryByText('2018')).toBeInTheDocument();
     expect(rendered.queryByText('2-woman')).not.toBeInTheDocument();
+  });
+
+  it('should render only one expand-collapse button per row', () => {
+    const rendered = render(<DataTable {...baseProps} />);
+    /**
+     * Even though two columns are marked as truncatable in each row, but only button should be shown
+     * in each row that will control the expand and collapse of the whole row.
+     * Since we have only three rows, it should render only three row expand-collapse buttons
+     */
+    const rowExpandCollapseButtons = rendered.container.querySelectorAll(
+      "svg[id='rowExpandCollapseButton']"
+    );
+    expect(rowExpandCollapseButtons).toHaveLength(3);
   });
 
   describe('when using a custom itemRenderer', () => {

--- a/packages/components/data-table/src/data-table.story.js
+++ b/packages/components/data-table/src/data-table.story.js
@@ -23,7 +23,7 @@ import NumberInput from '../../inputs/number-input';
 const items = [
   {
     id: '5e188c29791747d9c54250e2',
-    name: 'Morgan Bean',
+    name: 'Barry Allen - aka Flash - aka Fastest Man Alive',
     customRenderer: 'CYCLONICA',
     phone: '+1 (895) 529-3300',
     age: 23,

--- a/packages/components/data-table/src/data-table.story.js
+++ b/packages/components/data-table/src/data-table.story.js
@@ -23,7 +23,7 @@ import NumberInput from '../../inputs/number-input';
 const items = [
   {
     id: '5e188c29791747d9c54250e2',
-    name: 'Barry Allen - aka Flash - aka Fastest Man Alive',
+    name: 'Morgan Bean',
     customRenderer: 'CYCLONICA',
     phone: '+1 (895) 529-3300',
     age: 23,

--- a/packages/components/data-table/src/data-table.styles.js
+++ b/packages/components/data-table/src/data-table.styles.js
@@ -42,6 +42,11 @@ const Body = styled.tbody`
 const Row = styled.tr`
   display: contents;
   ${getClickableRowStyle}
+  :hover {
+    button[id='rowExpandCollapseButton'] {
+      visibility: visible;
+    }
+  }
 `;
 
 const Footer = styled.tfoot`

--- a/packages/components/data-table/src/data-table.styles.js
+++ b/packages/components/data-table/src/data-table.styles.js
@@ -1,6 +1,7 @@
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { customProperties as vars } from '@commercetools-uikit/design-system';
+import { RowExpandCollapseButton } from './cell.styles';
 
 const getClickableRowStyle = (props) => {
   if (props.onClick) {
@@ -43,7 +44,7 @@ const Row = styled.tr`
   display: contents;
   ${getClickableRowStyle}
   :hover {
-    button[id='rowExpandCollapseButton'] {
+    ${RowExpandCollapseButton} {
       visibility: visible;
     }
   }


### PR DESCRIPTION
#### Summary

- `DataTable` => Allow table users to expand or collapse data per rows when the table content is truncated 