### PR TITLE
fix: random infinite loop initializing project

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -25,6 +25,7 @@ if [ -n "$SKIP_INSTALL_STORYBOOK" ]; then
 
 else
   echo "Installing dependencies for Storybook."
-  yarn --cwd docs
+  pushd docs/
+  yarn
 
 fi


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Infinite loop when running initialization command in some cases

## Description

It seems that sometimes there is an infinite loop when running the initialization command on a fresh cloned repository.
Running `yarn` from the root directory have this [post-install](https://github.com/commercetools/ui-kit/blob/main/scripts/postinstall.sh) process where it tries to install isolated dependencies for the documentation tool (Storybook) but it does not end. After it install those dependencies, the process starts over again.
