### PR TITLE
docs(spacings-inline): flex-wrap alternative

### DIFF
--- a/.changeset/violet-beans-perform.md
+++ b/.changeset/violet-beans-perform.md
@@ -2,4 +2,4 @@
 "@commercetools-uikit/spacings-inline": patch
 ---
 
-docs(spacings-inline): flex-wrap alternative
+Document recommendation for [`<Grid />`](https://uikit.commercetools.com/?path=/story/components-grid--grid) instead of using `flex-wrap`.

--- a/.changeset/violet-beans-perform.md
+++ b/.changeset/violet-beans-perform.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-uikit/spacings-inline": patch
+---
+
+docs(spacings-inline): flex-wrap alternative

--- a/packages/components/spacings/spacings-inline/README.md
+++ b/packages/components/spacings/spacings-inline/README.md
@@ -41,6 +41,8 @@ import Spacings from '@commercetools-uikit/spacings';
 | `justifyContent` | `oneOf`          |    -     | `['flex-start', 'flex-end', 'center', 'space-between', 'space-around', 'space-evenly']` | `flex-start` |
 | `children`       | `PropTypes.node` |    -     | -                                                                                       | -            |
 
+If you need to use `flex-wrap` CSS property, consider using instead the component [`<Grid />`](https://uikit.commercetools.com/?path=/story/components-grid--grid).
+
 ## Scales
 
 | Scale | Pixel |


### PR DESCRIPTION
Document the alternative when it's needed to use the CSS property `flex-wrap` in the component `<Spacings.Inline />`. I found out about this via https://github.com/commercetools/ui-kit/pull/899.