### PR TITLE
packages/select-field: Enable hasWarning prop on SelectField

### DIFF
--- a/.changeset/flat-squids-decide.md
+++ b/.changeset/flat-squids-decide.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/select-field': minor
+---
+
+Expose `hasWarning` prop on SelectField

--- a/packages/components/fields/select-field/src/select-field.form.story.js
+++ b/packages/components/fields/select-field/src/select-field.form.story.js
@@ -74,6 +74,7 @@ storiesOf('Examples|Forms/Fields', module)
   })
   .add('SelectField', () => {
     const isMulti = boolean('isMulti', true);
+    const hasWarning = boolean('hasWarning', false);
     const initialValues = { animal: isMulti ? [] : undefined };
     return (
       <Section key={isMulti}>
@@ -107,6 +108,7 @@ storiesOf('Examples|Forms/Fields', module)
                 onBlur={formik.handleBlur}
                 isDisabled={formik.isSubmitting}
                 isMulti={isMulti}
+                hasWarning={hasWarning}
                 options={options}
                 title="Favourite animal"
                 description="Bonus points if it is a mammal"

--- a/packages/components/fields/select-field/src/select-field.js
+++ b/packages/components/fields/select-field/src/select-field.js
@@ -87,6 +87,7 @@ export default class SelectField extends React.Component {
     onInfoButtonClick: PropTypes.func,
     hintIcon: PropTypes.node,
     badge: PropTypes.node,
+    hasWarning: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -122,6 +123,7 @@ export default class SelectField extends React.Component {
           <SelectInput
             horizontalConstraint="scale"
             hasError={hasError}
+            hasWarning={this.props.hasWarning}
             aria-label={this.props['aria-label']}
             aria-labelledby={this.props['aria-labelledby']}
             isAutofocussed={this.props.isAutofocussed}

--- a/packages/components/fields/select-field/src/select-field.story.js
+++ b/packages/components/fields/select-field/src/select-field.story.js
@@ -142,6 +142,7 @@ storiesOf('Components|Fields', module)
                   ? action('onInfoButtonClick')
                   : undefined
               }
+              hasWarning={boolean('hasWarning', false)}
               hintIcon={hintIcon}
               badge={text('badge', '')}
             />

--- a/packages/components/fields/select-field/src/select-field.visualroute.js
+++ b/packages/components/fields/select-field/src/select-field.visualroute.js
@@ -76,5 +76,16 @@ export const component = () => (
         isReadOnly={true}
       />
     </Spec>
+    <Spec label="when has warning">
+      <SelectField
+        title="State"
+        name="form-field-name"
+        value={value}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        hasWarning={true}
+      />
+    </Spec>
   </Suite>
 );


### PR DESCRIPTION
#### Summary

`SelectInput` already expose a `hasWarning` prop. However this prop was not available on the `SelectField`. This PR exposes this prop on the `SelectField` as well.

p.s. It is needed for a feature in the MC-FE and it would be nice to have this released as soon as possible so that the MC-FE task can be started.