### PR TITLE
fix(data-table-manager): make top bar take up all available space

### DIFF
--- a/.changeset/old-bugs-exist.md
+++ b/.changeset/old-bugs-exist.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table-manager': patch
+---
+
+fix(data-table-manager): make top bar take up all available space

--- a/packages/components/data-table-manager/src/data-table-settings/data-table-settings.js
+++ b/packages/components/data-table-manager/src/data-table-settings/data-table-settings.js
@@ -23,6 +23,10 @@ const SelectContainer = styled.div`
   width: ${customProperties.constraint4};
 `;
 
+const TopBarContainer = styled.div`
+  flex-grow: 1;
+`;
+
 export const getDropdownOptions = ({
   areColumnSettingsEnabled,
   areDisplaySettingsEnabled,
@@ -97,7 +101,7 @@ const DataTableSettings = (props) => {
   return (
     <Spacings.Stack>
       <Spacings.Inline justifyContent="space-between" alignItems="center">
-        <div>{props.topBar}</div>
+        <TopBarContainer>{props.topBar}</TopBarContainer>
         {dropdownOptions.length > 0 && (
           <SelectContainer>
             <AccessibleHidden>


### PR DESCRIPTION
`<DataTableManager />` wraps provided top bar controls in an unstyled `<div />`. That brings some troubles when styling controls being shown in a table's top bar. In general, as that `<div />` doesn't grow, it works against UI-Kit layout pattern (or let's better say MC pattern of UIKit usage) of letting controls grow up to the limit provided by the wrapping `<Constraints.Horizontal />`.

This PR solves described issue by making top bar container grow (by adding `flex-grow: 1`):

|Before|After|
|--|--|
|![Screenshot from 2021-06-02 12-13-05](https://user-images.githubusercontent.com/1228431/120441835-6adc3e80-c39e-11eb-986b-3408c1af9031.png)|![Screenshot from 2021-06-02 12-11-43](https://user-images.githubusercontent.com/1228431/120441891-7cbde180-c39e-11eb-97d6-fd25b31dda16.png)| 

I have checked already how this change affects exiting usages of `tobBar` in MC and there are no visual changes.