### PR TITLE
fix(data-table): container not adjusting to table size when shrank

### DIFF
--- a/.changeset/yellow-chicken-lay.md
+++ b/.changeset/yellow-chicken-lay.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table': patch
+---
+
+Fixed table container not adjusting to table size when columns are shrinked

--- a/packages/components/data-table/package.json
+++ b/packages/components/data-table/package.json
@@ -34,6 +34,7 @@
     "react": ">= 16.8.0"
   },
   "devDependencies": {
-    "formik": "2.1.5"
+    "formik": "2.1.5",
+    "@testing-library/react-hooks" : "3.4.1"
   }
 }

--- a/packages/components/data-table/src/data-table.js
+++ b/packages/components/data-table/src/data-table.js
@@ -65,7 +65,9 @@ const DataTable = (props) => {
   }, [hasTableBeenResized, prevLayout, currentLayout, columnResizingReducer]);
 
   const resizedTotalWidth = hasTableBeenResized
-    ? columnResizingReducer.getTotalResizedTableWidth()
+    ? columnResizingReducer.getTotalResizedTableWidth() +
+      // if the table has a maxHeight, it might add a scrollbar which takes space inside the container
+      (tableRef.current.offsetWidth - tableRef.current.clientWidth)
     : undefined;
 
   return (

--- a/packages/components/data-table/src/data-table.js
+++ b/packages/components/data-table/src/data-table.js
@@ -64,10 +64,15 @@ const DataTable = (props) => {
     }
   }, [hasTableBeenResized, prevLayout, currentLayout, columnResizingReducer]);
 
