### PR TITLE
Upgrade ViewSwitcher story to allow icons to be enabled/disabled

### DIFF
--- a/packages/components/view-switcher/src/view-switcher.story.js
+++ b/packages/components/view-switcher/src/view-switcher.story.js
@@ -8,7 +8,6 @@ import Section from '../../../../docs/.storybook/decorators/section';
 import Readme from '../README.md';
 import ViewSwitcher from '.';
 
-const viewSwitcher = 'View Switcher';
 const BUTTONS_COUNT = 4;
 const DEFAULT_BUTTON_ICON = 'WorldIcon';
 
@@ -24,7 +23,6 @@ storiesOf('Components|ViewSwitcher', module)
     },
   })
   .add('ViewSwitcher', () => {
-    console.log({ CHANGE });
     // Reference: https://github.com/storybookjs/storybook/issues/3855#issuecomment-638245040
     const channel = addons.getChannel();
     channel.addListener(CHANGE, (event) => {
@@ -44,7 +42,7 @@ storiesOf('Components|ViewSwitcher', module)
     return (
       <Section allowIcons={allowIcons}>
         <ViewSwitcher.Group
-          isCondensed={boolean('isCondensed', false, viewSwitcher)}
+          isCondensed={boolean('isCondensed', false)}
           defaultSelected="Button #3"
         >
           {Array(BUTTONS_COUNT)

--- a/packages/components/view-switcher/src/view-switcher.story.js
+++ b/packages/components/view-switcher/src/view-switcher.story.js
@@ -1,5 +1,7 @@
 import { createElement } from 'react';
 import { storiesOf } from '@storybook/react';
+import { addons } from '@storybook/addons';
+import { CHANGE } from '@storybook/addon-knobs';
 import { withKnobs, select, boolean, text } from '@storybook/addon-knobs/react';
 import * as icons from '@commercetools-uikit/icons';
 import Section from '../../../../docs/.storybook/decorators/section';
@@ -7,6 +9,10 @@ import Readme from '../README.md';
 import ViewSwitcher from '.';
 
 const viewSwitcher = 'View Switcher';
+const BUTTONS_COUNT = 4;
+const DEFAULT_BUTTON_ICON = 'WorldIcon';
+
+const buttonName = (index) => `Button #${index}`;
 
 const iconNames = Object.keys(icons);
 storiesOf('Components|ViewSwitcher', module)
@@ -18,35 +24,53 @@ storiesOf('Components|ViewSwitcher', module)
     },
   })
   .add('ViewSwitcher', () => {
+    console.log({ CHANGE });
+    // Reference: https://github.com/storybookjs/storybook/issues/3855#issuecomment-638245040
+    const channel = addons.getChannel();
+    channel.addListener(CHANGE, (event) => {
+      if (event.name === 'Allow icons') {
+        Array(BUTTONS_COUNT)
+          .fill('')
+          .forEach((_, index) => {
+            channel.emit(CHANGE, {
+              name: `icon_${buttonName(index + 1)}`,
+              value: event.value ? DEFAULT_BUTTON_ICON : '',
+            });
+          });
+      }
+    });
+
+    const allowIcons = boolean('Allow icons', true);
     return (
-      <Section>
+      <Section allowIcons={allowIcons}>
         <ViewSwitcher.Group
           isCondensed={boolean('isCondensed', false, viewSwitcher)}
           defaultSelected="Button #3"
         >
-          {[...Array(4).keys()].map((j) => {
-            const i = j + 1;
-            const viewSwitcherButton = `Button #${i}`;
-            const selectedIcon = select(
-              'icon',
-              ['', ...iconNames],
-              '',
-              viewSwitcherButton
-            );
+          {Array(BUTTONS_COUNT)
+            .fill('')
+            .map((_, index) => {
+              const viewSwitcherButton = buttonName(index + 1);
+              const selectedIcon = select(
+                'icon',
+                ['', ...(allowIcons ? iconNames : [])],
+                allowIcons ? 'WorldIcon' : '',
+                viewSwitcherButton
+              );
 
-            return (
-              <ViewSwitcher.Button
-                key={i}
-                isDisabled={boolean('isDisabled', false, viewSwitcherButton)}
-                value={viewSwitcherButton}
-                {...(selectedIcon
-                  ? { icon: createElement(icons[selectedIcon]) }
-                  : {})}
-              >
-                {text('children', `View #${i}`, viewSwitcherButton)}
-              </ViewSwitcher.Button>
-            );
-          })}
+              return (
+                <ViewSwitcher.Button
+                  key={index + 1}
+                  isDisabled={boolean('isDisabled', false, viewSwitcherButton)}
+                  value={viewSwitcherButton}
+                  {...(selectedIcon
+                    ? { icon: createElement(icons[selectedIcon]) }
+                    : {})}
+                >
+                  {text('children', `View #${index + 1}`, viewSwitcherButton)}
+                </ViewSwitcher.Button>
+              );
+            })}
         </ViewSwitcher.Group>
       </Section>
     );


### PR DESCRIPTION
#### Summary

This is just an exploration about how to upgrade the `ViewSwitcher` component story in Storybook so users could both enable or disable icons for all switcher buttons at once.


