### PR TITLE
fix(data-table): add data-testid attributes to headers and cells

### DIFF
--- a/.changeset/fair-rabbits-tell.md
+++ b/.changeset/fair-rabbits-tell.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table': patch
+---
+
+add data-testid attributes to headers and cells

--- a/packages/components/data-table/src/cell.js
+++ b/packages/components/data-table/src/cell.js
@@ -27,7 +27,10 @@ const HeaderCell = (props) => {
     const Icon = props.sortDirection === 'desc' ? AngleDownIcon : AngleUpIcon;
 
     return (
-      <BaseHeaderCell disableHeaderStickiness={props.disableHeaderStickiness}>
+      <BaseHeaderCell
+        data-testid={`header-${props.columnKey}`}
+        disableHeaderStickiness={props.disableHeaderStickiness}
+      >
         <SortableHeaderInner
           label={props.sortDirection}
           onClick={() => props.onClick(props.columnKey, nextSortDirection)}
@@ -49,7 +52,10 @@ const HeaderCell = (props) => {
     );
   }
   return (
-    <BaseHeaderCell disableHeaderStickiness={props.disableHeaderStickiness}>
+    <BaseHeaderCell
+      data-testid={`header-${props.columnKey}`}
+      disableHeaderStickiness={props.disableHeaderStickiness}
+    >
       <HeaderCellInner
         shouldWrap={props.shouldWrap}
         isCondensed={props.isCondensed}

--- a/packages/components/data-table/src/data-row.js
+++ b/packages/components/data-table/src/data-row.js
@@ -28,6 +28,7 @@ const DataRow = (props) => {
         <DataCell
           key={`${props.row.id}-${column.key}`}
           alignment={column.align ? column.align : props.cellAlignment}
+          data-testid={`cell-${props.rowIndex}-${column.key}`}
           isTruncated={column.isTruncated && isRowCollapsed}
           isRowCollapsed={isRowCollapsed}
           isCondensed={props.isCondensed}

--- a/packages/components/data-table/src/data-table.spec.js
+++ b/packages/components/data-table/src/data-table.spec.js
@@ -38,6 +38,22 @@ describe('DataTable', () => {
     expect(rendered.queryByText('Year')).toBeInTheDocument();
   });
 
+  it('should be able to find headers by the data-testid', () => {
+    const rendered = render(<DataTable {...baseProps} />);
+
+    expect(rendered.queryByTestId('header-title')).toBeInTheDocument();
+    expect(rendered.queryByTestId('header-year')).toBeInTheDocument();
+  });
+
+  it('should be able to find cells by the data-testid', () => {
+    const rendered = render(<DataTable {...baseProps} />);
+
+    expect(rendered.queryByTestId('cell-0-title')).toBeInTheDocument();
+    expect(rendered.queryByTestId('cell-1-title')).toBeInTheDocument();
+    expect(rendered.queryByTestId('cell-2-title')).toBeInTheDocument();
+    expect(rendered.queryByTestId('cell-0-year')).toBeInTheDocument();
+  });
+
   it('should render item fields which have corresponding column keys', () => {
     const rendered = render(<DataTable {...baseProps} />);
 


### PR DESCRIPTION
#### Summary

This PR adds `data-testid` attributes to the headers and cells of the table, to improve their testability.

I used the same sequential id that was being used in the "old" table, but with the `data-testid` attribute instead of just `data-test`. This means the migration steps for the tests that query for these test ids will be minimal.
