### PR TITLE
fix(data-table-manager): adjust size of settings selector

### DIFF
--- a/.changeset/quick-walls-rescue.md
+++ b/.changeset/quick-walls-rescue.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table-manager': patch
+---
+
+Adjust size of settings selector

--- a/packages/components/data-table-manager/src/data-table-settings/data-table-settings.js
+++ b/packages/components/data-table-manager/src/data-table-settings/data-table-settings.js
@@ -110,6 +110,7 @@ const DataTableSettings = (props) => {
               onChange={handleDropdownChange}
               options={dropdownOptions}
               iconLeft={<TableIcon />}
+              horizontalConstraint={4}
             />
           </SelectContainer>
         )}


### PR DESCRIPTION
Sets a horizontal constraint on the DataTableManager settings selector.

A UI/UX team request.