### PR TITLE
refactor(text): accept `as` prop for inline render of `Text.Detail`

### DIFF
--- a/packages/components/text/README.md
+++ b/packages/components/text/README.md
@@ -133,8 +133,8 @@ import Text from '@commercetools-uikit/text';
 
 | Props         | Type             | Required | Values                                                                        | Default |
 | ------------- | ---------------- | :------: | ----------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------- |
+| `as`          | `string`         |    -     | `span` `[^]`                                                                  | `false` |
 | `isBold`      | `Boolean`        |    -     | -                                                                             | `false` |
-| `isInline`    | `Boolean`        |    -     | -                                                                             | `false` |
 | `isItalic`    | `Boolean`        |    -     | -                                                                             | `false` |
 | `tone`        | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative', 'warning'']` | -       |
 | `children`    | `PropTypes.node` | ✅ (\*)  | -                                                                             | -       |
@@ -143,6 +143,7 @@ import Text from '@commercetools-uikit/text';
 | `truncate`    | `Bool`           |    -     | -                                                                             | `false` |
 
 > `*`: `children` is required only if `intlMessage` is not provided
+> `[^]`: Only supported `as` value is `span`. Use `span` to apply inline styling.
 
 The component further forwards all `data-` attributes to the underlying component.
 

--- a/packages/components/text/README.md
+++ b/packages/components/text/README.md
@@ -48,15 +48,15 @@ import Text from '@commercetools-uikit/text';
 
 ### Properties
 
-| Props         | Type             | Required | Values                                                            | Default |
+| Props         | Type             | Required | Values                                                            | Default |                                                                        |
 | ------------- | ---------------- | :------: | ----------------------------------------------------------------- | ------- | ---------------------------------------------------------------------- |
-| `as`          | `String`         |    ✅    | `['h4', 'h5']`                                                    | -       |
-| `isBold`      | `Boolean`        |    -     | -                                                                 | `false` |
-| `tone`        | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative']` | -       |
-| `children`    | `PropTypes.node` | ✅ (\*)  | -                                                                 | -       |
+| `as`          | `String`         |    ✅    | `['h4', 'h5']`                                                    | -       |                                                                        |
+| `isBold`      | `Boolean`        |    -     | -                                                                 | `false` |                                                                        |
+| `tone`        | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative']` | -       |                                                                        |
+| `children`    | `PropTypes.node` | ✅ (\*)  | -                                                                 | -       |                                                                        |
 | `intlMessage` | `intl message`   | ✅ (\*)  | -                                                                 | -       | An `intl` message object that will be rendered with `FormattedMessage` |
-| `title`       | `String`         |    -     | -                                                                 | -       |
-| `truncate`    | `Bool`           |    -     | -                                                                 | `false` |
+| `title`       | `String`         |    -     | -                                                                 | -       |                                                                        |
+| `truncate`    | `Bool`           |    -     | -                                                                 | `false` |                                                                        |
 
 > `*`: `children` is required only if `intlMessage` is not provided
 
@@ -96,16 +96,16 @@ import Text from '@commercetools-uikit/text';
 
 ### Properties
 
-| Props         | Type             | Required | Values                                                                        | Default |
+| Props         | Type             | Required | Values                                                                        | Default |                                                                        |
 | ------------- | ---------------- | :------: | ----------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------- |
-| `as`          | `String`         |    -     | `['p', 'span']`                                                               | -       |
-| `isBold`      | `Boolean`        |    -     | -                                                                             | `false` |
-| `isItalic`    | `Boolean`        |    -     | -                                                                             | `false` |
-| `tone`        | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative', 'inverted']` | -       |
-| `children`    | `PropTypes.node` | ✅ (\*)  | -                                                                             | -       |
+| `as`          | `String`         |    -     | `['p', 'span']`                                                               | -       |                                                                        |
+| `isBold`      | `Boolean`        |    -     | -                                                                             | `false` |                                                                        |
+| `isItalic`    | `Boolean`        |    -     | -                                                                             | `false` |                                                                        |
+| `tone`        | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative', 'inverted']` | -       |                                                                        |
+| `children`    | `PropTypes.node` | ✅ (\*)  | -                                                                             | -       |                                                                        |
 | `intlMessage` | `intl message`   | ✅ (\*)  | -                                                                             | -       | An `intl` message object that will be rendered with `FormattedMessage` |
