### PR TITLE
Add CI job for stale bot

### DIFF
--- a/.github-labelsrc.json
+++ b/.github-labelsrc.json
@@ -1,5 +1,11 @@
 [
   {
+    "id": 4077473362,
+    "name": "⌛ Status: Waiting for Customer",
+    "color": "000000",
+    "description": "Waiting for the answer from customer"
+  },
+  {
     "id": 1045018569,
     "name": "⛑ Type: Refactoring",
     "color": "58ce3d",

--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -12,7 +12,8 @@ jobs:
       - uses: actions/stale@v3
         with:
           any-of-labels: "Status: Waiting for Customer"
-          start-date: "2022-04-06 00:00:00.000",
+          start-date: "2022-04-06 00:00:00.000"
+          debug-only: true
           days-before-issue-stale: 14
           days-before-issue-close: 14
           stale-issue-label: "stale"

--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
-          any-of-labels: "Status: Waiting for Customer"
+          any-of-labels: "⌛ Status: Waiting for Customer"
           start-date: "2022-04-06 00:00:00.000"
           debug-only: true
           days-before-issue-stale: 14

--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -1,0 +1,23 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v3
+        with:
+          any-of-labels: "Status: Waiting for Customer"
+          start-date: "2022-04-06 00:00:00.000",
+          days-before-issue-stale: 14
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue has been marked as 'stale' due to its inactivity for the last 14 days. Please, add a new comment to keep the conversation going; otherwise, the issue will be closed in two weeks."
+          close-issue-message: "This issue has been closed due to its inactivity for the last month. Please, feel free to reopen it and add a new comment in case you think the problem has not been resolved."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,22 @@ on:
   pull_request:
 
 jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v3
+        with:
+          any-of-labels: "Status: Waiting for Customer"
+          days-before-issue-stale: 14
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 14 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
   build_lint_and_test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,22 +11,6 @@ on:
   pull_request:
 
 jobs:
-  close-issues:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - uses: actions/stale@v3
-        with:
-          any-of-labels: "Status: Waiting for Customer"
-          days-before-issue-stale: 14
-          days-before-issue-close: 14
-          stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 14 days with no activity."
-          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
-          days-before-pr-stale: -1
-          days-before-pr-close: -1
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
   build_lint_and_test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Added action to mark issues as stale after 14 days of inactivity and close them after 14 more days

<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

<!-- provide a short summary of your changes -->

## Description

<!-- provide some context -->