+  const resizedTotalWidth = hasTableBeenResized
+    ? columnResizingReducer.getTotalResizedTableWidth()
+    : undefined;
+
   return (
     <TableContainer
       maxWidth={props.maxWidth}
       isBeingResized={columnResizingReducer.getIsAnyColumnBeingResized()}
+      resizedTotalWidth={resizedTotalWidth}
       disableSelfContainment={props.disableSelfContainment}
     >
       <TableGrid

--- a/packages/components/data-table/src/data-table.styles.js
+++ b/packages/components/data-table/src/data-table.styles.js
@@ -28,7 +28,7 @@ const getDisabledSelfContainmentStyles = (props) => {
 };
 
 const TableContainer = styled.div`
-  width: min-content;
+  width: fit-content;
   overflow-x: auto;
 
   ${(props) =>

--- a/packages/components/data-table/src/data-table.styles.js
+++ b/packages/components/data-table/src/data-table.styles.js
@@ -28,6 +28,8 @@ const getDisabledSelfContainmentStyles = (props) => {
 };
 
 const TableContainer = styled.div`
+  position: relative;
+  z-index: 0;
   overflow-x: auto;
 
   ${(props) =>
@@ -49,8 +51,6 @@ const TableContainer = styled.div`
 `;
 
 const TableGrid = styled.table`
-  position: relative;
-  z-index: 0;
   display: grid;
   /* stylelint-disable function-whitespace-after */
   grid-template-columns: ${(props) =>

--- a/packages/components/data-table/src/data-table.styles.js
+++ b/packages/components/data-table/src/data-table.styles.js
@@ -28,6 +28,7 @@ const getDisabledSelfContainmentStyles = (props) => {
 };
 
 const TableContainer = styled.div`
+  width: fit-content;
   overflow-x: auto;
 
   ${(props) =>

--- a/packages/components/data-table/src/data-table.styles.js
+++ b/packages/components/data-table/src/data-table.styles.js
@@ -28,7 +28,6 @@ const getDisabledSelfContainmentStyles = (props) => {
 };
 
 const TableContainer = styled.div`
-  width: fit-content;
   overflow-x: auto;
 
   ${(props) =>
@@ -42,6 +41,9 @@ const TableContainer = styled.div`
     * {
       user-select: none;
     }`}
+
+    ${(props) =>
+      props.resizedTotalWidth ? `width: ${props.resizedTotalWidth}px;` : ''}
 
   ${getDisabledSelfContainmentStyles}
 `;

--- a/packages/components/data-table/src/data-table.styles.js
+++ b/packages/components/data-table/src/data-table.styles.js
@@ -28,7 +28,7 @@ const getDisabledSelfContainmentStyles = (props) => {
 };
 
 const TableContainer = styled.div`
-  width: fit-content;
+  width: min-content;
   overflow-x: auto;
 
   ${(props) =>

--- a/packages/components/data-table/src/use-manual-column-resizing-reducer.js
+++ b/packages/components/data-table/src/use-manual-column-resizing-reducer.js
@@ -28,6 +28,7 @@ const initialState = (tableRef) => ({
   initialColWidth: undefined,
   initialMousePosition: undefined,
   columnBeingResized: undefined,
+  hasBeenResized: false,
   sizes: undefined,
   tableRef,
 });
@@ -58,6 +59,7 @@ function reducer(state, action) {
         initialColWidth: undefined,
         initialMousePosition: undefined,
         columnBeingResized: undefined,
+        hasBeenResized: true,
       };
     default:
       throw new Error(
@@ -135,10 +137,10 @@ const useManualColumnResizing = (tableRef) => {
   const getIsAnyColumnBeingResized = () =>
     state.columnBeingResized !== undefined;
 
-  const getHasTableBeenResized = () => !!state.sizes;
+  const getHasTableBeenResized = () => state.hasBeenResized;
 
   const getTotalResizedTableWidth = () => {
-    if (!state.sizes) {
+    if (!state.hasBeenResized || !state.sizes) {
       return -1;
     }
     return state.sizes.reduce((a, b) => a + b, 0);
@@ -152,10 +154,13 @@ const useManualColumnResizing = (tableRef) => {
     });
   };
 
+  const getSizes = () => state.sizes;
+
   React.useDebugValue(state);
 
   return {
     reset,
+    getSizes,
     startResizing,
     onDragResizing,
     finishResizing,

--- a/packages/components/data-table/src/use-manual-column-resizing-reducer.js
+++ b/packages/components/data-table/src/use-manual-column-resizing-reducer.js
@@ -137,6 +137,13 @@ const useManualColumnResizing = (tableRef) => {
 
   const getHasTableBeenResized = () => !!state.sizes;
 
+  const getTotalResizedTableWidth = () => {
+    if (!state.sizes) {
+      return -1;
+    }
+    return state.sizes.reduce((a, b) => a + b, 0);
+  };
+
   const reset = () => {
     state.tableRef.current.style.gridTemplateColumns = '';
 
@@ -155,6 +162,7 @@ const useManualColumnResizing = (tableRef) => {
     getHasTableBeenResized,
     getIsColumnBeingResized,
     getIsAnyColumnBeingResized,
+    getTotalResizedTableWidth,
   };
 };
 

--- a/packages/components/data-table/src/use-manual-column-resizing-reducer.spec.js
+++ b/packages/components/data-table/src/use-manual-column-resizing-reducer.spec.js
@@ -1,0 +1,201 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import useManualColumnResizing from './use-manual-column-resizing-reducer';
+
+const createMockedTableRef = (headersWidths) => {
+  return {
+    current: {
+      querySelectorAll: () => {
+        return headersWidths.map((item) => ({
+          getBoundingClientRect: () => ({
+            width: item,
+          }),
+        }));
+      },
+      style: {
+        gridTemplateColumns: '',
+      },
+    },
+  };
+};
+
+const createMockedHeaderRef = (headerWidth, index) => ({
+  current: {
+    clientWidth: headerWidth,
+    cellIndex: index,
+  },
+});
+
+const createMockedMouseEventPosition = (clientX) => ({
+  clientX,
+});
+
+describe('useManualColumnResizing', () => {
+  beforeAll(() => {
+    jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb) => cb());
+  });
+
+  it('should return all the reducer methods', () => {
+    const { result } = renderHook(() =>
+      useManualColumnResizing(createMockedTableRef([50, 100, 200]))
+    );
+
+    expect(result.current.reset).toBeDefined();
+    expect(result.current.getSizes).toBeDefined();
+    expect(result.current.startResizing).toBeDefined();
+    expect(result.current.onDragResizing).toBeDefined();
+    expect(result.current.finishResizing).toBeDefined();
+    expect(result.current.getHasTableBeenResized).toBeDefined();
+    expect(result.current.getIsColumnBeingResized).toBeDefined();
+    expect(result.current.getIsAnyColumnBeingResized).toBeDefined();
+    expect(result.current.getTotalResizedTableWidth).toBeDefined();
+  });
+
+  it('should correctly initialize with untouched state', () => {
+    const { result } = renderHook(() =>
+      useManualColumnResizing(createMockedTableRef([50, 100, 200]))
+    );
+
+    expect(result.current.getHasTableBeenResized()).toBe(false);
+    expect(result.current.getIsAnyColumnBeingResized()).toBe(false);
+    expect(result.current.getSizes()).toStrictEqual([50, 100, 200]);
+  });
+
+  it('should correctly register the start of a resize', () => {
+    const { result } = renderHook(() =>
+      useManualColumnResizing(createMockedTableRef([50, 100, 200]))
+    );
+
+    expect(result.current.getIsAnyColumnBeingResized()).toBe(false);
+    expect(result.current.getIsColumnBeingResized(0)).toBe(false);
+    expect(result.current.getIsColumnBeingResized(1)).toBe(false);
+    expect(result.current.getIsColumnBeingResized(2)).toBe(false);
+
+    // Pretend starting to resize the second column
+    act(() => {
+      result.current.startResizing(
+        createMockedHeaderRef(100, 1),
+        createMockedMouseEventPosition(300)
+      );
+    });
+
+    expect(result.current.getIsAnyColumnBeingResized()).toBe(true);
+
+    expect(result.current.getIsColumnBeingResized(0)).toBe(false);
+    expect(result.current.getIsColumnBeingResized(1)).toBe(true);
+    expect(result.current.getIsColumnBeingResized(2)).toBe(false);
+  });
+
+  it('should correctly register dragging', () => {
+    const { result } = renderHook(() =>
+      useManualColumnResizing(createMockedTableRef([50, 100, 200]))
+    );
+
+    expect(result.current.getIsAnyColumnBeingResized()).toBe(false);
+
+    // Pretend starting to resize the second column
+    act(() => {
+      result.current.startResizing(
+        createMockedHeaderRef(100, 1),
+        createMockedMouseEventPosition(300)
+      );
+    });
+
+    act(() => {
+      result.current.onDragResizing(
+        // move mouse 50px to the right
+        createMockedMouseEventPosition(350),
+        1
+      );
+    });
+
+    expect(result.current.getIsAnyColumnBeingResized()).toBe(true);
+    expect(result.current.getIsColumnBeingResized(1)).toBe(true);
+
+    // assert the second column is now 50px larger
+    expect(result.current.getSizes()).toStrictEqual([50, 100 + 50, 200]);
+  });
+
+  it('should correctly register finish of dragging', () => {
+    const { result } = renderHook(() =>
+      useManualColumnResizing(createMockedTableRef([50, 100, 200]))
+    );
+
+    act(() => {
+      result.current.startResizing(
+        createMockedHeaderRef(100, 1),
+        createMockedMouseEventPosition(300)
+      );
+    });
+
+    act(() => {
+      result.current.onDragResizing(
+        // move mouse 50px to the right
+        createMockedMouseEventPosition(350),
+        1
+      );
+    });
+
+    let sizes;
+    act(() => {
+      sizes = result.current.finishResizing();
+    });
+
+    // assert the second column is now 50px larger
+    expect(sizes).toStrictEqual([50, 100 + 50, 200]);
+
+    // assert the outputs are consistent
+    expect(result.current.getSizes()).toStrictEqual(sizes);
+
+    // assert no columns are being resized anymore
+    expect(result.current.getIsAnyColumnBeingResized()).toBe(false);
+    expect(result.current.getIsColumnBeingResized(1)).toBe(false);
+
+    // assert table has been resized
+    expect(result.current.getHasTableBeenResized()).toBe(true);
+
+    // assert final table width is consistent with sum of header widths
+    const finalSize = 50 + (100 + 50) + 200;
+    expect(result.current.getTotalResizedTableWidth()).toEqual(finalSize);
+  });
+
+  it('should allow resetting to the initial state', () => {
+    const { result } = renderHook(() =>
+      useManualColumnResizing(createMockedTableRef([50, 100, 200]))
+    );
+
+    act(() => {
+      result.current.startResizing(
+        createMockedHeaderRef(100, 1),
+        createMockedMouseEventPosition(300)
+      );
+    });
+
+    act(() => {
+      result.current.onDragResizing(
+        // move mouse 50px to the right
+        createMockedMouseEventPosition(350),
+        1
+      );
+    });
+
+    act(() => {
+      result.current.finishResizing();
+    });
+
+    expect(result.current.getHasTableBeenResized()).toBe(true);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.getHasTableBeenResized()).toBe(false);
+    expect(result.current.getIsAnyColumnBeingResized()).toBe(false);
+    expect(result.current.getSizes()).toStrictEqual([50, 100, 200]);
+  });
+
+  afterAll(() => {
+    window.requestAnimationFrame.mockRestore();
+  });
+});


### PR DESCRIPTION
#### Summary

`DataTable`: This PR fixed a bug where the table container is not adjusting to table size when columns are shrinked, which is noticeable when there is a footer present:

![image](https://user-images.githubusercontent.com/2941328/90246281-8fc5ec00-de34-11ea-9e6b-c3b0c80ec0c1.png)
