### PR TITLE
fix(ci): to have semantic commit for changesets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,7 @@ jobs:
         id: changesets
         uses: changesets/action@master
         with:
+          commit: 'ci(changesets): version packages'
           publish: yarn changeset publish
           version: yarn changeset:version-and-format
         env:


### PR DESCRIPTION
#### Summary

Recently I noticed that changesets do not perform a semantic commit. This is not too bad but when updating to Husky v5 the releases failed. To avoid running into this eventually I propose to be proactive and have a semantic commit for the release.