### PR TITLE
Fix issue with code snippet on grid component usage

### DIFF
--- a/.changeset/fuzzy-moose-fly.md
+++ b/.changeset/fuzzy-moose-fly.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/grid': minor
+---
+
+fix formatting code snippet on grid component usage documentation

--- a/.changeset/fuzzy-moose-fly.md
+++ b/.changeset/fuzzy-moose-fly.md
@@ -1,5 +1,0 @@
----
-'@commercetools-uikit/grid': minor
----
-
-fix formatting code snippet on grid component usage documentation

--- a/packages/components/grid/README.md
+++ b/packages/components/grid/README.md
@@ -39,7 +39,7 @@ import Grid from '@commercetools-uikit/grid';
 /**
  * We also recommend having a look at the [Grid story examples](https://uikit.commercetools.com/?path=/story/examples-components-grid--with-fixed-columns)
  * to see more detailed examples of common use cases of the CSS Grid layout.
- */
+ **/
 const Example = () => (
   <Grid
     gridGap="16px"

--- a/packages/components/grid/docs/usage-example.js
+++ b/packages/components/grid/docs/usage-example.js
@@ -3,7 +3,7 @@ import Grid from '@commercetools-uikit/grid';
 /**
  * We also recommend having a look at the [Grid story examples](https://uikit.commercetools.com/?path=/story/examples-components-grid--with-fixed-columns)
  * to see more detailed examples of common use cases of the CSS Grid layout.
- */
+ **/
 const Example = () => (
   <Grid
     gridGap="16px"


### PR DESCRIPTION
Fix issue with code snippet on grid component usage

### Initial formatting error: 
<img width="500" alt="image" src="https://user-images.githubusercontent.com/19975842/164240413-6c727e35-e8c0-4ef1-98c7-e36531d9255a.png">



### Fix: 
<img width="649" alt="image" src="https://user-images.githubusercontent.com/19975842/164240354-3685de13-740d-4f43-b50b-a743697bf917.png">
