### PR TITLE
fix unexpected warnings in some field components

### DIFF
--- a/.changeset/strange-bugs-vanish.md
+++ b/.changeset/strange-bugs-vanish.md
@@ -1,0 +1,8 @@
+---
+'@commercetools-uikit/async-creatable-select-field': patch
+'@commercetools-uikit/async-select-field': patch
+'@commercetools-uikit/creatable-select-field': patch
+'@commercetools-uikit/search-select-field': patch
+---
+
+Fixes incorrect `touched` prop validation warnings in field components which also have `isMulti` prop.

--- a/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.tsx
+++ b/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.tsx
@@ -427,7 +427,8 @@ export default class AsyncCreatableSelectField extends Component<
       );
 
       warning(
-        Array.isArray(this.props.touched),
+        typeof this.props.touched === 'undefined' ||
+          Array.isArray(this.props.touched),
         'AsyncCreatableSelectField: `touched` is expected to be an array of boolean when isMulti is true'
       );
     }

--- a/packages/components/fields/async-select-field/src/async-select-field.tsx
+++ b/packages/components/fields/async-select-field/src/async-select-field.tsx
@@ -373,7 +373,8 @@ export default class AsyncSelectField extends Component<
       );
 
       warning(
-        Array.isArray(this.props.touched),
+        typeof this.props.touched === 'undefined' ||
+          Array.isArray(this.props.touched),
         'AsyncSelectField: `touched` is expected to be an array of boolean when isMulti is true'
       );
     }

--- a/packages/components/fields/creatable-select-field/src/creatable-select-field.tsx
+++ b/packages/components/fields/creatable-select-field/src/creatable-select-field.tsx
@@ -405,7 +405,8 @@ export default class CreatableSelectField extends Component<
       );
 
       warning(
-        Array.isArray(this.props.touched),
+        typeof this.props.touched === 'undefined' ||
+          Array.isArray(this.props.touched),
         'CreatableSelectField: `touched` is expected to be an array of boolean when isMulti is true'
       );
     }

--- a/packages/components/fields/search-select-field/src/search-select-field.tsx
+++ b/packages/components/fields/search-select-field/src/search-select-field.tsx
@@ -321,7 +321,7 @@ const SearchSelectField = (props: TSearchSelectFieldProps) => {
     );
 
     warning(
-      Array.isArray(props.touched),
+      typeof props.touched === 'undefined' || Array.isArray(props.touched),
       'SearchSelectField: `touched` is expected to be an array of boolean when isMulti is true'
     );
   }


### PR DESCRIPTION
#### Summary

Suppress invalid props warnings in some field components.

## Description

We were told that some field components are raising some warnings regarding the `touched` prop when they also have the `isMulti` prop with the value `true`.
This is because we are not correctly checking that `touched` property can be undefined while the input has not been gained focus yet.

Affected components:
* async-creatable-table-field
* async-select-field
* creatable-select-field
* search-select-field

closes #2162 