### PR TITLE
chore: add focus/hover changeset to missing inputs and fields

### DIFF
--- a/.changeset/mean-hornets-explode.md
+++ b/.changeset/mean-hornets-explode.md
@@ -1,0 +1,22 @@
+---
+'@commercetools-uikit/async-creatable-select-field': patch
+'@commercetools-uikit/async-select-field': patch
+'@commercetools-uikit/creatable-select-field': patch
+'@commercetools-uikit/localized-multiline-text-field': patch
+'@commercetools-uikit/localized-text-field': patch
+'@commercetools-uikit/multiline-text-field': patch
+'@commercetools-uikit/number-field': patch
+'@commercetools-uikit/password-field': patch
+'@commercetools-uikit/text-field': patch
+'@commercetools-uikit/localized-multiline-text-input': patch
+'@commercetools-uikit/localized-text-input': patch
+'@commercetools-uikit/multiline-text-input': patch
+'@commercetools-uikit/number-input': patch
+'@commercetools-uikit/password-input': patch
+'@commercetools-uikit/text-input': patch
+'@commercetools-uikit/fields': patch
+'@commercetools-uikit/inputs': patch
+'@commercetools-frontend/ui-kit': patch
+---
+
+Improved keyboard navigation support by adding/enhancing visual indicators for hover and focus states, including for readOnly mode.


### PR DESCRIPTION
#### Summary

This PR is for bumping the version of some inputs and fields which weren't bumped in https://github.com/commercetools/ui-kit/pull/1539

All the inputs & fields were affected but not all had their versions bumped, which was a mistake.