### PR TITLE
fix(link): to use inline flex

### DIFF
--- a/.changeset/five-items-train.md
+++ b/.changeset/five-items-train.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-uikit/link": patch
+---
+
+Fix `Link` to use `inline-flex` for spacing of icon and text to support in text usage

--- a/packages/components/link/src/link.tsx
+++ b/packages/components/link/src/link.tsx
@@ -8,7 +8,6 @@ import { FormattedMessage } from 'react-intl';
 import { customProperties as vars } from '@commercetools-uikit/design-system';
 import { filterInvalidAttributes, warning } from '@commercetools-uikit/utils';
 import { ExternalLinkIcon } from '@commercetools-uikit/icons';
-import SpacingsInline from '@commercetools-uikit/spacings-inline';
 
 type TExtendedTheme = Theme & {
   [key: string]: string;
@@ -123,6 +122,14 @@ const getLinkStyles = (props: TLinkProps, theme: Theme) => {
   `;
 };
 
+const Wrapper = styled.span`
+  display: inline-flex;
+  align-items: center;
+  > svg {
+    margin: 0 0 0 ${vars.spacingXs} !important;
+  }
+`;
+
 const Link = (props: TLinkProps) => {
   const theme = useTheme();
 
@@ -138,7 +145,7 @@ const Link = (props: TLinkProps) => {
     }
 
     return (
-      <SpacingsInline scale="xs" alignItems="center">
+      <Wrapper>
         <a
           css={getLinkStyles(props, theme)}
           href={props.to}
@@ -158,7 +165,7 @@ const Link = (props: TLinkProps) => {
             color={getIconColorValue(props.tone)}
           />
         )}
-      </SpacingsInline>
+      </Wrapper>
     );
   }
 

--- a/packages/components/link/src/link.tsx
+++ b/packages/components/link/src/link.tsx
@@ -2,6 +2,7 @@ import type { LocationDescriptor } from 'history';
 import type { Theme } from '@emotion/react';
 import type { MessageDescriptor } from 'react-intl';
 import React from 'react';
+import styled from '@emotion/styled';
 import { Link as ReactRouterLink } from 'react-router-dom';
 import { css, useTheme } from '@emotion/react';
 import { FormattedMessage } from 'react-intl';


### PR DESCRIPTION
#### Summary

In some cases the `Link` is used in text where inline flex has to be used to not accidentally line break.