### PR TITLE
feat(link): add intlMessage prop to Link in ui-kit

### DIFF
--- a/.changeset/ten-suns-count.md
+++ b/.changeset/ten-suns-count.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/link': minor
+---
+
+Added `intlMessage` prop to Link component, which can replace the `children` prop for translated text.

--- a/packages/components/link/README.md
+++ b/packages/components/link/README.md
@@ -23,8 +23,8 @@ import { Link } from '@commercetools-frontend/ui-kit';
 | Props          | Type                                                              | Required | Values | Default | Description                                                                 |
 | -------------- | ----------------------------------------------------------------- | :------: | ------ | ------- | --------------------------------------------------------------------------- |
 | `to`           | `string` or `{ pathname: String, search: String, query: Object }` |    ✅    | -      | -       | The URL that the Link should point to                                       |
-| `children`     | `node`                                                            |  ✅(\*)  | -      | -       | Value of the link                                                           |
-| `intlMessage`  | `intl message`                                                    |  ✅(\*)  | -      | -       | An intl message object that will be rendered with `FormattedMessage`        |
+| `children`     | `node`                                                            | ✅ (\*)  | -      | -       | Value of the link                                                           |
+| `intlMessage`  | `intl message`                                                    | ✅ (\*)  | -      | -       | An intl message object that will be rendered with `FormattedMessage`        |
 | `isExternal`   | `boolean`                                                         |    -     | -      | false   | If true, a regular <a> is rendered instead of the default React Router Link |
 | `hasUnderline` | `boolean`                                                         |    -     | -      | true    | Either sets text-decoration to none or to underline                         |
 

--- a/packages/components/link/README.md
+++ b/packages/components/link/README.md
@@ -23,8 +23,12 @@ import { Link } from '@commercetools-frontend/ui-kit';
 | Props          | Type                                                              | Required | Values | Default | Description                                                                 |
 | -------------- | ----------------------------------------------------------------- | :------: | ------ | ------- | --------------------------------------------------------------------------- |
 | `to`           | `string` or `{ pathname: String, search: String, query: Object }` |    ✅    | -      | -       | The URL that the Link should point to                                       |
+| `children`     | `node`                                                            |  ✅(\*)  | -      | -       | Value of the link                                                           |
+| `intlMessage`  | `intl message`                                                    |  ✅(\*)  | -      | -       | An intl message object that will be rendered with `FormattedMessage`        |
 | `isExternal`   | `boolean`                                                         |    -     | -      | false   | If true, a regular <a> is rendered instead of the default React Router Link |
 | `hasUnderline` | `boolean`                                                         |    -     | -      | true    | Either sets text-decoration to none or to underline                         |
+
+> `*`: `children` is required only if `intlMessage` is not provided, and vice-versa
 
 The component further forwards all remaining props to the underlying component. The external link includes `target="_blank"` and `rel="noopener noreferrer"` by default.
 

--- a/packages/components/link/package.json
+++ b/packages/components/link/package.json
@@ -26,6 +26,7 @@
   },
   "peerDependencies": {
     "react": ">= 16.8.0",
-    "react-router-dom": "5.x"
+    "react-router-dom": "5.x",
+    "react-intl": "3.x || 4.x || 5.x"
   }
 }

--- a/packages/components/link/src/link.js
+++ b/packages/components/link/src/link.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import requiredIf from 'react-required-if';
 import { Link as ReactRouterLink } from 'react-router-dom';
 import { css } from '@emotion/core';
+import { FormattedMessage } from 'react-intl';
 import { customProperties as vars } from '@commercetools-uikit/design-system';
 import { getPassThroughProps } from '@commercetools-uikit/utils';
 
@@ -40,15 +41,28 @@ const Link = (props) => {
         target="_blank"
         rel="noopener noreferrer"
         {...remainingProps}
-      />
+      >
+        {props.intlMessage ? (
+          <FormattedMessage {...props.intlMessage} />
+        ) : (
+          props.children
+        )}
+      </a>
     );
   }
+
   return (
     <ReactRouterLink
       css={(theme) => getLinkStyles(props, theme)}
       to={props.to}
       {...remainingProps}
-    />
+    >
+      {props.intlMessage ? (
+        <FormattedMessage {...props.intlMessage} />
+      ) : (
+        props.children
+      )}
+    </ReactRouterLink>
   );
 };
 
@@ -69,6 +83,15 @@ Link.propTypes = {
     ]),
     (props) => !props.isExternal
   ),
+  intlMessage: requiredIf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      description: PropTypes.string,
+      defaultMessage: PropTypes.string.isRequired,
+    }),
+    (props) => !React.Children.count(props.children)
+  ),
+  children: requiredIf(PropTypes.node, (props) => !props.intlMessage),
 };
 
 Link.defaultProps = {

--- a/packages/components/link/src/link.spec.js
+++ b/packages/components/link/src/link.spec.js
@@ -7,6 +7,8 @@ const createTestProps = (custom) => ({
   ...custom,
 });
 
+const intlMessage = { id: 'link', defaultMessage: 'Link' };
+
 describe('rendering', () => {
   let props;
   describe('when rendering a default (react-router) link', () => {
@@ -31,6 +33,20 @@ describe('rendering', () => {
       const link = screen.getByText('Link');
       expect(link).toBeInTheDocument();
       expect(link).toHaveProperty('href', props.to);
+    });
+  });
+  describe('when rendering a translated link', () => {
+    beforeEach(() => {
+      props = createTestProps({
+        isExternal: true,
+        to: 'https://www.omg.com/',
+        intlMessage,
+      });
+    });
+    it('should render link with react-intl', () => {
+      render(<Link {...props} />);
+      const link = screen.getByText('Link');
+      expect(link).toBeInTheDocument();
     });
   });
 });

--- a/packages/components/link/src/link.visualroute.js
+++ b/packages/components/link/src/link.visualroute.js
@@ -5,6 +5,8 @@ import { Suite, Spec } from '../../../../test/percy';
 
 export const routePath = '/link';
 
+const intlMessage = { id: 'link', defaultMessage: 'Link' };
+
 const purpleTheme = {
   colorPrimary: 'purple',
   colorPrimary25: 'deeppurple',
@@ -30,5 +32,8 @@ export const component = () => (
         <Link to="/">A label text</Link>
       </Spec>
     </ThemeProvider>
+    <Spec label="intlMessage">
+      <Link to="/" intlMessage={intlMessage} />
+    </Spec>
   </Suite>
 );


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary
This PR adds a intlMessage prop to Link component, which can replace the children prop for translated text, in the same fashion as the Text components.
<!-- provide a short summary of your changes -->

#### Description

<!-- provide some context -->
