### PR TITLE
chore: update changeset to 2.14.1, which includes the publishing concurrency fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@changesets/changelog-github": "0.2.8",
-    "@changesets/cli": "2.14.0",
+    "@changesets/cli": "2.14.1",
     "@commercetools-frontend/babel-preset-mc-app": "18.1.0",
     "@commercetools-frontend/eslint-config-mc-app": "18.1.4",
     "@commercetools/github-labels": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1018,10 +1018,10 @@
     "@changesets/types" "^3.0.0"
     dotenv "^8.1.0"
 
-"@changesets/cli@2.14.0":
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/@changesets/cli/-/cli-2.14.0.tgz#b8d1d33d832c640ce0b95333bbd8d5ac5b9c9824"
-  integrity sha512-rbQMRDXl1cXOglnjUvYyrFLlYBbS0YZdfxZfW3ZbGLzLoS4n50+B9fLSE9oW20hQuL3zAnyLyacb9cwNhF2lig==
+"@changesets/cli@2.14.1":
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/@changesets/cli/-/cli-2.14.1.tgz#ef6ba9f69e4dd5f6cde4220e032200e3039a52f8"
+  integrity sha512-ydU2ZUP/s7nHQmz8TrliT+kE2dJUpZYKh8MBHrkV6suchCBhT4DmoP4VDF9M4215r18iPbMpE1TjskzXGXB8eQ==
   dependencies:
     "@babel/runtime" "^7.10.4"
     "@changesets/apply-release-plan" "^4.2.0"


### PR DESCRIPTION
The [concurrency fix](https://github.com/atlassian/changesets/releases/tag/%40changesets%2Fcli%402.14.1) has been merged and released.