### PR TITLE
chore(docs): to update spacings stack docs

### DIFF
--- a/src/components/spacings/stack/README.md
+++ b/src/components/spacings/stack/README.md
@@ -21,7 +21,7 @@ import { Spacings } from '@commercetools-frontend/ui-kit';
 | Props        | Type             | Required | Values                                            | Default      |
 | ------------ | ---------------- | :------: | ------------------------------------------------- | ------------ |
 | `scale`      | `String`         |    -     | `['xs', 's', 'm', 'l', 'xl']`                     | `s`          |
-| `alignItems` | `oneOf`          |    -     | `['stretch', 'flex-start', 'flex-end', 'center']` | `flex-start` |
+| `alignItems` | `oneOf`          |    -     | `['stretch', 'flex-start', 'flex-end', 'center']` | `stretch` |
 | `children`   | `PropTypes.node` |    -     | -                                                 | -            |
 
 ## Scales


### PR DESCRIPTION
This PR fixes an issue with the docs for `Spacings.Stack` default value for `alignItems`