### PR TITLE
chore: update pptr-testing-library

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -23,7 +23,6 @@
     "slate",
     "slate-html-serializer",
     "slate-react",
-    "@svgr/plugin-svgo",
-    "pptr-testing-library"
+    "@svgr/plugin-svgo"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "omit-empty": "1.0.0",
     "postcss": "7.0.32",
     "postcss-value-parser": "4.1.0",
-    "pptr-testing-library": "0.4.0",
+    "pptr-testing-library": "0.6.0",
     "prettier": "2.0.5",
     "puppeteer": "5.2.1",
     "qs": "6.9.4",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "omit-empty": "1.0.0",
     "postcss": "7.0.32",
     "postcss-value-parser": "4.1.0",
-    "pptr-testing-library": "0.6.0",
+    "pptr-testing-library": "0.6.1",
     "prettier": "2.0.5",
     "puppeteer": "5.2.1",
     "qs": "6.9.4",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "omit-empty": "1.0.0",
     "postcss": "7.0.32",
     "postcss-value-parser": "4.1.0",
-    "pptr-testing-library": "0.6.1",
+    "pptr-testing-library": "0.6.3",
     "prettier": "2.0.5",
     "puppeteer": "5.2.1",
     "qs": "6.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1051,7 +1051,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.3", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
@@ -1337,111 +1337,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@commercetools-uikit/accessible-button@10.22.1":
-  version "10.22.1"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/accessible-button/-/accessible-button-10.22.1.tgz#4a0eebf692963fb09ddce14b49982bbe7894a916"
-  integrity sha512-v7b+NR+8g7yO22AE9WooHUP/rkz88IgvVvNyh+paTYLjxLBWicps6+abvb3rz7XCTZnZdWBV7QG6qK6RxrTsbQ==
-  dependencies:
-    "@commercetools-uikit/design-system" "10.18.4"
-    "@commercetools-uikit/utils" "10.21.0"
-    "@emotion/core" "10.0.28"
-    "@emotion/styled" "10.0.27"
-    common-tags "1.8.0"
-    lodash "4.17.15"
-    prop-types "15.7.2"
-
-"@commercetools-uikit/collapsible-motion@10.21.0":
-  version "10.21.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/collapsible-motion/-/collapsible-motion-10.21.0.tgz#c65d86568a99b66f43c0d8cb6cdba84ed4e2320f"
-  integrity sha512-KDAz1fwJjTOdwb7MblakzUVYBiTqKeYvRV+DzgB5WUvQmdA/TNah8WS2FD6kKgThFbDoyhlXICUZtFS9+NKwug==
-  dependencies:
-    "@commercetools-uikit/hooks" "10.21.0"
-    "@emotion/core" "10.0.28"
-    "@emotion/styled" "10.0.27"
-    lodash "4.17.15"
-    prop-types "15.7.2"
-    tiny-invariant "1.1.0"
-
 "@commercetools-uikit/design-system@10.13.0":
   version "10.13.0"
   resolved "https://registry.yarnpkg.com/@commercetools-uikit/design-system/-/design-system-10.13.0.tgz#07a5b4dc70393b610212e3b9d5250674fd529f53"
   integrity sha512-e1y+GFtrf9jJhoViiM+pYcOgyITjpSwho0jkJJUmoIpPXlYe9ABGFiUukdTitN9SpTE/V3ojybiXn77rVMNFtg==
