### PR TITLE
fix(ci): missing bundlesize token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,3 +61,5 @@ jobs:
 
       - name: Checking bundle size of visual testing app
         run: yarn bundlesize
+        env:
+          BUNDLESIZE_GITHUB_TOKEN: ${{ secrets.BUNDLESIZE_GITHUB_TOKEN }}


### PR DESCRIPTION
Noticed this here

<img width="792" alt="image" src="https://user-images.githubusercontent.com/1110551/87303536-a4e8eb80-c513-11ea-9bfe-57c5a5c0ee0d.png">

The env variable was already defined in github secrets, but it wasn't referenced in the job step