### PR TITLE
refactor: tests to use `screen` where possible

### DIFF
--- a/packages/components/accessible-hidden/src/accessible-hidden.spec.js
+++ b/packages/components/accessible-hidden/src/accessible-hidden.spec.js
@@ -1,15 +1,15 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { render, screen } from '../../../../test/test-utils';
 import AccessibleHidden from './accessible-hidden';
 
 it('should find text inside AccessibleHidden', () => {
-  const rendered = render(<AccessibleHidden>Spies!</AccessibleHidden>);
+  render(<AccessibleHidden>Spies!</AccessibleHidden>);
 
-  expect(rendered.getByText('Spies!')).toBeInTheDocument();
+  expect(screen.getByText('Spies!')).toBeInTheDocument();
 });
 
 it('should find the input of a label inside AccessibleHidden', () => {
-  const rendered = render(
+  render(
     <>
       <AccessibleHidden>
         <label htmlFor="maiden-name-input">Enter your Maiden Name</label>
@@ -18,5 +18,5 @@ it('should find the input of a label inside AccessibleHidden', () => {
     </>
   );
 
-  expect(rendered.getByLabelText('Enter your Maiden Name')).toBeInTheDocument();
+  expect(screen.getByLabelText('Enter your Maiden Name')).toBeInTheDocument();
 });

--- a/packages/components/buttons/accessible-button/src/accessible-button.spec.js
+++ b/packages/components/buttons/accessible-button/src/accessible-button.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '../../../../../test/test-utils';
+import { screen, render } from '../../../../../test/test-utils';
 import AccessibleButton from './accessible-button';
 
 const createTestProps = (custom) => ({
@@ -15,15 +15,13 @@ describe('rendering', () => {
     props = createTestProps();
   });
   it('should render', () => {
-    const { getByLabelText } = render(<AccessibleButton {...props} />);
-    expect(getByLabelText('test-button')).toBeInTheDocument();
-    expect(getByLabelText('test-button')).toBeEnabled();
+    render(<AccessibleButton {...props} />);
+    expect(screen.getByLabelText('test-button')).toBeInTheDocument();
+    expect(screen.getByLabelText('test-button')).toBeEnabled();
   });
   it('should apply the className "foo" to the button', () => {
-    const { getByLabelText } = render(
-      <AccessibleButton {...props} className="foo" />
-    );
-    expect(getByLabelText('test-button')).toHaveClass('foo');
+    render(<AccessibleButton {...props} className="foo" />);
+    expect(screen.getByLabelText('test-button')).toHaveClass('foo');
   });
   it('should pass a ref', () => {
     const ref = React.createRef();
@@ -32,10 +30,8 @@ describe('rendering', () => {
   });
   it('should be marked as "disabled"', () => {
     const onClick = jest.fn();
-    const { getByLabelText } = render(
-      <AccessibleButton {...props} onClick={onClick} isDisabled={true} />
-    );
-    const button = getByLabelText('test-button');
+    render(<AccessibleButton {...props} onClick={onClick} isDisabled={true} />);
+    const button = screen.getByLabelText('test-button');
 
     expect(button).toBeDisabled();
     expect(button).toHaveAttribute('aria-disabled', 'true');
@@ -44,40 +40,49 @@ describe('rendering', () => {
     expect(onClick).not.toHaveBeenCalled();
   });
   it('should be marked as "active"', () => {
-    const { getByLabelText } = render(
+    render(
       <AccessibleButton {...props} isToggleButton={true} isToggled={true} />
     );
-    expect(getByLabelText('test-button')).toHaveAttribute(
+    expect(screen.getByLabelText('test-button')).toHaveAttribute(
       'aria-pressed',
       'true'
     );
   });
   describe('type variations', () => {
     it('should render a button of type "button"', () => {
-      const { getByLabelText } = render(<AccessibleButton {...props} />);
-      expect(getByLabelText('test-button')).toHaveAttribute('type', 'button');
+      render(<AccessibleButton {...props} />);
+      expect(screen.getByLabelText('test-button')).toHaveAttribute(
+        'type',
+        'button'
+      );
     });
     it('should render a button of type "submit"', () => {
-      const { getByLabelText } = render(
-        <AccessibleButton {...props} type="submit" />
+      render(<AccessibleButton {...props} type="submit" />);
+      expect(screen.getByLabelText('test-button')).toHaveAttribute(
+        'type',
+        'submit'
       );
-      expect(getByLabelText('test-button')).toHaveAttribute('type', 'submit');
     });
     it('should render a button of type "reset"', () => {
-      const { getByLabelText } = render(
-        <AccessibleButton {...props} type="reset" />
+      render(<AccessibleButton {...props} type="reset" />);
+      expect(screen.getByLabelText('test-button')).toHaveAttribute(
+        'type',
+        'reset'
       );
-      expect(getByLabelText('test-button')).toHaveAttribute('type', 'reset');
     });
   });
 
   describe('rendering as a div', () => {
     it('should render a div element with accessibility attributes', () => {
-      const { getByLabelText } = render(
-        <AccessibleButton {...props} as="div" />
+      render(<AccessibleButton {...props} as="div" />);
+      expect(screen.getByLabelText('test-button')).toHaveAttribute(
+        'role',
+        'button'
       );
-      expect(getByLabelText('test-button')).toHaveAttribute('role', 'button');
-      expect(getByLabelText('test-button')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByLabelText('test-button')).toHaveAttribute(
+        'tabindex',
+        '0'
+      );
     });
   });
 });

--- a/packages/components/buttons/flat-button/src/flat-button.spec.js
+++ b/packages/components/buttons/flat-button/src/flat-button.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { PlusThinIcon } from '@commercetools-uikit/icons';
-import { render } from '../../../../../test/test-utils';
+import { screen, render } from '../../../../../test/test-utils';
 import FlatButton from './flat-button';
 
 const createTestProps = (props) => ({
@@ -19,54 +19,53 @@ describe('rendering', () => {
     props = createTestProps();
   });
   it('should render', () => {
-    const { getByLabelText } = render(<FlatButton {...props} />);
-    expect(getByLabelText('Add')).toBeInTheDocument();
-    expect(getByLabelText('Add')).toBeEnabled();
+    render(<FlatButton {...props} />);
+    expect(screen.getByLabelText('Add')).toBeInTheDocument();
+    expect(screen.getByLabelText('Add')).toBeEnabled();
   });
   it('should pass aria attributes"', () => {
-    const { getByLabelText } = render(
+    render(
       <FlatButton {...props} isDisabled={true} aria-describedby="tooltip-1" />
     );
-    expect(getByLabelText('Add')).toHaveAttribute(
+    expect(screen.getByLabelText('Add')).toHaveAttribute(
       'aria-describedby',
       'tooltip-1'
     );
   });
   it('should be marked as "disabled"', () => {
-    const { getByLabelText } = render(
-      <FlatButton {...props} isDisabled={true} />
+    render(<FlatButton {...props} isDisabled={true} />);
+    expect(screen.getByLabelText('Add')).toBeDisabled();
+    expect(screen.getByLabelText('Add')).toHaveAttribute(
+      'aria-disabled',
+      'true'
     );
-    expect(getByLabelText('Add')).toBeDisabled();
-    expect(getByLabelText('Add')).toHaveAttribute('aria-disabled', 'true');
   });
   it('should render icon', () => {
     const { getByTestId } = render(<FlatButton {...props} />);
     expect(getByTestId('icon')).toBeInTheDocument();
   });
   it('should render label', () => {
-    const { getByLabelText } = render(<FlatButton {...props} />);
-    expect(getByLabelText('Add')).toHaveTextContent('Add');
+    render(<FlatButton {...props} />);
+    expect(screen.getByLabelText('Add')).toHaveTextContent('Add');
   });
   describe('type variations', () => {
     it('should render a button of type "button"', () => {
-      const { getByLabelText } = render(<FlatButton {...props} />);
-      expect(getByLabelText('Add')).toHaveAttribute('type', 'button');
+      render(<FlatButton {...props} />);
+      expect(screen.getByLabelText('Add')).toHaveAttribute('type', 'button');
     });
     it('should render a button of type "submit"', () => {
-      const { getByLabelText } = render(
-        <FlatButton {...props} type="submit" />
-      );
-      expect(getByLabelText('Add')).toHaveAttribute('type', 'submit');
+      render(<FlatButton {...props} type="submit" />);
+      expect(screen.getByLabelText('Add')).toHaveAttribute('type', 'submit');
     });
     it('should render a button of type "reset"', () => {
-      const { getByLabelText } = render(<FlatButton {...props} type="reset" />);
-      expect(getByLabelText('Add')).toHaveAttribute('type', 'reset');
+      render(<FlatButton {...props} type="reset" />);
+      expect(screen.getByLabelText('Add')).toHaveAttribute('type', 'reset');
     });
   });
   describe('when used with `as`', () => {
     describe('when as is a valid HTML element', () => {
       it('should render as that HTML element', () => {
-        const { getByLabelText } = render(
+        render(
           <FlatButton
             {...props}
             as="a"
@@ -74,7 +73,7 @@ describe('rendering', () => {
             target="_BLANK"
           />
         );
-        const linkButton = getByLabelText('Add');
+        const linkButton = screen.getByLabelText('Add');
         expect(linkButton).toHaveAttribute(
           'href',
           'https://www.kanyetothe.com'
@@ -85,11 +84,11 @@ describe('rendering', () => {
     });
     describe('when as is a React component', () => {
       it('should render as that component', () => {
-        const { getByLabelText } = render(
+        render(
           <FlatButton {...props} as={Link} to="foo/bar" target="_BLANK" />
         );
 
-        const linkButton = getByLabelText('Add');
+        const linkButton = screen.getByLabelText('Add');
         expect(linkButton).toHaveAttribute('href', '/foo/bar');
         expect(linkButton).toHaveAttribute('target', '_BLANK');
         expect(linkButton).not.toHaveAttribute('type', 'button');

--- a/packages/components/buttons/icon-button/src/icon-button.spec.js
+++ b/packages/components/buttons/icon-button/src/icon-button.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { PlusBoldIcon } from '@commercetools-uikit/icons';
-import { render } from '../../../../../test/test-utils';
+import { screen, render } from '../../../../../test/test-utils';
 import IconButton from './icon-button';
 
 const createTestProps = (custom) => ({
@@ -19,32 +19,28 @@ describe('rendering', () => {
     props = createTestProps();
   });
   it('should render', () => {
-    const { getByLabelText } = render(<IconButton {...props} />);
-    expect(getByLabelText('test-button')).toBeInTheDocument();
-    expect(getByLabelText('test-button')).toBeEnabled();
+    render(<IconButton {...props} />);
+    expect(screen.getByLabelText('test-button')).toBeInTheDocument();
+    expect(screen.getByLabelText('test-button')).toBeEnabled();
   });
   it('should be pass aria attributes', () => {
-    const { getByLabelText } = render(
-      <IconButton {...props} aria-describedby="tooltip-1" />
-    );
-    expect(getByLabelText('test-button')).toHaveAttribute(
+    render(<IconButton {...props} aria-describedby="tooltip-1" />);
+    expect(screen.getByLabelText('test-button')).toHaveAttribute(
       'aria-describedby',
       'tooltip-1'
     );
   });
   it('should be marked as "disabled"', () => {
-    const { getByLabelText } = render(
-      <IconButton {...props} isDisabled={true} />
-    );
-    expect(getByLabelText('test-button')).toBeDisabled();
-    expect(getByLabelText('test-button')).toHaveAttribute(
+    render(<IconButton {...props} isDisabled={true} />);
+    expect(screen.getByLabelText('test-button')).toBeDisabled();
+    expect(screen.getByLabelText('test-button')).toHaveAttribute(
       'aria-disabled',
       'true'
     );
   });
   it('should render icon', () => {
-    const { getByTestId } = render(<IconButton {...props} />);
-    expect(getByTestId('icon')).toBeInTheDocument();
+    render(<IconButton {...props} />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
   });
   describe('when used with `as`', () => {
     describe('when as is a valid HTML element', () => {
@@ -67,11 +63,11 @@ describe('rendering', () => {
     });
     describe('when as is a React component', () => {
       it('should render as that component', () => {
-        const { getByLabelText } = render(
+        render(
           <IconButton {...props} as={Link} to="foo/bar" target="_BLANK" />
         );
 
-        const linkButton = getByLabelText('test-button');
+        const linkButton = screen.getByLabelText('test-button');
         expect(linkButton).toHaveAttribute('href', '/foo/bar');
       });
     });

--- a/packages/components/buttons/link-button/src/link-button.spec.js
+++ b/packages/components/buttons/link-button/src/link-button.spec.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import { PlusBoldIcon } from '@commercetools-uikit/icons';
-import { render, fireEvent, waitFor } from '../../../../../test/test-utils';
+import {
+  screen,
+  render,
+  fireEvent,
+  waitFor,
+} from '../../../../../test/test-utils';
 import LinkButton from './link-button';
 
 const createTestProps = (custom) => ({
@@ -35,37 +40,33 @@ describe('rendering', () => {
   });
 
   it('should render', () => {
-    const { getByLabelText } = render(<LinkButton {...props} />);
-    expect(getByLabelText('test-button')).toBeInTheDocument();
-    expect(getByLabelText('test-button')).toBeEnabled();
+    render(<LinkButton {...props} />);
+    expect(screen.getByLabelText('test-button')).toBeInTheDocument();
+    expect(screen.getByLabelText('test-button')).toBeEnabled();
   });
   it('should navigate to link when clicked', async () => {
-    const { getByLabelText, history } = render(<LinkButton {...props} />);
-    fireEvent.click(getByLabelText('test-button'));
+    const { history } = render(<LinkButton {...props} />);
+    fireEvent.click(screen.getByLabelText('test-button'));
     await waitFor(() => {
       expect(history.location.pathname).toBe('/foo/bar');
     });
   });
   it('should pass aria attributes"', () => {
-    const { getByLabelText } = render(
-      <LinkButton {...props} aria-describedby="tooltip-1" />
-    );
-    expect(getByLabelText('test-button')).toHaveAttribute(
+    render(<LinkButton {...props} aria-describedby="tooltip-1" />);
+    expect(screen.getByLabelText('test-button')).toHaveAttribute(
       'aria-describedby',
       'tooltip-1'
     );
   });
   it('should prevent the navigation when "disabled"', async () => {
-    const { getByLabelText, history } = render(
-      <LinkButton {...props} isDisabled={true} />
-    );
-    fireEvent.click(getByLabelText('test-button'));
+    const { history } = render(<LinkButton {...props} isDisabled={true} />);
+    fireEvent.click(screen.getByLabelText('test-button'));
     await waitFor(() => {
       expect(history.location.pathname).toBe('/');
     });
   });
   it('should render icon', () => {
-    const { getByTestId } = render(<LinkButton {...props} />);
-    expect(getByTestId('icon')).toBeInTheDocument();
+    render(<LinkButton {...props} />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
   });
 });

--- a/packages/components/buttons/primary-button/src/primary-button.spec.js
+++ b/packages/components/buttons/primary-button/src/primary-button.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { PlusBoldIcon } from '@commercetools-uikit/icons';
-import { render } from '../../../../../test/test-utils';
+import { screen, render } from '../../../../../test/test-utils';
 import PrimaryButton from './primary-button';
 
 const createTestProps = (custom) => ({
@@ -17,13 +17,13 @@ describe('rendering', () => {
     props = createTestProps();
   });
   it('should render', () => {
-    const { getByLabelText } = render(<PrimaryButton {...props} />);
-    expect(getByLabelText('Add')).toBeInTheDocument();
-    expect(getByLabelText('Add')).toBeEnabled();
+    render(<PrimaryButton {...props} />);
+    expect(screen.getByLabelText('Add')).toBeInTheDocument();
+    expect(screen.getByLabelText('Add')).toBeEnabled();
   });
   it('should render icon', () => {
-    const { getByTestId } = render(<PrimaryButton {...props} />);
-    expect(getByTestId('icon')).toBeInTheDocument();
+    render(<PrimaryButton {...props} />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
   });
   it('should not render icon', () => {
     const { queryByTestId } = render(
@@ -32,49 +32,45 @@ describe('rendering', () => {
     expect(queryByTestId('icon')).not.toBeInTheDocument();
   });
   it('should pass aria attributes', () => {
-    const { getByLabelText } = render(
-      <PrimaryButton {...props} aria-describedby="tooltip-1" />
-    );
-    expect(getByLabelText('Add')).toHaveAttribute(
+    render(<PrimaryButton {...props} aria-describedby="tooltip-1" />);
+    expect(screen.getByLabelText('Add')).toHaveAttribute(
       'aria-describedby',
       'tooltip-1'
     );
   });
   it('should be marked as "disabled"', () => {
-    const { getByLabelText } = render(
-      <PrimaryButton {...props} isDisabled={true} />
+    render(<PrimaryButton {...props} isDisabled={true} />);
+    expect(screen.getByLabelText('Add')).toBeDisabled();
+    expect(screen.getByLabelText('Add')).toHaveAttribute(
+      'aria-disabled',
+      'true'
     );
-    expect(getByLabelText('Add')).toBeDisabled();
-    expect(getByLabelText('Add')).toHaveAttribute('aria-disabled', 'true');
   });
   it('should be marked as "active"', () => {
-    const { getByLabelText } = render(
-      <PrimaryButton {...props} isToggleButton={true} isToggled={true} />
+    render(<PrimaryButton {...props} isToggleButton={true} isToggled={true} />);
+    expect(screen.getByLabelText('Add')).toHaveAttribute(
+      'aria-pressed',
+      'true'
     );
-    expect(getByLabelText('Add')).toHaveAttribute('aria-pressed', 'true');
   });
   describe('type variations', () => {
     it('should render a button of type "button"', () => {
-      const { getByLabelText } = render(<PrimaryButton {...props} />);
-      expect(getByLabelText('Add')).toHaveAttribute('type', 'button');
+      render(<PrimaryButton {...props} />);
+      expect(screen.getByLabelText('Add')).toHaveAttribute('type', 'button');
     });
     it('should render a button of type "submit"', () => {
-      const { getByLabelText } = render(
-        <PrimaryButton {...props} type="submit" />
-      );
-      expect(getByLabelText('Add')).toHaveAttribute('type', 'submit');
+      render(<PrimaryButton {...props} type="submit" />);
+      expect(screen.getByLabelText('Add')).toHaveAttribute('type', 'submit');
     });
     it('should render a button of type "reset"', () => {
-      const { getByLabelText } = render(
-        <PrimaryButton {...props} type="reset" />
-      );
-      expect(getByLabelText('Add')).toHaveAttribute('type', 'reset');
+      render(<PrimaryButton {...props} type="reset" />);
+      expect(screen.getByLabelText('Add')).toHaveAttribute('type', 'reset');
     });
   });
   describe('when used with `as`', () => {
     describe('when as is a valid HTML element', () => {
       it('should render as that HTML element', () => {
-        const { getByLabelText } = render(
+        render(
           <PrimaryButton
             {...props}
             as="a"
@@ -82,7 +78,7 @@ describe('rendering', () => {
             target="_BLANK"
           />
         );
-        const linkButton = getByLabelText('Add');
+        const linkButton = screen.getByLabelText('Add');
         expect(linkButton).toHaveAttribute(
           'href',
           'https://www.kanyetothe.com'
@@ -93,11 +89,11 @@ describe('rendering', () => {
     });
     describe('when as is a React component', () => {
       it('should render as that component', () => {
-        const { getByLabelText } = render(
+        render(
           <PrimaryButton {...props} as={Link} to="foo/bar" target="_BLANK" />
         );
 
-        const linkButton = getByLabelText('Add');
+        const linkButton = screen.getByLabelText('Add');
         expect(linkButton).toHaveAttribute('href', '/foo/bar');
         expect(linkButton).toHaveAttribute('target', '_BLANK');
         expect(linkButton).not.toHaveAttribute('type', 'button');

--- a/packages/components/buttons/secondary-button/src/secondary-button.spec.js
+++ b/packages/components/buttons/secondary-button/src/secondary-button.spec.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { PlusBoldIcon } from '@commercetools-uikit/icons';
-import { render, fireEvent, waitFor } from '../../../../../test/test-utils';
+import {
+  screen,
+  render,
+  fireEvent,
+  waitFor,
+} from '../../../../../test/test-utils';
 import SecondaryButton from './secondary-button';
 
 const createTestProps = (custom) => ({
@@ -17,58 +22,54 @@ describe('rendering', () => {
     props = createTestProps();
   });
   it('should render', () => {
-    const { getByLabelText } = render(<SecondaryButton {...props} />);
-    expect(getByLabelText('Add')).toBeInTheDocument();
-    expect(getByLabelText('Add')).toBeEnabled();
+    render(<SecondaryButton {...props} />);
+    expect(screen.getByLabelText('Add')).toBeInTheDocument();
+    expect(screen.getByLabelText('Add')).toBeEnabled();
   });
   it('should render icon', () => {
-    const { getByTestId } = render(<SecondaryButton {...props} />);
-    expect(getByTestId('icon')).toBeInTheDocument();
+    render(<SecondaryButton {...props} />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
   });
   it('should not render icon', () => {
-    const { queryByTestId } = render(
-      <SecondaryButton {...props} iconLeft={undefined} />
-    );
-    expect(queryByTestId('icon')).not.toBeInTheDocument();
+    render(<SecondaryButton {...props} iconLeft={undefined} />);
+    expect(screen.queryByTestId('icon')).not.toBeInTheDocument();
   });
   it('should pass aria attributes', () => {
-    const { getByLabelText } = render(
-      <SecondaryButton {...props} aria-describedby="tooltip-1" />
-    );
-    expect(getByLabelText('Add')).toHaveAttribute(
+    render(<SecondaryButton {...props} aria-describedby="tooltip-1" />);
+    expect(screen.getByLabelText('Add')).toHaveAttribute(
       'aria-describedby',
       'tooltip-1'
     );
   });
   it('should be marked as "disabled"', () => {
-    const { getByLabelText } = render(
-      <SecondaryButton {...props} isDisabled={true} />
+    render(<SecondaryButton {...props} isDisabled={true} />);
+    expect(screen.getByLabelText('Add')).toBeDisabled();
+    expect(screen.getByLabelText('Add')).toHaveAttribute(
+      'aria-disabled',
+      'true'
     );
-    expect(getByLabelText('Add')).toBeDisabled();
-    expect(getByLabelText('Add')).toHaveAttribute('aria-disabled', 'true');
   });
   it('should be marked as "active"', () => {
-    const { getByLabelText } = render(
+    render(
       <SecondaryButton {...props} isToggleButton={true} isToggled={true} />
     );
-    expect(getByLabelText('Add')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByLabelText('Add')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
   });
   describe('type variations', () => {
     it('should render a button of type "button"', () => {
-      const { getByLabelText } = render(<SecondaryButton {...props} />);
-      expect(getByLabelText('Add')).toHaveAttribute('type', 'button');
+      render(<SecondaryButton {...props} />);
+      expect(screen.getByLabelText('Add')).toHaveAttribute('type', 'button');
     });
-    it('should render a button of type "submit"', () => {
-      const { getByLabelText } = render(
-        <SecondaryButton {...props} type="submit" />
-      );
-      expect(getByLabelText('Add')).toHaveAttribute('type', 'submit');
+    it('sscreen.hould render a button of type "submit"', () => {
+      render(<SecondaryButton {...props} type="submit" />);
+      expect(screen.getByLabelText('Add')).toHaveAttribute('type', 'submit');
     });
     it('should render a button of type "reset"', () => {
-      const { getByLabelText } = render(
-        <SecondaryButton {...props} type="reset" />
-      );
-      expect(getByLabelText('Add')).toHaveAttribute('type', 'reset');
+      render(<SecondaryButton {...props} type="reset" />);
+      expect(screen.getByLabelText('Add')).toHaveAttribute('type', 'reset');
     });
   });
   describe('when using "linkTo"', () => {
@@ -93,10 +94,10 @@ describe('rendering', () => {
     });
 
     it('should navigate to link when clicked', async () => {
-      const { getByLabelText, history } = render(
+      const { history } = render(
         <SecondaryButton {...props} onClick={null} linkTo="/foo/bar" />
       );
-      fireEvent.click(getByLabelText('Add'));
+      fireEvent.click(screen.getByLabelText('Add'));
       await waitFor(() => {
         expect(history.location.pathname).toBe('/foo/bar');
       });
@@ -125,10 +126,10 @@ describe('rendering', () => {
   });
   describe('when using as', () => {
     it('should navigate to link when clicked', async () => {
-      const { getByLabelText, history } = render(
+      const { history } = render(
         <SecondaryButton {...props} onClick={null} as={Link} to="/foo/bar" />
       );
-      fireEvent.click(getByLabelText('Add'));
+      fireEvent.click(screen.getByLabelText('Add'));
       await waitFor(() => {
         expect(history.location.pathname).toBe('/foo/bar');
       });

--- a/packages/components/buttons/secondary-icon-button/src/secondary-icon-button.spec.js
+++ b/packages/components/buttons/secondary-icon-button/src/secondary-icon-button.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { PlusBoldIcon } from '@commercetools-uikit/icons';
-import { render } from '../../../../../test/test-utils';
+import { screen, render } from '../../../../../test/test-utils';
 import SecondaryIconButton from './secondary-icon-button';
 
 const createTestProps = (custom) => ({
@@ -17,29 +17,25 @@ describe('rendering', () => {
     props = createTestProps();
   });
   it('should render', () => {
-    const { getByLabelText } = render(<SecondaryIconButton {...props} />);
-    expect(getByLabelText('test-button')).toBeInTheDocument();
-    expect(getByLabelText('test-button')).toBeEnabled();
+    render(<SecondaryIconButton {...props} />);
+    expect(screen.getByLabelText('test-button')).toBeInTheDocument();
+    expect(screen.getByLabelText('test-button')).toBeEnabled();
   });
   it('should render icon', () => {
-    const { getByTestId } = render(<SecondaryIconButton {...props} />);
-    expect(getByTestId('icon')).toBeInTheDocument();
+    render(<SecondaryIconButton {...props} />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
   });
   it('should pass aria attributes', () => {
-    const { getByLabelText } = render(
-      <SecondaryIconButton {...props} aria-describedby="tooltip-1" />
-    );
-    expect(getByLabelText('test-button')).toHaveAttribute(
+    render(<SecondaryIconButton {...props} aria-describedby="tooltip-1" />);
+    expect(screen.getByLabelText('test-button')).toHaveAttribute(
       'aria-describedby',
       'tooltip-1'
     );
   });
   it('should be marked as "disabled"', () => {
-    const { getByLabelText } = render(
-      <SecondaryIconButton {...props} isDisabled={true} />
-    );
-    expect(getByLabelText('test-button')).toBeDisabled();
-    expect(getByLabelText('test-button')).toHaveAttribute(
+    render(<SecondaryIconButton {...props} isDisabled={true} />);
+    expect(screen.getByLabelText('test-button')).toBeDisabled();
+    expect(screen.getByLabelText('test-button')).toHaveAttribute(
       'aria-disabled',
       'true'
     );
@@ -47,11 +43,11 @@ describe('rendering', () => {
   describe('when there is a divergence between `disabled` and `isDisabled`', () => {
     describe('when `isDisabled` and not `disabled`', () => {
       it('should favour `isDisabled`', () => {
-        const { getByLabelText } = render(
+        render(
           <SecondaryIconButton {...props} isDisabled={true} disabled={false} />
         );
-        expect(getByLabelText('test-button')).toBeDisabled();
-        expect(getByLabelText('test-button')).toHaveAttribute(
+        expect(screen.getByLabelText('test-button')).toBeDisabled();
+        expect(screen.getByLabelText('test-button')).toHaveAttribute(
           'aria-disabled',
           'true'
         );
@@ -59,11 +55,11 @@ describe('rendering', () => {
     });
     describe('when not `isDisabled` and `disabled`', () => {
       it('should favour `isDisabled`', () => {
-        const { getByLabelText } = render(
+        render(
           <SecondaryIconButton {...props} isDisabled={false} disabled={true} />
         );
-        expect(getByLabelText('test-button')).toBeEnabled();
-        expect(getByLabelText('test-button')).not.toHaveAttribute(
+        expect(screen.getByLabelText('test-button')).toBeEnabled();
+        expect(screen.getByLabelText('test-button')).not.toHaveAttribute(
           'aria-disabled',
           'true'
         );
@@ -72,26 +68,31 @@ describe('rendering', () => {
   });
   describe('type variations', () => {
     it('should render a button of type "button"', () => {
-      const { getByLabelText } = render(<SecondaryIconButton {...props} />);
-      expect(getByLabelText('test-button')).toHaveAttribute('type', 'button');
+      render(<SecondaryIconButton {...props} />);
+      expect(screen.getByLabelText('test-button')).toHaveAttribute(
+        'type',
+        'button'
+      );
     });
     it('should render a button of type "submit"', () => {
-      const { getByLabelText } = render(
-        <SecondaryIconButton {...props} type="submit" />
+      render(<SecondaryIconButton {...props} type="submit" />);
+      expect(screen.getByLabelText('test-button')).toHaveAttribute(
+        'type',
+        'submit'
       );
-      expect(getByLabelText('test-button')).toHaveAttribute('type', 'submit');
     });
     it('should render a button of type "reset"', () => {
-      const { getByLabelText } = render(
-        <SecondaryIconButton {...props} type="reset" />
+      render(<SecondaryIconButton {...props} type="reset" />);
+      expect(screen.getByLabelText('test-button')).toHaveAttribute(
+        'type',
+        'reset'
       );
-      expect(getByLabelText('test-button')).toHaveAttribute('type', 'reset');
     });
   });
   describe('when used with `as`', () => {
     describe('when as is a valid HTML element', () => {
       it('should render as that HTML element', () => {
-        const { container } = render(
+        render(
           <SecondaryIconButton
             {...props}
             as="a"
@@ -99,7 +100,7 @@ describe('rendering', () => {
             target="_BLANK"
           />
         );
-        const linkButton = container.querySelector('a');
+        const linkButton = screen.getByRole('button');
         expect(linkButton).toHaveAttribute(
           'href',
           'https://www.kanyetothe.com'
@@ -110,7 +111,7 @@ describe('rendering', () => {
     });
     describe('when as is a React component', () => {
       it('should render as that component', () => {
-        const { getByLabelText } = render(
+        render(
           <SecondaryIconButton
             {...props}
             as={Link}
@@ -119,7 +120,7 @@ describe('rendering', () => {
           />
         );
 
-        const linkButton = getByLabelText('test-button');
+        const linkButton = screen.getByLabelText('test-button');
         expect(linkButton).toHaveAttribute('href', '/foo/bar');
         expect(linkButton).toHaveAttribute('target', '_BLANK');
         expect(linkButton).not.toHaveAttribute('type', 'button');

--- a/packages/components/card/src/card.spec.js
+++ b/packages/components/card/src/card.spec.js
@@ -1,13 +1,14 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import Card from './card';
 
 it('should render children', () => {
-  const { container } = render(<Card>Bread</Card>);
-  expect(container).toHaveTextContent('Bread');
+  render(<Card>Bread</Card>);
+  expect(screen.getByText('Bread')).toBeInTheDocument();
 });
 
 it('should pass data attributes', () => {
   const { container } = render(<Card data-testid="hefe">Bread</Card>);
+
   expect(container.querySelector("[data-testid='hefe']")).toBeInTheDocument();
 });

--- a/packages/components/card/src/card.spec.js
+++ b/packages/components/card/src/card.spec.js
@@ -9,6 +9,5 @@ it('should render children', () => {
 
 it('should pass data attributes', () => {
   const { container } = render(<Card data-testid="hefe">Bread</Card>);
-
   expect(container.querySelector("[data-testid='hefe']")).toBeInTheDocument();
 });

--- a/packages/components/collapsible-motion/src/collapsible-motion.spec.js
+++ b/packages/components/collapsible-motion/src/collapsible-motion.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-shadow */
 import React from 'react';
-import { render, fireEvent } from '../../../../test/test-utils';
+import { screen, render, fireEvent } from '../../../../test/test-utils';
 import CollapsibleMotion from './collapsible-motion';
 
 describe('uncontrolled mode', () => {
@@ -20,11 +20,9 @@ describe('uncontrolled mode', () => {
       )
     );
 
-    const { getByTestId } = render(
-      <CollapsibleMotion>{renderProp}</CollapsibleMotion>
-    );
+    render(<CollapsibleMotion>{renderProp}</CollapsibleMotion>);
 
-    expect(getByTestId('content-node')).toBeVisible();
+    expect(screen.getByTestId('content-node')).toBeVisible();
     expect(renderProp).toHaveBeenLastCalledWith(
       expect.objectContaining({
         isOpen: true,
@@ -34,7 +32,7 @@ describe('uncontrolled mode', () => {
     );
 
     // hide the content
-    fireEvent.click(getByTestId('button'));
+    fireEvent.click(screen.getByTestId('button'));
 
     // ensure the container gets hidden
     expect(renderProp).toHaveBeenLastCalledWith(
@@ -51,7 +49,7 @@ describe('uncontrolled mode', () => {
     );
 
     // show the content
-    fireEvent.click(getByTestId('button'));
+    fireEvent.click(screen.getByTestId('button'));
 
     // ensure the container gets shown again
     expect(renderProp).toHaveBeenLastCalledWith(
@@ -83,11 +81,11 @@ describe('uncontrolled mode', () => {
         )
       );
 
-      const { getByTestId } = render(
+      render(
         <CollapsibleMotion minHeight={50}>{renderProp}</CollapsibleMotion>
       );
 
-      expect(getByTestId('content-node')).toBeVisible();
+      expect(screen.getByTestId('content-node')).toBeVisible();
       expect(renderProp).toHaveBeenLastCalledWith(
         expect.objectContaining({
           isOpen: true,
@@ -97,7 +95,7 @@ describe('uncontrolled mode', () => {
       );
 
       // hide the content
-      fireEvent.click(getByTestId('button'));
+      fireEvent.click(screen.getByTestId('button'));
 
       // ensure the container gets hidden
       expect(renderProp).toHaveBeenLastCalledWith(
@@ -114,7 +112,7 @@ describe('uncontrolled mode', () => {
       );
 
       // show the content
-      fireEvent.click(getByTestId('button'));
+      fireEvent.click(screen.getByTestId('button'));
 
       // ensure the container gets shown again
       expect(renderProp).toHaveBeenLastCalledWith(
@@ -170,9 +168,9 @@ describe('controlled mode', () => {
       }
     }
 
-    const { getByTestId } = render(<TestComponent />);
+    render(<TestComponent />);
 
-    expect(getByTestId('content-node')).toBeVisible();
+    expect(screen.getByTestId('content-node')).toBeVisible();
     expect(renderProp).toHaveBeenLastCalledWith(
       expect.objectContaining({
         isOpen: true,
@@ -182,7 +180,7 @@ describe('controlled mode', () => {
     );
 
     // hide the content
-    fireEvent.click(getByTestId('button'));
+    fireEvent.click(screen.getByTestId('button'));
 
     // ensure the container gets hidden
     expect(renderProp).toHaveBeenLastCalledWith(
@@ -199,7 +197,7 @@ describe('controlled mode', () => {
     );
 
     // show the content
-    fireEvent.click(getByTestId('button'));
+    fireEvent.click(screen.getByTestId('button'));
 
     // ensure the container gets shown again
     expect(renderProp).toHaveBeenLastCalledWith(
@@ -231,11 +229,11 @@ describe('controlled mode', () => {
         )
       );
 
-      const { getByTestId } = render(
+      render(
         <CollapsibleMotion minHeight={50}>{renderProp}</CollapsibleMotion>
       );
 
-      expect(getByTestId('content-node')).toBeVisible();
+      expect(screen.getByTestId('content-node')).toBeVisible();
       expect(renderProp).toHaveBeenLastCalledWith(
         expect.objectContaining({
           isOpen: true,
@@ -245,7 +243,7 @@ describe('controlled mode', () => {
       );
 
       // hide the content
-      fireEvent.click(getByTestId('button'));
+      fireEvent.click(screen.getByTestId('button'));
 
       // ensure the container gets hidden
       expect(renderProp).toHaveBeenLastCalledWith(
@@ -262,7 +260,7 @@ describe('controlled mode', () => {
       );
 
       // show the content
-      fireEvent.click(getByTestId('button'));
+      fireEvent.click(screen.getByTestId('button'));
 
       // ensure the container gets shown again
       expect(renderProp).toHaveBeenLastCalledWith(

--- a/packages/components/collapsible-panel/src/collapsible-panel.spec.js
+++ b/packages/components/collapsible-panel/src/collapsible-panel.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import CollapsiblePanel from './collapsible-panel';
 
 const HeaderControls = (props) => (
@@ -12,18 +12,16 @@ HeaderControls.propTypes = {
 };
 
 it('should smoke', () => {
-  const rendered = render(
-    <CollapsiblePanel header="Header">Children</CollapsiblePanel>
-  );
-  expect(rendered.getByText('Header')).toBeInTheDocument();
-  expect(rendered.getByText('Children')).toBeInTheDocument();
+  render(<CollapsiblePanel header="Header">Children</CollapsiblePanel>);
+  expect(screen.getByText('Header')).toBeInTheDocument();
+  expect(screen.getByText('Children')).toBeInTheDocument();
 });
 
 describe('header controls', () => {
   describe('when passed header controls without an onClick', () => {
     it('should not call onToggle when headerControls is clicked', () => {
       const onToggle = jest.fn();
-      const rendered = render(
+      render(
         <CollapsiblePanel
           header="Header"
           onToggle={onToggle}
@@ -34,14 +32,14 @@ describe('header controls', () => {
           Children
         </CollapsiblePanel>
       );
-      rendered.getByText('Header Controls').click();
+      screen.getByText('Header Controls').click();
       expect(onToggle).not.toHaveBeenCalled();
     });
   });
   describe('when passed header controls with an onClick', () => {
     it('should not call onToggle when headerControls is clicked', () => {
       const onToggle = jest.fn();
-      const rendered = render(
+      render(
         <CollapsiblePanel
           header="Header"
           onToggle={onToggle}
@@ -52,7 +50,7 @@ describe('header controls', () => {
           Children
         </CollapsiblePanel>
       );
-      rendered.getByText('Header Controls').click();
+      screen.getByText('Header Controls').click();
       expect(onToggle).not.toHaveBeenCalled();
     });
   });
@@ -125,18 +123,18 @@ describe('when onToggle is provided without isClosed', () => {
 
 it('should call "onToggle" when header is clicked', () => {
   const onToggle = jest.fn();
-  const rendered = render(
+  render(
     <CollapsiblePanel header="Header" onToggle={onToggle} isClosed={false}>
       Children
     </CollapsiblePanel>
   );
-  rendered.getByText('Header').click();
+  screen.getByText('Header').click();
   expect(onToggle).toHaveBeenCalledTimes(1);
 });
 
 it('should not call "onToggle" when header is clicked while disabled', () => {
   const onToggle = jest.fn();
-  const rendered = render(
+  render(
     <CollapsiblePanel
       header="Header"
       onToggle={onToggle}
@@ -146,7 +144,7 @@ it('should not call "onToggle" when header is clicked while disabled', () => {
       Children
     </CollapsiblePanel>
   );
-  rendered.getByText('Header').click();
+  screen.getByText('Header').click();
   expect(onToggle).not.toHaveBeenCalled();
 });
 
@@ -180,8 +178,7 @@ describe('aria attributes', () => {
         Children
       </CollapsiblePanel>
     );
-    const getPanelHeader = () =>
-      rendered.container.querySelector('[role=button]');
+    const getPanelHeader = () => screen.getByRole('button');
 
     const panelContentId = CollapsiblePanel.getPanelContentId(
       props.id || 'example'
@@ -196,46 +193,46 @@ describe('aria attributes', () => {
     };
   };
   it('should have a valid aria-controls correspondence', () => {
-    const rendered = renderPanel({ id: 'test-id' });
+    const { getPanelHeader, getPanelContent } = renderPanel({ id: 'test-id' });
 
     const panelContentId = CollapsiblePanel.getPanelContentId('test-id');
 
     // assert that the header button has the aria attribute
-    const headerButton = rendered.getPanelHeader();
+    const headerButton = getPanelHeader();
     expect(headerButton).toHaveAttribute('aria-controls', panelContentId);
 
     // find the correspondent panel content
-    expect(rendered.getPanelContent()).toBeInTheDocument();
+    expect(getPanelContent()).toBeInTheDocument();
   });
   describe('header', () => {
     it('should have aria-expanded true when panel is open', () => {
-      const rendered = renderPanel({ isClosed: false });
+      const { getPanelHeader } = renderPanel({ isClosed: false });
 
-      const headerButton = rendered.getPanelHeader();
+      const headerButton = getPanelHeader();
       expect(headerButton).toHaveAttribute('aria-expanded', 'true');
     });
 
     it('should have aria-expanded false when panel is closed', () => {
-      const rendered = renderPanel({ isClosed: true });
+      const { getPanelHeader } = renderPanel({ isClosed: true });
 
-      const headerButton = rendered.getPanelHeader();
+      const headerButton = getPanelHeader();
       expect(headerButton).toHaveAttribute('aria-expanded', 'false');
     });
   });
 
   describe('content', () => {
     it('should have aria-hidden true when panel is closed', () => {
-      const rendered = renderPanel({ isClosed: true });
+      const { getPanelContent } = renderPanel({ isClosed: true });
 
-      const panelContent = rendered.getPanelContent();
+      const panelContent = getPanelContent();
 
       expect(panelContent).toHaveAttribute('aria-hidden', 'true');
     });
 
     it('should have aria-hidden false when panel is open', () => {
-      const rendered = renderPanel({ isClosed: false });
+      const { getPanelContent } = renderPanel({ isClosed: false });
 
-      const panelContent = rendered.getPanelContent();
+      const panelContent = getPanelContent();
 
       expect(panelContent).toHaveAttribute('aria-hidden', 'false');
     });

--- a/packages/components/collapsible-panel/src/collapsible-panel.spec.js
+++ b/packages/components/collapsible-panel/src/collapsible-panel.spec.js
@@ -168,7 +168,7 @@ describe('getPanelContentId', () => {
 
 describe('aria attributes', () => {
   const renderPanel = (props) => {
-    const rendered = render(
+    const { container } = render(
       <CollapsiblePanel
         id="example"
         header="Header"
@@ -184,10 +184,9 @@ describe('aria attributes', () => {
       props.id || 'example'
     );
     const getPanelContent = () =>
-      rendered.container.querySelector(`[id=${panelContentId}]`);
+      container.querySelector(`[id=${panelContentId}]`);
 
     return {
-      ...rendered,
       getPanelHeader,
       getPanelContent,
     };

--- a/packages/components/collapsible/src/collapsible.spec.js
+++ b/packages/components/collapsible/src/collapsible.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Collapsible from './collapsible';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 
 const TestComponent = (props) => (
   <Collapsible {...props}>
@@ -17,43 +17,41 @@ const TestComponent = (props) => (
 
 describe('when component is uncontrolled', () => {
   it('should be open by default', () => {
-    const { getByTestId } = render(<TestComponent />);
-    expect(getByTestId('openState')).toHaveTextContent('open');
+    render(<TestComponent />);
+    expect(screen.getByTestId('openState')).toHaveTextContent('open');
   });
 
   it('should be possible to toggle the open state', () => {
-    const { getByTestId } = render(<TestComponent />);
-    expect(getByTestId('openState')).toHaveTextContent('open');
-    getByTestId('toggle').click();
-    expect(getByTestId('openState')).toHaveTextContent('closed');
+    render(<TestComponent />);
+    expect(screen.getByTestId('openState')).toHaveTextContent('open');
+    screen.getByTestId('toggle').click();
+    expect(screen.getByTestId('openState')).toHaveTextContent('closed');
   });
 
   it('should respect the default closed state', () => {
-    const { getByTestId } = render(<TestComponent isDefaultClosed={true} />);
-    expect(getByTestId('openState')).toHaveTextContent('closed');
+    render(<TestComponent isDefaultClosed={true} />);
+    expect(screen.getByTestId('openState')).toHaveTextContent('closed');
   });
 });
 
 describe('when component is controlled', () => {
   it('should be open by default', () => {
     const onToggle = jest.fn();
-    const { getByTestId } = render(
-      <TestComponent isClosed={false} onToggle={onToggle} />
-    );
-    expect(getByTestId('openState')).toHaveTextContent('open');
+    render(<TestComponent isClosed={false} onToggle={onToggle} />);
+    expect(screen.getByTestId('openState')).toHaveTextContent('open');
   });
 
   it('should be possible to toggle the open state', () => {
     const onToggle = jest.fn();
-    const { getByTestId, rerender } = render(
+    const { rerender } = render(
       <TestComponent isClosed={false} onToggle={onToggle} />
     );
-    expect(getByTestId('openState')).toHaveTextContent('open');
-    getByTestId('toggle').click();
+    expect(screen.getByTestId('openState')).toHaveTextContent('open');
+    screen.getByTestId('toggle').click();
     expect(onToggle).toHaveBeenCalledTimes(1);
     // simulate the parent react to onToggle by changing the isClosed state
     // to true
     rerender(<TestComponent isClosed={true} onToggle={onToggle} />);
-    expect(getByTestId('openState')).toHaveTextContent('closed');
+    expect(screen.getByTestId('openState')).toHaveTextContent('closed');
   });
 });

--- a/packages/components/constraints/src/horizontal/horizontal.spec.js
+++ b/packages/components/constraints/src/horizontal/horizontal.spec.js
@@ -1,24 +1,24 @@
 import React from 'react';
-import { render } from '../../../../../test/test-utils';
+import { screen, render } from '../../../../../test/test-utils';
 import Horizontal from './horizontal';
 
 // The different constraints are tested in the visual regression tests.
 // That tests also ensure this component accepts a "constraint" prop.
 
 it('should render children', () => {
-  const rendered = render(
+  render(
     <Horizontal>
       <div data-testid="child" />
     </Horizontal>
   );
-  expect(rendered.queryByTestId('child')).toBeInTheDocument();
+  expect(screen.queryByTestId('child')).toBeInTheDocument();
 });
 
 it('should pass down `data` prop', () => {
-  const rendered = render(
+  render(
     <Horizontal data-testid="child">
       <div />
     </Horizontal>
   );
-  expect(rendered.queryByTestId('child')).toBeInTheDocument();
+  expect(screen.queryByTestId('child')).toBeInTheDocument();
 });

--- a/packages/components/data-table/src/data-table.spec.js
+++ b/packages/components/data-table/src/data-table.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import DataTable from '.';
 
 const testRows = [
@@ -25,51 +25,49 @@ const baseProps = { rows: testRows, columns: testColumns };
 
 describe('DataTable', () => {
   it('should forward data-attributes', () => {
-    const rendered = render(<DataTable {...baseProps} data-foo="bar" />);
-    expect(
-      rendered.container.querySelector("[data-foo='bar']")
-    ).toBeInTheDocument();
+    const { container } = render(<DataTable {...baseProps} data-foo="bar" />);
+    expect(container.querySelector("[data-foo='bar']")).toBeInTheDocument();
   });
 
   it('should render the column labels', () => {
-    const rendered = render(<DataTable {...baseProps} />);
+    render(<DataTable {...baseProps} />);
 
-    expect(rendered.queryByText('Title')).toBeInTheDocument();
-    expect(rendered.queryByText('Year')).toBeInTheDocument();
+    expect(screen.queryByText('Title')).toBeInTheDocument();
+    expect(screen.queryByText('Year')).toBeInTheDocument();
   });
 
   it('should be able to find headers by the data-testid', () => {
-    const rendered = render(<DataTable {...baseProps} />);
+    render(<DataTable {...baseProps} />);
 
-    expect(rendered.queryByTestId('header-title')).toBeInTheDocument();
-    expect(rendered.queryByTestId('header-year')).toBeInTheDocument();
+    expect(screen.queryByTestId('header-title')).toBeInTheDocument();
+    expect(screen.queryByTestId('header-year')).toBeInTheDocument();
   });
 
   it('should be able to find cells by the data-testid', () => {
-    const rendered = render(<DataTable {...baseProps} />);
+    render(<DataTable {...baseProps} />);
 
-    expect(rendered.queryByTestId('cell-0-title')).toBeInTheDocument();
-    expect(rendered.queryByTestId('cell-1-title')).toBeInTheDocument();
-    expect(rendered.queryByTestId('cell-2-title')).toBeInTheDocument();
-    expect(rendered.queryByTestId('cell-0-year')).toBeInTheDocument();
+    expect(screen.queryByTestId('cell-0-title')).toBeInTheDocument();
+    expect(screen.queryByTestId('cell-1-title')).toBeInTheDocument();
+    expect(screen.queryByTestId('cell-2-title')).toBeInTheDocument();
+    expect(screen.queryByTestId('cell-0-year')).toBeInTheDocument();
   });
 
   it('should render item fields which have corresponding column keys', () => {
-    const rendered = render(<DataTable {...baseProps} />);
+    render(<DataTable {...baseProps} />);
 
-    expect(rendered.queryByText('Woman At War')).toBeInTheDocument();
-    expect(rendered.queryByText('2018')).toBeInTheDocument();
-    expect(rendered.queryByText('2-woman')).not.toBeInTheDocument();
+    expect(screen.queryByText('Woman At War')).toBeInTheDocument();
+    expect(screen.queryByText('2018')).toBeInTheDocument();
+    expect(screen.queryByText('2-woman')).not.toBeInTheDocument();
   });
 
   it('should render only one expand-collapse button per row', () => {
-    const rendered = render(<DataTable {...baseProps} />);
+    render(<DataTable {...baseProps} />);
     /**
      * Even though two columns are marked as truncatable in each row, only one button should be shown
      * per row, which controls the expand and collapse of its whole row.
      * Since we have only three rows, it should render only three row expand-collapse buttons
      */
-    const rowExpandCollapseButtons = rendered.queryAllByLabelText(
+    const rowExpandCollapseButtons = screen.queryAllByLabelText(
       /Expand\/Collapse Row/i
     );
     expect(rowExpandCollapseButtons).toHaveLength(3);
@@ -81,25 +79,23 @@ describe('DataTable', () => {
         <div data-testid="custom-wrapper">{item[column.key]}</div>
       );
 
-      const rendered = render(
-        <DataTable {...baseProps} itemRenderer={customRenderer} />
-      );
+      render(<DataTable {...baseProps} itemRenderer={customRenderer} />);
       const numberOfRenderedItemCells =
         baseProps.rows.length * baseProps.columns.length;
 
       // assert that we find our custom wrapper for every item cell
-      expect(rendered.queryAllByTestId('custom-wrapper')).toHaveLength(
+      expect(screen.queryAllByTestId('custom-wrapper')).toHaveLength(
         numberOfRenderedItemCells
       );
     });
   });
 
   it('should allow rendering a footer', () => {
-    const rendered = render(
+    const { container } = render(
       <DataTable {...baseProps} footer="This is in the footer" />
     );
 
-    const footerElement = rendered.container.querySelector('tfoot');
+    const footerElement = container.querySelector('tfoot');
 
     expect(footerElement).toHaveTextContent('This is in the footer');
   });
@@ -108,17 +104,15 @@ describe('DataTable', () => {
     // we will be expecting this mock function to be called with (row: object, rowIndex: number)
     const rowClickEvent = jest.fn();
     it('should call the action on clicking a row', () => {
-      const rendered = render(
-        <DataTable {...baseProps} onRowClick={rowClickEvent} />
-      );
+      render(<DataTable {...baseProps} onRowClick={rowClickEvent} />);
 
-      rendered.getByText('Parasite').click();
+      screen.getByText('Parasite').click();
       expect(rowClickEvent).toHaveBeenLastCalledWith(
         { id: '1-parasite', title: 'Parasite', year: 2019 },
         0 // first row / index 0
       );
 
-      rendered.getByText('Woman At War').click();
+      screen.getByText('Woman At War').click();
       expect(rowClickEvent).toHaveBeenLastCalledWith(
         { id: '2-woman', title: 'Woman At War', year: 2018 },
         1 // second row / index 1
@@ -130,7 +124,7 @@ describe('DataTable', () => {
         ...testColumns,
         { key: 'id', label: 'ID', shouldIgnoreRowClick: true },
       ];
-      const rendered = render(
+      render(
         <DataTable
           rows={testRows}
           columns={testColumnsWithIgnoreRowClick}
@@ -141,11 +135,11 @@ describe('DataTable', () => {
       // Click the same row twice
 
       // Click a column that ignores row clicks
-      rendered.getByText('1-parasite').click();
+      screen.getByText('1-parasite').click();
       expect(rowClickEvent).not.toHaveBeenCalled();
 
       // Click a column that doesn't ignore row clicks
-      rendered.getByText('Parasite').click();
+      screen.getByText('Parasite').click();
 
       expect(rowClickEvent).toHaveBeenCalledTimes(1);
     });

--- a/packages/components/field-errors/src/field-errors.spec.js
+++ b/packages/components/field-errors/src/field-errors.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import FieldErrors from './field-errors';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 
 describe('errorTypes', () => {
   it('should export errorTypes', () => {
@@ -10,33 +10,33 @@ describe('errorTypes', () => {
   });
 
   it('should render the "missing" error', () => {
-    const { container } = render(
+    render(
       <FieldErrors
         errors={{ [FieldErrors.errorTypes.MISSING]: true }}
         isVisible={true}
       />
     );
-    expect(container).toHaveTextContent(/field is required/i);
+    expect(screen.getByText(/field is required/i)).toBeInTheDocument();
   });
 
   it('should render the "negative" error', () => {
-    const { container } = render(
+    render(
       <FieldErrors
         errors={{ [FieldErrors.errorTypes.NEGATIVE]: true }}
         isVisible={true}
       />
     );
-    expect(container).toHaveTextContent(/negative/i);
+    expect(screen.getByText(/negative/i)).toBeInTheDocument();
   });
 
   it('should render the "fractions" error', () => {
-    const { container } = render(
+    render(
       <FieldErrors
         errors={{ [FieldErrors.errorTypes.FRACTIONS]: true }}
         isVisible={true}
       />
     );
-    expect(container).toHaveTextContent(/whole number/i);
+    expect(screen.getByText(/whole number/i)).toBeInTheDocument();
   });
 });
 
@@ -54,7 +54,7 @@ describe('when not visible', () => {
 
 describe('error renderers', () => {
   it('should give highest importance to renderError', () => {
-    const { container } = render(
+    render(
       <FieldErrors
         errors={{ [FieldErrors.errorTypes.MISSING]: true }}
         isVisible={true}
@@ -66,11 +66,11 @@ describe('error renderers', () => {
         }
       />
     );
-    expect(container).toHaveTextContent('RENDER_ERROR');
+    expect(screen.getByText('RENDER_ERROR')).toBeInTheDocument();
   });
 
   it('should give second highest importance to renderDefaultError', () => {
-    const { container } = render(
+    render(
       <FieldErrors
         errors={{ [FieldErrors.errorTypes.MISSING]: true }}
         isVisible={true}
@@ -80,11 +80,11 @@ describe('error renderers', () => {
         }
       />
     );
-    expect(container).toHaveTextContent('RENDER_DEFAULT_ERROR');
+    expect(screen.getByText('RENDER_DEFAULT_ERROR')).toBeInTheDocument();
   });
 
   it('should fall back to internal error handling', () => {
-    const { container } = render(
+    render(
       <FieldErrors
         errors={{ [FieldErrors.errorTypes.MISSING]: true }}
         isVisible={true}
@@ -92,6 +92,6 @@ describe('error renderers', () => {
         renderDefaultError={() => null}
       />
     );
-    expect(container).toHaveTextContent(/required/i);
+    expect(screen.getByText(/required/i)).toBeInTheDocument();
   });
 });

--- a/packages/components/field-label/src/field-label.spec.js
+++ b/packages/components/field-label/src/field-label.spec.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { WarningIcon } from '@commercetools-uikit/icons';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import FieldLabel from './field-label';
 
 jest.mock('tiny-invariant');
 
 it('should accept a title', () => {
-  const { container } = render(<FieldLabel title="Title" />);
-  expect(container).toHaveTextContent('Title');
+  render(<FieldLabel title="Title" />);
+  expect(screen.getByText('Title')).toBeInTheDocument();
 });
 
 it('should accept a hint', () => {
@@ -16,39 +16,33 @@ it('should accept a hint', () => {
 });
 
 it('should accept a hint icon', () => {
-  const { container, getByTestId } = render(
+  render(
     <FieldLabel
       title="Title"
       hint="Hint"
       hintIcon={<WarningIcon data-testid="warning-icon" />}
     />
   );
-  expect(container).toHaveTextContent('Hint');
-  expect(getByTestId('warning-icon')).toBeInTheDocument();
+  expect(screen.getByText('Hint')).toBeInTheDocument();
+  expect(screen.getByTestId('warning-icon')).toBeInTheDocument();
 });
 
 it('should accept display a required indicator', () => {
-  const { container } = render(
-    <FieldLabel title="Title" hasRequiredIndicator={true} />
-  );
-  expect(container).toHaveTextContent('*');
+  render(<FieldLabel title="Title" hasRequiredIndicator={true} />);
+  expect(screen.getByText('*')).toBeInTheDocument();
 });
 
 describe('when onInfoButtonClick is given', () => {
   it('should show an info button', () => {
     const onInfoButtonClick = jest.fn();
-    const { getByLabelText } = render(
-      <FieldLabel title="Title" onInfoButtonClick={onInfoButtonClick} />
-    );
-    expect(getByLabelText('More Info')).toBeInTheDocument();
-    getByLabelText('More Info').click();
+    render(<FieldLabel title="Title" onInfoButtonClick={onInfoButtonClick} />);
+    expect(screen.getByLabelText('More Info')).toBeInTheDocument();
+    screen.getByLabelText('More Info').click();
     expect(onInfoButtonClick).toHaveBeenCalledTimes(1);
   });
 });
 
 it('should accept a badge', () => {
-  const { getByTestId } = render(
-    <FieldLabel title="Title" badge={<div data-testid="badge" />} />
-  );
-  expect(getByTestId('badge')).toBeInTheDocument();
+  render(<FieldLabel title="Title" badge={<div data-testid="badge" />} />);
+  expect(screen.getByTestId('badge')).toBeInTheDocument();
 });

--- a/packages/components/label/src/label.spec.js
+++ b/packages/components/label/src/label.spec.js
@@ -1,32 +1,30 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import Label from './label';
 
 const intlMessage = { id: 'input-label', defaultMessage: 'translated-label' };
 
 it('should be usable as the label for an element', () => {
-  const { getByLabelText } = render(
+  render(
     <div>
       <Label htmlFor="input-id">input-label</Label>
       <input id="input-id" type="text" defaultValue="" />
     </div>
   );
-  expect(getByLabelText('input-label')).toBeInTheDocument();
+  expect(screen.getByLabelText('input-label')).toBeInTheDocument();
 });
 
 it('should render the children', () => {
-  const { container } = render(<Label>input-label</Label>);
-  expect(container).toHaveTextContent('input-label');
+  render(<Label>input-label</Label>);
+  expect(screen.getByText('input-label')).toBeInTheDocument();
 });
 
 it('should render a required indicator', () => {
-  const { container } = render(
-    <Label isRequiredIndicatorVisible={true}>input-label</Label>
-  );
-  expect(container).toHaveTextContent('*');
+  render(<Label isRequiredIndicatorVisible={true}>input-label</Label>);
+  expect(screen.getByText('*')).toBeInTheDocument();
 });
 
 it('should render given text with react-intl', () => {
-  const { container } = render(<Label intlMessage={intlMessage} />);
-  expect(container).toHaveTextContent('translated-label');
+  render(<Label intlMessage={intlMessage} />);
+  expect(screen.getByText('translated-label')).toBeInTheDocument();
 });

--- a/packages/components/label/src/required-indicator.spec.js
+++ b/packages/components/label/src/required-indicator.spec.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import RequiredIndicator from './required-indicator';
 
 it('should render', () => {
-  const { container } = render(<RequiredIndicator />);
-  expect(container).toHaveTextContent('*');
+  render(<RequiredIndicator />);
+  expect(screen.getByText('*')).toBeInTheDocument();
 });

--- a/packages/components/link/src/link.spec.js
+++ b/packages/components/link/src/link.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import Link from './link';
 
 const createTestProps = (custom) => ({
@@ -14,8 +14,8 @@ describe('rendering', () => {
       props = createTestProps();
     });
     it('should render a react router link', () => {
-      const { getByText } = render(<Link {...props}>Link</Link>);
-      const link = getByText('Link');
+      render(<Link {...props}>Link</Link>);
+      const link = screen.getByText('Link');
       expect(link).toBeInTheDocument();
     });
   });
@@ -27,8 +27,8 @@ describe('rendering', () => {
       });
     });
     it('should render a react router link', () => {
-      const { getByText } = render(<Link {...props}>Link</Link>);
-      const link = getByText('Link');
+      render(<Link {...props}>Link</Link>);
+      const link = screen.getByText('Link');
       expect(link).toBeInTheDocument();
       expect(link).toHaveProperty('href', props.to);
     });

--- a/packages/components/loading-spinner/src/loading-spinner.spec.js
+++ b/packages/components/loading-spinner/src/loading-spinner.spec.js
@@ -1,13 +1,13 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import LoadingSpinner from './loading-spinner';
 
 it('should render children', () => {
-  const { getByTestId } = render(
+  render(
     <LoadingSpinner>
       <div data-testid="child" />
     </LoadingSpinner>
   );
 
-  expect(getByTestId('child')).toBeInTheDocument();
+  expect(screen.getByTestId('child')).toBeInTheDocument();
 });

--- a/packages/components/messages/src/error-message/error-message.spec.js
+++ b/packages/components/messages/src/error-message/error-message.spec.js
@@ -1,21 +1,19 @@
 import React from 'react';
-import { render } from '../../../../../test/test-utils';
+import { screen, render } from '../../../../../test/test-utils';
 import ErrorMessage from './error-message';
 
 const intlMessage = { id: 'Title', defaultMessage: 'Hello' };
 
 describe('ErrorMessage', () => {
   it('should render children', () => {
-    const { container } = render(
-      <ErrorMessage>Some error message</ErrorMessage>
-    );
-
-    expect(container).toHaveTextContent('Some error message');
+    render(<ErrorMessage>Some error message</ErrorMessage>);
+    expect(screen.getByText('Some error message')).toBeInTheDocument();
   });
 
   it('should render given text with react-intl', () => {
-    const { container } = render(<ErrorMessage intlMessage={intlMessage} />);
-    expect(container).toHaveTextContent('Hello');
+    render(<ErrorMessage intlMessage={intlMessage} />);
+
+    expect(screen.getByText('Hello')).toBeInTheDocument();
   });
 
   it('should forward data-attributes', () => {

--- a/packages/components/messages/src/warning-message/warning-message.spec.js
+++ b/packages/components/messages/src/warning-message/warning-message.spec.js
@@ -1,20 +1,18 @@
 import React from 'react';
-import { render } from '../../../../../test/test-utils';
+import { screen, render } from '../../../../../test/test-utils';
 import WarningMessage from './warning-message';
 
 const intlMessage = { id: 'Title', defaultMessage: 'Hello' };
 
 describe('WarningMessage', () => {
   it('should render children', () => {
-    const { container } = render(
-      <WarningMessage>Some warning message</WarningMessage>
-    );
+    render(<WarningMessage>Some warning message</WarningMessage>);
 
-    expect(container).toHaveTextContent('Some warning message');
+    expect(screen.getByText('Some warning message')).toBeInTheDocument();
   });
 
   it('should render given text with react-intl', () => {
-    const { container } = render(<WarningMessage intlMessage={intlMessage} />);
-    expect(container).toHaveTextContent('Hello');
+    render(<WarningMessage intlMessage={intlMessage} />);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
   });
 });

--- a/packages/components/primary-action-dropdown/src/primary-action-dropdown.spec.js
+++ b/packages/components/primary-action-dropdown/src/primary-action-dropdown.spec.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { CloseBoldIcon } from '@commercetools-uikit/icons';
-import { render, fireEvent } from '../../../../test/test-utils';
+import { screen, render, fireEvent } from '../../../../test/test-utils';
 import PrimaryActionDropdown, { Option } from './primary-action-dropdown';
 
 it('should execute the primary actions callback when primary action is clicked', () => {
   const primaryAction = jest.fn();
-  const { getByLabelText } = render(
+  render(
     <PrimaryActionDropdown>
       <Option iconLeft={<CloseBoldIcon />} onClick={primaryAction}>
         Primary Action
@@ -15,14 +15,14 @@ it('should execute the primary actions callback when primary action is clicked',
       </Option>
     </PrimaryActionDropdown>
   );
-  getByLabelText('Primary Action').click();
+  screen.getByLabelText('Primary Action').click();
   expect(primaryAction).toHaveBeenCalledTimes(1);
 });
 
 describe('when all options are disabled', () => {
   it('should prevent interaction', () => {
     const primaryAction = jest.fn();
-    const { getByLabelText, queryByLabelText } = render(
+    render(
       <PrimaryActionDropdown>
         <Option
           iconLeft={<CloseBoldIcon />}
@@ -42,16 +42,16 @@ describe('when all options are disabled', () => {
     );
 
     // it should not allow opening the dropdown
-    expect(getByLabelText('Primary Action')).toBeDisabled();
+    expect(screen.getByLabelText('Primary Action')).toBeDisabled();
 
     // it should not invoke callback when primary action is clicked
-    getByLabelText('Primary Action').click();
+    screen.getByLabelText('Primary Action').click();
     expect(primaryAction).not.toHaveBeenCalled();
 
     // it should not allow opening remaining actions
-    expect(getByLabelText('Open Dropdown')).toBeDisabled();
-    getByLabelText('Open Dropdown').click();
-    expect(queryByLabelText('Secondary Action')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Open Dropdown')).toBeDisabled();
+    screen.getByLabelText('Open Dropdown').click();
+    expect(screen.queryByLabelText('Secondary Action')).not.toBeInTheDocument();
   });
 });
 
@@ -59,7 +59,7 @@ describe('when only primary option is disabled', () => {
   it('should prevent interaction with primary option', () => {
     const primaryAction = jest.fn();
     const secondaryAction = jest.fn();
-    const { getByLabelText } = render(
+    render(
       <PrimaryActionDropdown>
         <Option
           isDisabled={true}
@@ -76,16 +76,16 @@ describe('when only primary option is disabled', () => {
 
     // it should invoke callback when secondary action is clicked,
     // as secondary option gets hoisted to the top
-    getByLabelText('Secondary Action').click();
+    screen.getByLabelText('Secondary Action').click();
     expect(secondaryAction).toHaveBeenCalled();
 
     // it should allow opening remaining actions
-    getByLabelText('Open Dropdown').click();
-    expect(getByLabelText('Primary Action')).toBeInTheDocument();
+    screen.getByLabelText('Open Dropdown').click();
+    expect(screen.getByLabelText('Primary Action')).toBeInTheDocument();
 
     // it should not invoke callback when disabled primary action is clicked
-    expect(getByLabelText('Primary Action')).toBeDisabled();
-    getByLabelText('Primary Action').click();
+    expect(screen.getByLabelText('Primary Action')).toBeDisabled();
+    screen.getByLabelText('Primary Action').click();
     expect(primaryAction).not.toHaveBeenCalled();
   });
 });
@@ -94,7 +94,7 @@ describe('when only secondary option is disabled', () => {
   it('should prevent interaction with secondary option', () => {
     const primaryAction = jest.fn();
     const secondaryAction = jest.fn();
-    const { getByLabelText } = render(
+    render(
       <PrimaryActionDropdown>
         <Option iconLeft={<CloseBoldIcon />} onClick={primaryAction}>
           Primary Action
@@ -110,23 +110,23 @@ describe('when only secondary option is disabled', () => {
     );
 
     // it should invoke callback when primary action is clicked
-    getByLabelText('Primary Action').click();
+    screen.getByLabelText('Primary Action').click();
     expect(primaryAction).toHaveBeenCalled();
 
     // it should allow opening remaining actions
-    getByLabelText('Open Dropdown').click();
-    expect(getByLabelText('Secondary Action')).toBeInTheDocument();
+    screen.getByLabelText('Open Dropdown').click();
+    expect(screen.getByLabelText('Secondary Action')).toBeInTheDocument();
 
     // it should not invoke callback when disabled secondary action is clicked
-    expect(getByLabelText('Secondary Action')).toBeDisabled();
-    getByLabelText('Secondary Action').click();
+    expect(screen.getByLabelText('Secondary Action')).toBeDisabled();
+    screen.getByLabelText('Secondary Action').click();
     expect(secondaryAction).not.toHaveBeenCalled();
   });
 });
 
 describe('when dropdown is open and body is clicked', () => {
   it('should close the dropdown', () => {
-    const { container, getByLabelText, queryByLabelText } = render(
+    const { container } = render(
       <PrimaryActionDropdown>
         <Option iconLeft={<CloseBoldIcon />} onClick={() => {}}>
           Primary Action
@@ -138,13 +138,13 @@ describe('when dropdown is open and body is clicked', () => {
     );
 
     // it should allow opening remaining actions
-    getByLabelText('Open Dropdown').click();
-    expect(getByLabelText('Secondary Action')).toBeInTheDocument();
+    screen.getByLabelText('Open Dropdown').click();
+    expect(screen.getByLabelText('Secondary Action')).toBeInTheDocument();
 
     // click on document body
     fireEvent.click(container);
 
     // it should close the dropdown
-    expect(queryByLabelText('Secondary Action')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Secondary Action')).not.toBeInTheDocument();
   });
 });

--- a/packages/components/stamp/src/stamp.spec.js
+++ b/packages/components/stamp/src/stamp.spec.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import Stamp from './stamp';
 
 it('should render the children', () => {
-  const { container } = render(<Stamp tone="positive">Hello</Stamp>);
-  expect(container).toHaveTextContent('Hello');
+  render(<Stamp tone="positive">Hello</Stamp>);
+  expect(screen.getByText('Hello')).toBeInTheDocument();
 });

--- a/packages/components/tag/src/tag.spec.js
+++ b/packages/components/tag/src/tag.spec.js
@@ -1,42 +1,42 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import Tag from './tag';
 
 it('should render children', () => {
-  const { container } = render(<Tag>Bread</Tag>);
-  expect(container).toHaveTextContent('Bread');
+  render(<Tag>Bread</Tag>);
+  expect(screen.getByText('Bread')).toBeInTheDocument();
 });
 
 it('should call onClick when clicked', () => {
   const onClick = jest.fn();
-  const { getByText } = render(<Tag onClick={onClick}>Bread</Tag>);
-  getByText('Bread').click();
+  render(<Tag onClick={onClick}>Bread</Tag>);
+  screen.getByText('Bread').click();
   expect(onClick).toHaveBeenCalledTimes(1);
 });
 
 it('should call onRemove when remove icon is clicked', () => {
   const onRemove = jest.fn();
-  const { getByLabelText } = render(<Tag onRemove={onRemove}>Bread</Tag>);
-  getByLabelText('Remove').click();
+  render(<Tag onRemove={onRemove}>Bread</Tag>);
+  screen.getByLabelText('Remove').click();
   expect(onRemove).toHaveBeenCalledTimes(1);
 });
 
 it('should call the right handler when onClick and onRemove are provided', () => {
   const onClick = jest.fn();
   const onRemove = jest.fn();
-  const { getByText, getByLabelText } = render(
+  render(
     <Tag onRemove={onRemove} onClick={onClick}>
       Bread
     </Tag>
   );
 
   // clicking the Tag
-  getByText('Bread').click();
+  screen.getByText('Bread').click();
   expect(onClick).toHaveBeenCalledTimes(1);
   expect(onRemove).not.toHaveBeenCalled();
 
   // clicking the remove button
-  getByLabelText('Remove').click();
+  screen.getByLabelText('Remove').click();
   expect(onRemove).toHaveBeenCalledTimes(1);
   expect(onClick).toHaveBeenCalledTimes(1);
 });
@@ -44,43 +44,43 @@ it('should call the right handler when onClick and onRemove are provided', () =>
 describe('when disabled', () => {
   it('should not call onClick when clicked', () => {
     const onClick = jest.fn();
-    const { getByText } = render(
+    render(
       <Tag onClick={onClick} isDisabled={true}>
         Bread
       </Tag>
     );
-    getByText('Bread').click();
+    screen.getByText('Bread').click();
     expect(onClick).not.toHaveBeenCalled();
   });
 
   it('should not call onRemove when clicked', () => {
     const onRemove = jest.fn();
-    const { getByLabelText } = render(
+    render(
       <Tag onRemove={onRemove} isDisabled={true}>
         Bread
       </Tag>
     );
-    getByLabelText('Remove').click();
+    screen.getByLabelText('Remove').click();
     expect(onRemove).not.toHaveBeenCalled();
   });
 });
 
 describe('when linkTo is set', () => {
   it('should redirect when clicked', () => {
-    const { getByText, history } = render(<Tag linkTo="/foo">Bread</Tag>);
-    getByText('Bread').click();
+    const { history } = render(<Tag linkTo="/foo">Bread</Tag>);
+    screen.getByText('Bread').click();
 
     expect(history.location.pathname).toBe('/foo');
   });
 
   it('should still call onClick when clicked', () => {
     const onClick = jest.fn();
-    const { getByText, history } = render(
+    const { history } = render(
       <Tag onClick={onClick} linkTo="/foo">
         Bread
       </Tag>
     );
-    getByText('Bread').click();
+    screen.getByText('Bread').click();
     expect(onClick).toHaveBeenCalled();
 
     expect(history.location.pathname).toBe('/foo');
@@ -88,13 +88,13 @@ describe('when linkTo is set', () => {
 
   it('should not redirect when removed', () => {
     const onRemove = jest.fn();
-    const { getByLabelText, history } = render(
+    const { history } = render(
       <Tag onRemove={onRemove} linkTo="/foo">
         Bread
       </Tag>
     );
 
-    getByLabelText('Remove').click();
+    screen.getByLabelText('Remove').click();
 
     // ensure "onRemove" is stil called
     expect(onRemove).toHaveBeenCalled();
@@ -105,13 +105,13 @@ describe('when linkTo is set', () => {
   });
 
   it('should not redirect when disabled', () => {
-    const { getByText, history } = render(
+    const { history } = render(
       <Tag linkTo="/foo" isDisabled={true}>
         Bread
       </Tag>
     );
 
-    getByText('Bread').click();
+    screen.getByText('Bread').click();
 
     // ensure the pathname is not "/foo", otherwise a redirect would have
     // happend

--- a/packages/components/tooltip/src/tooltip.spec.js
+++ b/packages/components/tooltip/src/tooltip.spec.js
@@ -2,7 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { act } from 'react-dom/test-utils';
-import { render, fireEvent, waitFor } from '../../../../test/test-utils';
+import {
+  screen,
+  render,
+  fireEvent,
+  waitFor,
+} from '../../../../test/test-utils';
 import Tooltip from './tooltip';
 
 jest.useFakeTimers();
@@ -86,31 +91,35 @@ class TestComponent extends React.Component {
 
 describe('Tooltip', () => {
   it('should render children', () => {
-    const rendered = render(<TestComponent />);
-    const button = rendered.getByText('Submit');
+    render(<TestComponent />);
+    const button = screen.getByText('Submit');
     expect(button).toBeInTheDocument();
   });
 
   it('should set title on button', () => {
-    const rendered = render(<TestComponent />);
-    const button = rendered.getByText('Submit');
+    render(<TestComponent />);
+    const button = screen.getByText('Submit');
     expect(button).toHaveProperty('title', 'What kind of bear is best?');
   });
 
   it('should set aria-describedby on button when open', async () => {
-    const rendered = render(<TestComponent id="my-tooltip" isOpen={true} />);
+    const { container } = render(
+      <TestComponent id="my-tooltip" isOpen={true} />
+    );
 
     await waitFor(() =>
       expect(
-        rendered.container.querySelector("[aria-describedby='my-tooltip']")
+        container.querySelector("[aria-describedby='my-tooltip']")
       ).toBeInTheDocument()
     );
   });
 
   it('should not set aria-describedby on button when not open', () => {
-    const rendered = render(<TestComponent id="my-tooltip" isOpen={false} />);
+    const { container } = render(
+      <TestComponent id="my-tooltip" isOpen={false} />
+    );
     expect(
-      rendered.container.querySelector("[aria-describedby='my-tooltip']")
+      container.querySelector("[aria-describedby='my-tooltip']")
     ).not.toBeInTheDocument();
   });
 
@@ -121,7 +130,7 @@ describe('Tooltip', () => {
       const onClose = jest.fn();
       const onOpen = jest.fn();
 
-      const rendered = render(
+      render(
         <TestComponent
           onMouseOver={onMouseOver}
           onMouseLeave={onMouseLeave}
@@ -130,7 +139,7 @@ describe('Tooltip', () => {
         />
       );
 
-      const button = await rendered.findByText('Submit');
+      const button = await screen.findByText('Submit');
 
       fireEvent.mouseOver(button);
       // should call callbacks
@@ -138,7 +147,7 @@ describe('Tooltip', () => {
       expect(onOpen).toHaveBeenCalled();
       // should show the tooltip
 
-      rendered.findByText('What kind of bear is best?');
+      screen.findByText('What kind of bear is best?');
       // should remove the title
       expect(button).toHaveProperty('title', '');
       fireEvent.mouseLeave(button);
@@ -147,7 +156,7 @@ describe('Tooltip', () => {
       expect(onClose).toHaveBeenCalled();
       // should hide tooltip
       expect(
-        rendered.queryByText('What kind of bear is best?')
+        screen.queryByText('What kind of bear is best?')
       ).not.toBeInTheDocument();
       // should add the title again
       expect(button).toHaveProperty('title', 'What kind of bear is best?');
@@ -159,7 +168,7 @@ describe('Tooltip', () => {
       const onBlur = jest.fn();
       const onClose = jest.fn();
       const onOpen = jest.fn();
-      const rendered = render(
+      render(
         <TestComponent
           onClose={onClose}
           onOpen={onOpen}
@@ -167,13 +176,13 @@ describe('Tooltip', () => {
           onBlur={onBlur}
         />
       );
-      const button = await rendered.findByText('Submit');
+      const button = await screen.findByText('Submit');
       fireEvent.focus(button);
       // should call callbacks
       expect(onFocus).toHaveBeenCalled();
       expect(onOpen).toHaveBeenCalled();
       // should show the tooltip
-      rendered.findByText('What kind of bear is best?');
+      screen.findByText('What kind of bear is best?');
       // should remove the title
       expect(button).toHaveProperty('title', '');
       fireEvent.blur(button);
@@ -182,7 +191,7 @@ describe('Tooltip', () => {
       expect(onClose).toHaveBeenCalled();
       // should hide tooltip
       expect(
-        rendered.queryByText('What kind of bear is best?')
+        screen.queryByText('What kind of bear is best?')
       ).not.toBeInTheDocument();
       // should add the title again
       expect(button).toHaveProperty('title', 'What kind of bear is best?');
@@ -195,7 +204,7 @@ describe('Tooltip', () => {
       const onOpen = jest.fn();
       const onClose = jest.fn();
 
-      const rendered = render(
+      render(
         <TestComponent
           onClose={onClose}
           onOpen={onOpen}
@@ -205,13 +214,13 @@ describe('Tooltip', () => {
         />
       );
 
-      const button = await rendered.findByText('Submit');
+      const button = await screen.findByText('Submit');
       fireEvent.focus(button);
       // should call callbacks
       expect(onFocus).toHaveBeenCalled();
       expect(onOpen).toHaveBeenCalled();
       // should show the tooltip
-      rendered.findByText('What kind of bear is best?');
+      screen.findByText('What kind of bear is best?');
       fireEvent.blur(button);
       // should call callback
       expect(onBlur).toHaveBeenCalled();
@@ -224,26 +233,26 @@ describe('Tooltip', () => {
       expect(onClose).toHaveBeenCalled();
       // should hide tooltip again
       expect(
-        rendered.queryByText('What kind of bear is best?')
+        screen.queryByText('What kind of bear is best?')
       ).not.toBeInTheDocument();
     });
   });
   describe('when controlled with open prop', () => {
     it('should open and close based on open prop', async () => {
-      const rendered = render(<TestComponent isOpen={false} />);
+      render(<TestComponent isOpen={false} />);
 
-      const toggleButton = rendered.getByLabelText('Toggle tooltip');
+      const toggleButton = screen.getByLabelText('Toggle tooltip');
       // tooltip should be hidden
       expect(
-        rendered.queryByText('What kind of bear is best?')
+        screen.queryByText('What kind of bear is best?')
       ).not.toBeInTheDocument();
       toggleButton.click();
       // should show the tooltip
-      rendered.findByText('What kind of bear is best?');
+      screen.findByText('What kind of bear is best?');
       toggleButton.click();
       // tooltip should be hidden
       expect(
-        rendered.queryByText('What kind of bear is best?')
+        screen.queryByText('What kind of bear is best?')
       ).not.toBeInTheDocument();
     });
   });
@@ -278,7 +287,7 @@ describe('when used with a custom body component', () => {
     const onBlur = jest.fn();
     const onClose = jest.fn();
     const onOpen = jest.fn();
-    const rendered = render(
+    const { container } = render(
       <TestComponent
         onClose={onClose}
         onOpen={onOpen}
@@ -288,19 +297,17 @@ describe('when used with a custom body component', () => {
       />
     );
 
-    const button = rendered.getByText('Submit');
+    const button = screen.getByText('Submit');
     fireEvent.focus(button);
     // should call callbacks
     expect(onFocus).toHaveBeenCalled();
     expect(onOpen).toHaveBeenCalled();
     // should show the tooltip and show the custom body
     await waitFor(() =>
-      rendered.container.querySelector("[data-testid='tooltip-custom-body']")
+      container.querySelector("[data-testid='tooltip-custom-body']")
     );
 
-    expect(
-      rendered.getByText('What kind of bear is best?')
-    ).toBeInTheDocument();
+    expect(screen.getByText('What kind of bear is best?')).toBeInTheDocument();
     // should remove the title
     expect(button).toHaveProperty('title', '');
     fireEvent.blur(button);
@@ -309,7 +316,7 @@ describe('when used with a custom body component', () => {
     expect(onClose).toHaveBeenCalled();
     // should hide tooltip
     expect(
-      rendered.queryByText('What kind of bear is best?')
+      screen.queryByText('What kind of bear is best?')
     ).not.toBeInTheDocument();
     // should add the title again
     expect(button).toHaveProperty('title', 'What kind of bear is best?');
@@ -322,7 +329,7 @@ describe('when used with a custom wrapper component', () => {
     const onBlur = jest.fn();
     const onClose = jest.fn();
     const onOpen = jest.fn();
-    const rendered = render(
+    const { container } = render(
       <TestComponent
         onClose={onClose}
         onOpen={onOpen}
@@ -334,16 +341,16 @@ describe('when used with a custom wrapper component', () => {
 
     // should render the custom WrapperComponent
     expect(
-      rendered.container.querySelector("[data-testid='tooltip-custom-wrapper']")
+      container.querySelector("[data-testid='tooltip-custom-wrapper']")
     ).toBeInTheDocument();
 
-    const button = rendered.getByText('Submit');
+    const button = screen.getByText('Submit');
     fireEvent.focus(button);
     // should call callbacks
     expect(onFocus).toHaveBeenCalled();
     expect(onOpen).toHaveBeenCalled();
     // should show the tooltip
-    rendered.findByText('What kind of bear is best?');
+    screen.findByText('What kind of bear is best?');
     // should remove the title
     expect(button).toHaveProperty('title', '');
     fireEvent.blur(button);
@@ -352,7 +359,7 @@ describe('when used with a custom wrapper component', () => {
     expect(onClose).toHaveBeenCalled();
     // should hide tooltip
     expect(
-      rendered.queryByText('What kind of bear is best?')
+      screen.queryByText('What kind of bear is best?')
     ).not.toBeInTheDocument();
     // should add the title again
     expect(button).toHaveProperty('title', 'What kind of bear is best?');
@@ -366,7 +373,7 @@ describe('when used with a custom popper wrapper component', () => {
     const onClose = jest.fn();
     const onOpen = jest.fn();
 
-    const rendered = render(
+    const { container } = render(
       <TestComponent
         onClose={onClose}
         onOpen={onOpen}
@@ -379,30 +386,26 @@ describe('when used with a custom popper wrapper component', () => {
       />
     );
 
-    const button = rendered.getByText('Submit');
+    const button = screen.getByText('Submit');
     fireEvent.focus(button);
     // should call callbacks
     expect(onFocus).toHaveBeenCalled();
     expect(onOpen).toHaveBeenCalled();
 
     // should not render the tooltip inside of the main div
-    const mainContainer = await waitFor(() =>
-      rendered.container.querySelector('#main')
-    );
+    const mainContainer = await waitFor(() => container.querySelector('#main'));
     expect(
       mainContainer.querySelector("[data-testid='tooltip-custom-body']")
     ).not.toBeInTheDocument();
 
     // should render the tooltip inside of the portal
-    const portalContainer = rendered.container.querySelector('#portal-id');
+    const portalContainer = container.querySelector('#portal-id');
     expect(
       portalContainer.querySelector("[data-testid='tooltip-custom-body']")
     ).toBeInTheDocument();
 
     // should show the tooltip
-    expect(
-      rendered.getByText('What kind of bear is best?')
-    ).toBeInTheDocument();
+    expect(screen.getByText('What kind of bear is best?')).toBeInTheDocument();
     // should remove the title
     expect(button).toHaveProperty('title', '');
     fireEvent.blur(button);
@@ -411,7 +414,7 @@ describe('when used with a custom popper wrapper component', () => {
     expect(onClose).toHaveBeenCalled();
     // should hide tooltip
     expect(
-      rendered.queryByText('What kind of bear is best?')
+      screen.queryByText('What kind of bear is best?')
     ).not.toBeInTheDocument();
     // should add the title again
     expect(button).toHaveProperty('title', 'What kind of bear is best?');
@@ -426,7 +429,7 @@ describe('when off is true', () => {
     const onBlur = jest.fn();
     const onClose = jest.fn();
     const onOpen = jest.fn();
-    const rendered = render(
+    render(
       <TestComponent
         off={true}
         onClose={onClose}
@@ -438,7 +441,7 @@ describe('when off is true', () => {
       />
     );
 
-    const button = rendered.getByText('Submit');
+    const button = screen.getByText('Submit');
     fireEvent.focus(button);
     // should not call callbacks when using keyboard
     expect(onFocus).not.toHaveBeenCalled();
@@ -446,7 +449,7 @@ describe('when off is true', () => {
 
     // should not be visible
     expect(
-      rendered.queryByText('What kind of bear is best?')
+      screen.queryByText('What kind of bear is best?')
     ).not.toBeInTheDocument();
     // should not have title
     expect(button).not.toHaveAttribute('title');
@@ -465,7 +468,7 @@ describe('when off is true', () => {
 
     // should not be visible
     expect(
-      rendered.queryByText('What kind of bear is best?')
+      screen.queryByText('What kind of bear is best?')
     ).not.toBeInTheDocument();
     // should not have title
     expect(button).not.toHaveAttribute('title');

--- a/packages/hooks/src/use-field-id/use-field-id.spec.js
+++ b/packages/hooks/src/use-field-id/use-field-id.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { createSequentialId } from '@commercetools-uikit/utils';
 import useToggleState from '../use-toggle-state';
 import useFieldId from './use-field-id';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 
 const sequentialId = createSequentialId('test-id-');
 
@@ -24,20 +24,20 @@ const TestComponent = (props) => {
 
 describe('when id not provided', () => {
   it('should use sequential-id and not increment on rerender', () => {
-    const { container, getByTestId } = render(<TestComponent />);
+    const { container } = render(<TestComponent />);
     expect(container.querySelector('#test-id-1')).toBeInTheDocument();
-    getByTestId('toggle-btn').click();
+    screen.getByTestId('toggle-btn').click();
     expect(container.querySelector('#test-id-1')).toBeInTheDocument();
-    getByTestId('toggle-btn').click();
+    screen.getByTestId('toggle-btn').click();
     expect(container.querySelector('#test-id-1')).toBeInTheDocument();
   });
 });
 
 describe('when id is provided', () => {
   it('should use provided id and not change on rerender', () => {
-    const { container, getByTestId } = render(<TestComponent id="foo-bar" />);
+    const { container } = render(<TestComponent id="foo-bar" />);
     expect(container.querySelector('#foo-bar')).toBeInTheDocument();
-    getByTestId('toggle-btn').click();
+    screen.getByTestId('toggle-btn').click();
     expect(container.querySelector('#foo-bar')).toBeInTheDocument();
   });
 });

--- a/packages/hooks/src/use-previous/use-previous.spec.js
+++ b/packages/hooks/src/use-previous/use-previous.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import isNil from 'lodash/isNil';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import useToggleState from '../use-toggle-state';
 import usePrevious from './use-previous';
 
@@ -36,18 +36,18 @@ const TestComponent = (props) => {
 };
 
 it('should be `undefined` when no previous state', () => {
-  const { getByTestId } = render(<TestComponent />);
-  expect(getByTestId('openState')).toHaveTextContent('open');
-  expect(getByTestId('prevOpenState')).toHaveTextContent('undefined');
+  render(<TestComponent />);
+  expect(screen.getByTestId('openState')).toHaveTextContent('open');
+  expect(screen.getByTestId('prevOpenState')).toHaveTextContent('undefined');
 });
 
 it('should maintain the previous state after changing state', () => {
-  const { getByTestId } = render(<TestComponent />);
-  expect(getByTestId('openState')).toHaveTextContent('open');
-  getByTestId('toggle').click();
-  expect(getByTestId('openState')).toHaveTextContent('closed');
-  expect(getByTestId('prevOpenState')).toHaveTextContent('open');
-  getByTestId('toggle').click();
-  expect(getByTestId('prevOpenState')).toHaveTextContent('closed');
-  expect(getByTestId('openState')).toHaveTextContent('open');
+  render(<TestComponent />);
+  expect(screen.getByTestId('openState')).toHaveTextContent('open');
+  screen.getByTestId('toggle').click();
+  expect(screen.getByTestId('openState')).toHaveTextContent('closed');
+  expect(screen.getByTestId('prevOpenState')).toHaveTextContent('open');
+  screen.getByTestId('toggle').click();
+  expect(screen.getByTestId('prevOpenState')).toHaveTextContent('closed');
+  expect(screen.getByTestId('openState')).toHaveTextContent('open');
 });

--- a/packages/hooks/src/use-row-selection/use-row-selection.spec.js
+++ b/packages/hooks/src/use-row-selection/use-row-selection.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import useRowSelection from './use-row-selection';
 
 const testData = [
@@ -62,84 +62,84 @@ const TestComponent = (props) => {
 };
 
 it('should have no selected items by default', () => {
-  const rendered = render(<TestComponent keyName="checked" items={testData} />);
+  render(<TestComponent keyName="checked" items={testData} />);
 
   testData.forEach((item) => {
-    expect(rendered.queryByTestId(item.id)).toHaveTextContent('false');
+    expect(screen.queryByTestId(item.id)).toHaveTextContent('false');
   });
 });
 
 it('should be possible to toggle a row selection state', () => {
-  const rendered = render(<TestComponent keyName="checked" items={testData} />);
+  render(<TestComponent keyName="checked" items={testData} />);
 
-  expect(rendered.queryByTestId('system-crasher')).toHaveTextContent('false');
+  expect(screen.queryByTestId('system-crasher')).toHaveTextContent('false');
 
-  rendered.queryByTestId('toggle system-crasher').click();
-  expect(rendered.queryByTestId('system-crasher')).toHaveTextContent('true');
+  screen.queryByTestId('toggle system-crasher').click();
+  expect(screen.queryByTestId('system-crasher')).toHaveTextContent('true');
 });
 
 it('should be possible to select a row', () => {
-  const rendered = render(<TestComponent keyName="checked" items={testData} />);
+  render(<TestComponent keyName="checked" items={testData} />);
 
-  expect(rendered.queryByTestId('system-crasher')).toHaveTextContent('false');
+  expect(screen.queryByTestId('system-crasher')).toHaveTextContent('false');
 
-  rendered.queryByTestId('select system-crasher').click();
-  expect(rendered.queryByTestId('system-crasher')).toHaveTextContent('true');
+  screen.queryByTestId('select system-crasher').click();
+  expect(screen.queryByTestId('system-crasher')).toHaveTextContent('true');
 });
 
 it('should be possible to deselect a row', () => {
-  const rendered = render(<TestComponent keyName="checked" items={testData} />);
+  render(<TestComponent keyName="checked" items={testData} />);
 
-  rendered.queryByTestId('select system-crasher').click();
-  expect(rendered.queryByTestId('system-crasher')).toHaveTextContent('true');
+  screen.queryByTestId('select system-crasher').click();
+  expect(screen.queryByTestId('system-crasher')).toHaveTextContent('true');
 
-  rendered.queryByTestId('deselect system-crasher').click();
-  expect(rendered.queryByTestId('system-crasher')).toHaveTextContent('false');
+  screen.queryByTestId('deselect system-crasher').click();
+  expect(screen.queryByTestId('system-crasher')).toHaveTextContent('false');
 });
 
 it('should get the correct count of selected rows', () => {
-  const rendered = render(<TestComponent keyName="checked" items={testData} />);
+  render(<TestComponent keyName="checked" items={testData} />);
 
-  expect(rendered.queryByTestId('selectedCount')).toHaveTextContent('0');
+  expect(screen.queryByTestId('selectedCount')).toHaveTextContent('0');
 
-  rendered.queryByTestId('select system-crasher').click();
+  screen.queryByTestId('select system-crasher').click();
 
-  expect(rendered.queryByTestId('selectedCount')).toHaveTextContent('1');
+  expect(screen.queryByTestId('selectedCount')).toHaveTextContent('1');
 
-  rendered.queryByTestId('select birds-of-passage').click();
+  screen.queryByTestId('select birds-of-passage').click();
 
-  expect(rendered.queryByTestId('selectedCount')).toHaveTextContent('2');
+  expect(screen.queryByTestId('selectedCount')).toHaveTextContent('2');
 
-  rendered.queryByTestId('deselect system-crasher').click();
+  screen.queryByTestId('deselect system-crasher').click();
 
-  expect(rendered.queryByTestId('selectedCount')).toHaveTextContent('1');
+  expect(screen.queryByTestId('selectedCount')).toHaveTextContent('1');
 });
 
 it('should be possible to select all rows', () => {
-  const rendered = render(<TestComponent keyName="checked" items={testData} />);
+  render(<TestComponent keyName="checked" items={testData} />);
 
-  rendered.queryByTestId('selectAll').click();
+  screen.queryByTestId('selectAll').click();
 
-  expect(rendered.queryByTestId('selectedCount')).toHaveTextContent('3');
+  expect(screen.queryByTestId('selectedCount')).toHaveTextContent('3');
 
   testData.forEach((item) => {
-    expect(rendered.queryByTestId(item.id)).toHaveTextContent('true');
+    expect(screen.queryByTestId(item.id)).toHaveTextContent('true');
   });
 });
 
 it('should be possible to deselect all rows', () => {
-  const rendered = render(<TestComponent keyName="checked" items={testData} />);
+  render(<TestComponent keyName="checked" items={testData} />);
 
-  rendered.queryByTestId('selectAll').click();
+  screen.queryByTestId('selectAll').click();
 
-  expect(rendered.queryByTestId('selectedCount')).toHaveTextContent('3');
+  expect(screen.queryByTestId('selectedCount')).toHaveTextContent('3');
 
-  rendered.queryByTestId('deselectAll').click();
+  screen.queryByTestId('deselectAll').click();
 
-  expect(rendered.queryByTestId('selectedCount')).toHaveTextContent('0');
+  expect(screen.queryByTestId('selectedCount')).toHaveTextContent('0');
 
   testData.forEach((item) => {
-    expect(rendered.queryByTestId(item.id)).toHaveTextContent('false');
+    expect(screen.queryByTestId(item.id)).toHaveTextContent('false');
   });
 });
 
@@ -150,11 +150,9 @@ it('should respect existing selectable key values', () => {
     { id: 'woman-at-war' },
   ];
 
-  const rendered = render(
-    <TestComponent keyName="selected" items={customRows} />
-  );
+  render(<TestComponent keyName="selected" items={customRows} />);
 
-  expect(rendered.queryByTestId('system-crasher')).toHaveTextContent('false');
-  expect(rendered.queryByTestId('birds-of-passage')).toHaveTextContent('true');
-  expect(rendered.queryByTestId('woman-at-war')).toHaveTextContent('false');
+  expect(screen.queryByTestId('system-crasher')).toHaveTextContent('false');
+  expect(screen.queryByTestId('birds-of-passage')).toHaveTextContent('true');
+  expect(screen.queryByTestId('woman-at-war')).toHaveTextContent('false');
 });

--- a/packages/hooks/src/use-toggle-state/use-toggle-state.spec.js
+++ b/packages/hooks/src/use-toggle-state/use-toggle-state.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import useToggleState from './use-toggle-state';
 
 const TestComponent = (props) => {
@@ -30,27 +30,27 @@ const TestComponent = (props) => {
 };
 
 it('should be open by default', () => {
-  const { getByTestId } = render(<TestComponent />);
-  expect(getByTestId('openState')).toHaveTextContent('open');
+  render(<TestComponent />);
+  expect(screen.getByTestId('openState')).toHaveTextContent('open');
 });
 
 it('should be possible to toggle the open state', () => {
-  const { getByTestId } = render(<TestComponent />);
-  expect(getByTestId('openState')).toHaveTextContent('open');
-  getByTestId('toggle').click();
-  expect(getByTestId('openState')).toHaveTextContent('closed');
+  render(<TestComponent />);
+  expect(screen.getByTestId('openState')).toHaveTextContent('open');
+  screen.getByTestId('toggle').click();
+  expect(screen.getByTestId('openState')).toHaveTextContent('closed');
 });
 
 it('should be possible to set the state on and off', () => {
-  const { getByTestId } = render(<TestComponent />);
-  expect(getByTestId('openState')).toHaveTextContent('open');
-  getByTestId('setOff').click();
-  expect(getByTestId('openState')).toHaveTextContent('closed');
-  getByTestId('setOn').click();
-  expect(getByTestId('openState')).toHaveTextContent('open');
+  render(<TestComponent />);
+  expect(screen.getByTestId('openState')).toHaveTextContent('open');
+  screen.getByTestId('setOff').click();
+  expect(screen.getByTestId('openState')).toHaveTextContent('closed');
+  screen.getByTestId('setOn').click();
+  expect(screen.getByTestId('openState')).toHaveTextContent('open');
 });
 
 it('should respect the default closed state', () => {
-  const { getByTestId } = render(<TestComponent isDefaultOpen={false} />);
-  expect(getByTestId('openState')).toHaveTextContent('closed');
+  render(<TestComponent isDefaultOpen={false} />);
+  expect(screen.getByTestId('openState')).toHaveTextContent('closed');
 });

--- a/src/components/inputs/checkbox-input/checkbox-input.spec.js
+++ b/src/components/inputs/checkbox-input/checkbox-input.spec.js
@@ -128,7 +128,7 @@ describe('when indeterminate', () => {
         Accept Terms
       </CheckboxInput>
     );
-    expect(screen.getByLabelText('Accept Terms')).toBeChecked();
+    expect(screen.getByLabelText('Accept Terms')).not.toBeChecked();
   });
 
   // The input is always unchecked when the state is indeterminate!

--- a/src/components/inputs/checkbox-input/checkbox-input.spec.js
+++ b/src/components/inputs/checkbox-input/checkbox-input.spec.js
@@ -1,54 +1,54 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import CheckboxInput from './checkbox-input';
 
 jest.mock('tiny-invariant');
 
 it('should render the label', () => {
-  const { getByLabelText } = render(
+  render(
     <CheckboxInput onChange={() => {}} isChecked={false}>
       Accept Terms
     </CheckboxInput>
   );
-  expect(getByLabelText('Accept Terms')).toBeInTheDocument();
+  expect(screen.getByLabelText('Accept Terms')).toBeInTheDocument();
 });
 
 it('should call onChange when text is clicked', () => {
   const onChange = jest.fn();
-  const { getByLabelText } = render(
+  render(
     <CheckboxInput onChange={onChange} isChecked={false}>
       Accept Terms
     </CheckboxInput>
   );
-  getByLabelText('Accept Terms').click();
+  screen.getByLabelText('Accept Terms').click();
   expect(onChange).toHaveBeenCalledTimes(1);
 });
 
 it('should not call onChange when text is clicked while disabled', () => {
   const onChange = jest.fn();
-  const { getByLabelText } = render(
+  render(
     <CheckboxInput onChange={onChange} isChecked={false} isDisabled={true}>
       Accept Terms
     </CheckboxInput>
   );
-  getByLabelText('Accept Terms').click();
+  screen.getByLabelText('Accept Terms').click();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 it('should not call onChange when text is clicked while readOnly', () => {
   const onChange = jest.fn();
-  const { getByLabelText } = render(
+  render(
     <CheckboxInput onChange={onChange} isChecked={false} isReadOnly={true}>
       Accept Terms
     </CheckboxInput>
   );
-  getByLabelText('Accept Terms').click();
+  screen.getByLabelText('Accept Terms').click();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 it('should call onChange when outside label is clicked', () => {
   const onChange = jest.fn();
-  const { getByLabelText } = render(
+  render(
     <div>
       <label htmlFor="checkbox">Checkbox</label>
       <CheckboxInput onChange={onChange} isChecked={false} id="checkbox">
@@ -56,7 +56,7 @@ it('should call onChange when outside label is clicked', () => {
       </CheckboxInput>
     </div>
   );
-  getByLabelText('Checkbox').click();
+  screen.getByLabelText('Checkbox').click();
 
   expect(onChange).toHaveBeenCalledTimes(1);
   // it should get called with an event
@@ -74,33 +74,33 @@ it('should forward data attributes', () => {
 });
 
 it('should check the input when isChecked is "true"', () => {
-  const { getByLabelText } = render(
+  render(
     <CheckboxInput onChange={() => {}} isChecked={true}>
       Accept Terms
     </CheckboxInput>
   );
-  expect(getByLabelText('Accept Terms')).toBeChecked();
+  expect(screen.getByLabelText('Accept Terms')).toBeChecked();
 });
 
 it('should not check the input when isChecked is "false"', () => {
-  const { getByLabelText } = render(
+  render(
     <CheckboxInput onChange={() => {}} isChecked={false}>
       Accept Terms
     </CheckboxInput>
   );
-  expect(getByLabelText('Accept Terms')).not.toBeChecked();
+  expect(screen.getByLabelText('Accept Terms')).not.toBeChecked();
 });
 
 it('should allow changing the checked state', () => {
   const onChange = jest.fn();
-  const { getByLabelText, rerender } = render(
+  const { rerender } = render(
     <CheckboxInput onChange={onChange} isChecked={false}>
       Accept Terms
     </CheckboxInput>
   );
-  expect(getByLabelText('Accept Terms')).not.toBeChecked();
+  expect(screen.getByLabelText('Accept Terms')).not.toBeChecked();
 
-  getByLabelText('Accept Terms').click();
+  screen.getByLabelText('Accept Terms').click();
   expect(onChange).toHaveBeenCalledTimes(1);
 
   // simulate onChange function updating the state in the parent and passing
@@ -111,15 +111,15 @@ it('should allow changing the checked state', () => {
     </CheckboxInput>
   );
 
-  expect(getByLabelText('Accept Terms')).toBeChecked();
+  expect(screen.getByLabelText('Accept Terms')).toBeChecked();
 
-  getByLabelText('Accept Terms').click();
+  screen.getByLabelText('Accept Terms').click();
   expect(onChange).toHaveBeenCalledTimes(2);
 });
 
 describe('when indeterminate', () => {
   it('should not check the input when isChecked is "false"', () => {
-    const { getByLabelText } = render(
+    render(
       <CheckboxInput
         onChange={() => {}}
         isChecked={false}
@@ -128,12 +128,12 @@ describe('when indeterminate', () => {
         Accept Terms
       </CheckboxInput>
     );
-    expect(getByLabelText('Accept Terms')).not.toBeChecked();
+    expect(screen.getByLabelText('Accept Terms')).toBeChecked();
   });
 
   // The input is always unchecked when the state is indeterminate!
   it('should not check the input when isChecked is "true"', () => {
-    const { getByLabelText } = render(
+    render(
       <CheckboxInput
         onChange={() => {}}
         isChecked={true}
@@ -142,6 +142,6 @@ describe('when indeterminate', () => {
         Accept Terms
       </CheckboxInput>
     );
-    expect(getByLabelText('Accept Terms')).not.toBeChecked();
+    expect(screen.getByLabelText('Accept Terms')).not.toBeChecked();
   });
 });

--- a/src/components/inputs/localized-rich-text-input/localized-rich-text-input.spec.js
+++ b/src/components/inputs/localized-rich-text-input/localized-rich-text-input.spec.js
@@ -75,8 +75,15 @@ describe('LocalizedRichTextInput', () => {
           />
         );
         screen.getByLabelText(/show all languages/i).click();
-        expect(screen.getByTestId('rich-text-data-test-en')).toBeDisabled();
-        expect(screen.getByTestId('rich-text-data-test-de')).toBeDisabled();
+
+        // eslint-disable-next-line jest-dom/prefer-enabled-disabled
+        expect(screen.getByTestId('rich-text-data-test-en')).toHaveAttribute(
+          'disabled'
+        );
+        // eslint-disable-next-line jest-dom/prefer-enabled-disabled
+        expect(screen.getByTestId('rich-text-data-test-de')).toHaveAttribute(
+          'disabled'
+        );
       });
     });
     describe('when not expanded', () => {
@@ -88,7 +95,10 @@ describe('LocalizedRichTextInput', () => {
             isDisabled={true}
           />
         );
-        expect(screen.getByTestId('rich-text-data-test-en')).toBeDisabled();
+        // eslint-disable-next-line jest-dom/prefer-enabled-disabled
+        expect(screen.getByTestId('rich-text-data-test-en')).toHaveAttribute(
+          'disabled'
+        );
       });
     });
   });

--- a/src/components/inputs/localized-rich-text-input/localized-rich-text-input.spec.js
+++ b/src/components/inputs/localized-rich-text-input/localized-rich-text-input.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import LocalizedRichTextInput from './localized-rich-text-input';
 
 // mocks
@@ -16,122 +16,113 @@ const baseProps = {
 
 describe('LocalizedRichTextInput', () => {
   it('should have an HTML name', () => {
-    const { getByTestId } = render(
+    render(
       <LocalizedRichTextInput {...baseProps} name="foo" selectedLanguage="en" />
     );
-    expect(getByTestId('rich-text-data-test-en')).toHaveAttribute(
+    expect(screen.getByTestId('rich-text-data-test-en')).toHaveAttribute(
       'name',
       'foo.en'
     );
   });
   describe('when collapsed', () => {
     it('should render input the selected languages (en)', () => {
-      const { getByTestId, queryByLabelText } = render(
-        <LocalizedRichTextInput {...baseProps} selectedLanguage="en" />
-      );
-      expect(getByTestId('rich-text-data-test-en')).toBeInTheDocument();
+      render(<LocalizedRichTextInput {...baseProps} selectedLanguage="en" />);
+      expect(screen.getByTestId('rich-text-data-test-en')).toBeInTheDocument();
       expect(
-        queryByLabelText('rich-text-data-test-de')
+        screen.queryByLabelText('rich-text-data-test-de')
       ).not.toBeInTheDocument();
     });
   });
 
   describe('when expanded', () => {
     it('should render inputs for all the languages (en, de)', () => {
-      const { getByTestId } = render(
+      render(
         <LocalizedRichTextInput
           {...baseProps}
           selectedLanguage="en"
           defaultExpandLanguages={true}
         />
       );
-      expect(getByTestId('rich-text-data-test-en')).toBeInTheDocument();
-      expect(getByTestId('rich-text-data-test-de')).toBeInTheDocument();
+      expect(screen.getByTestId('rich-text-data-test-en')).toBeInTheDocument();
+      expect(screen.getByTestId('rich-text-data-test-de')).toBeInTheDocument();
     });
   });
   describe('when expansion controls are hidden', () => {
     it('should render one input per language and no hide button', () => {
-      const { getByTestId, queryByLabelText } = render(
+      render(
         <LocalizedRichTextInput
           {...baseProps}
           selectedLanguage="en"
           hideLanguageExpansionControls={true}
         />
       );
-      expect(getByTestId('rich-text-data-test-en')).toBeInTheDocument();
-      expect(getByTestId('rich-text-data-test-de')).toBeInTheDocument();
-      expect(queryByLabelText(/hide languages/i)).not.toBeInTheDocument();
+      expect(screen.getByTestId('rich-text-data-test-en')).toBeInTheDocument();
+      expect(screen.getByTestId('rich-text-data-test-de')).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText(/hide languages/i)
+      ).not.toBeInTheDocument();
     });
   });
 
   describe('when disabled', () => {
     describe('when expanded', () => {
       it('should render a disabled input for each language (en, de)', () => {
-        const { getByLabelText, getByTestId } = render(
+        render(
           <LocalizedRichTextInput
             {...baseProps}
             selectedLanguage="en"
             isDisabled={true}
           />
         );
-        getByLabelText(/show all languages/i).click();
-        // eslint-disable-next-line jest-dom/prefer-enabled-disabled
-        expect(getByTestId('rich-text-data-test-en')).toHaveAttribute(
-          'disabled'
-        );
-        // eslint-disable-next-line jest-dom/prefer-enabled-disabled
-        expect(getByTestId('rich-text-data-test-de')).toHaveAttribute(
-          'disabled'
-        );
+        screen.getByLabelText(/show all languages/i).click();
+        expect(screen.getByTestId('rich-text-data-test-en')).toBeDisabled();
+        expect(screen.getByTestId('rich-text-data-test-de')).toBeDisabled();
       });
     });
     describe('when not expanded', () => {
       it('should render a disabled input', () => {
-        const { getByTestId } = render(
+        render(
           <LocalizedRichTextInput
             {...baseProps}
             selectedLanguage="en"
             isDisabled={true}
           />
         );
-        // eslint-disable-next-line jest-dom/prefer-enabled-disabled
-        expect(getByTestId('rich-text-data-test-en')).toHaveAttribute(
-          'disabled'
-        );
+        expect(screen.getByTestId('rich-text-data-test-en')).toBeDisabled();
       });
     });
   });
   describe('when readonly', () => {
     describe('when expanded', () => {
       it('should render a readonly input for each language (en, de)', () => {
-        const { getByLabelText, getByTestId } = render(
+        render(
           <LocalizedRichTextInput
             {...baseProps}
             selectedLanguage="en"
             isReadOnly={true}
           />
         );
-        getByLabelText(/show all languages/i).click();
-        expect(getByTestId('rich-text-data-test-en')).not.toHaveAttribute(
-          'contenteditable'
-        );
-        expect(getByTestId('rich-text-data-test-de')).not.toHaveAttribute(
-          'contenteditable'
-        );
+        screen.getByLabelText(/show all languages/i).click();
+        expect(
+          screen.getByTestId('rich-text-data-test-en')
+        ).not.toHaveAttribute('contenteditable');
+        expect(
+          screen.getByTestId('rich-text-data-test-de')
+        ).not.toHaveAttribute('contenteditable');
       });
     });
     describe('when not expanded', () => {
       it('should render a disabled input', () => {
-        const { getByTestId } = render(
+        render(
           <LocalizedRichTextInput
             {...baseProps}
             selectedLanguage="en"
             isReadOnly={true}
           />
         );
-        expect(getByTestId('rich-text-data-test-en')).not.toHaveAttribute(
-          'contenteditable'
-        );
+        expect(
+          screen.getByTestId('rich-text-data-test-en')
+        ).not.toHaveAttribute('contenteditable');
       });
     });
   });
@@ -141,17 +132,17 @@ describe('LocalizedRichTextInput', () => {
       de: 'Another error',
     };
     it('should be open all fields and render errors', () => {
-      const { getByText, getByTestId } = render(
+      render(
         <LocalizedRichTextInput
           {...baseProps}
           selectedLanguage="en"
           errors={errors}
         />
       );
-      expect(getByTestId('rich-text-data-test-en')).toBeInTheDocument();
-      expect(getByTestId('rich-text-data-test-de')).toBeInTheDocument();
-      expect(getByText(errors.en)).toBeInTheDocument();
-      expect(getByText(errors.de)).toBeInTheDocument();
+      expect(screen.getByTestId('rich-text-data-test-en')).toBeInTheDocument();
+      expect(screen.getByTestId('rich-text-data-test-de')).toBeInTheDocument();
+      expect(screen.getByText(errors.en)).toBeInTheDocument();
+      expect(screen.getByText(errors.de)).toBeInTheDocument();
     });
   });
   describe('when the error is not on the selected language', () => {
@@ -160,16 +151,16 @@ describe('LocalizedRichTextInput', () => {
       de: 'An error',
     };
     it('should be open all fields and render errors', () => {
-      const { getByText, getByTestId } = render(
+      render(
         <LocalizedRichTextInput
           {...baseProps}
           selectedLanguage="en"
           errors={errors}
         />
       );
-      expect(getByTestId('rich-text-data-test-en')).toBeInTheDocument();
-      expect(getByTestId('rich-text-data-test-de')).toBeInTheDocument();
-      expect(getByText(errors.de)).toBeInTheDocument();
+      expect(screen.getByTestId('rich-text-data-test-en')).toBeInTheDocument();
+      expect(screen.getByTestId('rich-text-data-test-de')).toBeInTheDocument();
+      expect(screen.getByText(errors.de)).toBeInTheDocument();
     });
   });
   describe('when the error is on the selected language', () => {
@@ -177,17 +168,17 @@ describe('LocalizedRichTextInput', () => {
       const errors = {
         en: 'A value required',
       };
-      const { getByText, getByTestId, queryByLabelText } = render(
+      render(
         <LocalizedRichTextInput
           {...baseProps}
           selectedLanguage="en"
           errors={errors}
         />
       );
-      expect(getByTestId('rich-text-data-test-en')).toBeInTheDocument();
-      expect(getByText(errors.en)).toBeInTheDocument();
+      expect(screen.getByTestId('rich-text-data-test-en')).toBeInTheDocument();
+      expect(screen.getByText(errors.en)).toBeInTheDocument();
       expect(
-        queryByLabelText('rich-text-data-test-de')
+        screen.queryByLabelText('rich-text-data-test-de')
       ).not.toBeInTheDocument();
     });
   });

--- a/src/components/inputs/money-input/money-input.spec.js
+++ b/src/components/inputs/money-input/money-input.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import MoneyInput from './money-input';
-import { render, fireEvent } from '../../../../test/test-utils';
+import { screen, render, fireEvent } from '../../../../test/test-utils';
 
 // We use this component to simulate the whole flow of
 // changing a value and formatting on blur.
@@ -437,38 +437,44 @@ describe('MoneyInput.isHighPrecision', () => {
 
 describe('MoneyInput', () => {
   it('should forward data-attributes', () => {
-    const { getByLabelText } = render(<TestComponent data-foo="bar" />);
-    expect(getByLabelText('Amount')).toHaveAttribute('data-foo', 'bar');
+    render(<TestComponent data-foo="bar" />);
+    expect(screen.getByLabelText('Amount')).toHaveAttribute('data-foo', 'bar');
   });
 
   it('should have an HTML name based on the passed name', () => {
-    const { getByLabelText } = render(<TestComponent name="foo" />);
-    expect(getByLabelText('Amount')).toHaveAttribute('name', 'foo.amount');
+    render(<TestComponent name="foo" />);
+    expect(screen.getByLabelText('Amount')).toHaveAttribute(
+      'name',
+      'foo.amount'
+    );
   });
 
   it('should pass autoComplete', () => {
-    const { getByLabelText } = render(<TestComponent autoComplete="off" />);
-    expect(getByLabelText('Amount')).toHaveAttribute('autocomplete', 'off');
+    render(<TestComponent autoComplete="off" />);
+    expect(screen.getByLabelText('Amount')).toHaveAttribute(
+      'autocomplete',
+      'off'
+    );
   });
 
   it('should show the passed value', () => {
-    const { getByLabelText, getByTestId } = render(
-      <TestComponent value={{ amount: '20', currencyCode: 'EUR' }} />
+    render(<TestComponent value={{ amount: '20', currencyCode: 'EUR' }} />);
+    expect(screen.getByLabelText('Amount')).toHaveAttribute('value', '20');
+    expect(screen.getByTestId('money-input-container')).toHaveTextContent(
+      'EUR'
     );
-    expect(getByLabelText('Amount')).toHaveAttribute('value', '20');
-    expect(getByTestId('money-input-container')).toHaveTextContent('EUR');
   });
 
   it('should call onFocus when the currency select is focused', () => {
     const onFocus = jest.fn();
-    const { getByLabelText } = render(
+    render(
       <TestComponent
         value={{ amount: '20', currencyCode: 'EUR' }}
         onFocus={onFocus}
       />
     );
-    getByLabelText('EUR').focus();
-    expect(getByLabelText('EUR')).toHaveFocus();
+    screen.getByLabelText('EUR').focus();
+    expect(screen.getByLabelText('EUR')).toHaveFocus();
     expect(onFocus).toHaveBeenCalledWith({
       target: { id: 'some-id.currencyCode', name: 'some-name.currencyCode' },
     });
@@ -476,16 +482,16 @@ describe('MoneyInput', () => {
 
   it('should call onBlur twice when amount input loses focus for outside element', () => {
     const onBlur = jest.fn();
-    const { getByLabelText } = render(
+    render(
       <TestComponent
         value={{ amount: '20', currencyCode: 'EUR' }}
         onBlur={onBlur}
       />
     );
-    getByLabelText('Amount').focus();
-    expect(getByLabelText('Amount')).toHaveFocus();
-    getByLabelText('Amount').blur();
-    expect(getByLabelText('Amount')).not.toHaveFocus();
+    screen.getByLabelText('Amount').focus();
+    expect(screen.getByLabelText('Amount')).toHaveFocus();
+    screen.getByLabelText('Amount').blur();
+    expect(screen.getByLabelText('Amount')).not.toHaveFocus();
 
     // onBlur should be called twice as we want to mark both,
     // currency dropdown and amount input as touched when the element
@@ -500,16 +506,16 @@ describe('MoneyInput', () => {
 
   it('should call onBlur twice when currency select loses focus', () => {
     const onBlur = jest.fn();
-    const { getByLabelText } = render(
+    render(
       <TestComponent
         value={{ amount: '20', currencyCode: 'EUR' }}
         onBlur={onBlur}
       />
     );
-    getByLabelText('EUR').focus();
-    expect(getByLabelText('EUR')).toHaveFocus();
-    getByLabelText('EUR').blur();
-    expect(getByLabelText('EUR')).not.toHaveFocus();
+    screen.getByLabelText('EUR').focus();
+    expect(screen.getByLabelText('EUR')).toHaveFocus();
+    screen.getByLabelText('EUR').blur();
+    expect(screen.getByLabelText('EUR')).not.toHaveFocus();
 
     // onBlur should be called twice as we want to mark both,
     // currency dropdown and amount input as touched when the element
@@ -524,37 +530,37 @@ describe('MoneyInput', () => {
 
   it('should not call onBlur when focus switches from currency to amount', () => {
     const onBlur = jest.fn();
-    const { getByLabelText } = render(
+    render(
       <TestComponent
         value={{ amount: '20', currencyCode: 'EUR' }}
         onBlur={onBlur}
       />
     );
-    getByLabelText('EUR').focus();
-    expect(getByLabelText('EUR')).toHaveFocus();
+    screen.getByLabelText('EUR').focus();
+    expect(screen.getByLabelText('EUR')).toHaveFocus();
 
-    getByLabelText('Amount').focus();
-    expect(getByLabelText('EUR')).not.toHaveFocus();
-    expect(getByLabelText('Amount')).toHaveFocus();
+    screen.getByLabelText('Amount').focus();
+    expect(screen.getByLabelText('EUR')).not.toHaveFocus();
+    expect(screen.getByLabelText('Amount')).toHaveFocus();
 
     expect(onBlur).not.toHaveBeenCalled();
   });
 
   it('should not call onBlur when focus switches from amount to currency', () => {
     const onBlur = jest.fn();
-    const { getByLabelText } = render(
+    render(
       <TestComponent
         value={{ amount: '20', currencyCode: 'EUR' }}
         onBlur={onBlur}
       />
     );
 
-    getByLabelText('Amount').focus();
-    expect(getByLabelText('Amount')).toHaveFocus();
+    screen.getByLabelText('Amount').focus();
+    expect(screen.getByLabelText('Amount')).toHaveFocus();
 
-    getByLabelText('EUR').focus();
-    expect(getByLabelText('EUR')).toHaveFocus();
-    expect(getByLabelText('Amount')).not.toHaveFocus();
+    screen.getByLabelText('EUR').focus();
+    expect(screen.getByLabelText('EUR')).toHaveFocus();
+    expect(screen.getByLabelText('Amount')).not.toHaveFocus();
 
     expect(onBlur).not.toHaveBeenCalled();
   });
@@ -571,9 +577,11 @@ describe('MoneyInput', () => {
         },
       };
     };
-    const { getByLabelText } = render(<TestComponent onChange={onChange} />);
+    render(<TestComponent onChange={onChange} />);
 
-    fireEvent.change(getByLabelText('Amount'), { target: { value: '12' } });
+    fireEvent.change(screen.getByLabelText('Amount'), {
+      target: { value: '12' },
+    });
 
     // event should be the updated amount
     expect(event).toEqual({
@@ -587,9 +595,9 @@ describe('MoneyInput', () => {
 
   it('should not allow changing the amount with invalid numbers', () => {
     const onChange = jest.fn();
-    const { getByLabelText } = render(<TestComponent onChange={onChange} />);
+    render(<TestComponent onChange={onChange} />);
 
-    fireEvent.change(getByLabelText('Amount'), {
+    fireEvent.change(screen.getByLabelText('Amount'), {
       target: { value: 'non number' },
     });
 
@@ -601,15 +609,15 @@ describe('MoneyInput', () => {
 
     // We add labels here to be able to find the elements by their id and to
     // ensure the MoneyInput is usable in forms which use labels
-    const { getByLabelText } = render(<TestComponent onChange={onChange} />);
+    render(<TestComponent onChange={onChange} />);
 
     // open using keyboard
-    fireEvent.focus(getByLabelText('EUR'));
-    fireEvent.keyDown(getByLabelText('EUR'), { key: 'ArrowDown' });
+    fireEvent.focus(screen.getByLabelText('EUR'));
+    fireEvent.keyDown(screen.getByLabelText('EUR'), { key: 'ArrowDown' });
 
     // change currency to USD using keyboard
-    fireEvent.keyDown(getByLabelText('EUR'), { key: 'ArrowDown' });
-    fireEvent.keyDown(getByLabelText('EUR'), { key: 'Enter' });
+    fireEvent.keyDown(screen.getByLabelText('EUR'), { key: 'ArrowDown' });
+    fireEvent.keyDown(screen.getByLabelText('EUR'), { key: 'Enter' });
 
     // onChange should be called when changing the currency
     expect(onChange).toHaveBeenCalledWith({
@@ -622,29 +630,29 @@ describe('MoneyInput', () => {
     });
 
     // the amount input should have focus after changing the currency
-    expect(getByLabelText('Amount')).toHaveFocus();
+    expect(screen.getByLabelText('Amount')).toHaveFocus();
   });
 
   it('should format the amount on blur', () => {
-    const { getByLabelText } = render(<TestComponent />);
+    render(<TestComponent />);
 
     // change amount
-    fireEvent.change(getByLabelText('Amount'), {
+    fireEvent.change(screen.getByLabelText('Amount'), {
       target: { value: '12' },
     });
 
     // blur amount
-    fireEvent.blur(getByLabelText('Amount'));
+    fireEvent.blur(screen.getByLabelText('Amount'));
 
     // input should have the formatted value after blurring
-    expect(getByLabelText('Amount')).toHaveAttribute('value', '12.00');
+    expect(screen.getByLabelText('Amount')).toHaveAttribute('value', '12.00');
   });
 
   // The original currency (EUR) uses 2 fraction digits, whereas the
   // next currency (KWD) uses 3 fraction digits.
   // We expect the last fraction to get added when changing the value
   it('should format the amount when the currency changes', async () => {
-    const { getByLabelText } = render(
+    render(
       <TestComponent
         currencies={['EUR', 'KWD']}
         value={{ currencyCode: 'EUR', amount: '12.50' }}
@@ -652,21 +660,21 @@ describe('MoneyInput', () => {
     );
 
     // open currency dropdown using keyboard
-    fireEvent.focus(getByLabelText('EUR'));
-    fireEvent.keyDown(getByLabelText('EUR'), { key: 'ArrowDown' });
+    fireEvent.focus(screen.getByLabelText('EUR'));
+    fireEvent.keyDown(screen.getByLabelText('EUR'), { key: 'ArrowDown' });
 
     // change currency to KWD using keyboard
-    fireEvent.keyDown(getByLabelText('EUR'), { key: 'ArrowDown' });
-    fireEvent.keyDown(getByLabelText('EUR'), { key: 'Enter' });
+    fireEvent.keyDown(screen.getByLabelText('EUR'), { key: 'ArrowDown' });
+    fireEvent.keyDown(screen.getByLabelText('EUR'), { key: 'Enter' });
 
     // We can't use .toHaveAttribute('value', ' 12.500') as the attribute
     // itself does not change in the DOM tree. Only the actual value changes.
-    expect(getByLabelText('Amount').value).toEqual('12.500');
+    expect(screen.getByLabelText('Amount').value).toEqual('12.500');
   });
 
   describe('when the locale is custom', () => {
     it('should format the amount on blur to US format when locale is en', () => {
-      const { getByLabelText } = render(
+      render(
         <TestComponent
           currencies={['EUR']}
           value={{ currencyCode: 'EUR', amount: '12.5' }}
@@ -675,40 +683,40 @@ describe('MoneyInput', () => {
       );
 
       //
-      getByLabelText('Amount').focus();
-      fireEvent.blur(getByLabelText('Amount'));
+      screen.getByLabelText('Amount').focus();
+      fireEvent.blur(screen.getByLabelText('Amount'));
 
       // We can't use .toHaveAttribute() as the attribute
       // itself does not change in the DOM tree. Only the actual value changes.
-      expect(getByLabelText('Amount').value).toEqual('12.50');
+      expect(screen.getByLabelText('Amount').value).toEqual('12.50');
     });
   });
 
   it('should focus the amount input automatically when isAutofocussed is passed', () => {
-    const { getByLabelText } = render(<TestComponent isAutofocussed={true} />);
-    expect(getByLabelText('Amount')).toHaveFocus();
+    render(<TestComponent isAutofocussed={true} />);
+    expect(screen.getByLabelText('Amount')).toHaveFocus();
   });
 
   it('should render a readonly input when readonly', () => {
-    const { getByLabelText } = render(<TestComponent isReadOnly={true} />);
-    expect(getByLabelText('Amount')).toHaveAttribute('readonly');
+    render(<TestComponent isReadOnly={true} />);
+    expect(screen.getByLabelText('Amount')).toHaveAttribute('readonly');
   });
   it('should render a disabled currency select when readonly', () => {
-    const { getByLabelText } = render(<TestComponent isReadOnly={true} />);
-    expect(getByLabelText('EUR')).toBeDisabled();
+    render(<TestComponent isReadOnly={true} />);
+    expect(screen.getByLabelText('EUR')).toBeDisabled();
   });
 
   describe('when there are no currencies', () => {
     it('should call onFocus when the input is focused', () => {
       const onFocus = jest.fn();
-      const { getByLabelText } = render(
+      render(
         <TestComponent
           currencies={[]}
           onFocus={onFocus}
           value={{ currencyCode: 'EUR', amount: '12.33' }}
         />
       );
-      const input = getByLabelText('EUR');
+      const input = screen.getByLabelText('EUR');
       input.focus();
       expect(input).toHaveFocus();
       expect(onFocus).toHaveBeenCalledWith({

--- a/src/components/inputs/multiline-text-input/multiline-text-input.spec.js
+++ b/src/components/inputs/multiline-text-input/multiline-text-input.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { render, fireEvent } from '../../../../test/test-utils';
+import { screen, render, fireEvent } from '../../../../test/test-utils';
 import MultilineTextInput from './multiline-text-input';
 
 class TestComponent extends React.Component {
@@ -62,80 +62,87 @@ describe('MultilineTextInput.isEmpty', () => {
 
 describe('MultilineTextInput', () => {
   it('should forward data-attributes', () => {
-    const { getByLabelText } = render(<TestComponent data-foo="bar" />);
-    expect(getByLabelText('Description')).toHaveAttribute('data-foo', 'bar');
+    render(<TestComponent data-foo="bar" />);
+    expect(screen.getByLabelText('Description')).toHaveAttribute(
+      'data-foo',
+      'bar'
+    );
   });
 
   it('should have role `textbox`', () => {
-    const { getByLabelText } = render(<TestComponent />);
-    expect(getByLabelText('Description')).toHaveAttribute('role', 'textbox');
+    render(<TestComponent />);
+    expect(screen.getByLabelText('Description')).toHaveAttribute(
+      'role',
+      'textbox'
+    );
   });
 
   it('should have role aria-multiline set to `true`', () => {
-    const { getByLabelText } = render(<TestComponent />);
-    expect(getByLabelText('Description')).toHaveAttribute(
+    render(<TestComponent />);
+    expect(screen.getByLabelText('Description')).toHaveAttribute(
       'aria-multiline',
       'true'
     );
   });
 
   it('should pass autoComplete', () => {
-    const { getByLabelText } = render(<TestComponent autoComplete="off" />);
-    expect(getByLabelText('Description')).toHaveAttribute(
+    render(<TestComponent autoComplete="off" />);
+    expect(screen.getByLabelText('Description')).toHaveAttribute(
       'autoComplete',
       'off'
     );
   });
 
   it('should forward html name', () => {
-    const { getByLabelText } = render(<TestComponent name="field1" />);
-    expect(getByLabelText('Description')).toHaveAttribute('name', 'field1');
+    render(<TestComponent name="field1" />);
+    expect(screen.getByLabelText('Description')).toHaveAttribute(
+      'name',
+      'field1'
+    );
   });
 
   it('should render a textarea', () => {
-    const { getByLabelText } = render(<TestComponent />);
-    expect(getByLabelText('Description').tagName.toLowerCase()).toEqual(
+    render(<TestComponent />);
+    expect(screen.getByLabelText('Description').tagName.toLowerCase()).toEqual(
       'textarea'
     );
   });
 
   it('should forward the passed value', () => {
-    const { getByLabelText } = render(<TestComponent value="foo" />);
-    expect(getByLabelText('Description').value).toEqual('foo');
+    render(<TestComponent value="foo" />);
+    expect(screen.getByLabelText('Description').value).toEqual('foo');
   });
 
   it('should forward the placeholder', () => {
-    const { getByLabelText } = render(
-      <TestComponent placeholder="Enter a description" />
-    );
-    expect(getByLabelText('Description')).toHaveAttribute(
+    render(<TestComponent placeholder="Enter a description" />);
+    expect(screen.getByLabelText('Description')).toHaveAttribute(
       'placeholder',
       'Enter a description'
     );
   });
 
   it('should have focus automatically when isAutofocussed is passed', () => {
-    const { getByLabelText } = render(<TestComponent isAutofocussed={true} />);
-    expect(getByLabelText('Description')).toHaveFocus();
+    render(<TestComponent isAutofocussed={true} />);
+    expect(screen.getByLabelText('Description')).toHaveFocus();
   });
 
   it('should have ARIA properties for the readonly state', () => {
-    const { getByLabelText } = render(<TestComponent isReadOnly={true} />);
-    expect(getByLabelText('Description')).toHaveAttribute(
+    render(<TestComponent isReadOnly={true} />);
+    expect(screen.getByLabelText('Description')).toHaveAttribute(
       'aria-readonly',
       'true'
     );
   });
 
   it('should forward disabled attribute when disabled', () => {
-    const { getByLabelText } = render(<TestComponent isDisabled={true} />);
-    expect(getByLabelText('Description')).toBeDisabled();
+    render(<TestComponent isDisabled={true} />);
+    expect(screen.getByLabelText('Description')).toBeDisabled();
   });
 
   it('should call onFocus when the input is focused', () => {
     const onFocus = jest.fn();
-    const { getByLabelText } = render(<TestComponent onFocus={onFocus} />);
-    const textArea = getByLabelText('Description');
+    render(<TestComponent onFocus={onFocus} />);
+    const textArea = screen.getByLabelText('Description');
     textArea.focus();
     expect(textArea).toHaveFocus();
     expect(onFocus).toHaveBeenCalled();
@@ -143,8 +150,8 @@ describe('MultilineTextInput', () => {
 
   it('should call onBlur when the input is loses focus', () => {
     const onBlur = jest.fn();
-    const { getByLabelText } = render(<TestComponent onBlur={onBlur} />);
-    const textArea = getByLabelText('Description');
+    render(<TestComponent onBlur={onBlur} />);
+    const textArea = screen.getByLabelText('Description');
     textArea.focus();
     expect(textArea).toHaveFocus();
     textArea.blur();
@@ -152,9 +159,9 @@ describe('MultilineTextInput', () => {
   });
 
   it('should allow changing value of the textarea', () => {
-    const { getByLabelText } = render(<TestComponent />);
+    render(<TestComponent />);
     const event = { target: { value: 'I want chicken' } };
-    const textArea = getByLabelText('Description');
+    const textArea = screen.getByLabelText('Description');
     fireEvent.focus(textArea);
     fireEvent.change(textArea, event);
     fireEvent.keyDown(textArea, { key: 'Enter' });

--- a/src/components/inputs/radio-input/radio-input.spec.js
+++ b/src/components/inputs/radio-input/radio-input.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import Group from './radio-group';
 import Option from './radio-option';
 
@@ -7,14 +7,14 @@ jest.mock('tiny-invariant');
 
 it('should render all options', () => {
   const onChange = jest.fn();
-  const { getByLabelText } = render(
+  render(
     <Group name="radio-group" onChange={onChange} value="first-value">
       <Option value="first-value">First option</Option>
       <Option value="second-value">Second option</Option>
     </Group>
   );
-  expect(getByLabelText('First option')).toBeInTheDocument();
-  expect(getByLabelText('Second option')).toBeInTheDocument();
+  expect(screen.getByLabelText('First option')).toBeInTheDocument();
+  expect(screen.getByLabelText('Second option')).toBeInTheDocument();
 });
 
 it('should render option with a controlled wrapper', () => {
@@ -41,27 +41,27 @@ it('should render option with a controlled wrapper', () => {
       </Option>
     </Group>
   );
-  const { queryByLabelText, queryByText, rerender } = render(RadioInput);
-  expect(queryByText('Custom Element Content')).toBeInTheDocument();
-  expect(queryByLabelText('Option with wrapper')).toBeInTheDocument();
+  const { rerender } = render(RadioInput);
+  expect(screen.queryByText('Custom Element Content')).toBeInTheDocument();
+  expect(screen.queryByLabelText('Option with wrapper')).toBeInTheDocument();
   visible = false;
   rerender(RadioInput);
-  expect(queryByText('Custom Element Content')).not.toBeInTheDocument();
-  expect(queryByLabelText('Option with wrapper')).toBeInTheDocument();
+  expect(screen.queryByText('Custom Element Content')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Option with wrapper')).toBeInTheDocument();
 });
 
 it('should call onChange when options are clicked', () => {
   const onChange = jest.fn((event) => {
     event.persist();
   });
-  const { getByLabelText, rerender } = render(
+  const { rerender } = render(
     <Group name="radio-group" onChange={onChange} value="">
       <Option value="first-value">First option</Option>
       <Option value="second-value">Second option</Option>
     </Group>
   );
 
-  getByLabelText('First option').click();
+  screen.getByLabelText('First option').click();
   expect(onChange).toHaveBeenCalledTimes(1);
   expect(onChange.mock.calls[0][0].target.name).toEqual('radio-group');
   expect(onChange.mock.calls[0][0].target.value).toEqual('first-value');
@@ -74,7 +74,7 @@ it('should call onChange when options are clicked', () => {
     </Group>
   );
 
-  getByLabelText('Second option').click();
+  screen.getByLabelText('Second option').click();
   expect(onChange).toHaveBeenCalledTimes(2);
   expect(onChange.mock.calls[1][0].target.name).toEqual('radio-group');
   expect(onChange.mock.calls[1][0].target.value).toEqual('second-value');
@@ -82,20 +82,20 @@ it('should call onChange when options are clicked', () => {
 
 it('should not call onChange when selected option is clicked', () => {
   const onChange = jest.fn();
-  const { getByLabelText } = render(
+  render(
     <Group name="radio-group" onChange={onChange} value="first-value">
       <Option value="first-value">First option</Option>
       <Option value="second-value">Second option</Option>
     </Group>
   );
 
-  getByLabelText('First option').click();
+  screen.getByLabelText('First option').click();
   expect(onChange).not.toHaveBeenCalled();
 });
 
 it('should not call onChange when disabled option is clicked', () => {
   const onChange = jest.fn();
-  const { getByLabelText } = render(
+  render(
     <Group name="radio-group" onChange={onChange} value="first-value">
       <Option value="first-value">First option</Option>
       <Option value="second-value" isDisabled={true}>
@@ -104,6 +104,6 @@ it('should not call onChange when disabled option is clicked', () => {
     </Group>
   );
 
-  getByLabelText('Second option').click();
+  screen.getByLabelText('Second option').click();
   expect(onChange).not.toHaveBeenCalled();
 });

--- a/src/components/inputs/rich-text-input/rich-text-input.spec.js
+++ b/src/components/inputs/rich-text-input/rich-text-input.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import RichTextInput from './rich-text-input';
 
 // mocks
@@ -39,11 +39,11 @@ describe('RichTextInput', () => {
       });
 
       it(`should not show the 'expand' button`, () => {
-        const { queryByText } = render(
+        render(
           <RichTextInput {...baseProps} value={initialValue} data-foo="bar" />
         );
 
-        expect(queryByText('Expand')).not.toBeInTheDocument();
+        expect(screen.queryByText('Expand')).not.toBeInTheDocument();
       });
     });
     describe('when height of text is more than 32', () => {
@@ -55,14 +55,12 @@ describe('RichTextInput', () => {
       });
 
       it(`should show the 'expand' button and expand when clicked`, () => {
-        const { getByText } = render(
-          <RichTextInput {...baseProps} value={initialValue} />
-        );
+        render(<RichTextInput {...baseProps} value={initialValue} />);
 
-        const button = getByText('Expand');
+        const button = screen.getByText('Expand');
         expect(button).toBeInTheDocument(); // is this line necessary since getByText will fail if it's not found :thinking:
         button.click();
-        expect(getByText('Collapse')).toBeInTheDocument();
+        expect(screen.getByText('Collapse')).toBeInTheDocument();
       });
     });
   });
@@ -75,7 +73,7 @@ describe('RichTextInput', () => {
         });
       });
       it(`should not show the 'collapse' button`, () => {
-        const { queryByText } = render(
+        render(
           <RichTextInput
             {...baseProps}
             value={initialValue}
@@ -84,7 +82,7 @@ describe('RichTextInput', () => {
           />
         );
 
-        expect(queryByText('Collapse')).not.toBeInTheDocument();
+        expect(screen.queryByText('Collapse')).not.toBeInTheDocument();
       });
     });
     describe('when height of text is more than 32', () => {
@@ -96,7 +94,7 @@ describe('RichTextInput', () => {
       });
 
       it(`should show the 'collapse' button and collapse when clicked`, () => {
-        const { getByText } = render(
+        render(
           <RichTextInput
             {...baseProps}
             value={initialValue}
@@ -104,10 +102,10 @@ describe('RichTextInput', () => {
           />
         );
 
-        const button = getByText('Collapse');
+        const button = screen.getByText('Collapse');
         expect(button).toBeInTheDocument();
         button.click();
-        expect(getByText('Expand')).toBeInTheDocument();
+        expect(screen.getByText('Expand')).toBeInTheDocument();
       });
     });
   });

--- a/src/components/inputs/toggle-input/toggle-input.spec.js
+++ b/src/components/inputs/toggle-input/toggle-input.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import ToggleInput from './toggle-input';
 
 class TestComponent extends React.Component {
@@ -37,14 +37,14 @@ class TestComponent extends React.Component {
 
 it('should render children', () => {
   const onChange = jest.fn();
-  const { getByLabelText } = render(
+  render(
     <div>
       <label htmlFor="toggle">Toggle</label>
       <ToggleInput id="toggle" isChecked={false} onChange={onChange} />
     </div>
   );
 
-  expect(getByLabelText('Toggle')).toBeInTheDocument();
+  expect(screen.getByLabelText('Toggle')).toBeInTheDocument();
 });
 
 it('should call onChange when clicked', () => {
@@ -52,19 +52,17 @@ it('should call onChange when clicked', () => {
     event.persist();
   });
 
-  const { getByLabelText } = render(
-    <TestComponent id="toggle" isChecked={false} onChange={onChange} />
-  );
+  render(<TestComponent id="toggle" isChecked={false} onChange={onChange} />);
 
-  getByLabelText('Toggle').click();
+  screen.getByLabelText('Toggle').click();
 
   expect(onChange).toHaveBeenCalledTimes(1);
-  expect(getByLabelText('Toggle')).toBeChecked();
+  expect(screen.getByLabelText('Toggle')).toBeChecked();
 });
 
 it('should not call onChange when clicked while disabled', () => {
   const onChange = jest.fn();
-  const { getByLabelText } = render(
+  render(
     <div>
       <label htmlFor="toggle">Toggle</label>
       <ToggleInput
@@ -76,7 +74,7 @@ it('should not call onChange when clicked while disabled', () => {
     </div>
   );
 
-  getByLabelText('Toggle').click();
+  screen.getByLabelText('Toggle').click();
 
   expect(onChange).not.toHaveBeenCalled();
 });
@@ -84,25 +82,25 @@ it('should not call onChange when clicked while disabled', () => {
 describe('checked attribute', () => {
   it('should have checked state when checked', () => {
     const onChange = jest.fn();
-    const { getByLabelText } = render(
+    render(
       <div>
         <label htmlFor="toggle">Toggle</label>
         <ToggleInput id="toggle" isChecked={true} onChange={onChange} />
       </div>
     );
 
-    expect(getByLabelText('Toggle')).toBeChecked();
+    expect(screen.getByLabelText('Toggle')).toBeChecked();
   });
 
   it('should not have checked state when not checked', () => {
     const onChange = jest.fn();
-    const { getByLabelText } = render(
+    render(
       <div>
         <label htmlFor="toggle">Toggle</label>
         <ToggleInput id="toggle" isChecked={false} onChange={onChange} />
       </div>
     );
 
-    expect(getByLabelText('Toggle')).not.toBeChecked();
+    expect(screen.getByLabelText('Toggle')).not.toBeChecked();
   });
 });

--- a/src/components/spacings/inline/inline.spec.js
+++ b/src/components/spacings/inline/inline.spec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import Inline from './inline';
 
 it('should render children', () => {
-  const { getByTestId } = render(
+  render(
     <Inline>
       <div data-testid="first-child" />
       <div data-testid="second-child" />
     </Inline>
   );
-  expect(getByTestId('first-child')).toBeInTheDocument();
-  expect(getByTestId('second-child')).toBeInTheDocument();
+  expect(screen.getByTestId('first-child')).toBeInTheDocument();
+  expect(screen.getByTestId('second-child')).toBeInTheDocument();
 });

--- a/src/components/spacings/inset-squish/inset-squish.spec.js
+++ b/src/components/spacings/inset-squish/inset-squish.spec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import InsetSquish from './inset-squish';
 
 it('should render children', () => {
-  const { getByTestId } = render(
+  render(
     <InsetSquish>
       <div data-testid="first-child" />
       <div data-testid="second-child" />
     </InsetSquish>
   );
-  expect(getByTestId('first-child')).toBeInTheDocument();
-  expect(getByTestId('second-child')).toBeInTheDocument();
+  expect(screen.getByTestId('first-child')).toBeInTheDocument();
+  expect(screen.getByTestId('second-child')).toBeInTheDocument();
 });

--- a/src/components/spacings/inset/inset.spec.js
+++ b/src/components/spacings/inset/inset.spec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import Inset from './inset';
 
 it('should render children', () => {
-  const { getByTestId } = render(
+  render(
     <Inset>
       <div data-testid="first-child" />
       <div data-testid="second-child" />
     </Inset>
   );
-  expect(getByTestId('first-child')).toBeInTheDocument();
-  expect(getByTestId('second-child')).toBeInTheDocument();
+  expect(screen.getByTestId('first-child')).toBeInTheDocument();
+  expect(screen.getByTestId('second-child')).toBeInTheDocument();
 });

--- a/src/components/spacings/stack/stack.spec.js
+++ b/src/components/spacings/stack/stack.spec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import Stack from './stack';
 
 it('should render children', () => {
-  const { getByTestId } = render(
+  render(
     <Stack>
       <div data-testid="first-child" />
       <div data-testid="second-child" />
     </Stack>
   );
-  expect(getByTestId('first-child')).toBeInTheDocument();
-  expect(getByTestId('second-child')).toBeInTheDocument();
+  expect(screen.getByTestId('first-child')).toBeInTheDocument();
+  expect(screen.getByTestId('second-child')).toBeInTheDocument();
 });

--- a/src/components/typography/text/text.spec.js
+++ b/src/components/typography/text/text.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '../../../../test/test-utils';
+import { screen, render } from '../../../../test/test-utils';
 import Text from './text';
 
 const intlMessage = { id: 'Title', defaultMessage: 'Hello' };
@@ -27,47 +27,47 @@ describe('exports', () => {
 
 describe('<Headline>', () => {
   it('should render element tag h1', () => {
-    const { container } = render(
+    render(
       <Text.Headline as="h1" title="tooltip text">
-        {'Title'}
+        Title
       </Text.Headline>
     );
 
-    expect(container.querySelector('h1')).toBeInTheDocument();
+    expect(screen.getByRole('heading')).toBeInTheDocument();
   });
 
   it('should render given text', () => {
-    const { container } = render(
+    render(
       <Text.Headline as="h1" title="tooltip text">
-        {'Title'}
+        Title
       </Text.Headline>
     );
-    expect(container).toHaveTextContent('Title');
+    expect(screen.getByText('Title')).toBeInTheDocument();
   });
 
   it('should render given text with react-intl', () => {
-    const { container } = render(
+    render(
       <Text.Headline as="h1" title="tooltip text" intlMessage={intlMessage} />
     );
-    expect(container).toHaveTextContent('Hello');
+    expect(screen.getByText('Hello')).toBeInTheDocument();
   });
 
   it('should set `title` attribute', () => {
-    const { queryByTitle } = render(
+    render(
       <Text.Headline as="h1" title="tooltip text">
-        {'Title'}
+        Title
       </Text.Headline>
     );
-    expect(queryByTitle('tooltip text')).toBeInTheDocument();
+    expect(screen.queryByTitle('tooltip text')).toBeInTheDocument();
   });
 
   it('should forward data attriutes', () => {
-    const { getByTitle } = render(
+    render(
       <Text.Headline as="h1" data-foo="bar" title="headline">
-        {'Title'}
+        Title
       </Text.Headline>
     );
-    expect(getByTitle('headline')).toHaveAttribute('data-foo', 'bar');
+    expect(screen.getByTitle('headline')).toHaveAttribute('data-foo', 'bar');
   });
   describe('when no text is provided', () => {
     let log;
@@ -97,50 +97,50 @@ describe('<Headline>', () => {
 
 describe('<Subheadline>', () => {
   it('should render element tag h4', () => {
-    const { container } = render(
+    render(
       <Text.Subheadline as="h4" title="tooltip text">
-        {'Title'}
+        Title
       </Text.Subheadline>
     );
-    expect(container.querySelector('h4')).toBeInTheDocument();
+    expect(screen.getByRole('heading')).toBeInTheDocument();
   });
 
   it('should render given text', () => {
-    const { container } = render(
+    render(
       <Text.Subheadline as="h4" title="tooltip text">
-        {'Subtitle'}
+        Subtitle
       </Text.Subheadline>
     );
-    expect(container).toHaveTextContent('Subtitle');
+    expect(screen.getByText('Subtitle')).toBeInTheDocument();
   });
 
   it('should render given text with react-intl', () => {
-    const { container } = render(
+    render(
       <Text.Subheadline
         as="h4"
         title="tooltip text"
         intlMessage={intlMessage}
       />
     );
-    expect(container).toHaveTextContent('Hello');
+    expect(screen.getByText('Hello')).toBeInTheDocument();
   });
 
   it('should set `title` attribute', () => {
-    const { queryByTitle } = render(
+    render(
       <Text.Subheadline as="h4" title="tooltip text">
-        {'Title'}
+        Title
       </Text.Subheadline>
     );
-    expect(queryByTitle('tooltip text')).toBeInTheDocument();
+    expect(screen.queryByTitle('tooltip text')).toBeInTheDocument();
   });
 
   it('should forward data attriutes', () => {
-    const { getByTitle } = render(
+    render(
       <Text.Subheadline as="h4" data-foo="bar" title="subheadline">
-        {'Title'}
+        Title
       </Text.Subheadline>
     );
-    expect(getByTitle('subheadline')).toHaveAttribute('data-foo', 'bar');
+    expect(screen.getByTitle('subheadline')).toHaveAttribute('data-foo', 'bar');
   });
   describe('when no text is provided', () => {
     let log;
@@ -170,33 +170,27 @@ describe('<Subheadline>', () => {
 
 describe('<Wrap>', () => {
   it('should render given text', () => {
-    const { container } = render(
-      <Text.Wrap title="tooltip text">{'Text'}</Text.Wrap>
-    );
-    expect(container).toHaveTextContent('Text');
+    render(<Text.Wrap title="tooltip text">Text</Text.Wrap>);
+    expect(screen.getByText('Text')).toBeInTheDocument();
   });
 
   it('should render given text with react-intl', () => {
-    const { container } = render(
-      <Text.Wrap title="tooltip text" intlMessage={intlMessage} />
-    );
-    expect(container).toHaveTextContent('Hello');
+    render(<Text.Wrap title="tooltip text" intlMessage={intlMessage} />);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
   });
 
   it('should set `title` attribute', () => {
-    const { queryByTitle } = render(
-      <Text.Wrap title="tooltip text">{'Title'}</Text.Wrap>
-    );
-    expect(queryByTitle('tooltip text')).toBeInTheDocument();
+    render(<Text.Wrap title="tooltip text">Title</Text.Wrap>);
+    expect(screen.queryByTitle('tooltip text')).toBeInTheDocument();
   });
 
   it('should forward data attriutes', () => {
-    const { getByTitle } = render(
+    render(
       <Text.Wrap data-foo="bar" title="wrap">
-        {'Title'}
+        Title
       </Text.Wrap>
     );
-    expect(getByTitle('wrap')).toHaveAttribute('data-foo', 'bar');
+    expect(screen.getByTitle('wrap')).toHaveAttribute('data-foo', 'bar');
   });
   describe('when no text is provided', () => {
     let log;
@@ -227,49 +221,45 @@ describe('<Wrap>', () => {
 describe('<Body>', () => {
   it('should render element tag p', () => {
     const { container } = render(
-      <Text.Body title="tooltip text">{'Body'}</Text.Body>
+      <Text.Body title="tooltip text">Body</Text.Body>
     );
     expect(container.querySelector('p')).toBeInTheDocument();
   });
 
   it('should render given text', () => {
-    const { container } = render(
-      <Text.Body title="tooltip text">{'Text'}</Text.Body>
-    );
-    expect(container).toHaveTextContent('Text');
+    render(<Text.Body title="tooltip text">Text</Text.Body>);
+    expect(screen.getByText('Text')).toBeInTheDocument();
   });
 
   it('should render given text with react-intl', () => {
-    const { container } = render(
-      <Text.Body title="tooltip text" intlMessage={intlMessage} />
-    );
-    expect(container).toHaveTextContent('Hello');
+    render(<Text.Body title="tooltip text" intlMessage={intlMessage} />);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
   });
 
   it('should forward data attriutes', () => {
-    const { getByTitle } = render(
+    render(
       <Text.Body data-foo="bar" title="body">
-        {'Title'}
+        Title
       </Text.Body>
     );
-    expect(getByTitle('body')).toHaveAttribute('data-foo', 'bar');
+    expect(screen.getByTitle('body')).toHaveAttribute('data-foo', 'bar');
   });
 
   describe('when `as` prop is set to `span`', () => {
     it('should render as a span', () => {
       const { container } = render(
         <Text.Body title="tooltip text" as="span">
-          {'Body'}
+          Body
         </Text.Body>
       );
       expect(container.querySelector('span')).toBeInTheDocument();
     });
 
     it('should render given text with react-intl', () => {
-      const { container } = render(
+      render(
         <Text.Body title="tooltip text" intlMessage={intlMessage} as="span" />
       );
-      expect(container).toHaveTextContent('Hello');
+      expect(screen.getByText('Hello')).toBeInTheDocument();
     });
   });
   describe('when no text is provided', () => {
@@ -307,26 +297,22 @@ describe('<Detail>', () => {
   });
 
   it('should render given text', () => {
-    const { container } = render(
-      <Text.Detail title="tooltip text">{'Text'}</Text.Detail>
-    );
-    expect(container).toHaveTextContent('Text');
+    render(<Text.Detail title="tooltip text">Text</Text.Detail>);
+    expect(screen.getByText('Text')).toBeInTheDocument();
   });
 
   it('should render given text with react-intl', () => {
-    const { container } = render(
-      <Text.Detail title="tooltip text" intlMessage={intlMessage} />
-    );
-    expect(container).toHaveTextContent('Hello');
+    render(<Text.Detail title="tooltip text" intlMessage={intlMessage} />);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
   });
 
   it('should forward data attriutes', () => {
-    const { getByTitle } = render(
+    render(
       <Text.Detail data-foo="bar" title="detail">
-        {'Title'}
+        Title
       </Text.Detail>
     );
-    expect(getByTitle('detail')).toHaveAttribute('data-foo', 'bar');
+    expect(screen.getByTitle('detail')).toHaveAttribute('data-foo', 'bar');
   });
   describe('when no text is provided', () => {
     let log;


### PR DESCRIPTION
#### Summary

This pull request refactors all of UIKit to use the `screen` export from `react-testing-library` where possible.

#### Description

`screen` is a global exported from RTL to reduce the "noise" until being able to test. I refactored all usages of `const {}` or `const rendered` to use `screen` in expectations where possible. I also changed some odd usages of `container` where we expect text content.

As a follow-up: we should inspect all remaining usages of `container` and see if they're really needed at all times.