-
-"@commercetools-uikit/hooks@10.21.0":
-  version "10.21.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/hooks/-/hooks-10.21.0.tgz#ca7875c5be28694e2d67b01609a9ea6b1c80e010"
-  integrity sha512-Cj+26PvS8aa+2vcRbfN2pphwpcKKmshNWYbv36xgtYlP46QeaAPtFiBVWXQjZx1GKGpj1QVHKz/HQkGpzADhUQ==
-  dependencies:
-    "@commercetools-uikit/utils" "10.21.0"
-
-"@commercetools-uikit/icons@10.22.0":
-  version "10.22.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/icons/-/icons-10.22.0.tgz#5103b0d17b3da328acfd3b1a5cfd2ba6e9d9387e"
-  integrity sha512-w4cNErJojIqm3BLiArAmwC2JtXwI3ATONYsxooBszFBTyBkApKgWg8TXVD7QE7UBf6wtvgE5jAY4hFSJMuk0fA==
-  dependencies:
-    "@commercetools-uikit/design-system" "10.18.4"
-    "@emotion/core" "10.0.28"
-    "@emotion/styled" "10.0.27"
-    prop-types "15.7.2"
-    tiny-invariant "1.1.0"
-
-"@commercetools-uikit/select-input@10.22.0":
-  version "10.22.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/select-input/-/select-input-10.22.0.tgz#e03e69d7cc071c9804c8d0ddd463c5aa5c471be1"
-  integrity sha512-cKhi3KlnC5tAhyL0VyrhX2oQa5L+uRulCToUQYffQPye3CNzdvP+Cl7eobhyJB1QN2OPTdTK8HjSTNsKFMF08g==
-  dependencies:
-    "@commercetools-uikit/constraints" "10.21.0"
-    "@commercetools-uikit/design-system" "10.18.4"
-    "@commercetools-uikit/icons" "10.22.0"
-    "@commercetools-uikit/select-utils" "10.22.0"
-    "@commercetools-uikit/utils" "10.21.0"
-    "@emotion/core" "10.0.28"
-    "@emotion/is-prop-valid" "0.8.8"
-    "@emotion/styled" "10.0.27"
-    lodash "4.17.15"
-    prop-types "15.7.2"
-    react-select "3.1.0"
-
-"@commercetools-uikit/select-utils@10.22.0":
-  version "10.22.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/select-utils/-/select-utils-10.22.0.tgz#9c8a8d6f329f9e33d7097787df17ec701ba5a175"
-  integrity sha512-YyOZLYf6/lQ50H2QBqB1SsrzOYDgV8Qhr+HbdZDtKNys/D26xnUznS7IdCBTOS+q6WV7YtaEEk/R8iTUzdnzgw==
-  dependencies:
-    "@commercetools-uikit/design-system" "10.18.4"
-    "@commercetools-uikit/icons" "10.22.0"
-    "@commercetools-uikit/utils" "10.21.0"
-    "@emotion/core" "10.0.28"
-    "@emotion/styled" "10.0.27"
-    lodash "4.17.15"
-    prop-types "15.7.2"
-    react-select "3.1.0"
-
-"@commercetools-uikit/tag@10.22.1":
-  version "10.22.1"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/tag/-/tag-10.22.1.tgz#2acb1895463ce0739cd6c98b6e2f910daa34a94e"
-  integrity sha512-em3qmJuBwQWMY7P+Lcd5MDKcViFxg4ZTsb4gcW41QyY7fE4G4lTBicpLI23Vo/h5+v/MklmcFssc/Ewkln+O4A==
-  dependencies:
-    "@commercetools-uikit/accessible-button" "10.22.1"
-    "@commercetools-uikit/constraints" "10.21.0"
-    "@commercetools-uikit/design-system" "10.18.4"
-    "@commercetools-uikit/icons" "10.22.0"
-    "@commercetools-uikit/text" "10.21.0"
-    "@emotion/core" "10.0.28"
-    prop-types "15.7.2"
-
-"@commercetools-uikit/text@10.21.0":
-  version "10.21.0"
-  resolved "https://registry.yarnpkg.com/@commercetools-uikit/text/-/text-10.21.0.tgz#54eaccb7351ca31fc096ea8e53c12b51ba5361aa"
-  integrity sha512-w1hkC6VADsbSFt/2ECdoEheKNR/5/gHLt0weUmOlBlqVWViZrJLPA64KNxSbNkpB+HuJQk0YE0wEKh+MUJDePw==
-  dependencies:
-    "@commercetools-uikit/design-system" "10.18.4"
-    "@commercetools-uikit/utils" "10.21.0"
-    "@emotion/core" "10.0.28"
-    common-tags "1.8.0"
-    lodash "4.17.15"
-    prop-types "15.7.2"
-    react-required-if "1.0.3"
-    warning "4.0.3"
 
 "@commercetools/github-labels@1.1.0":
   version "1.1.0"
