### PR TITLE
feat: to add a `primary` and `inverted` tone to the `link` component

### DIFF
--- a/.changeset/tall-ladybugs-tan.md
+++ b/.changeset/tall-ladybugs-tan.md
@@ -2,4 +2,4 @@
 "@commercetools-uikit/link": minor
 ---
 
-Adds a `tone` property to the `link` component supporting a `primary` and `inverted` tone
+Adds a `tone` property to the `<Link>` component. Supported values are `primary` (the default) and `inverted`.

--- a/.changeset/tall-ladybugs-tan.md
+++ b/.changeset/tall-ladybugs-tan.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-uikit/link": minor
+---
+
+Adds a `tone` property to the `link` component supporting a `primary` and `inverted` tone

--- a/packages/components/link/README.md
+++ b/packages/components/link/README.md
@@ -20,13 +20,14 @@ import Link from '@commercetools-uikit/link';
 
 ## Properties
 
-| Props          | Type                                                              | Required | Values | Default | Description                                                                 |
-| -------------- | ----------------------------------------------------------------- | :------: | ------ | ------- | --------------------------------------------------------------------------- |
-| `to`           | `string` or `{ pathname: String, search: String, query: Object }` |    ✅    | -      | -       | The URL that the Link should point to                                       |
-| `children`     | `node`                                                            | ✅ (\*)  | -      | -       | Value of the link                                                           |
-| `intlMessage`  | `intl message`                                                    | ✅ (\*)  | -      | -       | An intl message object that will be rendered with `FormattedMessage`        |
-| `isExternal`   | `boolean`                                                         |    -     | -      | false   | If true, a regular <a> is rendered instead of the default React Router Link |
-| `hasUnderline` | `boolean`                                                         |    -     | -      | true    | Either sets text-decoration to none or to underline                         |
+| Props          | Type                                                              | Required | Values                | Default   | Description                                                                 |
+| -------------- | ----------------------------------------------------------------- | :------: | --------------------- | --------- | --------------------------------------------------------------------------- |
+| `to`           | `string` or `{ pathname: String, search: String, query: Object }` |    ✅    | -                     | -         | The URL that the Link should point to                                       |
+| `children`     | `node`                                                            | ✅ (\*)  | -                     | -         | Value of the link                                                           |
+| `intlMessage`  | `intl message`                                                    | ✅ (\*)  | -                     | -         | An intl message object that will be rendered with `FormattedMessage`        |
+| `isExternal`   | `boolean`                                                         |    -     | -                     | false     | If true, a regular <a> is rendered instead of the default React Router Link |
+| `hasUnderline` | `boolean`                                                         |    -     | -                     | true      | Either sets text-decoration to none or to underline                         |
+| `tone`         | `oneOf`                                                           |    -     | `primary`, `inverted` | `primary` | Color of the link                                                           |
 
 > `*`: `children` is required only if `intlMessage` is not provided, and vice-versa
 

--- a/packages/components/link/src/link.js
+++ b/packages/components/link/src/link.js
@@ -7,6 +7,21 @@ import { FormattedMessage } from 'react-intl';
 import { customProperties as vars } from '@commercetools-uikit/design-system';
 import { filterInvalidAttributes } from '@commercetools-uikit/utils';
 
