### PR TITLE
fix(icon): to prevent icon from shrinking inside of flex container

### DIFF
--- a/.changeset/little-items-press.md
+++ b/.changeset/little-items-press.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-uikit/icons": minor
+---
+
+Fixed icon shrinking inside of flex container

--- a/src/components/internals/icons/create-styled-icon.js
+++ b/src/components/internals/icons/create-styled-icon.js
@@ -60,7 +60,8 @@ export const getIconStyles = (props, theme) => css`
   * {
     fill: ${getColor(props.color, theme)};
   }
-  ${getSizeStyle(props.size)}
+  ${getSizeStyle(props.size)};
+  flex-shrink: 0;
 `;
 
 export const iconPropTypes = {
@@ -83,7 +84,8 @@ export default function createStyledIcon(Component, displayName) {
     * {
       fill: ${getColor(props.color, props.theme)};
     }
-    ${getSizeStyle(props.size)}
+    ${getSizeStyle(props.size)};
+    flex-shrink: 0;
   `
   );
   StyledComponent.displayName = displayName;


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

This PR prevents `Icon` component from shrinking when inside of resized flex container.

## Description

<img width="776" alt="Bildschirmfoto 2020-09-08 um 14 24 34" src="https://user-images.githubusercontent.com/22819128/92931902-99f00000-f45d-11ea-9188-fb6e6e038816.png">

