### PR TITLE
fix(data-table): Cell clickable area

### DIFF
--- a/.changeset/seven-bananas-argue.md
+++ b/.changeset/seven-bananas-argue.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table': patch
+---
+
+Fixed bug where clicking near the edge of a cell wouldn't trigger onRowClick if the cell was substantially taller than its own content

--- a/packages/components/data-table/src/cell.js
+++ b/packages/components/data-table/src/cell.js
@@ -16,16 +16,16 @@ const DataCell = (props) => {
     : RightTriangleLinearIcon;
   return (
     <BaseCell
+      onClick={props.onCellClick}
+      shouldIgnoreRowClick={props.shouldIgnoreRowClick}
       shouldClipContent={
         props.isTruncated && !props.shouldRenderResizingIndicator
       }
       shouldRenderBottomBorder={props.shouldRenderBottomBorder}
     >
       <CellInner
-        onClick={props.onCellClick}
         isCondensed={props.isCondensed}
         isTruncated={props.isTruncated}
-        shouldIgnoreRowClick={props.shouldIgnoreRowClick}
         verticalCellAlignment={props.verticalCellAlignment}
         horizontalCellAlignment={props.horizontalCellAlignment}
         {...filterDataAttributes(props)}

--- a/packages/components/data-table/src/cell.styles.js
+++ b/packages/components/data-table/src/cell.styles.js
@@ -84,10 +84,6 @@ const getCellInnerStyles = (props) => {
     getHorizontalAlignmentStyle(props),
     getTruncatedStyle(props),
     getOutlineStyles(),
-    props.shouldIgnoreRowClick &&
-      css`
-        cursor: auto;
-      `,
   ];
 };
 
@@ -114,6 +110,7 @@ const BaseCell = styled.td`
       ? `1px solid ${vars.colorNeutral90};`
       : 'none'};
   ${(props) => (props.shouldClipContent ? 'overflow: hidden;' : '')}
+  ${(props) => (props.shouldIgnoreRowClick ? 'cursor: auto;' : '')}
 `;
 
 const BaseFooterCell = styled.td`


### PR DESCRIPTION
#### Summary

`DataTable`
Fixed bug where clicking near the edge of a cell wouldn't trigger `onRowClick` if the cell was substantially taller than its own content.

![Kapture 2020-08-25 at 15 02 09](https://user-images.githubusercontent.com/2941328/91184041-70f50e80-e6ec-11ea-98c1-de8e1daf2fb4.gif)
