### PR TITLE
chore(ui-kit): add top-level storybook link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 > If you are building **Custom Applications** for the Merchant Center, be sure to check out our [documentation](https://docs.commercetools.com/custom-applications)
 
+> An interactive collection of UI Kit components can be found [in our Storybook](https://uikit.commercetools.com/?path=/story/introduction--getting-started)
+
 # Getting started
 
 The UI Kit is a set of React components that follows commercetools [Design System](#design-system).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 > If you are building **Custom Applications** for the Merchant Center, be sure to check out our [documentation](https://docs.commercetools.com/custom-applications)
 
-> An interactive collection of UI Kit components can be found [in our Storybook](https://uikit.commercetools.com/?path=/story/introduction--getting-started)
+> Interactive documentation of UI Kit components can be found in our [Storybook](https://uikit.commercetools.com/?path=/story/introduction--getting-started)
 
 # Getting started
 


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

## Summary

This PR adds a top-level Storybook link to the UI Kit documentation

## Description

A nonzero number of developers (myself included 😅 ) have reached out to ask where the link to the UI Kit Storybook is, and I've often found myself landing on this page finding it difficult to find it 🔍 .

I figured we could add one at the top level, but as this package is open source, I was unsure of any formalities surrounding editing the documentation here. I'm mostly just throwing this PR at the wall to see if it sticks.