-| `title`       | `String`         |    -     | -                                                                             | -       |
-| `truncate`    | `Bool`           |    -     | -                                                                             | `false` |
+| `title`       | `String`         |    -     | -                                                                             | -       |                                                                        |
+| `truncate`    | `Bool`           |    -     | -                                                                             | `false` |                                                                        |
 
 > `*`: `children` is required only if `intlMessage` is not provided
 
@@ -131,19 +131,19 @@ import Text from '@commercetools-uikit/text';
 
 ### Properties
 
-| Props         | Type             | Required | Values                                                                        | Default |
+| Props         | Type             | Required | Values                                                                        | Default |                                                                        |
 | ------------- | ---------------- | :------: | ----------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------- |
-| `as`          | `string`         |    -     | `span` `[^]`                                                                  | `false` |
-| `isBold`      | `Boolean`        |    -     | -                                                                             | `false` |
-| `isItalic`    | `Boolean`        |    -     | -                                                                             | `false` |
-| `tone`        | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative', 'warning'']` | -       |
-| `children`    | `PropTypes.node` | ✅ (\*)  | -                                                                             | -       |
+| `as`          | `string`         |    -     | `['small', 'span']` `[^]`                                                     | `false` |                                                                        |
+| `isBold`      | `Boolean`        |    -     | -                                                                             | `false` |                                                                        |
+| `isItalic`    | `Boolean`        |    -     | -                                                                             | `false` |                                                                        |
+| `tone`        | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative', 'warning'']` | -       |                                                                        |
+| `children`    | `PropTypes.node` | ✅ (\*)  | -                                                                             | -       |                                                                        |
 | `intlMessage` | `intl message`   | ✅ (\*)  | -                                                                             | -       | An `intl` message object that will be rendered with `FormattedMessage` |
-| `title`       | `String`         |    -     | -                                                                             | -       |
-| `truncate`    | `Bool`           |    -     | -                                                                             | `false` |
+| `title`       | `String`         |    -     | -                                                                             | -       |                                                                        |
+| `truncate`    | `Bool`           |    -     | -                                                                             | `false` |                                                                        |
 
-> `*`: `children` is required only if `intlMessage` is not provided
-> `[^]`: Only supported `as` value is `span`. Use `span` to apply inline styling.
+> `*`: `children` is required only if `intlMessage` is not provided.
+> `[^]`: Use `as` prop to render an inline element.
 
 The component further forwards all `data-` attributes to the underlying component.
 

--- a/packages/components/text/README.md
+++ b/packages/components/text/README.md
@@ -134,6 +134,7 @@ import Text from '@commercetools-uikit/text';
 | Props         | Type             | Required | Values                                                                        | Default |
 | ------------- | ---------------- | :------: | ----------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------- |
 | `isBold`      | `Boolean`        |    -     | -                                                                             | `false` |
