### PR TITLE
refactor(page-navigator): use formik state

### DIFF
--- a/.changeset/unlucky-mirrors-argue.md
+++ b/.changeset/unlucky-mirrors-argue.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/pagination': minor
+---
+
+refactor page-navigator to not use internal state

--- a/.changeset/unlucky-mirrors-argue.md
+++ b/.changeset/unlucky-mirrors-argue.md
@@ -1,5 +1,5 @@
 ---
-'@commercetools-uikit/pagination': minor
+'@commercetools-uikit/pagination': patch
 ---
 
-refactor page-navigator to not use internal state
+Fix issue with `Pagination` where programmatic changes to the `page` prop are not reflected into the component internal state.

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "cross-env": "7.0.3",
     "eslint": "7.22.0",
     "eslint-formatter-pretty": "4.0.0",
-    "formik": "2.2.6",
+    "formik": "^2.2.6",
     "glob": "7.1.6",
     "global": "4.4.0",
     "history": "5.0.0",

--- a/packages/components/data-table-manager/package.json
+++ b/packages/components/data-table-manager/package.json
@@ -53,7 +53,7 @@
     "react-required-if": "1.0.3"
   },
   "devDependencies": {
-    "formik": "2.2.6",
+    "formik": "^2.2.6",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-intl": "5.13.2"

--- a/packages/components/data-table/package.json
+++ b/packages/components/data-table/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@testing-library/react-hooks": "5.1.0",
-    "formik": "2.2.6",
+    "formik": "^2.2.6",
     "react": "17.0.1"
   },
   "peerDependencies": {

--- a/packages/components/pagination/package.json
+++ b/packages/components/pagination/package.json
@@ -37,6 +37,7 @@
     "@commercetools-uikit/utils": "11.2.1",
     "@emotion/react": "^11.1.1",
     "@emotion/styled": "^11.0.0",
+    "formik": "2.2.6",
     "lodash": "4.17.20",
     "prop-types": "15.7.2"
   },

--- a/packages/components/pagination/package.json
+++ b/packages/components/pagination/package.json
@@ -37,7 +37,7 @@
     "@commercetools-uikit/utils": "11.2.1",
     "@emotion/react": "^11.1.1",
     "@emotion/styled": "^11.0.0",
-    "formik": "2.2.6",
+    "formik": "^2.2.6",
     "lodash": "4.17.20",
     "prop-types": "15.7.2"
   },

