### PR TITLE
fix: to add `eslint-plugin-jest-dom`

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -8,6 +8,7 @@ parserOptions:
 extends:
   - 'airbnb-base'
   - 'plugin:jest/recommended'
+  - 'plugin:jest-dom/recommended'
   - 'plugin:react/recommended'
   - 'prettier'
   - 'prettier/react'

--- a/jest.eslint.config.js
+++ b/jest.eslint.config.js
@@ -2,6 +2,6 @@ module.exports = {
   runner: 'jest-runner-eslint',
   displayName: 'eslint',
   testMatch: ['<rootDir>/**/*.js'],
-  testPathIgnorePatterns: ['/node_modules/', '.public/', 'public/', 'dist/es;'],
+  testPathIgnorePatterns: ['/node_modules/', '.public/', 'public/', 'dist;'],
   watchPlugins: ['jest-watch-typeahead/filename'],
 };

--- a/jest.eslint.config.js
+++ b/jest.eslint.config.js
@@ -2,6 +2,6 @@ module.exports = {
   runner: 'jest-runner-eslint',
   displayName: 'eslint',
   testMatch: ['<rootDir>/**/*.js'],
-  testPathIgnorePatterns: ['/node_modules/', '.public/', 'public/', 'dist/'],
+  testPathIgnorePatterns: ['/node_modules/', '.public/', 'public/', 'dist/es;'],
   watchPlugins: ['jest-watch-typeahead/filename'],
 };

--- a/jest.eslint.config.js
+++ b/jest.eslint.config.js
@@ -2,6 +2,6 @@ module.exports = {
   runner: 'jest-runner-eslint',
   displayName: 'eslint',
   testMatch: ['<rootDir>/**/*.js'],
-  testPathIgnorePatterns: ['/node_modules/', '.public/', 'public/', 'dist;'],
+  testPathIgnorePatterns: ['/node_modules/', '.public/', 'public/', 'dist/'],
   watchPlugins: ['jest-watch-typeahead/filename'],
 };

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "eslint-formatter-pretty": "4.0.0",
     "eslint-plugin-import": "2.21.2",
     "eslint-plugin-jest": "23.13.2",
+    "eslint-plugin-jest-dom": "3.0.1",
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-prefer-object-spread": "1.2.1",
     "eslint-plugin-prettier": "3.1.4",

