### PR TITLE
fix(select-fields): Fix RTL tests

### DIFF
--- a/.changeset/fair-icons-talk.md
+++ b/.changeset/fair-icons-talk.md
@@ -1,0 +1,8 @@
+---
+'@commercetools-uikit/async-creatable-select-field': patch
+'@commercetools-uikit/async-select-field': patch
+'@commercetools-uikit/creatable-select-field': patch
+'@commercetools-uikit/select-field': patch
+---
+
+Fix RTL tests

--- a/src/components/fields/async-creatable-select-field/async-creatable-select-field.spec.js
+++ b/src/components/fields/async-creatable-select-field/async-creatable-select-field.spec.js
@@ -14,14 +14,15 @@ class Story extends React.Component {
   static displayName = 'Story';
   static propTypes = {
     onChange: PropTypes.func.isRequired,
+    title: PropTypes.string.isRequired,
     value: PropTypes.object,
     id: PropTypes.string,
     loadOptions: PropTypes.func,
     defaultOptions: PropTypes.bool,
   };
   static defaultProps = {
-    id: 'text-field',
-    title: 'foo',
+    id: 'async-creatable-select-field',
+    title: 'AsyncCreatableSelectField',
     onChange: () => {},
     loadOptions: () =>
       Promise.resolve([
@@ -43,7 +44,6 @@ class Story extends React.Component {
   render() {
     return (
       <div>
-        <label htmlFor={this.props.id}>AsyncCreatableSelectField</label>
         <AsyncCreatableSelectField
           {...this.props}
           value={this.state.value}

--- a/src/components/fields/async-select-field/async-select-field.spec.js
+++ b/src/components/fields/async-select-field/async-select-field.spec.js
@@ -14,14 +14,15 @@ class Story extends React.Component {
   static displayName = 'Story';
   static propTypes = {
     onChange: PropTypes.func.isRequired,
+    title: PropTypes.string.isRequired,
     value: PropTypes.object,
     id: PropTypes.string,
     loadOptions: PropTypes.func,
     defaultOptions: PropTypes.bool,
   };
   static defaultProps = {
-    id: 'text-field',
-    title: 'foo',
+    id: 'async-select-field',
+    title: 'AsyncSelectField',
     onChange: () => {},
     loadOptions: () =>
       Promise.resolve([
@@ -43,7 +44,6 @@ class Story extends React.Component {
   render() {
     return (
       <div>
-        <label htmlFor={this.props.id}>AsyncSelectField</label>
         <AsyncSelectField
           {...this.props}
           value={this.state.value}

--- a/src/components/fields/creatable-select-field/creatable-select-field.spec.js
+++ b/src/components/fields/creatable-select-field/creatable-select-field.spec.js
@@ -14,13 +14,14 @@ class Story extends React.Component {
   static displayName = 'Story';
   static propTypes = {
     onChange: PropTypes.func.isRequired,
+    title: PropTypes.string.isRequired,
     value: PropTypes.object,
     id: PropTypes.string,
     options: PropTypes.array.isRequired,
   };
   static defaultProps = {
-    id: 'text-field',
-    title: 'foo',
+    id: 'creatable-select-field',
+    title: 'CreatableSelectField',
     onChange: () => {},
     options: [
       { value: 'ready', label: 'Ready' },
@@ -40,7 +41,6 @@ class Story extends React.Component {
   render() {
     return (
       <div>
-        <label htmlFor={this.props.id}>CreatableSelectField</label>
         <CreatableSelectField
           {...this.props}
           value={this.state.value}

--- a/src/components/fields/select-field/select-field.spec.js
+++ b/src/components/fields/select-field/select-field.spec.js
@@ -14,13 +14,14 @@ class Story extends React.Component {
   static displayName = 'Story';
   static propTypes = {
     onChange: PropTypes.func.isRequired,
+    title: PropTypes.string.isRequired,
     value: PropTypes.string,
     id: PropTypes.string,
     options: PropTypes.array.isRequired,
   };
   static defaultProps = {
-    id: 'text-field',
-    title: 'foo',
+    id: 'select-field',
+    title: 'SelectField ',
     onChange: () => {},
     options: [
       { value: 'ready', label: 'Ready' },
@@ -39,7 +40,6 @@ class Story extends React.Component {
   render() {
     return (
       <div>
-        <label htmlFor={this.props.id}>SelectField</label>
         <SelectField
           {...this.props}
           value={this.state.value}


### PR DESCRIPTION
#### Summary

- **_All select fields_** => The select fields uses the `title` prop to render the labels of a select field. Therefore, the tests should use that for testing the rendered label instead of adding another separate label on top.