### PR TITLE
fix: storybook data-table example

### DIFF
--- a/packages/components/data-table/src/data-table.story.js
+++ b/packages/components/data-table/src/data-table.story.js
@@ -204,7 +204,7 @@ const ColumnConfigForm = (props) => {
       const updatedColumn = {
         ...props.column,
         width: values.width,
-        align: values.align,
+        align: values.align === 'default' ? undefined : values.align,
         isSortable: values.isSortable,
         isTruncated: values.isTruncated,
         disableResizing: values.disableResizing,
@@ -238,7 +238,7 @@ const ColumnConfigForm = (props) => {
               onChange={formik.handleChange}
               value={formik.values.align}
             >
-              <option value={undefined}>default</option>
+              <option value="default">default</option>
               <option value="left">left</option>
               <option value="center">center</option>
               <option value="right">right</option>


### PR DESCRIPTION
#### Summary

This PR fixes a bug in the storybook DataTable example:
When you set a value for the `align` option of a column, you can't change it back to the default. It keeps the previously selected option.

No changeset as this is just a bug in a storybook example.