### PR TITLE
Export Typescript types related to data tables

### DIFF
--- a/.changeset/quick-lions-obey.md
+++ b/.changeset/quick-lions-obey.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-uikit/data-table': patch
+'@commercetools-uikit/data-table-manager': patch
+'@commercetools-uikit/hooks': patch
+---
+
+Export several Typescript types related to data tables.

--- a/packages/components/data-table-manager/src/data-table-manager.tsx
+++ b/packages/components/data-table-manager/src/data-table-manager.tsx
@@ -10,11 +10,11 @@ import DataTableSettings, {
   type TDataTableSettingsProps,
 } from './data-table-settings';
 
-interface TRow {
+export interface TRow {
   id: string;
 }
 
-type TColumProps = {
+export type TColumProps = {
   /**
    * The unique key of the column that is used to identify your data type.
    * You can use this value to determine which value from a row item should be rendered.

--- a/packages/components/data-table-manager/src/export-types.ts
+++ b/packages/components/data-table-manager/src/export-types.ts
@@ -1,0 +1,1 @@
+export type { TRow, TColumProps } from './data-table-manager';

--- a/packages/components/data-table-manager/src/index.ts
+++ b/packages/components/data-table-manager/src/index.ts
@@ -1,6 +1,7 @@
 export { default } from './data-table-manager';
 export { UPDATE_ACTIONS } from './constants';
 export { default as version } from './version';
+export * from './export-types';
 
 // Re-exports for convenience
 export { useRowSelection, useSorting } from '@commercetools-uikit/hooks';

--- a/packages/components/data-table/src/export-types.ts
+++ b/packages/components/data-table/src/export-types.ts
@@ -1,0 +1,1 @@
+export type { TRow, TColumn } from './data-table';

--- a/packages/components/data-table/src/index.ts
+++ b/packages/components/data-table/src/index.ts
@@ -1,3 +1,4 @@
 export { default } from './data-table';
 export { useRowSelection, useSorting } from '@commercetools-uikit/hooks';
 export { default as version } from './version';
+export * from './export-types';

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -5,6 +5,6 @@ export { default as useRowSelection } from './use-row-selection';
 export { default as useSorting } from './use-sorting';
 export { default as usePaginationState } from './use-pagination-state';
 export { default as useDataTableSortingState } from './use-data-table-sorting-state';
-export * from './use-data-table-sorting-state';
+export * from './use-data-table-sorting-state/export-types';
 
 export { default as version } from './version';

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -5,5 +5,6 @@ export { default as useRowSelection } from './use-row-selection';
 export { default as useSorting } from './use-sorting';
 export { default as usePaginationState } from './use-pagination-state';
 export { default as useDataTableSortingState } from './use-data-table-sorting-state';
+export * from './use-data-table-sorting-state';
 
 export { default as version } from './version';

--- a/packages/hooks/src/use-data-table-sorting-state/export-types.ts
+++ b/packages/hooks/src/use-data-table-sorting-state/export-types.ts
@@ -1,0 +1,4 @@
+export type {
+  TSortDefinition,
+  TDataTableSortingState,
+} from './use-data-table-sorting-state';

--- a/packages/hooks/src/use-data-table-sorting-state/index.ts
+++ b/packages/hooks/src/use-data-table-sorting-state/index.ts
@@ -1,1 +1,2 @@
 export { default } from './use-data-table-sorting-state';
+export * from './export-types';

--- a/packages/hooks/src/use-data-table-sorting-state/use-data-table-sorting-state.ts
+++ b/packages/hooks/src/use-data-table-sorting-state/use-data-table-sorting-state.ts
@@ -1,12 +1,12 @@
 import { useState, useCallback } from 'react';
 import isNil from 'lodash/isNil';
 
-type TSortDefinition = {
+export type TSortDefinition = {
   key: string;
   order: 'desc' | 'asc';
 };
 
-type TDataTableSortingState = {
+export type TDataTableSortingState = {
   value: TSortDefinition;
   onChange: (
     key: TSortDefinition['key'],


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

### Summary

when trying to build a ui to display some data table information with typescript I found some useful types are not exported.

## Description

Some of the types regarding `DataTable` and `DataTableManager` components and also for `useDataTableSortingState' hook are needed to seamlessly integrate those in a new view so the goal of this PR would be to have them publicly exposed for consumers to use them.