+const getColorValue = (tone, overwrittenVars) => {
+  if (tone === 'primary') {
+    return overwrittenVars.colorPrimary;
+  }
+
+  return overwrittenVars.fontColorForTextWhenInverted;
+};
+const getActiveColorValue = (tone, overwrittenVars) => {
+  if (tone === 'primary') {
+    return overwrittenVars.colorPrimary25;
+  }
+
+  return overwrittenVars.fontColorForTextWhenInverted;
+};
+
 const getLinkStyles = (props, theme) => {
   const overwrittenVars = {
     ...vars,
@@ -15,14 +30,14 @@ const getLinkStyles = (props, theme) => {
 
   return css`
     font-family: inherit;
-    color: ${overwrittenVars.colorPrimary};
+    color: ${getColorValue(props.tone, overwrittenVars)};
     font-size: ${overwrittenVars.fontSizeDefault};
     text-decoration: ${props.hasUnderline ? 'underline' : 'none'};
 
     &:hover,
     &:focus,
     &:active {
-      color: ${overwrittenVars.colorPrimary25};
+      color: ${getActiveColorValue(props.tone, overwrittenVars)};
     }
   `;
 };
@@ -66,6 +81,7 @@ const Link = (props) => {
 Link.displayName = 'Link';
 
 Link.propTypes = {
+  tone: PropTypes.oneOf(['primary', 'inverted']),
   hasUnderline: PropTypes.bool.isRequired,
   isExternal: PropTypes.bool.isRequired,
   to: requiredIf(
@@ -92,6 +108,7 @@ Link.propTypes = {
 };
 
 Link.defaultProps = {
+  tone: 'primary',
   hasUnderline: true,
   isExternal: false,
 };

--- a/packages/components/link/src/link.spec.js
+++ b/packages/components/link/src/link.spec.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { customProperties as vars } from '@commercetools-uikit/design-system';
 import { screen, render } from '../../../../test/test-utils';
 import Link from './link';
 

--- a/packages/components/link/src/link.spec.js
+++ b/packages/components/link/src/link.spec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { customProperties as vars } from '@commercetools-uikit/design-system';
 import { screen, render } from '../../../../test/test-utils';
 import Link from './link';
 

--- a/packages/components/link/src/link.story.js
+++ b/packages/components/link/src/link.story.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text, boolean } from '@storybook/addon-knobs/react';
+import { withKnobs, text, boolean, select } from '@storybook/addon-knobs/react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import Section from '../../../../docs/.storybook/decorators/section';
 import Readme from '../README.md';
@@ -18,6 +18,7 @@ storiesOf('Components|Links', module)
     <Router>
       <Section>
         <Link
+          tone={select('Tone', ['primary', 'inverted'])}
           to={text('to', '/foo/bar')}
           hasUnderline={boolean('hasUnderline', true)}
           isExternal={boolean('isExternal', false)}

--- a/packages/components/link/src/link.visualroute.js
+++ b/packages/components/link/src/link.visualroute.js
@@ -35,5 +35,8 @@ export const component = () => (
     <Spec label="intlMessage">
       <Link to="/" intlMessage={intlMessage} />
     </Spec>
+    <Spec label="white">
+      <Link to="/" tone={'inverted'} />
+    </Spec>
   </Suite>
 );

--- a/packages/components/link/src/link.visualroute.js
+++ b/packages/components/link/src/link.visualroute.js
@@ -12,7 +12,7 @@ const purpleTheme = {
   colorPrimary25: 'deeppurple',
 };
 
-export const component = () => (
+export const component = ({ themes }) => (
   <Suite>
     <Spec label="regular">
       <Link to="/">A label text</Link>
@@ -35,8 +35,17 @@ export const component = () => (
     <Spec label="intlMessage">
       <Link to="/" intlMessage={intlMessage} />
     </Spec>
-    <Spec label="white">
-      <Link to="/" tone={'inverted'} />
-    </Spec>
+    <ThemeProvider theme={themes.darkTheme}>
+      <Spec label="tone - inverted - with underline">
+        <Link to="/" tone="inverted">
+          An inverted label text
+        </Link>
+      </Spec>
+      <Spec label="tone - inverted - without underline">
+        <Link to="/" hasUnderline={false} tone="inverted">
+          An inverted label text
+        </Link>
+      </Spec>
+    </ThemeProvider>
   </Suite>
 );


### PR DESCRIPTION

#### Summary

This PR adds `isWhite` prop to the `Link` component

## Description
Right now we can use the Link component only in one color which in some cases doesn't fit to background color: 
![link](https://user-images.githubusercontent.com/22819128/109945611-b74cab00-7cd7-11eb-8a71-a53ec25283f6.png)
This PR adds possibility to make the link white which is supposed to cover all the cases when primary color is not visible enough.