+| `isInline`    | `Boolean`        |    -     | -                                                                             | `false` |
 | `isItalic`    | `Boolean`        |    -     | -                                                                             | `false` |
 | `tone`        | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative', 'warning'']` | -       |
 | `children`    | `PropTypes.node` | ✅ (\*)  | -                                                                             | -       |

--- a/packages/components/text/src/text.spec.js
+++ b/packages/components/text/src/text.spec.js
@@ -255,11 +255,11 @@ describe('<Body>', () => {
 });
 
 describe('<Detail>', () => {
-  it('should render element tag small', () => {
+  it('should render element tag div', () => {
     const { container } = render(
       <Text.Detail title="tooltip text">{'Detail'}</Text.Detail>
     );
-    expect(container.querySelector('small')).toBeInTheDocument();
+    expect(container.querySelector('div')).toBeInTheDocument();
   });
 
   it('should render given text', () => {
@@ -279,6 +279,28 @@ describe('<Detail>', () => {
       </Text.Detail>
     );
     expect(screen.getByTitle('detail')).toHaveAttribute('data-foo', 'bar');
+  });
+  describe('when `as` is defined', () => {
+    describe('as `span`', () => {
+      it('should render element tag `span`', () => {
+        const { container } = render(
+          <Text.Detail as="span" title="tooltip text">
+            {'Detail'}
+          </Text.Detail>
+        );
+        expect(container.querySelector('span')).toBeInTheDocument();
+      });
+    });
+    describe('as `small`', () => {
+      it('should render element tag `small`', () => {
+        const { container } = render(
+          <Text.Detail as="small" title="tooltip text">
+            {'Detail'}
+          </Text.Detail>
+        );
+        expect(container.querySelector('small')).toBeInTheDocument();
+      });
+    });
   });
   describe('when no text is provided', () => {
     it('should warn but not crash', () => {

--- a/packages/components/text/src/text.story.js
+++ b/packages/components/text/src/text.story.js
@@ -93,6 +93,7 @@ storiesOf('Basics|Typography/Text', module)
   .add('Detail', () => (
     <Section>
       <Text.Detail
+        isInline={boolean('inline', false)}
         isBold={boolean('bold', false)}
         isItalic={boolean('italic', false)}
         tone={select('Text tone', {

--- a/packages/components/text/src/text.story.js
+++ b/packages/components/text/src/text.story.js
@@ -93,7 +93,10 @@ storiesOf('Basics|Typography/Text', module)
   .add('Detail', () => (
     <Section>
       <Text.Detail
-        isInline={boolean('inline', false)}
+        as={select('as', {
+          default: null,
+          span: 'span',
+        })}
         isBold={boolean('bold', false)}
         isItalic={boolean('italic', false)}
         tone={select('Text tone', {

--- a/packages/components/text/src/text.styles.ts
+++ b/packages/components/text/src/text.styles.ts
@@ -34,6 +34,10 @@ const italic = `
   font-style: italic;
 `;
 
+const inline = `
+  display: inline-block;
+`;
+
 const getTone = (tone: string, theme: Theme) => {
   const overwrittenVars = {
     ...vars,
@@ -117,6 +121,7 @@ export const detailStyles = (props: TDetailProps, theme: Theme) => css`
   ${getBaseStyles(theme)}
   display: block;
   font-size: 0.9231rem;
+  ${props.isInline && inline}
   ${props.isBold && bold}
   ${props.isItalic && italic}
   ${props.tone && getTone(props.tone, theme)}

--- a/packages/components/text/src/text.styles.ts
+++ b/packages/components/text/src/text.styles.ts
@@ -34,10 +34,6 @@ const italic = `
   font-style: italic;
 `;
 