@@ -1633,18 +1532,6 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
-"@emotion/core@10.0.28":
-  version "10.0.28"
-  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.28.tgz#bb65af7262a234593a9e952c041d0f1c9b9bef3d"
-  integrity sha512-pH8UueKYO5jgg0Iq+AmCLxBsvuGtvlmiDCOuv8fGNYn3cowFpLN98L8zO56U0H1PjDIyAlXymgL3Wu7u7v6hbA==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    "@emotion/cache" "^10.0.27"
-    "@emotion/css" "^10.0.27"
-    "@emotion/serialize" "^0.11.15"
-    "@emotion/sheet" "0.9.4"
-    "@emotion/utils" "0.11.3"
-
 "@emotion/core@^10.0.20", "@emotion/core@^10.0.34", "@emotion/core@^10.0.9":
   version "10.0.34"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.34.tgz#a643889dc32bdde829482539c9438a026631187c"
@@ -1709,7 +1596,7 @@
     "@emotion/serialize" "^0.11.15"
     "@emotion/utils" "0.11.3"
 
-"@emotion/styled@10.0.27", "@emotion/styled@^10.0.17", "@emotion/styled@^10.0.27":
+"@emotion/styled@^10.0.17", "@emotion/styled@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-10.0.27.tgz#12cb67e91f7ad7431e1875b1d83a94b814133eaf"
   integrity sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==
@@ -3896,7 +3783,7 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
-"@testing-library/dom@^7.17.1":
+"@testing-library/dom@^7.0.4", "@testing-library/dom@^7.17.1":
   version "7.22.2"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.22.2.tgz#6deaa828500993cc94bdd62875c251b5b5b70d69"
   integrity sha512-taxURh+4Lwr//uC1Eghat95aMnTlI4G4ETosnZK0wliwHWdutLDVKIvHXAOYdXGdzrBAy1wNhSGmNBbZ72ml4g==
@@ -7697,16 +7584,6 @@ dom-serializer@0, dom-serializer@^0.2.1:
   dependencies:
     domelementtype "^2.0.1"
     entities "^2.0.0"
-
-dom-testing-library@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-4.1.1.tgz#615af61bee06db51bd8ecea60c113eba7cb49dda"
-  integrity sha512-PUsG7aY5BJxzulDrOtkksqudRRypcVQF6d4RGAyj9xNwallOFqrNLOyg2QW2mCpFaNVPELX8hBX/wbHQtOto/A==
-  dependencies:
-    "@babel/runtime" "^7.4.3"
-    "@sheerun/mutationobserver-shim" "^0.3.2"
-    pretty-format "^24.7.0"
-    wait-for-expect "^1.1.1"
 
 dom-walk@^0.1.0:
   version "0.1.2"
@@ -12166,11 +12043,6 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
 lodash@4.17.20, lodash@^4.0.1, lodash@^4.1.1, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.2.1:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
@@ -14210,10 +14082,10 @@ postcss@7.0.32, postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-pptr-testing-library@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/pptr-testing-library/-/pptr-testing-library-0.6.0.tgz#fc028a77e8f2f089a3dfbf1e0b71fe5f6d48bfcd"
-  integrity sha512-vHQQebEYRcnk/fmmQSrCO67XiAjDcxEWZEITIAq3EW80nmrgQOUHOvN34vDwGOV1iBIsnm6eiSfPK8tG2wDi/g==
+pptr-testing-library@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/pptr-testing-library/-/pptr-testing-library-0.6.1.tgz#3c144ea1a1bc16bc3c99fabe4ffd7b899230bc7a"
+  integrity sha512-vlh9Mi9u+6ZvzdnYaltAgdZuu4f5H2It0ZVTLlovRQvW41pGN24twPhfKQg0nZcb+UYcVc2HwEUfcV17t0QyAg==
   dependencies:
     "@testing-library/dom" "^7.0.4"
     wait-for-expect "^3.0.2"
@@ -15694,6 +15566,11 @@ resolve-pathname@^3.0.0:
   resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
   integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
+resolve-url@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
+  integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
+
 resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
@@ -16447,6 +16324,17 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
+source-map-resolve@^0.5.0:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
+  integrity sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
+    resolve-url "^0.2.1"
+    source-map-url "^0.4.0"
+    urix "^0.1.0"
+
 source-map-resolve@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
