### PR TITLE
refactor(rich-text): return empty string instead of empty paragraph

### DIFF
--- a/.changeset/old-jeans-yell.md
+++ b/.changeset/old-jeans-yell.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/rich-text-utils': patch
+---
+
+Refactor html `serialize` method to make rich text inputs work properly with Formik. After changes if no text is entered the input should return empty string instead of string containing empty paragraph ('<p></p>') that was returned previously.

--- a/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.form.story.js
+++ b/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.form.story.js
@@ -38,7 +38,7 @@ storiesOf('Examples|Forms/Inputs', module)
     };
     const refAboutMe = useRef(null);
     const handleReset = useCallback((ref) => {
-      ref.current?.resetValue(initialLocalizedValue);
+      ref.current?.resetValue();
     }, []);
 
     return (

--- a/packages/components/inputs/rich-text-utils/src/html/html.spec.js
+++ b/packages/components/inputs/rich-text-utils/src/html/html.spec.js
@@ -7,10 +7,10 @@ global.window = dom.window;
 
 describe('html', () => {
   describe('deserialize', () => {
-    describe('with empty value', () => {
-      it('should return same value', () => {
+    describe('with empty paragraph', () => {
+      it('should return empty string', () => {
         const htmlValue = '<p></p>';
-        expect(html.serialize(html.deserialize(htmlValue))).toEqual(htmlValue);
+        expect(html.serialize(html.deserialize(htmlValue))).toEqual('');
       });
     });
     describe('with inline span styles', () => {

--- a/packages/components/inputs/rich-text-utils/src/html/index.ts
+++ b/packages/components/inputs/rich-text-utils/src/html/index.ts
@@ -1,1 +1,7 @@
-export { default, defaultSlateState, type Deserialized } from './html';
+export {
+  default,
+  defaultSlateState,
+  type Deserialized,
+  type Format,
+  type CustomElement,
+} from './html';

--- a/packages/components/inputs/rich-text-utils/src/localized/localized.spec.js
+++ b/packages/components/inputs/rich-text-utils/src/localized/localized.spec.js
@@ -4,7 +4,7 @@ import {
   omitEmptyTranslations,
 } from './localized';
 
-const emptyValue = '<p></p>';
+const emptyValue = '';
 
 describe('createLocalizedString', () => {
   describe('when existingTranslations is not passed', () => {

--- a/packages/components/inputs/rich-text-utils/src/slate-helpers.tsx
+++ b/packages/components/inputs/rich-text-utils/src/slate-helpers.tsx
@@ -4,48 +4,21 @@ import {
   Transforms,
   Element as SlateElement,
   Text,
-  type BaseEditor,
-  type BaseText,
   type Editor as TEditor,
   type Descendant,
 } from 'slate';
 import {
   ReactEditor,
-  type ReactEditor as TReactEditor,
   type RenderElementProps,
   type RenderLeafProps,
 } from 'slate-react';
-import type { HistoryEditor } from 'slate-history';
-import { BLOCK_TAGS, MARK_TAGS } from './tags';
-import html, { defaultSlateState, type Deserialized } from './html';
-
-type CustomElement = {
-  type: Format;
-  children: CustomText[];
-  align?: string;
-};
-type CustomText = BaseText & {
-  bold?: boolean;
-  code?: string;
-  italic?: string;
-  underline?: string;
-  superscript?: string;
-  subscript?: string;
-  strikethrough?: string;
-};
-type Format = typeof BLOCK_TAGS[keyof typeof BLOCK_TAGS] &
-  typeof MARK_TAGS[keyof typeof MARK_TAGS];
-
-// Slate's way of providing custom type annotations comes down to extending `CustomTypes` interface
-// more: https://docs.slatejs.org/concepts/12-typescript
-// example: https://github.com/ianstormtaylor/slate/blob/main/packages/slate-react/src/custom-types.ts
-declare module 'slate' {
-  interface CustomTypes {
-    Editor: BaseEditor & TReactEditor & HistoryEditor;
-    Element: CustomElement;
-    Text: CustomText;
-  }
-}
+import { BLOCK_TAGS } from './tags';
+import html, {
+  defaultSlateState,
+  type Deserialized,
+  type Format,
+  type CustomElement,
+} from './html';
 
 const LIST_TYPES = [BLOCK_TAGS.ol, BLOCK_TAGS.ul];
 


### PR DESCRIPTION
#### Summary

In order to make rich text inputs work properly with Formik if there is no text entered the input should return empty string instead of empty paragraph (`<p></p>`). That implies some changes in the way serialization has worked before and what some unit tests expected.

Other than that, custom module declarations were moved to `html.tsx` file, since they were not visible previously during `tsc-files` type checks. 