--- a/packages/components/buttons/accessible-button/src/accessible-button.spec.js
+++ b/packages/components/buttons/accessible-button/src/accessible-button.spec.js
@@ -17,7 +17,7 @@ describe('rendering', () => {
   it('should render', () => {
     const { getByLabelText } = render(<AccessibleButton {...props} />);
     expect(getByLabelText('test-button')).toBeInTheDocument();
-    expect(getByLabelText('test-button')).not.toHaveAttribute('disabled');
+    expect(getByLabelText('test-button')).toBeEnabled();
   });
   it('should apply the className "foo" to the button', () => {
     const { getByLabelText } = render(
@@ -37,7 +37,7 @@ describe('rendering', () => {
     );
     const button = getByLabelText('test-button');
 
-    expect(button).toHaveAttribute('disabled');
+    expect(button).toBeDisabled();
     expect(button).toHaveAttribute('aria-disabled', 'true');
 
     button.click();

--- a/packages/components/buttons/flat-button/src/flat-button.spec.js
+++ b/packages/components/buttons/flat-button/src/flat-button.spec.js
@@ -21,7 +21,7 @@ describe('rendering', () => {
   it('should render', () => {
     const { getByLabelText } = render(<FlatButton {...props} />);
     expect(getByLabelText('Add')).toBeInTheDocument();
-    expect(getByLabelText('Add')).not.toHaveAttribute('disabled');
+    expect(getByLabelText('Add')).toBeEnabled();
   });
   it('should pass aria attributes"', () => {
     const { getByLabelText } = render(
@@ -36,7 +36,7 @@ describe('rendering', () => {
     const { getByLabelText } = render(
       <FlatButton {...props} isDisabled={true} />
     );
-    expect(getByLabelText('Add')).toHaveAttribute('disabled');
+    expect(getByLabelText('Add')).toBeDisabled();
     expect(getByLabelText('Add')).toHaveAttribute('aria-disabled', 'true');
   });
   it('should render icon', () => {

--- a/packages/components/buttons/icon-button/src/icon-button.spec.js
+++ b/packages/components/buttons/icon-button/src/icon-button.spec.js
@@ -21,7 +21,7 @@ describe('rendering', () => {
   it('should render', () => {
     const { getByLabelText } = render(<IconButton {...props} />);
     expect(getByLabelText('test-button')).toBeInTheDocument();
-    expect(getByLabelText('test-button')).not.toHaveAttribute('disabled');
+    expect(getByLabelText('test-button')).toBeEnabled();
   });
   it('should be pass aria attributes', () => {
     const { getByLabelText } = render(
@@ -36,7 +36,7 @@ describe('rendering', () => {
     const { getByLabelText } = render(
       <IconButton {...props} isDisabled={true} />
     );
-    expect(getByLabelText('test-button')).toHaveAttribute('disabled');
+    expect(getByLabelText('test-button')).toBeDisabled();
     expect(getByLabelText('test-button')).toHaveAttribute(
       'aria-disabled',
       'true'

--- a/packages/components/buttons/link-button/src/link-button.spec.js
+++ b/packages/components/buttons/link-button/src/link-button.spec.js
@@ -37,7 +37,7 @@ describe('rendering', () => {
   it('should render', () => {
     const { getByLabelText } = render(<LinkButton {...props} />);
     expect(getByLabelText('test-button')).toBeInTheDocument();
-    expect(getByLabelText('test-button')).not.toHaveAttribute('disabled');
+    expect(getByLabelText('test-button')).toBeEnabled();
   });
   it('should navigate to link when clicked', async () => {
     const { getByLabelText, history } = render(<LinkButton {...props} />);

--- a/packages/components/buttons/primary-button/src/primary-button.spec.js
+++ b/packages/components/buttons/primary-button/src/primary-button.spec.js
@@ -19,7 +19,7 @@ describe('rendering', () => {
   it('should render', () => {
     const { getByLabelText } = render(<PrimaryButton {...props} />);
     expect(getByLabelText('Add')).toBeInTheDocument();
-    expect(getByLabelText('Add')).not.toHaveAttribute('disabled');
+    expect(getByLabelText('Add')).toBeEnabled();
   });
   it('should render icon', () => {
     const { getByTestId } = render(<PrimaryButton {...props} />);
@@ -44,7 +44,7 @@ describe('rendering', () => {
     const { getByLabelText } = render(
       <PrimaryButton {...props} isDisabled={true} />
     );
-    expect(getByLabelText('Add')).toHaveAttribute('disabled');
+    expect(getByLabelText('Add')).toBeDisabled();
     expect(getByLabelText('Add')).toHaveAttribute('aria-disabled', 'true');
   });
   it('should be marked as "active"', () => {

--- a/packages/components/buttons/secondary-button/src/secondary-button.spec.js
+++ b/packages/components/buttons/secondary-button/src/secondary-button.spec.js
@@ -19,7 +19,7 @@ describe('rendering', () => {
   it('should render', () => {
     const { getByLabelText } = render(<SecondaryButton {...props} />);
     expect(getByLabelText('Add')).toBeInTheDocument();
-    expect(getByLabelText('Add')).not.toHaveAttribute('disabled');
+    expect(getByLabelText('Add')).toBeEnabled();
   });
   it('should render icon', () => {
     const { getByTestId } = render(<SecondaryButton {...props} />);
@@ -44,7 +44,7 @@ describe('rendering', () => {
     const { getByLabelText } = render(
       <SecondaryButton {...props} isDisabled={true} />
     );
-    expect(getByLabelText('Add')).toHaveAttribute('disabled');
+    expect(getByLabelText('Add')).toBeDisabled();
     expect(getByLabelText('Add')).toHaveAttribute('aria-disabled', 'true');
   });
   it('should be marked as "active"', () => {

--- a/packages/components/buttons/secondary-icon-button/src/secondary-icon-button.spec.js
+++ b/packages/components/buttons/secondary-icon-button/src/secondary-icon-button.spec.js
@@ -19,7 +19,7 @@ describe('rendering', () => {
   it('should render', () => {
     const { getByLabelText } = render(<SecondaryIconButton {...props} />);
     expect(getByLabelText('test-button')).toBeInTheDocument();
-    expect(getByLabelText('test-button')).not.toHaveAttribute('disabled');
+    expect(getByLabelText('test-button')).toBeEnabled();
   });
   it('should render icon', () => {
     const { getByTestId } = render(<SecondaryIconButton {...props} />);
@@ -38,7 +38,7 @@ describe('rendering', () => {
     const { getByLabelText } = render(
       <SecondaryIconButton {...props} isDisabled={true} />
     );
-    expect(getByLabelText('test-button')).toHaveAttribute('disabled');
+    expect(getByLabelText('test-button')).toBeDisabled();
     expect(getByLabelText('test-button')).toHaveAttribute(
       'aria-disabled',
       'true'
@@ -50,7 +50,7 @@ describe('rendering', () => {
         const { getByLabelText } = render(
           <SecondaryIconButton {...props} isDisabled={true} disabled={false} />
         );
-        expect(getByLabelText('test-button')).toHaveAttribute('disabled');
+        expect(getByLabelText('test-button')).toBeDisabled();
         expect(getByLabelText('test-button')).toHaveAttribute(
           'aria-disabled',
           'true'
@@ -62,7 +62,7 @@ describe('rendering', () => {
         const { getByLabelText } = render(
           <SecondaryIconButton {...props} isDisabled={false} disabled={true} />
         );
-        expect(getByLabelText('test-button')).not.toHaveAttribute('disabled');
+        expect(getByLabelText('test-button')).toBeEnabled();
         expect(getByLabelText('test-button')).not.toHaveAttribute(
           'aria-disabled',
           'true'

--- a/packages/components/data-table/src/data-table.spec.js
+++ b/packages/components/data-table/src/data-table.spec.js
@@ -101,7 +101,7 @@ describe('DataTable', () => {
 
     const footerElement = rendered.container.querySelector('tfoot');
 
-    expect(footerElement.textContent).toBe('This is in the footer');
+    expect(footerElement).toHaveTextContent('This is in the footer');
   });
 
   describe('when setting an action for onRowClick', () => {

--- a/packages/components/primary-action-dropdown/src/primary-action-dropdown.spec.js
+++ b/packages/components/primary-action-dropdown/src/primary-action-dropdown.spec.js
@@ -42,14 +42,14 @@ describe('when all options are disabled', () => {
     );
 
     // it should not allow opening the dropdown
-    expect(getByLabelText('Primary Action')).toHaveAttribute('disabled');
+    expect(getByLabelText('Primary Action')).toBeDisabled();
 
     // it should not invoke callback when primary action is clicked
     getByLabelText('Primary Action').click();
     expect(primaryAction).not.toHaveBeenCalled();
 
     // it should not allow opening remaining actions
-    expect(getByLabelText('Open Dropdown')).toHaveAttribute('disabled');
+    expect(getByLabelText('Open Dropdown')).toBeDisabled();
     getByLabelText('Open Dropdown').click();
     expect(queryByLabelText('Secondary Action')).not.toBeInTheDocument();
   });
@@ -84,7 +84,7 @@ describe('when only primary option is disabled', () => {
     expect(getByLabelText('Primary Action')).toBeInTheDocument();
 
     // it should not invoke callback when disabled primary action is clicked
-    expect(getByLabelText('Primary Action')).toHaveAttribute('disabled');
+    expect(getByLabelText('Primary Action')).toBeDisabled();
     getByLabelText('Primary Action').click();
     expect(primaryAction).not.toHaveBeenCalled();
   });
@@ -118,7 +118,7 @@ describe('when only secondary option is disabled', () => {
     expect(getByLabelText('Secondary Action')).toBeInTheDocument();
 
     // it should not invoke callback when disabled secondary action is clicked
-    expect(getByLabelText('Secondary Action')).toHaveAttribute('disabled');
+    expect(getByLabelText('Secondary Action')).toBeDisabled();
     getByLabelText('Secondary Action').click();
     expect(secondaryAction).not.toHaveBeenCalled();
   });

--- a/packages/components/table/src/base-table.spec.js
+++ b/packages/components/table/src/base-table.spec.js
@@ -1,3 +1,4 @@
+import 'jest-enzyme';
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { CellMeasurer, MultiGrid } from 'react-virtualized';

--- a/packages/components/table/src/table.spec.js
+++ b/packages/components/table/src/table.spec.js
@@ -1,3 +1,4 @@
+import 'jest-enzyme';
 import React from 'react';
 import { shallow } from 'enzyme';
 import BaseTable from './base-table';

--- a/scripts/setup-test-framework.js
+++ b/scripts/setup-test-framework.js
@@ -18,15 +18,6 @@ import * as commerceToolsEnzymeMatchers from '@commercetools/jest-enzyme-matcher
 
 Enzyme.configure({ adapter: new Adapter(), disableLifecycleMethods: true });
 
-expect.extend({
-  toBeComponentWithName(received, actual) {
-    const pass = received && received.displayName === actual;
-    const message = () =>
-      `expected ${received} ${pass ? 'not ' : ''} to be ${actual}`;
-    return { message, pass };
-  },
-});
-
 expect.extend(commerceToolsEnzymeMatchers);
 
 configureEnzymeExtensions(ShallowWrapper);

--- a/scripts/setup-test-framework.js
+++ b/scripts/setup-test-framework.js
@@ -10,7 +10,6 @@ import 'intl-pluralrules';
 import '@formatjs/intl-relativetimeformat/polyfill-locales';
 
 // enzyme setup
-import 'jest-enzyme';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import ShallowWrapper from 'enzyme/ShallowWrapper';

--- a/src/components/fields/async-creatable-select-field/async-creatable-select-field.spec.js
+++ b/src/components/fields/async-creatable-select-field/async-creatable-select-field.spec.js
@@ -149,9 +149,7 @@ describe('when disabled', () => {
     const { getByLabelText } = renderAsyncCreatableSelectField({
       isDisabled: true,
     });
-    expect(getByLabelText('AsyncCreatableSelectField')).toHaveAttribute(
-      'disabled'
-    );
+    expect(getByLabelText('AsyncCreatableSelectField')).toBeDisabled();
   });
 });
 

--- a/src/components/fields/async-select-field/async-select-field.spec.js
+++ b/src/components/fields/async-select-field/async-select-field.spec.js
@@ -141,7 +141,7 @@ describe('when `badge` is passed', () => {
 describe('when disabled', () => {
   it('should disable the input', () => {
     const { getByLabelText } = renderAsyncSelectField({ isDisabled: true });
-    expect(getByLabelText('AsyncSelectField')).toHaveAttribute('disabled');
+    expect(getByLabelText('AsyncSelectField')).toBeDisabled();
   });
 });
 

--- a/src/components/fields/creatable-select-field/creatable-select-field.spec.js
+++ b/src/components/fields/creatable-select-field/creatable-select-field.spec.js
@@ -137,7 +137,7 @@ describe('when `badge` is passed', () => {
 describe('when disabled', () => {
   it('should disable the input', () => {
     const { getByLabelText } = renderCreatableSelectField({ isDisabled: true });
-    expect(getByLabelText('CreatableSelectField')).toHaveAttribute('disabled');
+    expect(getByLabelText('CreatableSelectField')).toBeDisabled();
   });
 });
 

--- a/src/components/fields/date-field/date-field.spec.js
+++ b/src/components/fields/date-field/date-field.spec.js
@@ -121,7 +121,7 @@ describe('when `badge` is passed', () => {
 describe('when disabled', () => {
   it('should disable the input', () => {
     const { getByLabelText } = renderDateField({ isDisabled: true });
-    expect(getByLabelText('DateField')).toHaveAttribute('disabled');
+    expect(getByLabelText('DateField')).toBeDisabled();
   });
 });
 

--- a/src/components/fields/date-range-field/date-range-field.spec.js
+++ b/src/components/fields/date-range-field/date-range-field.spec.js
@@ -123,7 +123,7 @@ describe('when `badge` is passed', () => {
 describe('when disabled', () => {
   it('should disable the input', () => {
     const { getByLabelText } = renderDateRangeField({ isDisabled: true });
-    expect(getByLabelText('DateRangeField')).toHaveAttribute('disabled');
+    expect(getByLabelText('DateRangeField')).toBeDisabled();
   });
 });
 

--- a/src/components/fields/date-time-field/date-time-field.spec.js
+++ b/src/components/fields/date-time-field/date-time-field.spec.js
@@ -124,7 +124,7 @@ describe('when `badge` is passed', () => {
 describe('when disabled', () => {
   it('should disable the input', () => {
     const { getByLabelText } = renderDateTimeField({ isDisabled: true });
-    expect(getByLabelText('DateTimeField')).toHaveAttribute('disabled');
+    expect(getByLabelText('DateTimeField')).toBeDisabled();
   });
 });
 

--- a/src/components/fields/localized-multiline-text-field/localized-multiline-text-field.spec.js
+++ b/src/components/fields/localized-multiline-text-field/localized-multiline-text-field.spec.js
@@ -178,15 +178,15 @@ describe('when disabled', () => {
     const { getByLabelText } = renderLocalizedMultilineTextField({
       isDisabled: true,
     });
-    expect(getByLabelText('EN')).toHaveAttribute('disabled');
+    expect(getByLabelText('EN')).toBeDisabled();
   });
   it('should disable all inputs when all languages  are visible', () => {
     const { getByLabelText } = renderLocalizedMultilineTextField({
       isDisabled: true,
       defaultExpandLanguages: true,
     });
-    expect(getByLabelText('EN')).toHaveAttribute('disabled');
-    expect(getByLabelText('DE')).toHaveAttribute('disabled');
+    expect(getByLabelText('EN')).toBeDisabled();
+    expect(getByLabelText('DE')).toBeDisabled();
   });
 });
 

--- a/src/components/fields/localized-text-field/localized-text-field.spec.js
+++ b/src/components/fields/localized-text-field/localized-text-field.spec.js
@@ -136,15 +136,15 @@ describe('when `badge` is passed', () => {
 describe('when disabled', () => {
   it('should disable the inputs', () => {
     const { getByLabelText } = renderLocalizedTextField({ isDisabled: true });
-    expect(getByLabelText('EN')).toHaveAttribute('disabled');
+    expect(getByLabelText('EN')).toBeDisabled();
   });
   it('should disable all inputs when all languages  are visible', () => {
     const { getByLabelText } = renderLocalizedTextField({
       isDisabled: true,
       defaultExpandLanguages: true,
     });
-    expect(getByLabelText('EN')).toHaveAttribute('disabled');
-    expect(getByLabelText('DE')).toHaveAttribute('disabled');
+    expect(getByLabelText('EN')).toBeDisabled();
+    expect(getByLabelText('DE')).toBeDisabled();
   });
 });
 

--- a/src/components/fields/money-field/money-field.spec.js
+++ b/src/components/fields/money-field/money-field.spec.js
@@ -193,8 +193,8 @@ describe('when `hint` is passed', () => {
 describe('when disabled', () => {
   it('should disable the inputs', () => {
     const { getByLabelText } = renderMoneyField({ isDisabled: true });
-    expect(getByLabelText('Amount')).toHaveAttribute('disabled');
-    expect(getByLabelText('EUR')).toHaveAttribute('disabled');
+    expect(getByLabelText('Amount')).toBeDisabled();
+    expect(getByLabelText('EUR')).toBeDisabled();
   });
 });
 
@@ -203,7 +203,7 @@ describe('when readOnly', () => {
     const { getByLabelText } = renderMoneyField({ isReadOnly: true });
     expect(getByLabelText('Amount')).toHaveAttribute('readonly');
     // currency select should be disabled
-    expect(getByLabelText('EUR')).toHaveAttribute('disabled');
+    expect(getByLabelText('EUR')).toBeDisabled();
   });
 });
 

--- a/src/components/fields/multiline-text-field/multiline-text-field.spec.js
+++ b/src/components/fields/multiline-text-field/multiline-text-field.spec.js
@@ -131,7 +131,7 @@ describe('when `badge` is passed', () => {
 describe('when disabled', () => {
   it('should disable the input', () => {
     const { getByLabelText } = renderMultilineTextField({ isDisabled: true });
-    expect(getByLabelText('MultilineTextField')).toHaveAttribute('disabled');
+    expect(getByLabelText('MultilineTextField')).toBeDisabled();
   });
 });
 

--- a/src/components/fields/number-field/number-field.spec.js
+++ b/src/components/fields/number-field/number-field.spec.js
@@ -158,7 +158,7 @@ describe('when `badge` is passed', () => {
 describe('when disabled', () => {
   it('should disable the input', () => {
     const { getByLabelText } = renderNumberField({ isDisabled: true });
-    expect(getByLabelText('NumberField')).toHaveAttribute('disabled');
+    expect(getByLabelText('NumberField')).toBeDisabled();
   });
 });
 

--- a/src/components/fields/password-field/password-field.spec.js
+++ b/src/components/fields/password-field/password-field.spec.js
@@ -129,7 +129,7 @@ describe('when `badge` is passed', () => {
 describe('when disabled', () => {
   it('should disable the input', () => {
     const { getByLabelText } = renderPasswordField({ isDisabled: true });
-    expect(getByLabelText('PasswordField')).toHaveAttribute('disabled');
+    expect(getByLabelText('PasswordField')).toBeDisabled();
   });
 });
 
@@ -195,14 +195,14 @@ describe('when field is touched and has errors', () => {
 describe('when input has no value', () => {
   it('should disable the `show` button`', () => {
     const { getByLabelText } = renderPasswordField();
-    expect(getByLabelText('show')).toHaveAttribute('disabled');
+    expect(getByLabelText('show')).toBeDisabled();
   });
 });
 
 describe('when input value is not empty', () => {
   it('should enable the `show` button`', () => {
     const { getByLabelText } = renderPasswordField({ value: 'foo' });
-    expect(getByLabelText('show')).not.toHaveAttribute('disabled');
+    expect(getByLabelText('show')).toBeEnabled();
   });
   describe('when the `show` button is clicked', () => {
     it('should change the label of the button to `hide`', () => {

--- a/src/components/fields/radio-field/radio-field.spec.js
+++ b/src/components/fields/radio-field/radio-field.spec.js
@@ -129,8 +129,8 @@ describe('when `badge` is passed', () => {
 describe('when disabled', () => {
   it('should disable the input', () => {
     const { getByLabelText } = renderRadioField({ isDisabled: true });
-    expect(getByLabelText(/RadioField Option 1/)).toHaveAttribute('disabled');
-    expect(getByLabelText(/RadioField Option 2/)).toHaveAttribute('disabled');
+    expect(getByLabelText(/RadioField Option 1/)).toBeDisabled();
+    expect(getByLabelText(/RadioField Option 2/)).toBeDisabled();
   });
 });
 

--- a/src/components/fields/select-field/select-field.spec.js
+++ b/src/components/fields/select-field/select-field.spec.js
@@ -130,7 +130,7 @@ describe('when `badge` is passed', () => {
 describe('when disabled', () => {
   it('should disable the input', () => {
     const { getByLabelText } = renderSelectField({ isDisabled: true });
-    expect(getByLabelText('SelectField')).toHaveAttribute('disabled');
+    expect(getByLabelText('SelectField')).toBeDisabled();
   });
 });
 

--- a/src/components/fields/text-field/text-field.spec.js
+++ b/src/components/fields/text-field/text-field.spec.js
@@ -129,7 +129,7 @@ describe('when `badge` is passed', () => {
 describe('when disabled', () => {
   it('should disable the input', () => {
     const { getByLabelText } = renderTextField({ isDisabled: true });
-    expect(getByLabelText('TextField')).toHaveAttribute('disabled');
+    expect(getByLabelText('TextField')).toBeDisabled();
   });
 });
 

--- a/src/components/fields/time-field/time-field.spec.js
+++ b/src/components/fields/time-field/time-field.spec.js
@@ -135,7 +135,7 @@ describe('when `badge` is passed', () => {
 describe('when disabled', () => {
   it('should disable the input', () => {
     const { getByLabelText } = renderTimeField({ isDisabled: true });
-    expect(getByLabelText('TimeField')).toHaveAttribute('disabled');
+    expect(getByLabelText('TimeField')).toBeDisabled();
   });
 });
 

--- a/src/components/inputs/checkbox-input/checkbox-input.spec.js
+++ b/src/components/inputs/checkbox-input/checkbox-input.spec.js
@@ -79,7 +79,7 @@ it('should check the input when isChecked is "true"', () => {
       Accept Terms
     </CheckboxInput>
   );
-  expect(getByLabelText('Accept Terms')).toHaveAttribute('checked');
+  expect(getByLabelText('Accept Terms')).toBeChecked();
 });
 
 it('should not check the input when isChecked is "false"', () => {
@@ -88,7 +88,7 @@ it('should not check the input when isChecked is "false"', () => {
       Accept Terms
     </CheckboxInput>
   );
-  expect(getByLabelText('Accept Terms')).not.toHaveAttribute('checked');
+  expect(getByLabelText('Accept Terms')).not.toBeChecked();
 });
 
 it('should allow changing the checked state', () => {
@@ -98,7 +98,7 @@ it('should allow changing the checked state', () => {
       Accept Terms
     </CheckboxInput>
   );
-  expect(getByLabelText('Accept Terms')).not.toHaveAttribute('checked');
+  expect(getByLabelText('Accept Terms')).not.toBeChecked();
 
   getByLabelText('Accept Terms').click();
   expect(onChange).toHaveBeenCalledTimes(1);
@@ -111,7 +111,7 @@ it('should allow changing the checked state', () => {
     </CheckboxInput>
   );
 
-  expect(getByLabelText('Accept Terms')).toHaveAttribute('checked');
+  expect(getByLabelText('Accept Terms')).toBeChecked();
 
   getByLabelText('Accept Terms').click();
   expect(onChange).toHaveBeenCalledTimes(2);
@@ -128,7 +128,7 @@ describe('when indeterminate', () => {
         Accept Terms
       </CheckboxInput>
     );
-    expect(getByLabelText('Accept Terms')).not.toHaveAttribute('checked');
+    expect(getByLabelText('Accept Terms')).not.toBeChecked();
   });
 
   // The input is always unchecked when the state is indeterminate!
@@ -142,6 +142,6 @@ describe('when indeterminate', () => {
         Accept Terms
       </CheckboxInput>
     );
-    expect(getByLabelText('Accept Terms')).not.toHaveAttribute('checked');
+    expect(getByLabelText('Accept Terms')).not.toBeChecked();
   });
 });

--- a/src/components/inputs/date-input/date-input.spec.js
+++ b/src/components/inputs/date-input/date-input.spec.js
@@ -80,7 +80,7 @@ it('should call onBlur when input loses focus', () => {
 describe('when disabled', () => {
   it('should disable the input', () => {
     const { getByLabelText } = renderDateInput({ isDisabled: true });
-    expect(getByLabelText('Date')).toHaveAttribute('disabled');
+    expect(getByLabelText('Date')).toBeDisabled();
   });
 });
 

--- a/src/components/inputs/date-range-input/date-range-input.spec.js
+++ b/src/components/inputs/date-range-input/date-range-input.spec.js
@@ -90,7 +90,7 @@ it('should call onBlur when input loses focus', () => {
 describe('when disabled', () => {
   it('should disable the input', () => {
     const { getByLabelText } = renderDateRangeInput({ isDisabled: true });
-    expect(getByLabelText('Date')).toHaveAttribute('disabled');
+    expect(getByLabelText('Date')).toBeDisabled();
   });
 });
 

--- a/src/components/inputs/date-time-input/date-time-input.spec.js
+++ b/src/components/inputs/date-time-input/date-time-input.spec.js
@@ -81,7 +81,7 @@ it('should call onBlur when input loses focus', () => {
 describe('when disabled', () => {
   it('should disable the input', () => {
     const { getByLabelText } = renderDateTimeInput({ isDisabled: true });
-    expect(getByLabelText('Date')).toHaveAttribute('disabled');
+    expect(getByLabelText('Date')).toBeDisabled();
   });
 });
 

--- a/src/components/inputs/localized-money-input/localized-money-input.spec.js
+++ b/src/components/inputs/localized-money-input/localized-money-input.spec.js
@@ -190,7 +190,7 @@ describe('when disabled', () => {
         isDisabled: true,
         selectedCurrency: 'CAD',
       });
-      expect(queryByLabelText('CAD')).toHaveAttribute('disabled');
+      expect(queryByLabelText('CAD')).toBeDisabled();
     });
   });
   describe('when expanded', () => {
@@ -204,8 +204,8 @@ describe('when disabled', () => {
       const usdInput = getByLabelText('USD');
       const CADInput = getByLabelText('CAD');
 
-      expect(usdInput).toHaveAttribute('disabled');
-      expect(CADInput).toHaveAttribute('disabled');
+      expect(usdInput).toBeDisabled();
+      expect(CADInput).toBeDisabled();
     });
   });
 });

--- a/src/components/inputs/localized-multiline-text-input/localized-multiline-text-input.spec.js
+++ b/src/components/inputs/localized-multiline-text-input/localized-multiline-text-input.spec.js
@@ -172,7 +172,7 @@ describe('when disabled', () => {
       const { getByLabelText } = renderLocalizedMultilineTextInput({
         isDisabled: true,
       });
-      expect(getByLabelText('EN')).toHaveAttribute('disabled');
+      expect(getByLabelText('EN')).toBeDisabled();
     });
   });
   describe('when expanded', () => {
@@ -181,8 +181,8 @@ describe('when disabled', () => {
         isDisabled: true,
       });
       getByLabelText(/show all languages/i).click();
-      expect(getByLabelText('EN')).toHaveAttribute('disabled');
-      expect(getByLabelText('FR')).toHaveAttribute('disabled');
+      expect(getByLabelText('EN')).toBeDisabled();
+      expect(getByLabelText('FR')).toBeDisabled();
     });
   });
 });

--- a/src/components/inputs/localized-rich-text-input/localized-rich-text-input.spec.js
+++ b/src/components/inputs/localized-rich-text-input/localized-rich-text-input.spec.js
@@ -75,8 +75,14 @@ describe('LocalizedRichTextInput', () => {
           />
         );
         getByLabelText(/show all languages/i).click();
-        expect(getByTestId('rich-text-data-test-en')).toBeDisabled();
-        expect(getByTestId('rich-text-data-test-de')).toBeDisabled();
+        // eslint-disable-next-line jest-dom/prefer-enabled-disabled
+        expect(getByTestId('rich-text-data-test-en')).toHaveAttribute(
+          'disabled'
+        );
+        // eslint-disable-next-line jest-dom/prefer-enabled-disabled
+        expect(getByTestId('rich-text-data-test-de')).toHaveAttribute(
+          'disabled'
+        );
       });
     });
     describe('when not expanded', () => {
@@ -88,7 +94,10 @@ describe('LocalizedRichTextInput', () => {
             isDisabled={true}
           />
         );
-        expect(getByTestId('rich-text-data-test-en')).toBeDisabled();
+        // eslint-disable-next-line jest-dom/prefer-enabled-disabled
+        expect(getByTestId('rich-text-data-test-en')).toHaveAttribute(
+          'disabled'
+        );
       });
     });
   });

--- a/src/components/inputs/localized-rich-text-input/localized-rich-text-input.spec.js
+++ b/src/components/inputs/localized-rich-text-input/localized-rich-text-input.spec.js
@@ -75,12 +75,8 @@ describe('LocalizedRichTextInput', () => {
           />
         );
         getByLabelText(/show all languages/i).click();
-        expect(getByTestId('rich-text-data-test-en')).toHaveAttribute(
-          'disabled'
-        );
-        expect(getByTestId('rich-text-data-test-de')).toHaveAttribute(
-          'disabled'
-        );
+        expect(getByTestId('rich-text-data-test-en')).toBeDisabled();
+        expect(getByTestId('rich-text-data-test-de')).toBeDisabled();
       });
     });
     describe('when not expanded', () => {
@@ -92,9 +88,7 @@ describe('LocalizedRichTextInput', () => {
             isDisabled={true}
           />
         );
-        expect(getByTestId('rich-text-data-test-en')).toHaveAttribute(
-          'disabled'
-        );
+        expect(getByTestId('rich-text-data-test-en')).toBeDisabled();
       });
     });
   });

--- a/src/components/inputs/localized-text-input/localized-text-input.spec.js
+++ b/src/components/inputs/localized-text-input/localized-text-input.spec.js
@@ -162,7 +162,7 @@ describe('when disabled', () => {
       const { getByLabelText } = renderLocalizedTextInput({
         isDisabled: true,
       });
-      expect(getByLabelText('EN')).toHaveAttribute('disabled');
+      expect(getByLabelText('EN')).toBeDisabled();
     });
   });
   describe('when expanded', () => {
@@ -171,8 +171,8 @@ describe('when disabled', () => {
         isDisabled: true,
       });
       getByLabelText(/show all languages/i).click();
-      expect(getByLabelText('EN')).toHaveAttribute('disabled');
-      expect(getByLabelText('FR')).toHaveAttribute('disabled');
+      expect(getByLabelText('EN')).toBeDisabled();
+      expect(getByLabelText('FR')).toBeDisabled();
     });
   });
 });

--- a/src/components/inputs/money-input/money-input.spec.js
+++ b/src/components/inputs/money-input/money-input.spec.js
@@ -695,7 +695,7 @@ describe('MoneyInput', () => {
   });
   it('should render a disabled currency select when readonly', () => {
     const { getByLabelText } = render(<TestComponent isReadOnly={true} />);
-    expect(getByLabelText('EUR')).toHaveAttribute('disabled');
+    expect(getByLabelText('EUR')).toBeDisabled();
   });
 
   describe('when there are no currencies', () => {

--- a/src/components/inputs/multiline-text-input/multiline-text-input.spec.js
+++ b/src/components/inputs/multiline-text-input/multiline-text-input.spec.js
@@ -129,7 +129,7 @@ describe('MultilineTextInput', () => {
 
   it('should forward disabled attribute when disabled', () => {
     const { getByLabelText } = render(<TestComponent isDisabled={true} />);
-    expect(getByLabelText('Description')).toHaveAttribute('disabled');
+    expect(getByLabelText('Description')).toBeDisabled();
   });
 
   it('should call onFocus when the input is focused', () => {

--- a/src/components/inputs/password-input/password-input.spec.js
+++ b/src/components/inputs/password-input/password-input.spec.js
@@ -89,7 +89,7 @@ describe('PasswordInput', () => {
 
   it('should be disabled when isDisabled is passed', () => {
     const { container } = render(<PasswordInput {...baseProps} isDisabled />);
-    expect(container.querySelector('input')).toHaveAttribute('disabled');
+    expect(container.querySelector('input')).toBeDisabled();
   });
 
   it('should have autoComplete set to `on`', () => {

--- a/src/components/inputs/toggle-input/toggle-input.spec.js
+++ b/src/components/inputs/toggle-input/toggle-input.spec.js
@@ -59,7 +59,7 @@ it('should call onChange when clicked', () => {
   getByLabelText('Toggle').click();
 
   expect(onChange).toHaveBeenCalledTimes(1);
-  expect(getByLabelText('Toggle')).toHaveProperty('checked', true);
+  expect(getByLabelText('Toggle')).toBeChecked();
 });
 
 it('should not call onChange when clicked while disabled', () => {
@@ -91,7 +91,7 @@ describe('checked attribute', () => {
       </div>
     );
 
-    expect(getByLabelText('Toggle')).toHaveAttribute('checked');
+    expect(getByLabelText('Toggle')).toBeChecked();
   });
 
   it('should not have checked state when not checked', () => {
@@ -103,6 +103,6 @@ describe('checked attribute', () => {
       </div>
     );
 
-    expect(getByLabelText('Toggle')).not.toHaveAttribute('checked');
+    expect(getByLabelText('Toggle')).not.toBeChecked();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8052,6 +8052,14 @@ eslint-plugin-import@2.21.2:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
+eslint-plugin-jest-dom@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest-dom/-/eslint-plugin-jest-dom-3.0.1.tgz#ab446c015bb7c9faed769533dfc3cecc2fcf6230"
+  integrity sha512-RszrVljcf+jxfudrvFo469HMVT+yeB5wt/6tY+33Ebiiq7Za1Uh5RVu+ZKPCKSd7E4buyi8bxcHLfNCFXSSz7w==
+  dependencies:
+    "@babel/runtime" "^7.9.6"
+    requireindex "^1.2.0"
+
 eslint-plugin-jest@23.13.2:
   version "23.13.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.13.2.tgz#7b7993b4e09be708c696b02555083ddefd7e4cc7"
@@ -15696,6 +15704,11 @@ require-uncached@^1.0.2:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+requireindex@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
 requires-port@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
#### Summary

This pull request adds the `eslint-plugin-jest-dom`.

#### Description

The `eslint-plugin-jest-dom` helps to verify that correct attributes are set on the correct elements. For instance a `<a />` not being `disabled` through the prop but an "nulled" `href`. 

Adding the plugin required to move enzyme matchers into the two specs of the legacy table which use shallow rendering at the moment.