### PR TITLE
chore: add data-table-manager to Changeset config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -29,6 +29,7 @@
       "@commercetools-uikit/creatable-select-field",
       "@commercetools-uikit/creatable-select-input",
       "@commercetools-uikit/data-table",
+      "@commercetools-uikit/data-table-manager",
       "@commercetools-uikit/date-field",
       "@commercetools-uikit/date-input",
       "@commercetools-uikit/date-range-field",

--- a/.changeset/neat-cups-relate.md
+++ b/.changeset/neat-cups-relate.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table-manager': patch
+---
+
+Bump version for proper updated release


### PR DESCRIPTION
#### Summary

We forgot to add `@commercetools-uikit/data-table-manager` to our Changeset config when we created the component, which basically means it didn't get any version update since it was created 🤦‍♂️ 

This PR fixes this and bumps the version to force an update with all the previous changes.