### PR TITLE
Add isCondensed prop to the Stamp component

### DIFF
--- a/.changeset/stale-guests-rhyme.md
+++ b/.changeset/stale-guests-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/stamp': minor
+---
+
+Add a new prop (isCondensed) for Stamp componet to allow for stamps with small paddings

--- a/.changeset/stale-guests-rhyme.md
+++ b/.changeset/stale-guests-rhyme.md
@@ -2,4 +2,4 @@
 '@commercetools-uikit/stamp': minor
 ---
 
-Add a new prop (isCondensed) for Stamp componet to allow for stamps with small paddings
+Add a new prop (isCondensed) for the Stamp component to allow for stamps with small paddings

--- a/packages/components/fields/search-select-field/README.md
+++ b/packages/components/fields/search-select-field/README.md
@@ -137,10 +137,9 @@ export default Example;
 
 The component further forwards all `data-` attributes to the underlying `SearchSelectInput` component.
 
-This field is built on top of [`react-select`](https://github.com/JedWatson/react-select) v3.
-It supports mostly same properties as `react-select`. Behaviour for some props was changed, and support for others was dropped.
+The underlying `@commercetools-uikit/search-select-input` is built on top of `@commercetools-uikit/async-select-input` which on its own turn is built on top of [`react-select`](https://github.com/JedWatson/react-select) v3. `@commercetools-uikit/async-select-input` supports mostly the same properties as `react-select` with some minor changes in the behaviour of some of the props. The `@commercetools-uikit/search-select-input` which is built on top `@commercetools-uikit/async-select-input` has predefined values for some the props. The props that have predefined values in `@commercetools-uikit/search-select-input` are as follows:
 
-In case you need one of the currently excluded props, feel free to open a PR adding them.
+In case you need one of the currently excluded props, feel free to open a PR adding them to either `@commercetools-uikit/search-select-input` or `@commercetools-uikit/async-select-input`.
 
 ## `errors`
 

--- a/packages/components/stamp/README.md
+++ b/packages/components/stamp/README.md
@@ -45,7 +45,8 @@ export default Example;
 
 ## Properties
 
-| Props      | Type                                                                                                               | Required | Default | Description                         |
-| ---------- | ------------------------------------------------------------------------------------------------------------------ | :------: | ------- | ----------------------------------- |
-| `tone`     | `enum`<br>Possible values:<br>`'critical' \| 'warning' \| 'positive' \| 'information' \| 'primary' \| 'secondary'` |    ✅    |         | Indicates the color scheme of stamp |
-| `children` | `node`                                                                                                             |    ✅    |         |                                     |
+| Props         | Type                                                                                                               | Required | Default | Description                         |
+| ------------- | ------------------------------------------------------------------------------------------------------------------ | :------: | ------- | ----------------------------------- |
+| `tone`        | `enum`<br>Possible values:<br>`'critical' \| 'warning' \| 'positive' \| 'information' \| 'primary' \| 'secondary'` |    ✅    |         | Indicates the color scheme of stamp |
+| `isCondensed` | `bool`                                                                                                             |          |         |                                     |
+| `children`    | `node`                                                                                                             |    ✅    |         |                                     |

--- a/packages/components/stamp/package.json
+++ b/packages/components/stamp/package.json
@@ -14,12 +14,13 @@
     "build": "cross-env NODE_ENV=production rollup -c ../../../rollup.config.js -i ./src/index.js",
     "generate-readme": "generate-readme ."
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "sideEffects": false,
   "license": "MIT",
   "dependencies": {
     "@commercetools-uikit/design-system": "10.18.4",
-    "@commercetools-uikit/spacings-inset-squish": "10.30.1",
     "@emotion/core": "^10.0.34",
     "prop-types": "15.7.2"
   },

--- a/packages/components/stamp/src/stamp.js
+++ b/packages/components/stamp/src/stamp.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { customProperties as vars } from '@commercetools-uikit/design-system';
-import InsetSquish from '@commercetools-uikit/spacings-inset-squish';
 
 export const availableTones = [
   'critical',
@@ -12,6 +11,15 @@ export const availableTones = [
   'primary',
   'secondary',
 ];
+const getPaddingStyle = (props) => {
+  if (props.isCondensed)
+    return css`
+      padding: 1px ${vars.spacingXs};
+    `;
+  return css`
+    padding: ${vars.spacingXs} ${vars.spacingS};
+  `;
+};
 
 const getToneStyles = (props, theme) => {
   const overwrittenVars = { ...vars, ...theme };
@@ -70,9 +78,13 @@ const getStampStyles = (props, theme) => {
 
 const Stamp = (props) => (
   <div
-    css={(theme) => [getStampStyles(props, theme), getToneStyles(props, theme)]}
+    css={(theme) => [
+      getStampStyles(props, theme),
+      getToneStyles(props, theme),
+      getPaddingStyle(props),
+    ]}
   >
-    <InsetSquish scale="s">{props.children}</InsetSquish>
+    {props.children}
   </div>
 );
 
@@ -82,6 +94,7 @@ Stamp.propTypes = {
    * Indicates the color scheme of stamp
    */
   tone: PropTypes.oneOf(availableTones).isRequired,
+  isCondensed: PropTypes.bool,
   children: PropTypes.node.isRequired,
 };
 

--- a/packages/components/stamp/src/stamp.story.js
+++ b/packages/components/stamp/src/stamp.story.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { boolean, withKnobs } from '@storybook/addon-knobs';
 import Section from '../../../../.storybook/decorators/section';
 import Text from '../../text';
 import SpacingsStack from '../../spacings/stack';
@@ -20,6 +21,7 @@ storiesOf('Components|Stamps', module)
       sidebar: Readme,
     },
   })
+  .addDecorator(withKnobs)
   .add('Stamp', () => (
     <Section>
       <SpacingsStack>
@@ -28,13 +30,13 @@ storiesOf('Components|Stamps', module)
           const Icon = icons[iconNames[iconIndex]];
           return (
             <SpacingsInline key={tone} alignItems="center">
-              <Stamp tone={tone}>
+              <Stamp tone={tone} isCondensed={boolean('isCondensed', false)}>
                 <SpacingsInline alignItems="center">
                   <Icon size="medium" />
                   <Text.Detail>{'Hello'}</Text.Detail>
                 </SpacingsInline>
               </Stamp>
-              <Stamp tone={tone}>
+              <Stamp tone={tone} isCondensed={boolean('isCondensed', false)}>
                 <Text.Detail>{`tone="${tone}"`}</Text.Detail>
               </Stamp>
             </SpacingsInline>

--- a/packages/components/stamp/src/stamp.visualroute.js
+++ b/packages/components/stamp/src/stamp.visualroute.js
@@ -24,5 +24,10 @@ export const component = () => (
     <Spec label="when secondary">
       <Stamp tone="secondary">Secondary</Stamp>
     </Spec>
+    <Spec label="when condensed">
+      <Stamp tone="information" isCondensed={true}>
+        Secondary
+      </Stamp>
+    </Spec>
   </Suite>
 );


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Currently, the stamp component has too much padding for some use-cases, the smaller version is important for use-cases that need the stamps after the text. With the small padding from the top and bottom, the stamp will be highlighted but not too much.

![image](https://user-images.githubusercontent.com/7680511/97276059-002ab980-1837-11eb-8c55-7845501675a4.png)
