### PR TITLE
fix(data-table): cast getHasTableBeenResized to a boolean

### DIFF
--- a/.changeset/few-bananas-explode.md
+++ b/.changeset/few-bananas-explode.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table': patch
+---
+
+fixes getHasTableBeenResized to ensure it returns a boolean

--- a/packages/components/data-table/src/use-manual-column-resizing-reducer.js
+++ b/packages/components/data-table/src/use-manual-column-resizing-reducer.js
@@ -127,7 +127,7 @@ const useManualColumnResizing = (tableRef) => {
     state.columnBeingResized !== undefined
       ? state.columnBeingResized === columnIndex
       : false;
-  const getHasTableBeenResized = () => state.sizes;
+  const getHasTableBeenResized = () => !!state.sizes;
 
   const reset = () => {
     state.tableRef.current.style.gridTemplateColumns = '';


### PR DESCRIPTION
#### Summary

Quick fix related to typings. Not casting the return value of the aforementioned function causes warnings to be thrown because we should expect it to be a boolean.

We should add proper specs to the reducer as a follow-up, but for now I would like this fix to be merged so we can unblock the next release of ui-kit with the resizing feature 🙏 