### PR TITLE
fix(data-table): Row collapsing behaviour

### DIFF
--- a/.changeset/angry-carrots-accept.md
+++ b/.changeset/angry-carrots-accept.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table': patch
+---
+
+Properly update row collapsed state when `isTruncated` options are adjusted for whole row

--- a/packages/components/data-table/src/data-row.js
+++ b/packages/components/data-table/src/data-row.js
@@ -25,11 +25,8 @@ const DataRow = (props) => {
     }
   }, [rowHasTruncatedColumn]);
 
-  const shouldRenderCollapseButton = (
-    isTruncated,
-    totalColumnsLength,
-    currentColumnIndex
-  ) => isTruncated && totalColumnsLength - 1 === currentColumnIndex;
+  const shouldRenderCollapseButton = (totalColumnsLength, currentColumnIndex) =>
+    rowHasTruncatedColumn && totalColumnsLength - 1 === currentColumnIndex;
 
   return (
     <Row
@@ -53,7 +50,6 @@ const DataRow = (props) => {
           shouldIgnoreRowClick={column.shouldIgnoreRowClick}
           handleRowCollapseClick={handleRowCollapseClick}
           shouldRenderCollapseButton={shouldRenderCollapseButton(
-            column.isTruncated,
             props.columns.length,
             columnIndex
           )}

--- a/packages/components/data-table/src/data-row.js
+++ b/packages/components/data-table/src/data-row.js
@@ -15,6 +15,16 @@ const DataRow = (props) => {
   const handleRowCollapseClick = () => {
     collapseRow(!isRowCollapsed);
   };
+
+  // update the collapsed state if isTruncated options are changed for the whole row
+  React.useEffect(() => {
+    if (rowHasTruncatedColumn) {
+      collapseRow(true);
+    } else if (!rowHasTruncatedColumn) {
+      collapseRow(false);
+    }
+  }, [rowHasTruncatedColumn]);
+
   const shouldRenderCollapseButton = (totalColumnsLength, currentColumnIndex) =>
     totalColumnsLength - 1 === currentColumnIndex &&
     ((isRowCollapsed && rowHasTruncatedColumn) ||

--- a/packages/components/data-table/src/data-row.js
+++ b/packages/components/data-table/src/data-row.js
@@ -20,7 +20,7 @@ const DataRow = (props) => {
   React.useEffect(() => {
     if (rowHasTruncatedColumn) {
       collapseRow(true);
-    } else if (!rowHasTruncatedColumn) {
+    } else {
       collapseRow(false);
     }
   }, [rowHasTruncatedColumn]);

--- a/packages/components/data-table/src/data-row.js
+++ b/packages/components/data-table/src/data-row.js
@@ -26,9 +26,7 @@ const DataRow = (props) => {
   }, [rowHasTruncatedColumn]);
 
   const shouldRenderCollapseButton = (totalColumnsLength, currentColumnIndex) =>
-    totalColumnsLength - 1 === currentColumnIndex &&
-    ((isRowCollapsed && rowHasTruncatedColumn) ||
-      (rowHasTruncatedColumn && !isRowCollapsed));
+    totalColumnsLength - 1 === currentColumnIndex && isRowCollapsed;
 
   return (
     <Row

--- a/packages/components/data-table/src/data-row.js
+++ b/packages/components/data-table/src/data-row.js
@@ -25,8 +25,11 @@ const DataRow = (props) => {
     }
   }, [rowHasTruncatedColumn]);
 
-  const shouldRenderCollapseButton = (totalColumnsLength, currentColumnIndex) =>
-    totalColumnsLength - 1 === currentColumnIndex && isRowCollapsed;
+  const shouldRenderCollapseButton = (
+    isTruncated,
+    totalColumnsLength,
+    currentColumnIndex
+  ) => isTruncated && totalColumnsLength - 1 === currentColumnIndex;
 
   return (
     <Row
@@ -50,6 +53,7 @@ const DataRow = (props) => {
           shouldIgnoreRowClick={column.shouldIgnoreRowClick}
           handleRowCollapseClick={handleRowCollapseClick}
           shouldRenderCollapseButton={shouldRenderCollapseButton(
+            column.isTruncated,
             props.columns.length,
             columnIndex
           )}


### PR DESCRIPTION
#### Summary

This PR fixes the `DataTable` to properly update row collapsed state when `isTruncated` options are changed for the whole row.

#### Description

A bit of context:
* `isTruncated` is a flag that only controls whether a row can be truncated.
* `isRowCollapsed` actually controls if a column with isTruncated=true is in fact truncated(=collapsed)
When a table is initially rendered, the row’s `isRowCollapsed` state is initialized according to the `isTruncated` props of the columns. 
Changing the `isTruncated` prop doesn’t re-initialize that state, which is why the table remains uncollapsed if it was initialized like that (and vice versa). Only the expand/collapse button controls that state.

This was a problem for developing the ManagedDataTable, which allows imperatively toggling the `isTruncated` of the columns but it wasn't actually toggling the collapsed state of the rows.
