### PR TITLE
fix(data-table): clip cells when table is resized

### DIFF
--- a/.changeset/young-jeans-grow.md
+++ b/.changeset/young-jeans-grow.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table': patch
+---
+
+fix clipping of cells when table is resized

--- a/packages/components/data-table/src/cell.js
+++ b/packages/components/data-table/src/cell.js
@@ -51,6 +51,7 @@ const HeaderCellWrapper = (props) => {
     <BaseHeaderCell
       ref={headerRef}
       data-testid={`header-${props.columnKey}`}
+      shouldClipContent={columnResizingReducer.getHasTableBeenResized()}
       disableHeaderStickiness={props.disableHeaderStickiness}
     >
       {props.children}

--- a/packages/components/data-table/src/cell.styles.js
+++ b/packages/components/data-table/src/cell.styles.js
@@ -148,6 +148,30 @@ const getSortableHeaderStyles = (props) => css`
     }
   }
 `;
+
+const CellInner = styled.div`
+  box-sizing: border-box;
+  flex: 1;
+
+  ${(props) => getPaddingStyle(props, false)}
+  ${getCellInnerStyles}
+  ${(props) => (props.shouldClipContent ? 'overflow: hidden;' : '')}
+`;
+
+const HeaderCellInner = styled.div`
+  ${(props) => getPaddingStyle(props, true)}
+  ${getCellInnerStyles}
+  ${(props) => (props.shouldWrap ? '' : 'white-space: nowrap')}
+`;
+
+const SortableHeaderInner = styled.button`
+  ${(props) => getPaddingStyle(props, true)}
+  ${getCellInnerStyles}
+  ${getButtonStyle}
+  ${getSortableHeaderStyles}
+  ${(props) => (props.shouldWrap ? '' : 'white-space: nowrap')}
+`;
+
 const BaseHeaderCell = styled.th`
   color: ${vars.colorSurface};
   background-color: ${vars.colorAccent};
@@ -169,10 +193,11 @@ const BaseHeaderCell = styled.th`
   :hover,
   :active {
     z-index: 2;
+  }
 
-    & > * {
-      overflow: hidden;
-    }
+  ${HeaderCellInner},
+  ${SortableHeaderInner} {
+    ${(props) => (props.shouldClipContent ? 'overflow: hidden;' : '')}
   }
 `;
 
@@ -196,28 +221,6 @@ const BaseFooterCell = styled.td`
 
   /* makes the footer top border overlap the border of the last data row: */
   margin-top: -1px;
-`;
-
-const HeaderCellInner = styled.div`
-  ${(props) => getPaddingStyle(props, true)}
-  ${getCellInnerStyles}
-  ${(props) => (props.shouldWrap ? '' : 'white-space: nowrap')}
-`;
-
-const CellInner = styled.div`
-  box-sizing: border-box;
-  flex: 1;
-
-  ${(props) => getPaddingStyle(props, false)}
-  ${getCellInnerStyles}
-`;
-
-const SortableHeaderInner = styled.button`
-  ${(props) => getPaddingStyle(props, true)}
-  ${getCellInnerStyles}
-  ${getButtonStyle}
-  ${getSortableHeaderStyles}
-  ${(props) => (props.shouldWrap ? '' : 'white-space: nowrap')}
 `;
 
 const RowExpandCollapseButton = styled(SecondaryIconButton)`

--- a/packages/components/data-table/src/data-row.js
+++ b/packages/components/data-table/src/data-row.js
@@ -45,6 +45,7 @@ const DataRow = (props) => {
             props.columns.length,
             columnIndex
           )}
+          shouldClipContent={props.shouldClipContent}
           shouldRenderResizingIndicator={getIsColumnBeingResized(columnIndex)}
         >
           {column.renderItem
@@ -73,6 +74,7 @@ DataRow.propTypes = {
   ).isRequired,
   onRowClick: PropTypes.func,
   isCondensed: PropTypes.bool,
+  shouldClipContent: PropTypes.bool.isRequired,
   verticalCellAlignment: PropTypes.oneOf(['top', 'center', 'bottom']),
   horizontalCellAlignment: PropTypes.oneOf(['left', 'center', 'right']),
   /* the default item (cell) renderer.
@@ -83,6 +85,7 @@ DataRow.propTypes = {
 };
 DataRow.defaultProps = {
   isCondensed: false,
+  shouldClipContent: false,
   verticalCellAlignment: 'top',
   horizontalCellAlignment: 'left',
   itemRenderer: (row, column) => row[column.key],

--- a/packages/components/data-table/src/data-table.js
+++ b/packages/components/data-table/src/data-table.js
@@ -82,7 +82,13 @@ const DataTable = (props) => {
         </Header>
         <Body>
           {props.rows.map((row, rowIndex) => (
-            <DataRow {...props} row={row} key={row.id} rowIndex={rowIndex} />
+            <DataRow
+              {...props}
+              row={row}
+              key={row.id}
+              rowIndex={rowIndex}
+              shouldClipContent={hasTableBeenResized}
+            />
           ))}
         </Body>
         {props.footer && (

--- a/packages/components/data-table/src/data-table.styles.js
+++ b/packages/components/data-table/src/data-table.styles.js
@@ -19,7 +19,6 @@ const TableGrid = styled.table`
   position: relative;
   z-index: 0;
   display: grid;
-  background-color: ${vars.colorSurface};
   /* stylelint-disable function-whitespace-after */
   grid-template-columns: ${(props) =>
     props.columns.map((column) => column.width || 'auto').join(' ')};


### PR DESCRIPTION
#### Summary

There are a few edge cases when a DataTable is resized that cause content to overflow out of their cell. This is more noticeable on the last column of a table and especially if the background isn't white.
![Kapture 2020-06-22 at 17 37 07](https://user-images.githubusercontent.com/2941328/86145132-da92db00-baf6-11ea-82ff-16a526d15d1a.gif)

This PR addresses this problem by making sure cell content is clipped when a column may be narrower than its content, and the table edge (seen by its background color) is moved along with the edge of the last column:
![Kapture 2020-06-30 at 11 38 56](https://user-images.githubusercontent.com/2941328/86145041-bdf6a300-baf6-11ea-9d07-7ffa23622c58.gif)
