### PR TITLE
fix: prepare tsconfig.json for TS migration

### DIFF
--- a/generators/package-json/bin/generate_package_json.sh
+++ b/generators/package-json/bin/generate_package_json.sh
@@ -12,4 +12,4 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 # Execute the script using the `ts-node` CLI.
-npx ts-node "$DIR/generate-package-json.ts" "$@"
+npx ts-node --compiler-options '{"module": "commonjs"}' "$DIR/generate-package-json.ts" "$@"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,16 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "commonjs",
-    "lib": ["DOM", "ES2020"],
-    "declaration": true,
-    "baseUrl": ".",
-    "outDir": "lib",
-    "rootDir": ".",
-    "strict": true,
+    "allowSyntheticDefaultImports": true,
+    "emitDecoratorMetadata": false,
+    "experimentalDecorators": false,
     "esModuleInterop": true,
     "importHelpers": true,
+    // See https://devblogs.microsoft.com/typescript/typescript-and-babel-7/
+    "isolatedModules": true,
+    "jsx": "react",
+    "lib": ["ESNext", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Node",
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
@@ -21,9 +22,15 @@
     "pretty": true,
     "removeComments": true,
     "sourceMap": true,
+    "strict": true,
     "strictNullChecks": true,
     "stripInternal": true,
+    "target": "ES2019",
     "allowJs": false,
-    "typeRoots": ["@types", "node_modules/@types"]
+    "typeRoots": [
+      "@types",
+      // "@types-extensions",
+      "node_modules/@types"
+    ]
   }
 }


### PR DESCRIPTION
Using the same `tsconfig.json` as in appkit.

In preparation for #1669 