### PR TITLE
fix(data-table): Apply cell alignment prop to header cells as well

### DIFF
--- a/packages/components/data-table/src/cell.js
+++ b/packages/components/data-table/src/cell.js
@@ -33,6 +33,7 @@ const HeaderCell = (props) => {
           isActive={isActive}
           shouldWrap={props.shouldWrap}
           isCondensed={props.isCondensed}
+          alignment={props.alignment}
         >
           {props.children}
           {/** conditional rendering of one of the icons at a time is handled by CSS. Checkout cell.styles */}
@@ -51,6 +52,7 @@ const HeaderCell = (props) => {
       <HeaderCellInner
         shouldWrap={props.shouldWrap}
         isCondensed={props.isCondensed}
+        alignment={props.alignment}
       >
         {props.children}
       </HeaderCellInner>
@@ -61,6 +63,7 @@ HeaderCell.displayName = 'HeaderCell';
 HeaderCell.propTypes = {
   onClick: requiredIf(PropTypes.func, (props) => props.isSortable),
   sortedBy: PropTypes.string,
+  alignment: PropTypes.string,
   children: PropTypes.node.isRequired,
   columnKey: PropTypes.string.isRequired,
   shouldWrap: PropTypes.bool,

--- a/packages/components/data-table/src/cell.styles.js
+++ b/packages/components/data-table/src/cell.styles.js
@@ -89,43 +89,48 @@ const getCellInnerStyles = (props) => {
   ];
 };
 
-const getSortableHeaderStyles = (props) => css`
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+const getSortableHeaderStyles = (props) => [
+  getAlignmentStyle(props),
+  css`
+    width: 100%;
 
-  /* A sortable header has the two arrow svg icons
-  * GIVEN column is sortable and is not focused
-  * THEN AngleUpDown icon is shown (default behaviour)
-  * AND AngleUp or AngleDown icon is not shown
-  * 
-  * GIVEN column is sortable and foucsed
-  * THEN AngleUpDown icon is hidden
-  * AND AngleUp or AngleDown icon is shown
-  */
-  svg[id='nonActiveSortingIcon'] {
-    display: ${props.isActive ? 'none' : 'inline-block'};
-    margin-left: ${vars.spacingS};
-  }
-  svg[id='activeSortingIcon'] {
-    display: ${props.isActive ? 'inline-block' : 'none'};
-    margin-left: ${vars.spacingS};
-  }
+    /* A sortable header has the two arrow svg icons
+    * GIVEN column is sortable and is not focused
+    * THEN AngleUpDown icon is shown (default behaviour)
+    * AND AngleUp or AngleDown icon is not shown
+    *
+    * GIVEN column is sortable and foucsed
+    * THEN AngleUpDown icon is hidden
+    * AND AngleUp or AngleDown icon is shown
+    */
 
-  :hover,
-  :focus {
     svg[id='nonActiveSortingIcon'] {
-      display: none;
+      display: ${props.isActive ? 'none' : 'inline-block'};
+      float: right;
+      margin-top: 2px;
+      margin-left: ${vars.spacingS};
     }
     svg[id='activeSortingIcon'] {
-      display: inline-block;
-      * {
-        fill: ${vars.colorNeutral};
+      display: ${props.isActive ? 'inline-block' : 'none'};
+      float: right;
+      margin-top: 2px;
+      margin-left: ${vars.spacingS};
+    }
+
+    :hover,
+    :focus {
+      svg[id='nonActiveSortingIcon'] {
+        display: none;
+      }
+      svg[id='activeSortingIcon'] {
+        display: inline-block;
+        * {
+          fill: ${vars.colorNeutral};
+        }
       }
     }
-  }
-`;
+  `,
+];
 
 const BaseHeaderCell = styled.th`
   color: ${vars.colorSurface};

--- a/packages/components/data-table/src/data-table.js
+++ b/packages/components/data-table/src/data-table.js
@@ -26,6 +26,7 @@ const DataTable = (props) => (
             shouldWrap={props.wrapHeaderLabels}
             sortDirection={props.sortDirection}
             disableHeaderStickiness={props.disableHeaderStickiness}
+            alignment={column.align ? column.align : props.cellAlignment}
           >
             {column.label}
           </HeaderCell>


### PR DESCRIPTION
#### Summary
 
- `DataTable` => Header cells of the `DataTable` should also consider the cell alignment prop when rendering content.
