### PR TITLE
refactor(text): remove deprecated props

### DIFF
--- a/.changeset/smooth-spoons-walk.md
+++ b/.changeset/smooth-spoons-walk.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/text': major
+---
+
+refactor(text): remove deprecated isInline and elementType props

--- a/packages/components/text/README.md
+++ b/packages/components/text/README.md
@@ -18,14 +18,13 @@ import Text from '@commercetools-uikit/text';
 
 ### Properties
 
-| Props         | Type             | Required | Values               | Default | Description                                                          |
-| ------------- | ---------------- | :------: | -------------------- | ------- | -------------------------------------------------------------------- |
-| `as`          | `String`         |    ✅    | `['h1', 'h2', 'h3']` | -       | -                                                                    |
-| `children`    | `PropTypes.node` | ✅ (\*)  | -                    | -       | -                                                                    |
-| `intlMessage` | `intl message`   | ✅ (\*)  | -                    | -       | An intl message object that will be rendered with `FormattedMessage` |
-| `title`       | `String`         |    -     | -                    | -       | Text to show in a tooltip on hover over the element                  |
-| `truncate`    | `Bool`           |    -     | -                    | `false` | Option for truncate content in case the screen has small width       |
-| `elementType` | `String`         |    -     | `['h1', 'h2', 'h3']` | -       | ⚠️ Deprecated                                                        |
+| Props         | Type             | Required | Values               | Default | Description                                                            |
+| ------------- | ---------------- | :------: | -------------------- | ------- | ---------------------------------------------------------------------- |
+| `as`          | `String`         |    ✅    | `['h1', 'h2', 'h3']` | -       | -                                                                      |
+| `children`    | `PropTypes.node` | ✅ (\*)  | -                    | -       | -                                                                      |
+| `intlMessage` | `intl message`   | ✅ (\*)  | -                    | -       | An `intl` message object that will be rendered with `FormattedMessage` |
+| `title`       | `String`         |    -     | -                    | -       | Text to show in a tooltip on hover over the element                    |
+| `truncate`    | `Bool`           |    -     | -                    | `false` | Option for truncate content in case the screen has small width         |
 
 > `*`: `children` is required only if `intlMessage` is not provided
 
@@ -44,21 +43,20 @@ Wraps the given text in the given HTML header `size`.
 ```js
 import Text from '@commercetools-uikit/text';
 
-<Text.Subheadline elementType="h4">{'The subtitle'}</Text.Subheadline>;
+<Text.Subheadline as="h4">{'The subtitle'}</Text.Subheadline>;
 ```
 
 ### Properties
 
 | Props         | Type             | Required | Values                                                            | Default |
-| ------------- | ---------------- | :------: | ----------------------------------------------------------------- | ------- |
+| ------------- | ---------------- | :------: | ----------------------------------------------------------------- | ------- | ---------------------------------------------------------------------- |
 | `as`          | `String`         |    ✅    | `['h4', 'h5']`                                                    | -       |
 | `isBold`      | `Boolean`        |    -     | -                                                                 | `false` |
 | `tone`        | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative']` | -       |
 | `children`    | `PropTypes.node` | ✅ (\*)  | -                                                                 | -       |
-| `intlMessage` | `intl message`   | ✅ (\*)  | -                                                                 | -       | An intl message object that will be rendered with `FormattedMessage` |
+| `intlMessage` | `intl message`   | ✅ (\*)  | -                                                                 | -       | An `intl` message object that will be rendered with `FormattedMessage` |
 | `title`       | `String`         |    -     | -                                                                 | -       |
 | `truncate`    | `Bool`           |    -     | -                                                                 | `false` |
-| `elementType` | `String`         |    -     | `['h4', 'h5']`                                                    | -       | ⚠️ Deprecated |
 
 > `*`: `children` is required only if `intlMessage` is not provided
 
@@ -99,16 +97,15 @@ import Text from '@commercetools-uikit/text';
 ### Properties
 
 | Props         | Type             | Required | Values                                                                        | Default |
-| ------------- | ---------------- | :------: | ----------------------------------------------------------------------------- | ------- |
+| ------------- | ---------------- | :------: | ----------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------- |
 | `as`          | `String`         |    -     | `['p', 'span']`                                                               | -       |
 | `isBold`      | `Boolean`        |    -     | -                                                                             | `false` |
 | `isItalic`    | `Boolean`        |    -     | -                                                                             | `false` |
 | `tone`        | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative', 'inverted']` | -       |
 | `children`    | `PropTypes.node` | ✅ (\*)  | -                                                                             | -       |
