### PR TITLE
fix: disable bundlesize status check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,5 +61,12 @@ jobs:
 
       - name: Checking bundle size of visual testing app
         run: yarn bundlesize
-        env:
-          BUNDLESIZE_GITHUB_TOKEN: ${{ secrets.BUNDLESIZE_GITHUB_TOKEN }}
+        # env:
+        # NOTE: it seems that currently bundlesize server is having problems
+        # resulting in status code 500. Because of that, the bundlesize script
+        # is not able to handle the response, resulting in the exit code command
+        # to be 0, which makes the test pass.
+        # To keep the bundlesize check, we avoid passing the token to the command.
+        # This results in the script to run and fail in case of error, but no status
+        # code is reported to the github PR.
+        #   BUNDLESIZE_GITHUB_TOKEN: ${{ secrets.BUNDLESIZE_GITHUB_TOKEN }}


### PR DESCRIPTION
After we enabled bundlesize status check in #1431, it appears that the server is not working fine

<img width="845" alt="image" src="https://user-images.githubusercontent.com/1110551/87311858-1a5ab900-c520-11ea-8d0c-d5cc8c0b95d0.png">

It seems to be a general issue. For now we just disable the status check again.