### PR TITLE
fix(spacings): be explicit in typing Spacings object

### DIFF
--- a/.changeset/tidy-mails-reflect.md
+++ b/.changeset/tidy-mails-reflect.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/spacings': patch
+---
+
+Be explicit in typing `Spacings` object as otherwise inferred type declarations are not generated correctly.

--- a/presets/spacings/src/index.ts
+++ b/presets/spacings/src/index.ts
@@ -3,4 +3,12 @@ import Inset from '@commercetools-uikit/spacings-inset';
 import InsetSquish from '@commercetools-uikit/spacings-inset-squish';
 import Stack from '@commercetools-uikit/spacings-stack';
 
-export default { Inline, Inset, InsetSquish, Stack };
+type TSpacings = {
+  Inline: typeof Inline;
+  Inset: typeof Inset;
+  InsetSquish: typeof InsetSquish;
+  Stack: typeof Stack;
+};
+const Spacings: TSpacings = { Inline, Inset, InsetSquish, Stack };
+
+export default Spacings;


### PR DESCRIPTION
Follow up of #1742 

Letting TS inferring the exported type somehow leads to weird imports such as `import("@commercetools-uikit/spacings-inline/src/inline")`, whichis an invalid path.