### PR TITLE
feat: to add table icon to data-table-manager dropdown

### DIFF
--- a/.changeset/gorgeous-poets-cry.md
+++ b/.changeset/gorgeous-poets-cry.md
@@ -1,0 +1,6 @@
+---
+"@commercetools-uikit/data-table-manager": minor
+"@commercetools-uikit/data-table": minor
+---
+
+Added table icon to data-table-manager dropdown

--- a/packages/components/data-table-manager/src/data-table-settings/data-table-settings.js
+++ b/packages/components/data-table-manager/src/data-table-settings/data-table-settings.js
@@ -5,6 +5,7 @@ import { useIntl } from 'react-intl';
 import styled from '@emotion/styled';
 import AccessibleHidden from '@commercetools-uikit/accessible-hidden';
 import SelectInput from '@commercetools-uikit/select-input';
+import { TableIcon } from '@commercetools-uikit/icons';
 import Spacings from '@commercetools-uikit/spacings';
 import { UPDATE_ACTIONS, COLUMN_MANAGER, DISPLAY_SETTINGS } from '../constants';
 import DisplaySettingsManager, {
@@ -108,6 +109,7 @@ const DataTableSettings = (props) => {
               placeholder={intl.formatMessage(messages.placeholder)}
               onChange={handleDropdownChange}
               options={dropdownOptions}
+              iconLeft={<TableIcon />}
             />
           </SelectContainer>
         )}


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

This PR adds the TableIcon to the Table Settings dropdown.

## Description

<img width="393" alt="Screenshot 2020-09-10 at 12 14 03" src="https://user-images.githubusercontent.com/22819128/92693490-2962b980-f35f-11ea-9bb9-538c53845c00.png">

