### PR TITLE
fix: not pass `to` prop to `SecondaryButton` when disabled

### DIFF
--- a/packages/components/buttons/secondary-button/src/secondary-button.js
+++ b/packages/components/buttons/secondary-button/src/secondary-button.js
@@ -34,7 +34,8 @@ export const SecondaryButton = (props) => {
   const buttonAttributes = {
     'data-track-component': 'SecondaryButton',
     ...filterInvalidAttributes(props),
-    ...(shouldUseLinkTag ? { to: props.linkTo } : {}),
+    ...(shouldUseLinkTag && { to: props.linkTo }),
+    ...(props.isDisabled && { to: '#' }),
   };
 
   const containerStyles = [

--- a/packages/components/buttons/secondary-button/src/secondary-button.spec.js
+++ b/packages/components/buttons/secondary-button/src/secondary-button.spec.js
@@ -124,13 +124,36 @@ describe('rendering', () => {
     });
   });
   describe('when using as', () => {
-    it('should navigate to link when clicked', async () => {
-      const { getByLabelText, history } = render(
-        <SecondaryButton {...props} onClick={null} as={Link} to="/foo/bar" />
-      );
-      fireEvent.click(getByLabelText('Add'));
-      await waitFor(() => {
-        expect(history.location.pathname).toBe('/foo/bar');
+    describe('when not disabled', () => {
+      it('should navigate to link when clicked', async () => {
+        const { getByLabelText, history } = render(
+          <SecondaryButton {...props} onClick={null} as={Link} to="/foo/bar" />
+        );
+
+        fireEvent.click(getByLabelText('Add'));
+
+        await waitFor(() => {
+          expect(history.location.pathname).toBe('/foo/bar');
+        });
+      });
+    });
+
+    describe('when disabled', () => {
+      it('should navigate to link when clicked', async () => {
+        const { getByLabelText } = render(
+          <SecondaryButton
+            {...props}
+            isDisabled={true}
+            onClick={null}
+            as={Link}
+            to="/foo/bar"
+          />
+        );
+
+        const button = getByLabelText('Add');
+
+        expect(button).toHaveAttribute('aria-disabled');
+        expect(button).toHaveAttribute('href', '/');
       });
     });
   });


### PR DESCRIPTION
#### Summary

This pull request overwrites the `to` prop which is being passed to the `as`-component when using a `SecondaryButton`.

#### Description

Given a `SecondaryButton` is used with a `RouterLink` it would render a `<a />`. The `<a />` receives `aria-disabled` etc but should also not receive a `href` to be the full path.