-const inline = `
-  display: inline-block;
-`;
-
 const getTone = (tone: string, theme: Theme) => {
   const overwrittenVars = {
     ...vars,
@@ -119,9 +115,7 @@ export const wrapStyles = (theme: Theme) => css`
 
 export const detailStyles = (props: TDetailProps, theme: Theme) => css`
   ${getBaseStyles(theme)}
-  display: block;
   font-size: 0.9231rem;
-  ${props.isInline && inline}
   ${props.isBold && bold}
   ${props.isItalic && italic}
   ${props.tone && getTone(props.tone, theme)}

--- a/packages/components/text/src/text.tsx
+++ b/packages/components/text/src/text.tsx
@@ -203,6 +203,7 @@ Body.displayName = 'TextBody';
 export type TDetailProps = {
   isBold?: boolean;
   isItalic?: boolean;
+  isInline?: boolean;
   tone?:
     | 'primary'
     | 'secondary'

--- a/packages/components/text/src/text.tsx
+++ b/packages/components/text/src/text.tsx
@@ -203,8 +203,7 @@ Body.displayName = 'TextBody';
 export type TDetailProps = {
   isBold?: boolean;
   isItalic?: boolean;
-  // only span is supported for now.
-  as?: 'span';
+  as?: 'span' | 'small';
   tone?:
     | 'primary'
     | 'secondary'

--- a/packages/components/text/src/text.tsx
+++ b/packages/components/text/src/text.tsx
@@ -203,7 +203,8 @@ Body.displayName = 'TextBody';
 export type TDetailProps = {
   isBold?: boolean;
   isItalic?: boolean;
-  isInline?: boolean;
+  // only span is supported for now.
+  as?: 'span';
   tone?:
     | 'primary'
     | 'secondary'
@@ -220,14 +221,27 @@ const Detail = (props: TDetailProps) => {
   const theme = useTheme();
   warnIfMissingTitle(props, 'TextDetail');
   warnIfMissingContent(props, 'TextDetail');
+  if (props.as) {
+    const TextDetailElement = props.as;
+    return (
+      <TextDetailElement
+        css={detailStyles(props, theme)}
+        title={props.title}
+        {...filterDataAttributes(props)}
+      >
+        <Text intlMessage={props.intlMessage}>{props.children}</Text>
+      </TextDetailElement>
+    );
+  }
+
   return (
-    <small
+    <div
       css={detailStyles(props, theme)}
       title={props.title}
       {...filterDataAttributes(props)}
     >
       <Text intlMessage={props.intlMessage}>{props.children}</Text>
-    </small>
+    </div>
   );
 };
 Detail.displayName = 'TextDetail';

--- a/packages/components/text/src/text.visualroute.js
+++ b/packages/components/text/src/text.visualroute.js
@@ -129,6 +129,9 @@ export const component = ({ themes }) => (
     <Spec label="Detail">
       <Text.Detail>Detail text</Text.Detail>
     </Spec>
+    <Spec label="Detail - inline">
+      <Text.Detail isInline={true}>Detail text bold</Text.Detail>
+    </Spec>
     <Spec label="Detail - bold">
       <Text.Detail isBold={true}>Detail text bold</Text.Detail>
     </Spec>

--- a/packages/components/text/src/text.visualroute.js
+++ b/packages/components/text/src/text.visualroute.js
@@ -129,9 +129,6 @@ export const component = ({ themes }) => (
     <Spec label="Detail">
       <Text.Detail>Detail text</Text.Detail>
     </Spec>
-    <Spec label="Detail - inline">
-      <Text.Detail as="span">Detail text bold</Text.Detail>
-    </Spec>
     <Spec label="Detail - bold">
       <Text.Detail isBold={true}>Detail text bold</Text.Detail>
     </Spec>

--- a/packages/components/text/src/text.visualroute.js
+++ b/packages/components/text/src/text.visualroute.js
@@ -130,7 +130,7 @@ export const component = ({ themes }) => (
       <Text.Detail>Detail text</Text.Detail>
     </Spec>
     <Spec label="Detail - inline">
-      <Text.Detail isInline={true}>Detail text bold</Text.Detail>
+      <Text.Detail as="span">Detail text bold</Text.Detail>
     </Spec>
     <Spec label="Detail - bold">
       <Text.Detail isBold={true}>Detail text bold</Text.Detail>


### PR DESCRIPTION
#### Summary

- caused by #1824 

Discovered when migration app-kit
https://github.com/commercetools/merchant-center-application-kit/pull/2131#discussion_r609585711

I don't think `isInline` was marked deprecated on `Text.Detail` in the first place, nor was it intended that `Text.Detail` should support `as={}` prop.