### PR TITLE
fix(components): set text-input.onChange option, update to prop to use Location

### DIFF
--- a/.changeset/great-pumpkins-fry.md
+++ b/.changeset/great-pumpkins-fry.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/secondary-button': patch
+---
+
+Update `to` prop to use `history.LocationDescriptor`

--- a/.changeset/wild-elephants-hug.md
+++ b/.changeset/wild-elephants-hug.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/text-input': patch
+---
+
+Update `onChange` prop to optional

--- a/packages/components/buttons/secondary-button/src/secondary-button.tsx
+++ b/packages/components/buttons/secondary-button/src/secondary-button.tsx
@@ -1,3 +1,4 @@
+import type { LocationDescriptorObject, LocationDescriptor } from 'history';
 import React, {
   ReactElement,
   KeyboardEvent,
@@ -12,6 +13,10 @@ import Inline from '@commercetools-uikit/spacings-inline';
 import { filterInvalidAttributes, warning } from '@commercetools-uikit/utils';
 import AccessibleButton from '@commercetools-uikit/accessible-button';
 import { getStateStyles, getThemeStyles } from './secondary-button.styles';
+
+type TLocationDescriptionWithQuery = LocationDescriptorObject & {
+  query?: unknown;
+};
 
 export type TSecondaryButtonProps = {
   /**
@@ -52,8 +57,8 @@ export type TSecondaryButtonProps = {
     event: MouseEvent<HTMLButtonElement> | KeyboardEvent<HTMLButtonElement>
   ) => void;
 
-  theme?: 'default' | 'info'; // TODO consider renaming this to `tone`
-  to?: string;
+  theme?: 'default' | 'info';
+  to?: LocationDescriptor | TLocationDescriptionWithQuery;
 };
 
 // Gets the color which the icon sho√uld have based on context of button's state/cursor behavior

--- a/packages/components/inputs/text-input/src/text-input.tsx
+++ b/packages/components/inputs/text-input/src/text-input.tsx
@@ -27,9 +27,8 @@ type TTextInputProps = {
   value: string;
   /**
    * Called with an event containing the new value. Required when input is not read only. Parent should pass it back as value.
-   * <br />
    */
-  onChange: ChangeEventHandler;
+  onChange?: ChangeEventHandler;
   /**
    * Called when input is blurred
    */
@@ -89,7 +88,7 @@ const TextInput = (props: TTextInputProps) => {
   const theme = useTheme();
   if (!props.isReadOnly) {
     warning(
-      Boolean(props.onChange),
+      typeof props.onChange === 'function',
       'TextInput: `onChange` is required when is not read only.'
     );
   }


### PR DESCRIPTION
## Description

It turns out that the TypeScript migration came with some mistakes 😅 .

My idea to address this is continue pushing towards master and use the canary build on this PR until the tests has passed. 
Given the tests passes, I will then do a release and update the client PR again.
https://github.com/commercetools/merchant-center-frontend/pull/10770
