### PR TITLE
chore(renovate): preserve semver ranges

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,19 +1,10 @@
 {
-  "extends": [
-    "config:base",
-    ":pinOnlyDevDependencies",
-    "schedule:weekly"
-  ],
+  "extends": ["config:base", ":preserveSemverRanges", "schedule:weekly"],
   "separateMajorMinor": true,
   "packageRules": [
     {
-      "packagePatterns": [
-        "*"
-      ],
-      "updateTypes": [
-        "minor",
-        "patch"
-      ],
+      "packagePatterns": ["*"],
+      "updateTypes": ["minor", "patch"],
       "groupName": "all dependencies",
       "groupSlug": "all"
     }
@@ -21,9 +12,7 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "labels": [
-    "🤖 Type: Dependencies"
-  ],
+  "labels": ["🤖 Type: Dependencies"],
   "ignoreDeps": [
     "@svgr/plugin-svgo",
     "@storybook/addon-a11y",


### PR DESCRIPTION
* Moves renovate config into `.github` folder
* Uses `preserveSemverRanges` instead of `pinOnlyDevDependencies`