### PR TITLE
fix typescript props declarations to make menuPortalZIndex optional

### DIFF
--- a/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input.tsx
+++ b/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input.tsx
@@ -204,7 +204,7 @@ type TAsyncCreatableSelectInputProps = {
   /**
    * z-index value for the menu portal
    */
-  menuPortalZIndex: number;
+  menuPortalZIndex?: number;
   /**
    * whether the menu should block scroll while open
    * <br>

--- a/packages/components/inputs/async-select-input/src/async-select-input.tsx
+++ b/packages/components/inputs/async-select-input/src/async-select-input.tsx
@@ -196,7 +196,7 @@ type TAsyncSelectInputProps = {
   /**
    * z-index value for the menu portal
    */
-  menuPortalZIndex: number;
+  menuPortalZIndex?: number;
   /**
    * whether the menu should block scroll while open
    * <br>

--- a/packages/components/inputs/creatable-select-input/src/creatable-select-input.tsx
+++ b/packages/components/inputs/creatable-select-input/src/creatable-select-input.tsx
@@ -203,7 +203,7 @@ type TCreatableSelectInputProps = {
   /**
    * z-index value for the menu portal
    */
-  menuPortalZIndex: number;
+  menuPortalZIndex?: number;
   /**
    * whether the menu should block scroll while open
    * <br>

--- a/packages/components/inputs/search-select-input/src/search-select-input.tsx
+++ b/packages/components/inputs/search-select-input/src/search-select-input.tsx
@@ -172,7 +172,7 @@ export type TSearchSelectInputProps = {
   /**
    * z-index value for the menu portal
    */
-  menuPortalZIndex: number;
+  menuPortalZIndex?: number;
   /**
    * whether the menu should block scroll while open
    * <br>


### PR DESCRIPTION
### Summary

We found we have a property called `menuPortalZIndex` in several components typed as mandatory for their props where it actually is optional.

### Description

This prop is present in several components and, in all of them, we have a default value for it but some of them have it defined as required in its props typescript declaration.

closes #2204 