### PR TITLE
fix(data-table): table column sizes not being properly reset

### DIFF
--- a/.changeset/silver-cars-kiss.md
+++ b/.changeset/silver-cars-kiss.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table': patch
+---
+
+Fixed bug where column resizing could break after changing number of columns

--- a/packages/components/data-table/src/data-table.js
+++ b/packages/components/data-table/src/data-table.js
@@ -40,30 +40,25 @@ const DataTable = (props) => {
   const tableRef = React.useRef();
   const columnResizingReducer = useManualColumnResizing(tableRef);
 
-  // if the table has been manually resized
+  // if the table columns have been measured
   // and if the list of columns, their width field, or the isCondensed prop has changed
   // then we need to reset the resized column widths
-  const hasTableBeenResized = columnResizingReducer.getHasTableBeenResized();
   const columnsInfo = getColumnsLayoutInfo(props.columns);
   const prevLayout = usePrevious({
     columns: columnsInfo,
     isCondensed: props.isCondensed,
   });
-  let currentLayout;
-  if (hasTableBeenResized) {
-    currentLayout = {
-      columns: columnsInfo,
-      isCondensed: props.isCondensed,
-    };
-  }
+  const currentLayout = {
+    columns: columnsInfo,
+    isCondensed: props.isCondensed,
+  };
   React.useLayoutEffect(() => {
-    if (hasTableBeenResized) {
-      if (!isEqual(prevLayout, currentLayout)) {
-        columnResizingReducer.reset();
-      }
+    if (!isEqual(prevLayout, currentLayout)) {
+      columnResizingReducer.reset();
     }
-  }, [hasTableBeenResized, prevLayout, currentLayout, columnResizingReducer]);
+  }, [prevLayout, currentLayout, columnResizingReducer]);
 
+  const hasTableBeenResized = columnResizingReducer.getHasTableBeenResized();
   const resizedTotalWidth = hasTableBeenResized
     ? columnResizingReducer.getTotalResizedTableWidth() +
       // if the table has a maxHeight, it might add a scrollbar which takes space inside the container

--- a/packages/components/data-table/src/data-table.story.js
+++ b/packages/components/data-table/src/data-table.story.js
@@ -403,7 +403,9 @@ storiesOf('Components|DataTable', module)
               : null
           }
           maxHeight={castToNumberIfPossible(
-            text('maxHeight', 'calc(100vh - 200px)')
+            // in this example, the table has a dynamic height equal to the viewport height minus 200px
+            // floored to a minimum value of 400px
+            text('maxHeight', 'max(400px, calc(100vh - 200px))')
           )}
           maxWidth={castToNumberIfPossible(text('maxWidth', undefined))}
           horizontalCellAlignment={select('horizontalCellAlignment', [


### PR DESCRIPTION


#### Summary
`DataTable`
This PR fixes a bug where the table column resizing could break after changing the number of columns, because the column measurements were not being properly reset.