--- a/packages/components/pagination/src/pagination.spec.js
+++ b/packages/components/pagination/src/pagination.spec.js
@@ -53,24 +53,26 @@ it('should display the correct number of items displayed', () => {
 });
 
 describe('page navigator interaction', () => {
-  it('should increment page number on clicking the Next page button', () => {
-    const onPageChange = jest.fn();
+  it('should increment page number on clicking the Next page button', async () => {
+    const onPageChange = jest.fn().mockName('onPageChange');
     render(
       <Pagination
         {...createTestProps({
           onPageChange,
+          page: 1,
         })}
       />
     );
 
-    const nextPageButton = screen.getByLabelText(/Next page/);
+    const nextPageButton = await screen.findByLabelText(/Next page/);
     nextPageButton.click();
 
+    await screen.findByLabelText('Page');
     expect(onPageChange).toHaveBeenCalledWith(2);
-    expect(screen.getByLabelText('Page')).toHaveDisplayValue(2);
+    expect(await screen.findByLabelText('Page')).toHaveDisplayValue(2);
   });
-  it('should decrement page number on clicking the Previous page button', () => {
-    const onPageChange = jest.fn();
+  it('should decrement page number on clicking the Previous page button', async () => {
+    const onPageChange = jest.fn().mockName('onPageChange');
     render(
       <Pagination
         {...createTestProps({
@@ -80,11 +82,12 @@ describe('page navigator interaction', () => {
       />
     );
 
-    const prevPageButton = screen.getByLabelText(/Previous page/);
+    const prevPageButton = await screen.findByLabelText(/Previous page/);
     prevPageButton.click();
 
+    await screen.findByLabelText('Page');
     expect(onPageChange).toHaveBeenCalledWith(1);
-    expect(screen.getByLabelText('Page')).toHaveDisplayValue(1);
+    expect(await screen.findByLabelText('Page')).toHaveDisplayValue(1);
   });
   it('should disable next page button when there are no next pages', () => {
     render(

--- a/packages/components/pagination/src/pagination.spec.js
+++ b/packages/components/pagination/src/pagination.spec.js
@@ -111,7 +111,7 @@ describe('page navigator interaction', () => {
 });
 
 describe('per page selector interaction', () => {
-  it('should call onPerPageChange with the selected value', async () => {
+  it('should call onPerPageChange with the selected value', () => {
     const onPerPageChange = jest.fn();
     render(<Pagination {...createTestProps({ onPerPageChange })} />);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2754,7 +2754,7 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@testing-library/dom@7.30.0", "@testing-library/dom@^7.22.2", "@testing-library/dom@^7.28.1":
+"@testing-library/dom@^7.22.2", "@testing-library/dom@^7.28.1":
   version "7.30.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.30.0.tgz#53697851f7708a1448cc30b74a2ea056dd709cd6"
   integrity sha512-v4GzWtltaiDE0yRikLlcLAfEiiK8+ptu6OuuIebm9GdC2XlZTNDPGEfM2UkEtnH7hr9TRq2sivT5EA9P1Oy7bw==
@@ -5123,7 +5123,7 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-js-compat@3.9.1, core-js-compat@^3.8.1, core-js-compat@^3.9.0:
+core-js-compat@^3.8.1, core-js-compat@^3.9.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.9.1.tgz#4e572acfe90aff69d76d8c37759d21a5c59bb455"
   integrity sha512-jXAirMQxrkbiiLsCx9bQPJFA6llDadKMpYrBJQJ3/c4/vsPP/fAf29h24tviRlvwUL6AmY5CHLu2GvjuYviQqA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2754,7 +2754,7 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@testing-library/dom@^7.22.2", "@testing-library/dom@^7.28.1":
+"@testing-library/dom@7.30.0", "@testing-library/dom@^7.22.2", "@testing-library/dom@^7.28.1":
   version "7.30.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.30.0.tgz#53697851f7708a1448cc30b74a2ea056dd709cd6"
   integrity sha512-v4GzWtltaiDE0yRikLlcLAfEiiK8+ptu6OuuIebm9GdC2XlZTNDPGEfM2UkEtnH7hr9TRq2sivT5EA9P1Oy7bw==
@@ -5123,7 +5123,7 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-js-compat@^3.8.1, core-js-compat@^3.9.0:
+core-js-compat@3.9.1, core-js-compat@^3.8.1, core-js-compat@^3.9.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.9.1.tgz#4e572acfe90aff69d76d8c37759d21a5c59bb455"
   integrity sha512-jXAirMQxrkbiiLsCx9bQPJFA6llDadKMpYrBJQJ3/c4/vsPP/fAf29h24tviRlvwUL6AmY5CHLu2GvjuYviQqA==
@@ -6723,7 +6723,7 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-formik@2.2.6:
+formik@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/formik/-/formik-2.2.6.tgz#378a4bafe4b95caf6acf6db01f81f3fe5147559d"
   integrity sha512-Kxk2zQRafy56zhLmrzcbryUpMBvT0tal5IvcifK5+4YNGelKsnrODFJ0sZQRMQboblWNym4lAW3bt+tf2vApSA==


### PR DESCRIPTION
#### Summary

- use `formik` state with `enableReinitialize`
- reference #1838 

#### Description

In previous implementation, when the client passes a `page` it is set as the `initial` state of `PageNavigator` and from there leverage an internal state via `useState()`
When the `page` prop updates, `PageNavigator` doesn't reflect the updated changes as the prop is accept in subsequent renders.

#### Proposal

use `formik` to manage the state with `enableReinitialize`, this gives us a couple of advantages.

- previous implementation of focus and blur handle are abstracted away from the pagination. They are now handled with formik with the help of the `validateOnBlur`, `validateOnChange` and `validateOnMount` configs
- via `enableReinitialize`, the internal formik state updates 
