### PR TITLE
refactor(link): remove `hasUnderline`

### DIFF
--- a/.changeset/two-months-obey.md
+++ b/.changeset/two-months-obey.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/link': major
+---
+
+refactor(link): remove `hasUnderline` prop

--- a/packages/components/link/README.md
+++ b/packages/components/link/README.md
@@ -20,14 +20,13 @@ import Link from '@commercetools-uikit/link';
 
 ## Properties
 
-| Props          | Type                                                              | Required | Values                | Default   | Description                                                                 |
-| -------------- | ----------------------------------------------------------------- | :------: | --------------------- | --------- | --------------------------------------------------------------------------- |
-| `to`           | `string` or `{ pathname: String, search: String, query: Object }` |    ✅    | -                     | -         | The URL that the Link should point to                                       |
-| `children`     | `node`                                                            | ✅ (\*)  | -                     | -         | Value of the link                                                           |
-| `intlMessage`  | `intl message`                                                    | ✅ (\*)  | -                     | -         | An intl message object that will be rendered with `FormattedMessage`        |
-| `isExternal`   | `boolean`                                                         |    -     | -                     | false     | If true, a regular <a> is rendered instead of the default React Router Link |
-| `hasUnderline` | `boolean`                                                         |    -     | -                     | true      | Either sets text-decoration to none or to underline                         |
-| `tone`         | `oneOf`                                                           |    -     | `primary`, `inverted` | `primary` | Color of the link                                                           |
+| Props         | Type                                                              | Required | Values                | Default   | Description                                                                 |
+| ------------- | ----------------------------------------------------------------- | :------: | --------------------- | --------- | --------------------------------------------------------------------------- |
+| `to`          | `string` or `{ pathname: String, search: String, query: Object }` |    ✅    | -                     | -         | The URL that the Link should point to                                       |
+| `children`    | `node`                                                            | ✅ (\*)  | -                     | -         | Value of the link                                                           |
+| `intlMessage` | `intl message`                                                    | ✅ (\*)  | -                     | -         | An intl message object that will be rendered with `FormattedMessage`        |
+| `isExternal`  | `boolean`                                                         |    -     | -                     | false     | If true, a regular <a> is rendered instead of the default React Router Link |
+| `tone`        | `oneOf`                                                           |    -     | `primary`, `inverted` | `primary` | Color of the link                                                           |
 
 > `*`: `children` is required only if `intlMessage` is not provided, and vice-versa
 

--- a/packages/components/link/src/link.js
+++ b/packages/components/link/src/link.js
@@ -32,7 +32,7 @@ const getLinkStyles = (props, theme) => {
     font-family: inherit;
     color: ${getColorValue(props.tone, overwrittenVars)};
     font-size: ${overwrittenVars.fontSizeDefault};
-    text-decoration: ${props.hasUnderline ? 'underline' : 'none'};
+    text-decoration: 'underline';
 
     &:hover,
     &:focus,
@@ -82,7 +82,6 @@ Link.displayName = 'Link';
 
 Link.propTypes = {
   tone: PropTypes.oneOf(['primary', 'inverted']),
-  hasUnderline: PropTypes.bool.isRequired,
   isExternal: PropTypes.bool.isRequired,
   to: requiredIf(
     PropTypes.oneOfType([
@@ -109,7 +108,6 @@ Link.propTypes = {
 
 Link.defaultProps = {
   tone: 'primary',
-  hasUnderline: true,
   isExternal: false,
 };
 

--- a/packages/components/link/src/link.story.js
+++ b/packages/components/link/src/link.story.js
@@ -20,7 +20,6 @@ storiesOf('Components|Links', module)
         <Link
           tone={select('Tone', ['primary', 'inverted'])}
           to={text('to', '/foo/bar')}
-          hasUnderline={boolean('hasUnderline', true)}
           isExternal={boolean('isExternal', false)}
         >
           {text('label', 'Accessibility text')}


### PR DESCRIPTION
#### Summary

- removes `hasUnderline`. 
- link is underlined by default

ref #1737 