### PR TITLE
fix(data-table): Fixed warning from columns prop-type requirement when using DataTableManager

### DIFF
--- a/.changeset/poor-cycles-hang.md
+++ b/.changeset/poor-cycles-hang.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table': patch
+---
+
+# Fixed warning from columns prop-type requirement when using DataTableManager

--- a/packages/components/data-table/package.json
+++ b/packages/components/data-table/package.json
@@ -27,7 +27,8 @@
     "@emotion/styled": "^10.0.27",
     "lodash": "4.17.20",
     "prop-types": "15.7.2",
-    "react-required-if": "1.0.3"
+    "react-required-if": "1.0.3",
+    "tiny-invariant": "1.1.0"
   },
   "peerDependencies": {
     "react": ">= 16.8.0"

--- a/packages/components/data-table/src/data-table.js
+++ b/packages/components/data-table/src/data-table.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
+import invariant from 'tiny-invariant';
 import { filterDataAttributes } from '@commercetools-uikit/utils';
 import { usePrevious } from '@commercetools-uikit/hooks';
 import {
@@ -32,6 +33,11 @@ const shouldRenderRowBottomBorder = (rowIndex, rowCount, footer) => {
 };
 
 const DataTable = (props) => {
+  invariant(
+    props.columns === undefined,
+    'ui-kit/DataTable: missing required prop "columns".'
+  );
+
   const tableRef = React.useRef();
   const columnResizingReducer = useManualColumnResizing(tableRef);
 
@@ -241,7 +247,7 @@ DataTable.propTypes = {
        */
       shouldIgnoreRowClick: PropTypes.bool,
     })
-  ).isRequired,
+  ),
   /**
    * Element to render within the `tfoot` (footer) element of the table.
    */


### PR DESCRIPTION
#### Summary

When using the `DataTable` as a compound component with `DataTableManager`, the `columns` prop is passed by the Manager (when it does `React.cloneElement`) and as such doesn't have to be passed directly to `DataTable`, which means it cannot be a required prop.