### PR TITLE
Activate stale github action

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -13,7 +13,6 @@ jobs:
         with:
           any-of-labels: "⌛ Status: Waiting for Customer"
           start-date: "2022-04-06 00:00:00.000"
-          debug-only: true
           days-before-issue-stale: 14
           days-before-issue-close: 14
           stale-issue-label: "stale"


### PR DESCRIPTION
### Summary

This PR activates the GitHub action we implemented to deal with issues that don't have replies from their authors in a long period of time after we replied.
(_currently it's working in `dry-run` mode_).