-| `intlMessage` | `intl message`   | ✅ (\*)  | -                                                                             | -       | An intl message object that will be rendered with `FormattedMessage` |
+| `intlMessage` | `intl message`   | ✅ (\*)  | -                                                                             | -       | An `intl` message object that will be rendered with `FormattedMessage` |
 | `title`       | `String`         |    -     | -                                                                             | -       |
 | `truncate`    | `Bool`           |    -     | -                                                                             | `false` |
-| `isInline`    | `Bool`           |    -     | -                                                                             | `false` | ⚠️ Deprecated |
 
 > `*`: `children` is required only if `intlMessage` is not provided
 
@@ -135,15 +132,14 @@ import Text from '@commercetools-uikit/text';
 ### Properties
 
 | Props         | Type             | Required | Values                                                                        | Default |
-| ------------- | ---------------- | :------: | ----------------------------------------------------------------------------- | ------- |
+| ------------- | ---------------- | :------: | ----------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------- |
 | `isBold`      | `Boolean`        |    -     | -                                                                             | `false` |
 | `isItalic`    | `Boolean`        |    -     | -                                                                             | `false` |
 | `tone`        | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative', 'warning'']` | -       |
 | `children`    | `PropTypes.node` | ✅ (\*)  | -                                                                             | -       |
-| `intlMessage` | `intl message`   | ✅ (\*)  | -                                                                             | -       | An intl message object that will be rendered with `FormattedMessage` |
+| `intlMessage` | `intl message`   | ✅ (\*)  | -                                                                             | -       | An `intl` message object that will be rendered with `FormattedMessage` |
 | `title`       | `String`         |    -     | -                                                                             | -       |
 | `truncate`    | `Bool`           |    -     | -                                                                             | `false` |
-| `isInline`    | `Bool`           |    -     | -                                                                             | `false` |
 
 > `*`: `children` is required only if `intlMessage` is not provided
 

--- a/packages/components/text/src/text.styles.ts
+++ b/packages/components/text/src/text.styles.ts
@@ -34,10 +34,6 @@ const italic = `
   font-style: italic;
 `;
 
-const inline = `
-  display: inline-block;
-`;
-
 const getTone = (tone: string, theme: Theme) => {
   const overwrittenVars = {
     ...vars,
@@ -93,7 +89,7 @@ export const bodyStyles = (props: TBodyProps, theme: Theme) => css`
 export const headlineStyles = (props: THeadlineProps, theme: Theme) => css`
   ${getBaseStyles(theme)}
   margin: 0;
-  font-size: ${getElementFontSize(props.as || props.elementType)};
+  font-size: ${getElementFontSize(props.as)};
   font-weight: 300;
   ${props.truncate && truncate}
 `;
@@ -104,7 +100,7 @@ export const subheadlineStyles = (
 ) => css`
   ${getBaseStyles(theme)}
   margin: 0;
-  font-size: ${getElementFontSize(props.as || props.elementType)};
+  font-size: ${getElementFontSize(props.as)};
   font-weight: normal;
   ${props.truncate && truncate}
   ${props.isBold && bold}
@@ -121,7 +117,6 @@ export const detailStyles = (props: TDetailProps, theme: Theme) => css`
   ${getBaseStyles(theme)}
   display: block;
   font-size: 0.9231rem;
-  ${props.isInline && inline}
   ${props.isBold && bold}
   ${props.isItalic && italic}
   ${props.tone && getTone(props.tone, theme)}