@@ -16463,7 +16351,12 @@ source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.1
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map@^0.5.0, source-map@^0.5.7, source-map@~0.5.0:
+source-map-url@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
+  integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
+
+source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -17929,6 +17822,11 @@ uri-js@^4.2.2:
   integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
   dependencies:
     punycode "^2.1.0"
+
+urix@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+  integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
 url-loader@^2.0.1:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3196,11 +3196,6 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@sheerun/mutationobserver-shim@^0.3.2":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
-  integrity sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==
-
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
@@ -4765,7 +4760,7 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
-ansi-regex@^4.0.0, ansi-regex@^4.1.0:
+ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
@@ -14215,13 +14210,13 @@ postcss@7.0.32, postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-pptr-testing-library@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/pptr-testing-library/-/pptr-testing-library-0.4.0.tgz#b1efdf502341390ef1798cdc3f56bbb3814003f6"
-  integrity sha512-QXvQ4C4jPl9YLabnEFewnPbEDRrzSz2jauvCxB8cw92HG86vS+cUU02OiVieTU+a7PiN9wDVK+LAw0wszuPFaQ==
+pptr-testing-library@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/pptr-testing-library/-/pptr-testing-library-0.6.0.tgz#fc028a77e8f2f089a3dfbf1e0b71fe5f6d48bfcd"
+  integrity sha512-vHQQebEYRcnk/fmmQSrCO67XiAjDcxEWZEITIAq3EW80nmrgQOUHOvN34vDwGOV1iBIsnm6eiSfPK8tG2wDi/g==
   dependencies:
-    dom-testing-library "^4.1.1"
-    wait-for-expect "^1.2.0"
+    "@testing-library/dom" "^7.0.4"
+    wait-for-expect "^3.0.2"
 
 prebuild-install@^5.3.3:
   version "5.3.5"
@@ -14293,16 +14288,6 @@ pretty-error@^2.1.1:
   dependencies:
     renderkid "^2.0.1"
     utila "~0.4"
-
-pretty-format@^24.7.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
-  integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    ansi-regex "^4.0.0"
-    ansi-styles "^3.2.0"
-    react-is "^16.8.4"
 
 pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"
@@ -14913,7 +14898,7 @@ react-intl@5.6.3:
     intl-messageformat-parser "^5.4.0"
     shallow-equal "^1.2.1"
 
-react-is@16.13.1, react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.3, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
+react-is@16.13.1, react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.3, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -18214,10 +18199,10 @@ w3c-xmlserializer@^2.0.0:
   dependencies:
     xml-name-validator "^3.0.0"
 
-wait-for-expect@^1.1.1, wait-for-expect@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.3.0.tgz#65241ce355425f907f5d127bdb5e72c412ff830c"
-  integrity sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA==
+wait-for-expect@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
+  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
 
 wait-on@^3.3.0:
   version "3.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14082,10 +14082,10 @@ postcss@7.0.32, postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-pptr-testing-library@0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/pptr-testing-library/-/pptr-testing-library-0.6.1.tgz#3c144ea1a1bc16bc3c99fabe4ffd7b899230bc7a"
-  integrity sha512-vlh9Mi9u+6ZvzdnYaltAgdZuu4f5H2It0ZVTLlovRQvW41pGN24twPhfKQg0nZcb+UYcVc2HwEUfcV17t0QyAg==
+pptr-testing-library@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/pptr-testing-library/-/pptr-testing-library-0.6.3.tgz#3371fbd8e4d3860069da45a43f57ae305dd8ef1d"
+  integrity sha512-GGX5A6p1HUYox24fBp/GiC59OmT2i/SnSs9XJHgpaUeGQJ/nuvyTRxrbP08XneMyK+S8qdZ+2z6nmIotgc8yjQ==
   dependencies:
     "@testing-library/dom" "^7.0.4"
     wait-for-expect "^3.0.2"


### PR DESCRIPTION
#### Summary

`pptr-testing-library` version was locked because of https://github.com/testing-library/pptr-testing-library/issues/31
That has been fixed with https://github.com/testing-library/pptr-testing-library/pull/34.

This PR unlocks the version and updates.

<del>EDIT: Actually, we need to wait for the new version with the fix to be released 😅 </del>