### PR TITLE
fix(github): action to use recent puppeteer action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         run: yarn visual-testing-app:build
 
       - name: Running Visual Regression Tests for UI components
-        uses: ianwalter/puppeteer@3.0.0
+        uses: ianwalter/puppeteer-container@v4.0.0
         with:
           args: "yarn vrt:components"
         env:


### PR DESCRIPTION
An attempt to solve this error.

<img width="555" alt="CleanShot 2020-08-26 at 17 24 38@2x" src="https://user-images.githubusercontent.com/1877073/91323317-0bbf1d00-e7c1-11ea-891e-d8095f10ed38.png">

Alternatively we might `sudo apt-get install libxss1`.