--- a/packages/components/text/src/text.tsx
+++ b/packages/components/text/src/text.tsx
@@ -3,11 +3,7 @@ import type { MessageDescriptor } from 'react-intl';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useTheme } from '@emotion/react';
-import {
-  filterDataAttributes,
-  warnDeprecatedProp,
-  warning,
-} from '@commercetools-uikit/utils';
+import { filterDataAttributes, warning } from '@commercetools-uikit/utils';
 import {
   bodyStyles,
   detailStyles,
@@ -75,8 +71,6 @@ Text.displayName = 'Text';
 
 export type THeadlineProps = {
   as?: 'h1' | 'h2' | 'h3';
-  // @deprecated: use `as` instead
-  elementType?: 'h1' | 'h2' | 'h3';
   truncate?: boolean;
 } & TBasicTextProps &
   TBasicHeadlineProps;
@@ -84,23 +78,10 @@ export type THeadlineProps = {
 const Headline = (props: THeadlineProps) => {
   const theme = useTheme();
 
-  if (props.elementType) {
-    warnDeprecatedProp(
-      'elementType',
-      'TextHeadline',
-      `\n \`elementType\` is deprecated. \n Please use "as" prop instead.`
-    );
-  }
-
   warnIfMissingTitle(props, 'TextHeadline');
   warnIfMissingContent(props, 'TextHeadline');
 
-  // For backwards compatibility
-  // we allow both `as` and `elementType` to be optional.
-  const HeadlineElement = props.as || props.elementType;
-
-  // however, if none of the prop is specified,
-  // we render plain text and set a warning on the log.
+  const HeadlineElement = props.as;
   if (!HeadlineElement) {
     warning(
       false,
@@ -122,8 +103,6 @@ Headline.displayName = 'TextHeadline';
 
 export type TSubheadlineProps = {
   as?: 'h4' | 'h5';
-  // @deprecated: use `as` instead
-  elementType?: 'h4' | 'h5';
   truncate?: boolean;
   isBold?: boolean;
   tone?: 'primary' | 'secondary' | 'information' | 'positive' | 'negative';
@@ -133,17 +112,10 @@ export type TSubheadlineProps = {
 const Subheadline = (props: TSubheadlineProps) => {
   const theme = useTheme();
 
-  if (props.elementType) {
-    warnDeprecatedProp(
-      'elementType',
-      'TextSubheadline',
-      `\n \`elementType\` is deprecated. \n Please use "as" prop instead.`
-    );
-  }
   warnIfMissingTitle(props, 'TextSubheadline');
   warnIfMissingContent(props, 'TextSubheadline');
 
-  const SubheadlineElement = props.as || props.elementType;
+  const SubheadlineElement = props.as;
   if (!SubheadlineElement) {
     warning(
       false,
@@ -151,6 +123,7 @@ const Subheadline = (props: TSubheadlineProps) => {
     );
     return <Text intlMessage={props.intlMessage}>{props.children}</Text>;
   }
+
   return (
     <SubheadlineElement
       title={props.title}
@@ -185,8 +158,6 @@ export type TBodyProps = {
   as?: 'span' | 'p';
   isBold?: boolean;
   isItalic?: boolean;
-  // @deprecated: use `as="span"` instead
-  isInline?: boolean;
   tone?:
     | 'primary'
     | 'secondary'
@@ -204,14 +175,6 @@ const Body = (props: TBodyProps) => {
   warnIfMissingTitle(props, 'TextBody');
   warnIfMissingContent(props, 'TextBody');
 
-  if (props.isInline) {
-    warnDeprecatedProp(
-      'isInline',
-      'TextSubheadline',
-      `\n \`isInline\` is deprecated. \n Please use "as" prop instead.`
-    );
-  }
-
   if (props.as) {
     const BodyElement = props.as;
     return (
@@ -225,15 +188,7 @@ const Body = (props: TBodyProps) => {
     );
   }
 
-  return props.isInline ? (
-    <span
-      css={bodyStyles(props, theme)}
-      title={props.title}
-      {...filterDataAttributes(props)}
-    >
-      <Text intlMessage={props.intlMessage}>{props.children}</Text>
-    </span>
-  ) : (
+  return (
     <p
       css={bodyStyles(props, theme)}
       title={props.title}
@@ -248,8 +203,6 @@ Body.displayName = 'TextBody';
 export type TDetailProps = {
   isBold?: boolean;
   isItalic?: boolean;
-  // used for styling via `detailStyles`
-  isInline?: boolean;
   tone?:
     | 'primary'
     | 'secondary'


### PR DESCRIPTION
#### Summary

- removes `isInline`
- removes `elementType`
- targets `v12` branch.

ref: #1737 


it's time to start the breaking changes IMO, but to ease the flow of introducing other changes in parallel without blocking release, we take a strangling approach and target an intermediate branch