### PR TITLE
fix(data-table-manager): areHiddenColumnsSearchable prop has no effect

### DIFF
--- a/.changeset/big-bobcats-shout.md
+++ b/.changeset/big-bobcats-shout.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table-manager': patch
+---
+
+fix(data-table-manager): areHiddenColumnsSearchable prop has no effect

--- a/packages/components/data-table-manager/src/column-settings-manager/column-settings-manager.js
+++ b/packages/components/data-table-manager/src/column-settings-manager/column-settings-manager.js
@@ -147,7 +147,7 @@ export const ColumnSettingsManager = (props) => {
                   title={intl.formatMessage(messages.hiddenColumns)}
                 />
               </Spacings.Inline>
-              {!props.disableHiddenColumnSearch && (
+              {props.areHiddenColumnsSearchable && (
                 <AsyncSelectInput
                   {...(props.searchHiddenColumnsPlaceholder
                     ? {
@@ -175,7 +175,7 @@ export const ColumnSettingsManager = (props) => {
                   messages.noHiddenColumnsToShow
                 )}
                 columns={hiddenColumns}
-                isSearchable={!props.disableHiddenColumnSearch}
+                isSearchable={props.areHiddenColumnsSearchable}
               />
             </Spacings.Stack>
           </DroppableContainer>
@@ -225,10 +225,10 @@ ColumnSettingsManager.propTypes = {
   ).isRequired,
   onUpdateColumns: PropTypes.func.isRequired,
 
-  disableHiddenColumnSearch: PropTypes.bool,
+  areHiddenColumnsSearchable: PropTypes.bool,
   searchHiddenColumns: requiredIf(
     PropTypes.func,
-    (props) => !props.disableHiddenColumnSearch
+    (props) => props.areHiddenColumnsSearchable
   ),
   searchHiddenColumnsPlaceholder: PropTypes.string,
 
@@ -240,7 +240,6 @@ ColumnSettingsManager.propTypes = {
 
 ColumnSettingsManager.defaultProps = {
   availableColumns: [],
-  disableHiddenColumnSearch: true,
 };
 
 export default ColumnSettingsManager;

--- a/packages/components/data-table-manager/src/column-settings-manager/column-settings-manager.spec.js
+++ b/packages/components/data-table-manager/src/column-settings-manager/column-settings-manager.spec.js
@@ -38,7 +38,7 @@ describe('ColumnSettingsManager', () => {
     expect(screen.getByText(/Column 1/i)).toBeInTheDocument();
   });
 
-  describe('when `disableHiddenColumnSearch` is false', () => {
+  describe('when `areColumnSettingsEnabled` is true', () => {
     it('should render columns search input', () => {
       const props = createTestProps({
         selectedColumns: [
@@ -53,7 +53,7 @@ describe('ColumnSettingsManager', () => {
             label: 'Column 1',
           },
         ],
-        disableHiddenColumnSearch: false,
+        areHiddenColumnsSearchable: true,
         searchHiddenColumnsPlaceholder: 'search',
         searchHiddenColumns: jest.fn(),
       });

--- a/packages/components/data-table-manager/src/data-table-manager.story.js
+++ b/packages/components/data-table-manager/src/data-table-manager.story.js
@@ -262,6 +262,8 @@ storiesOf('Components|DataTable', module)
     };
 
     const columnManager = {
+      areHiddenColumnsSearchable: boolean('areHiddenColumnsSearchable', true),
+      searchHiddenColumns: () => {},
       disableColumnManager: boolean('disableColumnManager', false),
       visibleColumnKeys: tableData.visibleColumnKeys,
       hideableColumns: tableData.columns,

--- a/packages/components/data-table-manager/src/data-table-settings/data-table-settings.js
+++ b/packages/components/data-table-manager/src/data-table-settings/data-table-settings.js
@@ -172,6 +172,7 @@ DataTableSettings.propTypes = {
     secondaryButton: PropTypes.element,
   }),
   columnManager: PropTypes.shape({
+    areHiddenColumnsSearchable: PropTypes.bool,
     disableColumnManager: PropTypes.bool,
     visibleColumnKeys: PropTypes.arrayOf(PropTypes.string.isRequired),
     hideableColumns: PropTypes.arrayOf(


### PR DESCRIPTION
According to `<DataTableManager />` documentation the name of the prop controlling presence of search fields in column manager is `areHiddenColumnsSearchable`. But, it is never took in account, and `<ColumnSettingsManager/>` relies on an undocumented prop called `disableHiddenColumnSearch`. 

This PR brings searching behaviour in accordance with docs.
 