### PR TITLE
fix(data-table): set default height for table rows

### DIFF
--- a/packages/components/data-table/src/cell.styles.js
+++ b/packages/components/data-table/src/cell.styles.js
@@ -94,6 +94,7 @@ const getCellInnerStyles = (props) => {
 const CellInner = styled.div`
   box-sizing: border-box;
   flex: 1;
+  height: 50px;
 
   ${getPaddingStyle}
   ${getCellInnerStyles}


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary
With the implementation of the new Data Table component, all rows should have a default height of 50px.

<!-- provide a short summary of your changes -->

#### Description

<!-- provide some context -->
Without setting a default height, if an icon is part of a table row, it pushes the height of the row above 50px.