### PR TITLE
fix(link): vertical alignment of icon

### DIFF
--- a/.changeset/light-gifts-jam.md
+++ b/.changeset/light-gifts-jam.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-uikit/link": patch
+---
+
+Fix vertical alignment of external link icon to text when using `isExternal`

--- a/packages/components/link/src/link.tsx
+++ b/packages/components/link/src/link.tsx
@@ -124,10 +124,9 @@ const getLinkStyles = (props: TLinkProps, theme: Theme) => {
 };
 
 const Wrapper = styled.span`
-  display: inline-flex;
-  align-items: center;
   > svg {
     margin: 0 0 0 ${vars.spacingXs} !important;
+    vertical-align: bottom;
   }
 `;
 


### PR DESCRIPTION
#### Summary

This fixes an alignment issue with the icon on small screens.

## Description

Internally we always used a spacing `Spacings.Inline` or `inline-flex` to position the icon to the text. Turns out this implementation is flawed. On small screen sizes it will, due to a line breaks, position the icon falsely. 

As a proposed solution we can avoid Flexbox altogether and just vertically align the icon to the buttom.

#### Now

<img width="275" alt="CleanShot 2021-06-21 at 10 35 19@2x" src="https://user-images.githubusercontent.com/1877073/122733185-3a8d0f00-d27d-11eb-8759-543fecf83b45.png">

#### Before

<img width="294" alt="CleanShot 2021-06-21 at 10 35 30@2x" src="https://user-images.githubusercontent.com/1877073/122733191-3bbe3c00-d27d-11eb-93d3-f4e2701964b1.png">
