### PR TITLE
fix(link): prop-types for children

### DIFF
--- a/.changeset/smooth-phones-look.md
+++ b/.changeset/smooth-phones-look.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-uikit/link": patch
+---
+
+Fix prop-types of `Link` for children

--- a/packages/components/link/src/link.tsx
+++ b/packages/components/link/src/link.tsx
@@ -45,7 +45,7 @@ type TLinkProps = {
 type TIconColor = 'primary' | 'surface';
 
 const warnIfMissingContent = (props: TLinkProps) => {
-const hasContent =
+  const hasContent =
     Boolean(props.intlMessage) || Boolean(React.Children.count(props.children));
 
   warning(

--- a/packages/components/link/src/link.tsx
+++ b/packages/components/link/src/link.tsx
@@ -20,7 +20,7 @@ type TLinkProps = {
    * <br />
    * Required if `intlMessage` is not provided.
    */
-  children: React.ReactNode;
+  children?: React.ReactNode;
   /**
    * An `intl` message object that will be rendered with `FormattedMessage`.
    * <br />
@@ -45,7 +45,7 @@ type TLinkProps = {
 type TIconColor = 'primary' | 'surface';
 
 const warnIfMissingContent = (props: TLinkProps) => {
-  const hasContent =
+const hasContent =
     Boolean(props.intlMessage) || Boolean(React.Children.count(props.children));
 
   warning(


### PR DESCRIPTION
#### Summary

`children` is not required by the types, neither prop-types.