### PR TITLE
Add aria error attributes to field components

### DIFF
--- a/packages/components/fields/radio-field/src/radio-field.spec.js
+++ b/packages/components/fields/radio-field/src/radio-field.spec.js
@@ -178,21 +178,27 @@ describe('when showing an info button', () => {
 describe('when field is touched and has errors', () => {
   describe('when field empty', () => {
     it('should render a default error', () => {
-      const { getByText } = renderRadioField({
+      const { container, getByText } = renderRadioField({
         touched: true,
         errors: { missing: true },
       });
       expect(getByText(/field is required/i)).toBeInTheDocument();
+      expect(
+        container.querySelector('[aria-invalid="true"]')
+      ).toBeInTheDocument();
     });
   });
   describe('when there is a custom error', () => {
     it('should render the custom error message', () => {
-      const { getByText } = renderRadioField({
+      const { container, getByText } = renderRadioField({
         touched: true,
         errors: { custom: true },
         renderError: () => 'Custom error',
       });
       expect(getByText('Custom error')).toBeInTheDocument();
+      expect(
+        container.querySelector('[aria-invalid="true"]')
+      ).toBeInTheDocument();
     });
   });
 });

--- a/packages/components/fields/radio-field/src/radio-field.tsx
+++ b/packages/components/fields/radio-field/src/radio-field.tsx
@@ -28,6 +28,7 @@ type TCustomFormErrors<Values> = {
 };
 
 const sequentialId = createSequentialId('radio-field-');
+const sequentialErrorsId = createSequentialId('radio-field-error-')();
 
 const hasErrors = (errors?: TFieldErrors) =>
   errors && Object.values(errors).some(Boolean);
@@ -229,6 +230,9 @@ class RadioField extends Component<TRadioFieldProps, TRadioFieldStates> {
             direction={this.props.direction}
             directionProps={this.props.directionProps}
             {...filterDataAttributes(this.props)}
+            /* ARIA */
+            aria-invalid={hasError}
+            aria-errormessage={sequentialErrorsId}
           >
             {this.props.children}
           </RadioInput.Group>

--- a/packages/components/fields/select-field/src/select-field.spec.js
+++ b/packages/components/fields/select-field/src/select-field.spec.js
@@ -163,20 +163,22 @@ describe('when showing an info button', () => {
 describe('when field is touched and has errors', () => {
   describe('when field empty', () => {
     it('should render a default error', () => {
-      const { getByText } = renderSelectField({
+      const { getByText, getByLabelText } = renderSelectField({
         touched: true,
         errors: { missing: true },
       });
+      expect(getByLabelText('SelectField')).toBeInvalid();
       expect(getByText(/field is required/i)).toBeInTheDocument();
     });
   });
   describe('when there is a custom error', () => {
     it('should render the custom error message', () => {
-      const { getByText } = renderSelectField({
+      const { getByText, getByLabelText } = renderSelectField({
         touched: true,
         errors: { custom: true },
         renderError: () => 'Custom error',
       });
+      expect(getByLabelText('SelectField')).toBeInvalid();
       expect(getByText('Custom error')).toBeInTheDocument();
     });
   });
@@ -185,23 +187,25 @@ describe('when field is touched and has errors', () => {
 describe('when field is not touched', () => {
   describe('when isMulti is false', () => {
     it('should not render an error', () => {
-      const { queryByText } = renderSelectField({
+      const { queryByText, getByLabelText } = renderSelectField({
         touched: false,
         isMulti: false,
         value: ['1', '2', '3'],
         errors: { missing: true },
       });
+      expect(getByLabelText('SelectField')).toBeValid();
       expect(queryByText(/field is required/i)).not.toBeInTheDocument();
     });
   });
   describe('when isMulti is true', () => {
     it('should not render an error', () => {
-      const { queryByText } = renderSelectField({
+      const { queryByText, getByLabelText } = renderSelectField({
         touched: undefined,
         isMulti: true,
         value: ['1', '2', '3'],
         errors: { missing: true },
       });
+      expect(getByLabelText('SelectField')).toBeValid();
       expect(queryByText(/field is required/i)).not.toBeInTheDocument();
     });
   });

--- a/packages/components/fields/select-field/src/select-field.tsx
+++ b/packages/components/fields/select-field/src/select-field.tsx
@@ -276,6 +276,7 @@ type TSelectFieldProps = {
 type TFieldState = Pick<TSelectFieldProps, 'id'>;
 
 const sequentialId = createSequentialId('select-field-');
+const sequentialErrorsId = createSequentialId('select-field-error-')();
 
 const hasErrors = (errors?: TFieldErrors) =>
   errors && Object.values(errors).some(Boolean);
@@ -386,6 +387,9 @@ export default class SelectField extends Component<TSelectFieldProps> {
             iconLeft={this.props.iconLeft}
             inputValue={this.props.inputValue}
             {...filterDataAttributes(this.props)}
+            /* ARIA */
+            aria-invalid={hasError}
+            aria-errormessage={sequentialErrorsId}
           />
           <FieldErrors
             errors={this.props.errors}

--- a/packages/components/fields/time-field/src/time-field.spec.js
+++ b/packages/components/fields/time-field/src/time-field.spec.js
@@ -164,20 +164,22 @@ describe('when showing an info button', () => {
 describe('when field is touched and has errors', () => {
   describe('when field empty', () => {
     it('should render a default error', () => {
-      const { getByText } = renderTimeField({
+      const { getByLabelText, getByText } = renderTimeField({
         touched: true,
         errors: { missing: true },
       });
+      expect(getByLabelText('TimeField')).toBeInvalid();
       expect(getByText(/field is required/i)).toBeInTheDocument();
     });
   });
   describe('when there is a custom error', () => {
     it('should render the custom error message', () => {
-      const { getByText } = renderTimeField({
+      const { getByLabelText, getByText } = renderTimeField({
         touched: true,
         errors: { custom: true },
         renderError: () => 'Custom error',
       });
+      expect(getByLabelText('TimeField')).toBeInvalid();
       expect(getByText('Custom error')).toBeInTheDocument();
     });
   });

--- a/packages/components/fields/time-field/src/time-field.tsx
+++ b/packages/components/fields/time-field/src/time-field.tsx
@@ -169,6 +169,7 @@ type TTimeFieldProps = {
 type TTimeFieldState = Pick<TTimeFieldProps, 'id'>;
 
 const sequentialId = createSequentialId('time-field-');
+const sequentialErrorsId = createSequentialId('time-field-error-')();
 
 const hasErrors = (errors?: TFieldErrors) =>
   errors && Object.values(errors).some(Boolean);
@@ -249,6 +250,9 @@ class TimeField extends Component<TTimeFieldProps, TTimeFieldState> {
             horizontalConstraint="scale"
             isReadOnly={this.props.isReadOnly}
             {...filterDataAttributes(this.props)}
+            /* ARIA */
+            aria-invalid={hasError}
+            aria-errormessage={sequentialErrorsId}
           />
           <FieldErrors
             errors={this.props.errors}


### PR DESCRIPTION
### Summary

We found out that error aria attributes (`aria-invalid` and `aria-errormessage`) were missing in some field components.

### Description

The problem is that field components were not providing those attributes to their inner input components and so, the latter were not being marked as invalid at the aria level.
