### PR TITLE
fix(kodiak): to use blocking wording not blacklist

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -2,8 +2,8 @@ version = 1
 
 [merge]
 automerge_label = "🚀 Status: ship it"
-blacklist_title_regex = "^WIP.*"
-blacklist_labels = ["🖐 Status: On Hold", "🚧 Status: WIP"]
+blocking_title_regex = "^WIP.*"
+blocking_labels = ["🖐 Status: On Hold", "🚧 Status: WIP"]
 method = "squash"
 delete_branch_on_merge = true
 block_on_reviews_requested = true


### PR DESCRIPTION
#### Summary

In [this issues](https://github.com/chdsbd/kodiak/issues/437) I proposed that Kodiak would change it's wording from `blacklist_*` to `denylist`. 

They now adopted the wording of `blocking_*`. The documentation PR is pending [here](https://github.com/chdsbd/kodiak/pull/454) while the change is already merged [here[(https://github.com/chdsbd/kodiak/pull/444).

The deployment and deployment of Kodiak was done. I contacted them to make sure.

The documentation can also be found [here](https://kodiakhq.com/docs/config-reference#mergeblocking_title_regex).