### PR TITLE
fix(collapsible-motion): make content effectively invisible when collapsed

### DIFF
--- a/.changeset/plenty-pianos-bow.md
+++ b/.changeset/plenty-pianos-bow.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/collapsible-motion': patch
+---
+
+When closed, the content of the component now gains `visibility: hidden`, which means it's visually hidden from the DOM and removed from the accessibility tree and cannot receive focus, even though it remains present in the layout.

--- a/packages/components/collapsible-motion/src/collapsible-motion.js
+++ b/packages/components/collapsible-motion/src/collapsible-motion.js
@@ -38,9 +38,13 @@ const defaultProps = {
 const getMinHeight = (minHeight) =>
   minHeight !== 0 ? `${minHeight}px` : minHeight;
 
+const getVisibility = (height) => (height === 0 ? 'hidden' : 'visible');
+
 const createOpeningAnimation = (height, minHeight = 0) =>
   keyframes`
-    0% { height: ${getMinHeight(minHeight)}; overflow: hidden; }
+    0% { height: ${getMinHeight(
+      minHeight
+    )}; overflow: hidden; visibility: ${getVisibility(minHeight)}; }
     99% { height: ${height}px; overflow: hidden; }
     100% { height: auto; overflow: visible; }
   `;
@@ -48,7 +52,9 @@ const createOpeningAnimation = (height, minHeight = 0) =>
 const createClosingAnimation = (height, minHeight) =>
   keyframes`
     from { height: ${height}px; }
-    to { height: ${getMinHeight(minHeight)}; overflow: hidden; }
+    to { height: ${getMinHeight(
+      minHeight
+    )}; overflow: hidden; visibility: ${getVisibility(minHeight)}; }
   `;
 
 const useToggleAnimation = (isOpen, toggle, minHeight) => {
@@ -81,7 +87,11 @@ const useToggleAnimation = (isOpen, toggle, minHeight) => {
 
   const containerStyles = isOpen
     ? { height: 'auto' }
-    : { height: getMinHeight(minHeight), overflow: 'hidden' };
+    : {
+        height: getMinHeight(minHeight),
+        overflow: 'hidden',
+        visibility: getVisibility(minHeight),
+      };
 
   // if state has changed
   if (typeof prevIsOpen !== 'undefined' && prevIsOpen !== isOpen) {

--- a/packages/components/collapsible-motion/src/collapsible-motion.spec.js
+++ b/packages/components/collapsible-motion/src/collapsible-motion.spec.js
@@ -44,6 +44,7 @@ describe('uncontrolled mode', () => {
           ),
           height: 0,
           overflow: 'hidden',
+          visibility: 'hidden',
         },
       })
     );
@@ -97,7 +98,7 @@ describe('uncontrolled mode', () => {
       // hide the content
       fireEvent.click(screen.getByTestId('button'));
 
-      // ensure the container gets hidden
+      // ensure the container gets shrunk to 50px
       expect(renderProp).toHaveBeenLastCalledWith(
         expect.objectContaining({
           isOpen: false,
@@ -107,6 +108,7 @@ describe('uncontrolled mode', () => {
             ),
             height: '50px',
             overflow: 'hidden',
+            visibility: 'visible',
           },
         })
       );
@@ -192,6 +194,7 @@ describe('controlled mode', () => {
           ),
           height: 0,
           overflow: 'hidden',
+          visibility: 'hidden',
         },
       })
     );
@@ -245,7 +248,7 @@ describe('controlled mode', () => {
       // hide the content
       fireEvent.click(screen.getByTestId('button'));
 
-      // ensure the container gets hidden
+      // ensure the container gets shrunk to 50px
       expect(renderProp).toHaveBeenLastCalledWith(
         expect.objectContaining({
           isOpen: false,
@@ -255,6 +258,7 @@ describe('controlled mode', () => {
             ),
             height: '50px',
             overflow: 'hidden',
+            visibility: 'visible',
           },
         })
       );

--- a/packages/components/collapsible-motion/src/collapsible-motion.spec.js
+++ b/packages/components/collapsible-motion/src/collapsible-motion.spec.js
@@ -281,3 +281,72 @@ describe('controlled mode', () => {
     });
   });
 });
+
+describe('content visibility', () => {
+  it('should make content invisible when isDefaultClosed', async () => {
+    const renderProp = jest.fn(({ containerStyles, registerContentNode }) => (
+      <div style={containerStyles}>
+        <div data-testid="content-node" ref={registerContentNode}>
+          <button aria-label="I am invisible!" />
+        </div>
+      </div>
+    ));
+
+    render(<CollapsibleMotion isDefaultClosed>{renderProp}</CollapsibleMotion>);
+
+    expect(screen.queryByLabelText('I am invisible!')).not.toBeVisible();
+    expect(screen.queryByLabelText('I am invisible!')).toBeInTheDocument();
+  });
+
+  it('should make content invisible when it is collapsed', async () => {
+    const renderProp = jest.fn(
+      ({ isOpen, toggle, containerStyles, registerContentNode }) => (
+        <div>
+          <button data-testid="button" onClick={toggle}>
+            {isOpen ? 'Close' : 'Open'}
+          </button>
+          <div style={containerStyles}>
+            <div data-testid="content-node" ref={registerContentNode}>
+              <button aria-label="I am invisible!" />
+            </div>
+          </div>
+        </div>
+      )
+    );
+
+    render(<CollapsibleMotion>{renderProp}</CollapsibleMotion>);
+
+    expect(screen.queryByLabelText('I am invisible!')).toBeVisible();
+
+    fireEvent.click(screen.getByTestId('button'));
+
+    expect(screen.queryByLabelText('I am invisible!')).not.toBeVisible();
+    expect(screen.queryByLabelText('I am invisible!')).toBeInTheDocument();
+  });
+
+  it('should make content visible when it is opened', async () => {
+    const renderProp = jest.fn(
+      ({ isOpen, toggle, containerStyles, registerContentNode }) => (
+        <div>
+          <button data-testid="button" onClick={toggle}>
+            {isOpen ? 'Close' : 'Open'}
+          </button>
+          <div style={containerStyles}>
+            <div data-testid="content-node" ref={registerContentNode}>
+              <button aria-label="I am invisible!" />
+            </div>
+          </div>
+        </div>
+      )
+    );
+
+    render(<CollapsibleMotion isDefaultClosed>{renderProp}</CollapsibleMotion>);
+
+    expect(screen.queryByLabelText('I am invisible!')).not.toBeVisible();
+    expect(screen.queryByLabelText('I am invisible!')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('button'));
+
+    expect(screen.queryByLabelText('I am invisible!')).toBeVisible();
+  });
+});


### PR DESCRIPTION
#### Summary

This PR changes the `CollapsibleMotion` component to actually hide the content from the accessibility tree when collapsed so that elements like buttons or inputs won't continue to receive focus when they're visually nowhere to be seen.

This is achieved with the CSS property `visibility`.