### PR TITLE
fix(data-table):horizontal scrolling

### DIFF
--- a/.changeset/slow-ligers-stare.md
+++ b/.changeset/slow-ligers-stare.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table': patch
+---
+
+Fixed bug of not being able to scroll horizontally

--- a/packages/components/data-table/src/data-table.styles.js
+++ b/packages/components/data-table/src/data-table.styles.js
@@ -17,6 +17,8 @@ const getClickableRowStyle = (props) => {
 };
 
 const TableContainer = styled.div`
+  overflow-x: auto;
+
   ${(props) =>
     props.maxWidth
       ? `max-width: ${convertNumericDimensionToPixelValue(props.maxWidth)};`
@@ -32,12 +34,12 @@ const TableGrid = styled.table`
     props.columns.map((column) => column.width || 'auto').join(' ')};
   /* stylelint-enable function-whitespace-after */
 
+  overflow-y: auto;
+
   ${(props) =>
     props.maxHeight
       ? `max-height: ${convertNumericDimensionToPixelValue(props.maxHeight)};`
       : ''}
-
-  overflow: auto;
 `;
 
 const Header = styled.thead`


### PR DESCRIPTION
#### Summary

This PR fixes a bug where the user can't scroll horizontally on the DataTable when it exceeds the container's size.