### PR TITLE
Add pagination and table sorting state

### DIFF
--- a/.changeset/slow-grapes-hope.md
+++ b/.changeset/slow-grapes-hope.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/hooks': minor
+---
+
+Add pagination-state and data-table-sorting-state.

--- a/.changeset/slow-grapes-hope.md
+++ b/.changeset/slow-grapes-hope.md
@@ -2,4 +2,4 @@
 '@commercetools-uikit/hooks': minor
 ---
 
-Add pagination-state and data-table-sorting-state.
+Add `usePaginationState` and `useDataTableSortingState`. These hooks help to manage pagination state and should be used together with the `<Pagination>` and/or `<DataTable>` components.

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -26,6 +26,7 @@
     "@babel/runtime": "7.13.10",
     "@babel/runtime-corejs3": "7.13.10",
     "@commercetools-uikit/utils": "11.2.1",
+    "@testing-library/react": "11.2.5",
     "lodash": "4.17.20"
   },
   "devDependencies": {

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -26,10 +26,10 @@
     "@babel/runtime": "7.13.10",
     "@babel/runtime-corejs3": "7.13.10",
     "@commercetools-uikit/utils": "11.2.1",
-    "@testing-library/react": "11.2.5",
     "lodash": "4.17.20"
   },
   "devDependencies": {
+    "@testing-library/react": "11.2.5",
     "react": "17.0.1"
   },
   "peerDependencies": {

--- a/packages/hooks/src/index.js
+++ b/packages/hooks/src/index.js
@@ -3,5 +3,6 @@ export { default as usePrevious } from './use-previous';
 export { default as useFieldId } from './use-field-id';
 export { default as useRowSelection } from './use-row-selection';
 export { default as useSorting } from './use-sorting';
+export { default as usePaginationState } from './use-pagination-state';
 
 export { default as version } from './version';

--- a/packages/hooks/src/index.js
+++ b/packages/hooks/src/index.js
@@ -4,5 +4,6 @@ export { default as useFieldId } from './use-field-id';
 export { default as useRowSelection } from './use-row-selection';
 export { default as useSorting } from './use-sorting';
 export { default as usePaginationState } from './use-pagination-state';
+export { default as useDataTableSortingState } from './use-data-table-sorting-state';
 
 export { default as version } from './version';

--- a/packages/hooks/src/use-data-table-sorting-state/index.js
+++ b/packages/hooks/src/use-data-table-sorting-state/index.js
@@ -1,0 +1,1 @@
+export { default } from './use-data-table-sorting-state';

--- a/packages/hooks/src/use-data-table-sorting-state/use-data-table-sorting-state.js
+++ b/packages/hooks/src/use-data-table-sorting-state/use-data-table-sorting-state.js
@@ -3,7 +3,7 @@ import { useState, useCallback } from 'react';
 const defaultValues = { key: 'createdAt', order: 'desc' };
 const applyIf = (values, key) => (values[key] ? { key } : {});
 
-const useDataTableSortingState = (initialValues) => {
+const useDataTableSortingState = (initialValues = {}) => {
   const mergedValues = {
     ...defaultValues,
     ...applyIf(initialValues, 'key'),

--- a/packages/hooks/src/use-data-table-sorting-state/use-data-table-sorting-state.js
+++ b/packages/hooks/src/use-data-table-sorting-state/use-data-table-sorting-state.js
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 
 const defaultValues = { key: 'createdAt', order: 'desc' };
 
-const useDataTableSortingState = (initialValues = defaultValues) => {
+const useDataTableSortingState = (initialValues) => {
   const mergedValues = {
     ...defaultValues,
     ...initialValues,

--- a/packages/hooks/src/use-data-table-sorting-state/use-data-table-sorting-state.js
+++ b/packages/hooks/src/use-data-table-sorting-state/use-data-table-sorting-state.js
@@ -1,12 +1,15 @@
 import { useState, useCallback } from 'react';
 
 const defaultValues = { key: 'createdAt', order: 'desc' };
+const applyIf = (values, key) => (values[key] ? { key } : {});
 
 const useDataTableSortingState = (initialValues) => {
   const mergedValues = {
     ...defaultValues,
-    ...initialValues,
+    ...applyIf(initialValues, 'key'),
+    ...applyIf(initialValues, 'order'),
   };
+
   const [sortDefinition, setSortDefinition] = useState(mergedValues);
   const onTableSortingChange = useCallback(
     (key, order) => setSortDefinition({ key, order }),

--- a/packages/hooks/src/use-data-table-sorting-state/use-data-table-sorting-state.js
+++ b/packages/hooks/src/use-data-table-sorting-state/use-data-table-sorting-state.js
@@ -1,0 +1,22 @@
+import { useState, useCallback } from 'react';
+
+const defaultValues = { key: 'createdAt', order: 'desc' };
+
+const useDataTableSortingState = (initialValues = defaultValues) => {
+  const mergedValues = {
+    ...defaultValues,
+    ...initialValues,
+  };
+  const [sortDefinition, setSortDefinition] = useState(mergedValues);
+  const onTableSortingChange = useCallback(
+    (key, order) => setSortDefinition({ key, order }),
+    []
+  );
+  return {
+    // { key: string, order: asc | desc }
+    value: sortDefinition,
+    onChange: onTableSortingChange,
+  };
+};
+
+export default useDataTableSortingState;

--- a/packages/hooks/src/use-data-table-sorting-state/use-data-table-sorting-state.spec.js
+++ b/packages/hooks/src/use-data-table-sorting-state/use-data-table-sorting-state.spec.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { Spacings, PrimaryButton } from '@commercetools-frontend/ui-kit';
+import useDataTableSortingState from './use-data-table-sorting-state';
+
+const TestComponent = () => {
+  const tableSorting = useDataTableSortingState();
+
+  return (
+    <>
+      <div>
+        Sorting: {`${tableSorting.value.key}:${tableSorting.value.order}`}
+      </div>
+      <Spacings.Stack>
+        <PrimaryButton
+          onClick={() => tableSorting.onChange('name', 'asc')}
+          label="Change sorting"
+        />
+      </Spacings.Stack>
+    </>
+  );
+};
+
+describe('sorting', () => {
+  it('should default sorting and allow changing order and key', async () => {
+    const rendered = render(<TestComponent />);
+    expect(rendered.getByText(/Sorting: createdAt:desc/)).toBeInTheDocument();
+    fireEvent.click(rendered.getByLabelText(/Change sorting/));
+    expect(rendered.getByText(/Sorting: name:asc/)).toBeInTheDocument();
+  });
+});

--- a/packages/hooks/src/use-data-table-sorting-state/use-data-table-sorting-state.spec.js
+++ b/packages/hooks/src/use-data-table-sorting-state/use-data-table-sorting-state.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import { Spacings, PrimaryButton } from '@commercetools-frontend/ui-kit';
 import useDataTableSortingState from './use-data-table-sorting-state';
 
@@ -23,9 +23,9 @@ const TestComponent = () => {
 
 describe('sorting', () => {
   it('should default sorting and allow changing order and key', async () => {
-    const rendered = render(<TestComponent />);
-    expect(rendered.getByText(/Sorting: createdAt:desc/)).toBeInTheDocument();
-    fireEvent.click(rendered.getByLabelText(/Change sorting/));
-    expect(rendered.getByText(/Sorting: name:asc/)).toBeInTheDocument();
+    render(<TestComponent />);
+    expect(screen.getByText(/Sorting: createdAt:desc/)).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText(/Change sorting/));
+    expect(screen.getByText(/Sorting: name:asc/)).toBeInTheDocument();
   });
 });

--- a/packages/hooks/src/use-pagination-state/index.js
+++ b/packages/hooks/src/use-pagination-state/index.js
@@ -1,0 +1,1 @@
+export { default } from './use-pagination-state';

--- a/packages/hooks/src/use-pagination-state/use-pagination-state.js
+++ b/packages/hooks/src/use-pagination-state/use-pagination-state.js
@@ -23,6 +23,9 @@ const usePaginationState = (initialValues) => {
 
   const onPerPageChange = useCallback(
     (nextPerPage) => {
+      // side-effect:
+      // GIVEN client updates `perPage`,
+      // THEN we reset `page` (discards initialValues.page)
       setPage(1);
       setPerPage(nextPerPage);
     },

--- a/packages/hooks/src/use-pagination-state/use-pagination-state.js
+++ b/packages/hooks/src/use-pagination-state/use-pagination-state.js
@@ -1,0 +1,44 @@
+import { useState, useCallback } from 'react';
+
+const defaultValues = {
+  page: 1,
+  perPage: 20,
+};
+
+const usePaginationState = (initialValues = defaultValues) => {
+  const mergedValues = {
+    ...defaultValues,
+    ...initialValues,
+  };
+
+  const [page, setPage] = useState(mergedValues.page);
+  const [perPage, setPerPage] = useState(mergedValues.perPage);
+
+  const onPageChange = useCallback(
+    (nextPage) => {
+      setPage(nextPage);
+    },
+    [setPage]
+  );
+
+  const onPerPageChange = useCallback(
+    (nextPerPage) => {
+      setPage(1);
+      setPerPage(nextPerPage);
+    },
+    [setPerPage, setPage]
+  );
+
+  return {
+    page: {
+      value: page,
+      onChange: onPageChange,
+    },
+    perPage: {
+      value: perPage,
+      onChange: onPerPageChange,
+    },
+  };
+};
+
+export default usePaginationState;

--- a/packages/hooks/src/use-pagination-state/use-pagination-state.js
+++ b/packages/hooks/src/use-pagination-state/use-pagination-state.js
@@ -5,7 +5,7 @@ const defaultValues = {
   perPage: 20,
 };
 
-const usePaginationState = (initialValues = defaultValues) => {
+const usePaginationState = (initialValues) => {
   const mergedValues = {
     ...defaultValues,
     ...initialValues,

--- a/packages/hooks/src/use-pagination-state/use-pagination-state.js
+++ b/packages/hooks/src/use-pagination-state/use-pagination-state.js
@@ -1,14 +1,16 @@
 import { useState, useCallback } from 'react';
 
+const applyIf = (values, key) => (values[key] ? { key } : {});
 const defaultValues = {
   page: 1,
   perPage: 20,
 };
 
-const usePaginationState = (initialValues) => {
+const usePaginationState = (initialValues = {}) => {
   const mergedValues = {
     ...defaultValues,
-    ...initialValues,
+    ...applyIf(initialValues, 'page'),
+    ...applyIf(initialValues, 'perPage'),
   };
 
   const [page, setPage] = useState(mergedValues.page);

--- a/packages/hooks/src/use-pagination-state/use-pagination-state.spec.js
+++ b/packages/hooks/src/use-pagination-state/use-pagination-state.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import { Spacings, PrimaryButton } from '@commercetools-frontend/ui-kit';
 import usePaginationState from './use-pagination-state';
 
@@ -28,32 +28,32 @@ const TestComponent = () => {
 
 describe('per page', () => {
   it('should default per page and allow increasing page size', async () => {
-    const rendered = render(<TestComponent />);
-    expect(rendered.getByText(/Per page: 20/)).toBeInTheDocument();
-    fireEvent.click(rendered.getByLabelText(/Change per page/));
-    expect(rendered.getByText(/Per page: 50/)).toBeInTheDocument();
+    render(<TestComponent />);
+    expect(screen.getByText(/Per page: 20/)).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText(/Change per page/));
+    expect(screen.getByText(/Per page: 50/)).toBeInTheDocument();
   });
   describe('when changing per page', () => {
     it('should reset page state', () => {
-      const rendered = render(<TestComponent />);
+      render(<TestComponent />);
       // update page state
-      expect(rendered.getByText(/Page: 1/)).toBeInTheDocument();
-      fireEvent.click(rendered.getByLabelText(/Change page/));
-      expect(rendered.getByText(/Page: 2/)).toBeInTheDocument();
+      expect(screen.getByText(/Page: 1/)).toBeInTheDocument();
+      fireEvent.click(screen.getByLabelText(/Change page/));
+      expect(screen.getByText(/Page: 2/)).toBeInTheDocument();
 
       // update per page
       // reset page
-      fireEvent.click(rendered.getByLabelText(/Change per page/));
-      expect(rendered.getByText(/Page: 1/)).toBeInTheDocument();
+      fireEvent.click(screen.getByLabelText(/Change per page/));
+      expect(screen.getByText(/Page: 1/)).toBeInTheDocument();
     });
   });
 });
 
 describe('page', () => {
   it('should default page and allow moving to next page', async () => {
-    const rendered = render(<TestComponent />);
-    expect(rendered.getByText(/Page: 1/)).toBeInTheDocument();
-    fireEvent.click(rendered.getByLabelText(/Change page/));
-    expect(rendered.getByText(/Page: 2/)).toBeInTheDocument();
+    render(<TestComponent />);
+    expect(screen.getByText(/Page: 1/)).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText(/Change page/));
+    expect(screen.getByText(/Page: 2/)).toBeInTheDocument();
   });
 });

--- a/packages/hooks/src/use-pagination-state/use-pagination-state.spec.js
+++ b/packages/hooks/src/use-pagination-state/use-pagination-state.spec.js
@@ -33,6 +33,20 @@ describe('per page', () => {
     fireEvent.click(rendered.getByLabelText(/Change per page/));
     expect(rendered.getByText(/Per page: 50/)).toBeInTheDocument();
   });
+  describe('when changing per page', () => {
+    it('should reset page state', () => {
+      const rendered = render(<TestComponent />);
+      // update page state
+      expect(rendered.getByText(/Page: 1/)).toBeInTheDocument();
+      fireEvent.click(rendered.getByLabelText(/Change page/));
+      expect(rendered.getByText(/Page: 2/)).toBeInTheDocument();
+
+      // update per page
+      // reset page
+      fireEvent.click(rendered.getByLabelText(/Change per page/));
+      expect(rendered.getByText(/Page: 1/)).toBeInTheDocument();
+    });
+  });
 });
 
 describe('page', () => {

--- a/packages/hooks/src/use-pagination-state/use-pagination-state.spec.js
+++ b/packages/hooks/src/use-pagination-state/use-pagination-state.spec.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { Spacings, PrimaryButton } from '@commercetools-frontend/ui-kit';
+import usePaginationState from './use-pagination-state';
+
+const TestComponent = () => {
+  const { page, perPage } = usePaginationState();
+
+  return (
+    <>
+      <ul>
+        <li>Per page: {perPage.value}</li>
+        <li>Page: {page.value}</li>
+      </ul>
+      <Spacings.Stack>
+        <PrimaryButton
+          onClick={() => perPage.onChange(50)}
+          label="Change per page"
+        />
+        <PrimaryButton
+          onClick={() => page.onChange(page.value + 1)}
+          label="Change page"
+        />
+      </Spacings.Stack>
+    </>
+  );
+};
+
+describe('per page', () => {
+  it('should default per page and allow increasing page size', async () => {
+    const rendered = render(<TestComponent />);
+    expect(rendered.getByText(/Per page: 20/)).toBeInTheDocument();
+    fireEvent.click(rendered.getByLabelText(/Change per page/));
+    expect(rendered.getByText(/Per page: 50/)).toBeInTheDocument();
+  });
+});
+
+describe('page', () => {
+  it('should default page and allow moving to next page', async () => {
+    const rendered = render(<TestComponent />);
+    expect(rendered.getByText(/Page: 1/)).toBeInTheDocument();
+    fireEvent.click(rendered.getByLabelText(/Change page/));
+    expect(rendered.getByText(/Page: 2/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
#### Summary

- adds `pagination-state` hook
- adds `data-table-sort-state` hook
to be frank, I'm not sure if this is the correct naming or if this is the repo for it,
because it is more than likely that this hook is used to forward the state to fetchers within the MC. feedback welcome


#### Description

We need to expose these hooks so that other consumers than the Merchant Center can use this interchangeably with the Pagination component (for pagination-state) without having to re-implement it themselves.

The idea is that once this is merged, we migrate the MC to use this.

shall be included in this release https://github.com/commercetools/ui-kit/pull/1841