### PR TITLE
feat(link): add icon when link is external

### DIFF
--- a/.changeset/khaki-mirrors-fold.md
+++ b/.changeset/khaki-mirrors-fold.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-uikit/link": patch
+---
+
+Add an icon to the `Link` whenever `isExternal` is passed

--- a/packages/components/link/package.json
+++ b/packages/components/link/package.json
@@ -26,6 +26,8 @@
     "@babel/runtime": "7.14.5",
     "@babel/runtime-corejs3": "7.14.5",
     "@commercetools-uikit/design-system": "12.0.7",
+    "@commercetools-uikit/icons": "12.0.7",
+    "@commercetools-uikit/spacings-inline": "12.0.7",
     "@commercetools-uikit/utils": "12.0.7",
     "@emotion/react": "^11.4.0",
     "@emotion/styled": "^11.3.0",

--- a/packages/components/link/src/link.tsx
+++ b/packages/components/link/src/link.tsx
@@ -7,6 +7,8 @@ import { css, useTheme } from '@emotion/react';
 import { FormattedMessage } from 'react-intl';
 import { customProperties as vars } from '@commercetools-uikit/design-system';
 import { filterInvalidAttributes, warning } from '@commercetools-uikit/utils';
+import { ExternalLinkIcon } from '@commercetools-uikit/icons';
+import SpacingsInline from '@commercetools-uikit/spacings-inline';
 
 type TExtendedTheme = Theme & {
   [key: string]: string;
@@ -40,10 +42,11 @@ type TLinkProps = {
    */
   tone?: 'primary' | 'inverted';
 };
+type TIconColor = 'primary' | 'surface';
 
 const warnIfMissingContent = (props: TLinkProps) => {
   const hasContent =
-    props.intlMessage || Boolean(React.Children.count(props.children));
+    Boolean(props.intlMessage) || Boolean(React.Children.count(props.children));
 
   warning(
     hasContent,
@@ -68,8 +71,8 @@ const defaultProps: Pick<TLinkProps, 'tone' | 'isExternal'> = {
   isExternal: false,
 };
 
-const getColorValue = (
-  tone: string = 'primary',
+const getTextColorValue = (
+  tone: TLinkProps['tone'] = 'primary',
   overwrittenVars: TExtendedTheme
 ) => {
   if (tone === 'primary') {
@@ -77,6 +80,15 @@ const getColorValue = (
   }
 
   return overwrittenVars.fontColorForTextWhenInverted;
+};
+const getIconColorValue = (
+  tone: TLinkProps['tone'] = 'primary'
+): TIconColor => {
+  if (tone === 'inverted') {
+    return 'surface';
+  }
+
+  return tone;
 };
 const getActiveColorValue = (
   tone: string = 'primary',
@@ -95,19 +107,19 @@ const getLinkStyles = (props: TLinkProps, theme: Theme) => {
     ...theme,
   };
 
-  const color = getColorValue(props.tone, overwrittenVars);
+  const color = getTextColorValue(props.tone, overwrittenVars);
   const hoverColor = getActiveColorValue(props.tone, overwrittenVars);
 
   return css`
     font-family: inherit;
     color: ${color};
     font-size: ${overwrittenVars.fontSizeDefault};
-    text-decoration: underline;
     &:hover,
     &:focus,
     &:active {
       color: ${hoverColor};
     }
+    text-decoration: 'underline';
   `;
 };
 
@@ -126,19 +138,27 @@ const Link = (props: TLinkProps) => {
     }
 
     return (
-      <a
-        css={getLinkStyles(props, theme)}
-        href={props.to}
-        target="_blank"
-        rel="noopener noreferrer"
-        {...remainingProps}
-      >
-        {props.intlMessage ? (
-          <FormattedMessage {...props.intlMessage} />
-        ) : (
-          props.children
+      <SpacingsInline scale="xs" alignItems="center">
+        <a
+          css={getLinkStyles(props, theme)}
+          href={props.to}
+          target="_blank"
+          rel="noopener noreferrer"
+          {...remainingProps}
+        >
+          {props.intlMessage ? (
+            <FormattedMessage {...props.intlMessage} />
+          ) : (
+            props.children
+          )}
+        </a>
+        {props.isExternal && (
+          <ExternalLinkIcon
+            size="medium"
+            color={getIconColorValue(props.tone)}
+          />
         )}
-      </a>
+      </SpacingsInline>
     );
   }
 

--- a/packages/components/link/src/link.visualroute.js
+++ b/packages/components/link/src/link.visualroute.js
@@ -18,12 +18,7 @@ export const component = ({ themes }) => (
       <Link to="/">A label text</Link>
     </Spec>
     <Spec label="external">
-      <Link to="/" isExternal={true}>
-        A label text
-      </Link>
-    </Spec>
-    <Spec label="without underline">
-      <Link to="/" hasUnderline={false}>
+      <Link to="/" isExternal>
         A label text
       </Link>
     </Spec>
@@ -36,13 +31,8 @@ export const component = ({ themes }) => (
       <Link to="/" intlMessage={intlMessage} />
     </Spec>
     <ThemeProvider theme={themes.darkTheme}>
-      <Spec label="tone - inverted - with underline">
+      <Spec label="tone - inverted">
         <Link to="/" tone="inverted">
-          An inverted label text
-        </Link>
-      </Spec>
-      <Spec label="tone - inverted - without underline">
-        <Link to="/" hasUnderline={false} tone="inverted">
           An inverted label text
         </Link>
       </Spec>


### PR DESCRIPTION
#### Summary

This automatically adds an `ExternalLinkIcon` to any `Link` which has `isExternal`.

## Description

We learned that we don't consistently use the same patterns for external links and have to custom build components internally when a link is external and should have an icon to reflect that.

The discussion has open ends, for instance if the link should be underlined. As a result this is not ready. It's merely the result of a first investigation anybody could pick up.

![CleanShot 2021-06-17 at 15 57 50](https://user-images.githubusercontent.com/1877073/122411192-d7e9f980-cf84-11eb-9265-94a4b84b0fc1.gif)

![CleanShot 2021-06-17 at 16 48 59](https://user-images.githubusercontent.com/1877073/122428584-513c1900-cf92-11eb-8332-e52962f70f9e.gif)

## Todos

- [ ] Should the link have an underline or not
- [ ] How do we deal with active colour on the icon 
