### PR TITLE
chore(docs): add prism@1.23.0 as peer

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -27,5 +27,11 @@
     "storybook-readme": "5.0.9",
     "yaml": "1.10.0",
     "yaml-loader": "0.6.0"
+  },
+  "devDependencies": {
+    "prismjs": "1.23.0"
+  },
+  "peerDependencies": {
+    "prismjs": "1.23.0"
   }
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -6849,7 +6849,7 @@ prism-themes@^1.1.0:
   resolved "https://registry.yarnpkg.com/prism-themes/-/prism-themes-1.5.0.tgz#92925e4aa0ab5e0afefcea1032df7d61bbcdc1a5"
   integrity sha512-aqKD610WNYO90MVXm0xM8P1pX5jPHyTjbAefV0TtWFLZk7eNWnGqLGx+HH6Xxlf9hiC66VjBeCP7m3P72FS+ZQ==
 
-prismjs@^1.16.0, prismjs@^1.8.4:
+prismjs@1.23.0, prismjs@^1.16.0, prismjs@^1.8.4:
   version "1.23.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.23.0.tgz#d3b3967f7d72440690497652a9d40ff046067f33"
   integrity sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==


### PR DESCRIPTION
#### Summary

I'm not sure if this helps, but I got this notification
![image](https://user-images.githubusercontent.com/462507/109811446-21f3dd00-7c2b-11eb-99e4-f39d9bcb80f0.png)


so I added `prism@v1.23.0` as peer/dev dependency to docs
inspecting the version after installation, it looks like it's in place

![image](https://user-images.githubusercontent.com/462507/109811565-4d76c780-7c2b-11eb-86fd-d87d348fad3c.png)
