### PR TITLE
docs(rich-text): remove beta

### DIFF
--- a/.changeset/eleven-meals-remain.md
+++ b/.changeset/eleven-meals-remain.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-uikit/localized-rich-text-input': patch
+'@commercetools-uikit/rich-text-input': patch
+---
+
+set rich-text out of beta

--- a/packages/components/inputs/localized-rich-text-input/README.md
+++ b/packages/components/inputs/localized-rich-text-input/README.md
@@ -1,11 +1,5 @@
 # LocalizedRichTextInput
 
-### THIS COMPONENT IS IN BETA!
-
-Please be aware that this component may be subject to upcoming breaking changes as it's still in active development.
-
----
-
 ## Description
 
 A controlled text input component for localized rich text input with validation

--- a/packages/components/inputs/rich-text-input/README.md
+++ b/packages/components/inputs/rich-text-input/README.md
@@ -1,11 +1,5 @@
 # RichTextInput
 
-### THIS COMPONENT IS IN BETA!
-
-Please be aware that this component may be subject to upcoming breaking changes as it's still in active development.
-
----
-
 ## Description
 
 A controlled rich text input component for rich text with validation


### PR DESCRIPTION
#### Summary

- removes `beta` flag from rich text #1737 
