### PR TITLE
Expose hasWarning prop on select fields

### DIFF
--- a/.changeset/slimy-windows-yell.md
+++ b/.changeset/slimy-windows-yell.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-uikit/async-creatable-select-field': minor
+'@commercetools-uikit/async-select-field': minor
+'@commercetools-uikit/creatable-select-field': minor
+---
+
+Expose `hasWarning` prop on `CreatableSelectField`, `AsyncSelectField` and `AsyncCreatableSelectField` components

--- a/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.form.story.js
+++ b/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.form.story.js
@@ -81,6 +81,7 @@ storiesOf('Examples|Forms/Fields', module)
   })
   .add('AsyncCreatableSelectField', () => {
     const isMulti = boolean('isMulti', true);
+    const hasWarning = boolean('hasWarning', false);
     const initialValues = { animal: isMulti ? [] : undefined };
     const delayTimeMs = number('Load delay in ms', 250, {
       range: true,
@@ -119,6 +120,7 @@ storiesOf('Examples|Forms/Fields', module)
                 onBlur={formik.handleBlur}
                 isDisabled={formik.isSubmitting}
                 isMulti={isMulti}
+                hasWarning={hasWarning}
                 title="Favourite animal"
                 description="Bonus points if it is a mammal"
                 isClearable={true}

--- a/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.js
+++ b/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.js
@@ -17,11 +17,11 @@ const sequentialId = createSequentialId('async-creatable-select-field-');
 
 const hasErrors = (errors) => errors && Object.values(errors).some(Boolean);
 
-export default class SelectField extends React.Component {
-  static displayName = 'SelectField';
+export default class AsyncCreatableSelectField extends React.Component {
+  static displayName = 'AsyncCreatableSelectField';
 
   static propTypes = {
-    // SelectField
+    // AsyncCreatableSelectField
     id: PropTypes.string,
     horizontalConstraint: PropTypes.oneOf(['s', 'm', 'l', 'xl', 'scale']),
     errors: PropTypes.shape({

--- a/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.js
+++ b/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.js
@@ -48,6 +48,7 @@ export default class AsyncCreatableSelectField extends React.Component {
     isOptionDisabled: PropTypes.func,
     isMulti: PropTypes.bool,
     isSearchable: PropTypes.bool,
+    hasWarning: PropTypes.bool,
     maxMenuHeight: PropTypes.number,
     menuPortalTarget: PropTypes.instanceOf(SafeHTMLElement),
     menuPortalZIndex: PropTypes.number,
@@ -162,6 +163,7 @@ export default class AsyncCreatableSelectField extends React.Component {
             isOptionDisabled={this.props.isOptionDisabled}
             isMulti={this.props.isMulti}
             isSearchable={this.props.isSearchable}
+            hasWarning={this.props.hasWarning}
             maxMenuHeight={this.props.maxMenuHeight}
             menuPortalTarget={this.props.menuPortalTarget}
             menuPortalZIndex={this.props.menuPortalZIndex}

--- a/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.story.js
+++ b/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.story.js
@@ -141,6 +141,7 @@ storiesOf('Components|Fields', module)
               isDisabled={boolean('isDisabled', false)}
               isReadOnly={boolean('isReadOnly', false)}
               isMulti={isMulti}
+              hasWarning={boolean('hasWarning', false)}
               placeholder={text('placeholder', 'Select...')}
               title={text('title', 'Favourite animal')}
               maxMenuHeight={number('maxMenuHeight', 220)}

--- a/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.visualroute.js
+++ b/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.visualroute.js
@@ -78,6 +78,17 @@ const DefaultRoute = () => (
         isReadOnly={true}
       />
     </Spec>
+    <Spec label="when has warning">
+      <AsyncCreatableSelectField
+        title="State"
+        name="form-field-name"
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        hasWarning={true}
+      />
+    </Spec>
   </Suite>
 );
 

--- a/packages/components/fields/async-select-field/src/async-select-field.form.story.js
+++ b/packages/components/fields/async-select-field/src/async-select-field.form.story.js
@@ -81,6 +81,7 @@ storiesOf('Examples|Forms/Fields', module)
   })
   .add('AsyncSelectField', () => {
     const isMulti = boolean('isMulti', true);
+    const hasWarning = boolean('hasWarning', false);
     const initialValues = { animal: isMulti ? [] : undefined };
     const delayTimeMs = number('Load delay in ms', 250, {
       range: true,
@@ -119,6 +120,7 @@ storiesOf('Examples|Forms/Fields', module)
                 onBlur={formik.handleBlur}
                 isDisabled={formik.isSubmitting}
                 isMulti={isMulti}
+                hasWarning={hasWarning}
                 title="Favourite animal"
                 description="Bonus points if it is a mammal"
                 isClearable={true}

--- a/packages/components/fields/async-select-field/src/async-select-field.js
+++ b/packages/components/fields/async-select-field/src/async-select-field.js
@@ -48,6 +48,7 @@ export default class AsyncSelectField extends React.Component {
     isOptionDisabled: PropTypes.func,
     isMulti: PropTypes.bool,
     isSearchable: PropTypes.bool,
+    hasWarning: PropTypes.bool,
     maxMenuHeight: PropTypes.number,
     menuPortalTarget: PropTypes.instanceOf(SafeHTMLElement),
     menuPortalZIndex: PropTypes.number,
@@ -143,6 +144,7 @@ export default class AsyncSelectField extends React.Component {
             isOptionDisabled={this.props.isOptionDisabled}
             isMulti={this.props.isMulti}
             isSearchable={this.props.isSearchable}
+            hasWarning={this.props.hasWarning}
             maxMenuHeight={this.props.maxMenuHeight}
             menuPortalTarget={this.props.menuPortalTarget}
             menuPortalZIndex={this.props.menuPortalZIndex}

--- a/packages/components/fields/async-select-field/src/async-select-field.story.js
+++ b/packages/components/fields/async-select-field/src/async-select-field.story.js
@@ -141,6 +141,7 @@ storiesOf('Components|Fields', module)
               isDisabled={boolean('isDisabled', false)}
               isReadOnly={boolean('isReadOnly', false)}
               isMulti={isMulti}
+              hasWarning={boolean('hasWarning', false)}
               placeholder={text('placeholder', 'Select...')}
               title={text('title', 'Favourite animal')}
               maxMenuHeight={number('maxMenuHeight', 220)}

--- a/packages/components/fields/async-select-field/src/async-select-field.visualroute.js
+++ b/packages/components/fields/async-select-field/src/async-select-field.visualroute.js
@@ -78,6 +78,17 @@ const DefaultRoute = () => (
         isReadOnly={true}
       />
     </Spec>
+    <Spec label="when has warning">
+      <AsyncSelectField
+        title="State"
+        name="form-field-name"
+        value={value}
+        onChange={() => {}}
+        loadOptions={loadOptions}
+        horizontalConstraint="m"
+        hasWarning={true}
+      />
+    </Spec>
   </Suite>
 );
 

--- a/packages/components/fields/creatable-select-field/src/creatable-select-field.form.story.js
+++ b/packages/components/fields/creatable-select-field/src/creatable-select-field.form.story.js
@@ -74,6 +74,7 @@ storiesOf('Examples|Forms/Fields', module)
   })
   .add('CreatableSelectField', () => {
     const isMulti = boolean('isMulti', true);
+    const hasWarning = boolean('hasWarning', false);
     const initialValues = { animal: isMulti ? [] : undefined };
 
     return (
@@ -107,6 +108,7 @@ storiesOf('Examples|Forms/Fields', module)
                 onBlur={formik.handleBlur}
                 isDisabled={formik.isSubmitting}
                 isMulti={isMulti}
+                hasWarning={hasWarning}
                 options={options}
                 title="Favourite animal"
                 description="Bonus points if it is a mammal"

--- a/packages/components/fields/creatable-select-field/src/creatable-select-field.js
+++ b/packages/components/fields/creatable-select-field/src/creatable-select-field.js
@@ -48,6 +48,7 @@ export default class CreatableSelectField extends React.Component {
     isOptionDisabled: PropTypes.func,
     isMulti: PropTypes.bool,
     isSearchable: PropTypes.bool,
+    hasWarning: PropTypes.bool,
     maxMenuHeight: PropTypes.number,
     menuPortalTarget: PropTypes.instanceOf(SafeHTMLElement),
     menuPortalZIndex: PropTypes.number,
@@ -149,6 +150,7 @@ export default class CreatableSelectField extends React.Component {
             isOptionDisabled={this.props.isOptionDisabled}
             isMulti={this.props.isMulti}
             isSearchable={this.props.isSearchable}
+            hasWarning={this.props.hasWarning}
             maxMenuHeight={this.props.maxMenuHeight}
             menuPortalTarget={this.props.menuPortalTarget}
             menuPortalZIndex={this.props.menuPortalZIndex}

--- a/packages/components/fields/creatable-select-field/src/creatable-select-field.js
+++ b/packages/components/fields/creatable-select-field/src/creatable-select-field.js
@@ -17,11 +17,11 @@ const sequentialId = createSequentialId('creatable-select-field-');
 
 const hasErrors = (errors) => errors && Object.values(errors).some(Boolean);
 
-export default class SelectField extends React.Component {
-  static displayName = 'SelectField';
+export default class CreatableSelectField extends React.Component {
+  static displayName = 'CreatableSelectField';
 
   static propTypes = {
-    // SelectField
+    // CreatableSelectField
     id: PropTypes.string,
     horizontalConstraint: PropTypes.oneOf(['s', 'm', 'l', 'xl', 'scale']),
     errors: PropTypes.shape({

--- a/packages/components/fields/creatable-select-field/src/creatable-select-field.story.js
+++ b/packages/components/fields/creatable-select-field/src/creatable-select-field.story.js
@@ -127,6 +127,7 @@ storiesOf('Components|Fields', module)
               isDisabled={boolean('isDisabled', false)}
               isReadOnly={boolean('isReadOnly', false)}
               isMulti={isMulti}
+              hasWarning={boolean('hasWarning', false)}
               placeholder={text('placeholder', 'Select...')}
               title={text('title', 'Favourite animal')}
               maxMenuHeight={number('maxMenuHeight', 220)}

--- a/packages/components/fields/creatable-select-field/src/creatable-select-field.visualroute.js
+++ b/packages/components/fields/creatable-select-field/src/creatable-select-field.visualroute.js
@@ -76,5 +76,16 @@ export const component = () => (
         isReadOnly={true}
       />
     </Spec>
+    <Spec label="when has warning">
+      <CreatableSelectField
+        title="State"
+        name="form-field-name"
+        value={value}
+        onChange={() => {}}
+        options={options}
+        horizontalConstraint="m"
+        hasWarning={true}
+      />
+    </Spec>
   </Suite>
 );


### PR DESCRIPTION
#### Summary

- `AsyncSelectInput` has `hasWarning` prop to indicate that the field has a warning. This prop was not passed down from the `AsyncSelectField` and this PR passes down via the `hasWarning` field.


