### PR TITLE
fix(date-range-input): rendering of weekdays with dates in calendar body

### DIFF
--- a/.changeset/mighty-birds-vanish.md
+++ b/.changeset/mighty-birds-vanish.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/date-range-input': patch
+---
+
+Fix rendering of weekdays and dates in `<DateRangeInput>` calendar dropdown

--- a/packages/components/inputs/date-range-input/src/date-range-input.js
+++ b/packages/components/inputs/date-range-input/src/date-range-input.js
@@ -364,7 +364,10 @@ class DateRangeCalendar extends React.Component {
             );
             const allItems = [...this.state.suggestedItems, ...calendarItems];
 
-            const paddingDayCount = getPaddingDayCount(this.state.calendarDate);
+            const paddingDayCount = getPaddingDayCount(
+              this.state.calendarDate,
+              this.props.intl.locale
+            );
             const paddingDays = Array(paddingDayCount).fill();
 
             const weekdays = getWeekdayNames(this.props.intl.locale);


### PR DESCRIPTION
Fixes #1567 

**Before**

<img width="541" alt="image" src="https://user-images.githubusercontent.com/1110551/93240257-31b65c80-f784-11ea-96b6-c3c45c6afda9.png">

**After**

<img width="589" alt="image" src="https://user-images.githubusercontent.com/1110551/93247284-5a435400-f78e-11ea-9312-a0ddf01dac4a.png">
