### PR TITLE
Chore: Group select inputs and fields in the storybook

### DIFF
--- a/.changeset/bright-ants-grow.md
+++ b/.changeset/bright-ants-grow.md
@@ -1,0 +1,13 @@
+---
+'@commercetools-uikit/async-creatable-select-field': patch
+'@commercetools-uikit/async-select-field': patch
+'@commercetools-uikit/creatable-select-field': patch
+'@commercetools-uikit/select-field': patch
+'@commercetools-uikit/async-creatable-select-input': patch
+'@commercetools-uikit/async-select-input': patch
+'@commercetools-uikit/creatable-select-input': patch
+'@commercetools-uikit/select-input': patch
+'@commercetools-uikit/select-utils': patch
+---
+
+Group select inputs and fields in the storybook

--- a/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.form.story.js
+++ b/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.form.story.js
@@ -71,7 +71,7 @@ const options = [
   { value: 'deer', label: 'Deer' },
 ];
 
-storiesOf('Examples|Forms/Fields', module)
+storiesOf('Examples|Forms/Fields/SelectFields', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {

--- a/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.story.js
+++ b/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.story.js
@@ -78,7 +78,7 @@ const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const loadOptions = (inputValue) =>
   delay(500).then(() => filterColors(inputValue));
 
-storiesOf('Components|Fields', module)
+storiesOf('Components|Fields/SelectFields', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {

--- a/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.story.js
+++ b/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.story.js
@@ -68,7 +68,7 @@ const animalOptions = [
   { value: 'deer', label: 'Deer' },
 ];
 
-const filterColors = (inputValue) =>
+const filterAnimals = (inputValue) =>
   animalOptions.filter((animalOption) =>
     animalOption.label.toLowerCase().includes(inputValue.toLowerCase())
   );
@@ -76,7 +76,7 @@ const filterColors = (inputValue) =>
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const loadOptions = (inputValue) =>
-  delay(500).then(() => filterColors(inputValue));
+  delay(500).then(() => filterAnimals(inputValue));
 
 storiesOf('Components|Fields/SelectFields', module)
   .addDecorator(withKnobs)

--- a/packages/components/fields/async-select-field/src/async-select-field.form.story.js
+++ b/packages/components/fields/async-select-field/src/async-select-field.form.story.js
@@ -71,7 +71,7 @@ const options = [
   { value: 'deer', label: 'Deer' },
 ];
 
-storiesOf('Examples|Forms/Fields', module)
+storiesOf('Examples|Forms/Fields/SelectFields', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {

--- a/packages/components/fields/async-select-field/src/async-select-field.story.js
+++ b/packages/components/fields/async-select-field/src/async-select-field.story.js
@@ -78,7 +78,7 @@ const filterAnimals = (inputValue) =>
 const loadOptions = (inputValue) =>
   delay(500).then(() => filterAnimals(inputValue));
 
-storiesOf('Components|Fields', module)
+storiesOf('Components|Fields/SelectFields', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {

--- a/packages/components/fields/creatable-select-field/src/creatable-select-field.form.story.js
+++ b/packages/components/fields/creatable-select-field/src/creatable-select-field.form.story.js
@@ -64,7 +64,7 @@ const options = [
   { value: 'deer', label: 'Deer' },
 ];
 
-storiesOf('Examples|Forms/Fields', module)
+storiesOf('Examples|Forms/Fields/SelectFields', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {

--- a/packages/components/fields/creatable-select-field/src/creatable-select-field.story.js
+++ b/packages/components/fields/creatable-select-field/src/creatable-select-field.story.js
@@ -68,7 +68,7 @@ const options = [
   { value: 'deer', label: 'Deer' },
 ];
 
-storiesOf('Components|Fields', module)
+storiesOf('Components|Fields/SelectFields', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {

--- a/packages/components/fields/select-field/src/select-field.form.story.js
+++ b/packages/components/fields/select-field/src/select-field.form.story.js
@@ -64,7 +64,7 @@ const options = [
   { value: 'deer', label: 'Deer' },
 ];
 
-storiesOf('Examples|Forms/Fields', module)
+storiesOf('Examples|Forms/Fields/SelectFields', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {

--- a/packages/components/fields/select-field/src/select-field.story.js
+++ b/packages/components/fields/select-field/src/select-field.story.js
@@ -68,7 +68,7 @@ const options = [
   { value: 'deer', label: 'Deer' },
 ];
 
-storiesOf('Components|Fields', module)
+storiesOf('Components|Fields/SelectFields', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {

--- a/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input.form.story.js
+++ b/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input.form.story.js
@@ -219,7 +219,7 @@ class AsyncCreatableSelectInputStory extends React.Component {
   }
 }
 
-storiesOf('Examples|Forms/Inputs', module)
+storiesOf('Examples|Forms/Inputs/SelectInputs', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {

--- a/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input.story.js
+++ b/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input.story.js
@@ -38,9 +38,14 @@ const colourOptions = [
 ];
 
 const filterColors = (inputValue) =>
-  colourOptions.filter((colourOption) =>
-    colourOption.label.toLowerCase().includes(inputValue.toLowerCase())
-  );
+  colourOptions.map((groupedOptionsList) => {
+    const filteredOptions = groupedOptionsList.options.filter((option) =>
+      option.label.toLowerCase().includes(inputValue.toLowerCase())
+    );
+    return {
+      options: filteredOptions,
+    };
+  });
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 

--- a/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input.story.js
+++ b/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input.story.js
@@ -125,7 +125,7 @@ class SelectStory extends React.Component {
   }
 }
 
-storiesOf('Components|Inputs', module)
+storiesOf('Components|Inputs/SelectInputs', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {

--- a/packages/components/inputs/async-select-input/src/async-select-input.form.story.js
+++ b/packages/components/inputs/async-select-input/src/async-select-input.form.story.js
@@ -218,7 +218,7 @@ class AsyncSelectInputStory extends React.Component {
   }
 }
 
-storiesOf('Examples|Forms/Inputs', module)
+storiesOf('Examples|Forms/Inputs/SelectInputs', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {

--- a/packages/components/inputs/async-select-input/src/async-select-input.story.js
+++ b/packages/components/inputs/async-select-input/src/async-select-input.story.js
@@ -38,9 +38,14 @@ const colourOptions = [
 ];
 
 const filterColors = (inputValue) =>
-  colourOptions.filter((colourOption) =>
-    colourOption.label.toLowerCase().includes(inputValue.toLowerCase())
-  );
+  colourOptions.map((groupedOptionsList) => {
+    const filteredOptions = groupedOptionsList.options.filter((option) =>
+      option.label.toLowerCase().includes(inputValue.toLowerCase())
+    );
+    return {
+      options: filteredOptions,
+    };
+  });
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 

--- a/packages/components/inputs/async-select-input/src/async-select-input.story.js
+++ b/packages/components/inputs/async-select-input/src/async-select-input.story.js
@@ -115,7 +115,7 @@ class SelectStory extends React.Component {
   }
 }
 
-storiesOf('Components|Inputs', module)
+storiesOf('Components|Inputs/SelectInputs', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {

--- a/packages/components/inputs/creatable-select-input/src/creatable-select-input.form.story.js
+++ b/packages/components/inputs/creatable-select-input/src/creatable-select-input.form.story.js
@@ -50,7 +50,7 @@ const stateOptions = [
   { value: 'returned', label: 'Returned' },
 ];
 
-storiesOf('Examples|Forms/Inputs', module)
+storiesOf('Examples|Forms/Inputs/SelectInputs', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {

--- a/packages/components/inputs/creatable-select-input/src/creatable-select-input.story.js
+++ b/packages/components/inputs/creatable-select-input/src/creatable-select-input.story.js
@@ -18,7 +18,7 @@ import * as icons from '../../../icons';
 
 const iconNames = Object.keys(icons);
 
-storiesOf('Components|Inputs', module)
+storiesOf('Components|Inputs/SelectInputs', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {

--- a/packages/components/inputs/select-input/src/select-input.form.story.js
+++ b/packages/components/inputs/select-input/src/select-input.form.story.js
@@ -37,7 +37,7 @@ export const groupedOptions = [
   { options: flavourOptions },
 ];
 
-storiesOf('Examples|Forms/Inputs', module)
+storiesOf('Examples|Forms/Inputs/SelectInputs', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {

--- a/packages/components/inputs/select-input/src/select-input.story.js
+++ b/packages/components/inputs/select-input/src/select-input.story.js
@@ -18,7 +18,7 @@ import * as icons from '../../../icons';
 
 const iconNames = Object.keys(icons);
 
-storiesOf('Components|Inputs', module)
+storiesOf('Components|Inputs/SelectInputs', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {


### PR DESCRIPTION
#### Summary
- `SelectInput`s and `SelectField`s are group under their own sub-menus in the storybook to ease the find. 
- Also fixed a bug in the options filtering in the `async-select-input` and `async-createable-select-input`