### PR TITLE
Fix CollapsiblePanel default ID generation

### DIFF
--- a/.changeset/weak-avocados-flow.md
+++ b/.changeset/weak-avocados-flow.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-uikit/collapsible-panel': patch
+---
+
+Fix auto ID generation.
+
+There was an issue when using several `CollapsiblePanel` components in the same view and relying on them to auto generate the IDs used for the rendered HTML resulting in the same ID value for all the components.

--- a/packages/components/collapsible-panel/package.json
+++ b/packages/components/collapsible-panel/package.json
@@ -25,6 +25,7 @@
     "@commercetools-uikit/collapsible-motion": "15.0.0",
     "@commercetools-uikit/constraints": "15.0.0",
     "@commercetools-uikit/design-system": "15.0.0",
+    "@commercetools-uikit/hooks": "15.0.0",
     "@commercetools-uikit/icons": "15.0.0",
     "@commercetools-uikit/spacings": "15.0.0",
     "@commercetools-uikit/text": "15.0.0",

--- a/packages/components/collapsible-panel/src/collapsible-panel.spec.js
+++ b/packages/components/collapsible-panel/src/collapsible-panel.spec.js
@@ -212,7 +212,7 @@ describe('aria attributes', () => {
       expect(panelContent).toHaveAttribute('hidden');
     });
 
-    it('should not have aria attribute when panel is open', () => {
+    it('should not have hidden attribute when panel is open', () => {
       const { panelContent } = renderPanel({ isClosed: false });
 
       expect(panelContent).not.toHaveAttribute('hidden');

--- a/packages/components/collapsible-panel/src/collapsible-panel.spec.js
+++ b/packages/components/collapsible-panel/src/collapsible-panel.spec.js
@@ -206,16 +206,16 @@ describe('aria attributes', () => {
   });
 
   describe('content', () => {
-    it('should have aria-hidden true when panel is closed', () => {
+    it('should have hidden attribute when panel is closed', () => {
       const { panelContent } = renderPanel({ isClosed: true });
 
-      expect(panelContent).not.toHaveAttribute('hidden');
+      expect(panelContent).toHaveAttribute('hidden');
     });
 
-    it('should have aria-hidden false when panel is open', () => {
+    it('should not have aria attribute when panel is open', () => {
       const { panelContent } = renderPanel({ isClosed: false });
 
-      expect(panelContent).toHaveAttribute('hidden');
+      expect(panelContent).not.toHaveAttribute('hidden');
     });
   });
 });

--- a/packages/components/collapsible-panel/src/collapsible-panel.spec.js
+++ b/packages/components/collapsible-panel/src/collapsible-panel.spec.js
@@ -160,85 +160,62 @@ it('should forward data-attributes', () => {
   expect(container.querySelector("[data-foo='bar']")).toBeInTheDocument();
 });
 
-describe('getPanelContentId', () => {
-  it('should return a string containing the given id', () => {
-    const panelContentId = CollapsiblePanel.getPanelContentId('example');
-
-    expect(panelContentId).toEqual(expect.stringContaining('example'));
-  });
-});
-
 describe('aria attributes', () => {
   const renderPanel = (props) => {
     const { container } = render(
-      <CollapsiblePanel
-        id="example"
-        header="Header"
-        onToggle={jest.fn()}
-        {...props}
-      >
+      <CollapsiblePanel header="Header" onToggle={jest.fn()} {...props}>
         Children
       </CollapsiblePanel>
     );
-    const getPanelHeader = () => screen.getByRole('button');
 
-    const panelContentId = CollapsiblePanel.getPanelContentId(
-      props.id || 'example'
+    const panelHeader = screen.getByRole('button');
+    const panelHeaderId = panelHeader.getAttribute('id');
+    const panelContent = container.querySelector(
+      `[aria-labelledby="${panelHeaderId}"]`
     );
-    const getPanelContent = () =>
-      container.querySelector(`[id=${panelContentId}]`);
 
     return {
-      getPanelHeader,
-      getPanelContent,
+      panelHeader,
+      panelContent,
     };
   };
   it('should have a valid aria-controls correspondence', () => {
-    const { getPanelHeader, getPanelContent } = renderPanel({
+    const { panelHeader, panelContent } = renderPanel({
       id: 'test-id',
       isClosed: false,
     });
 
-    const panelContentId = CollapsiblePanel.getPanelContentId('test-id');
-
-    // assert that the header button has the aria attribute
-    const headerButton = getPanelHeader();
-    expect(headerButton).toHaveAttribute('aria-controls', panelContentId);
-
-    // find the correspondent panel content
-    expect(getPanelContent()).toBeInTheDocument();
+    // assert that the header button has the aria attribute linked to the panel content
+    expect(panelHeader).toHaveAttribute(
+      'aria-controls',
+      panelContent.getAttribute('id')
+    );
   });
   describe('header', () => {
     it('should have aria-expanded true when panel is open', () => {
-      const { getPanelHeader } = renderPanel({ isClosed: false });
+      const { panelHeader } = renderPanel({ isClosed: false });
 
-      const headerButton = getPanelHeader();
-      expect(headerButton).toHaveAttribute('aria-expanded', 'true');
+      expect(panelHeader).toHaveAttribute('aria-expanded', 'true');
     });
 
     it('should have aria-expanded false when panel is closed', () => {
-      const { getPanelHeader } = renderPanel({ isClosed: true });
+      const { panelHeader } = renderPanel({ isClosed: true });
 
-      const headerButton = getPanelHeader();
-      expect(headerButton).toHaveAttribute('aria-expanded', 'false');
+      expect(panelHeader).toHaveAttribute('aria-expanded', 'false');
     });
   });
 
   describe('content', () => {
     it('should have aria-hidden true when panel is closed', () => {
-      const { getPanelContent } = renderPanel({ isClosed: true });
+      const { panelContent } = renderPanel({ isClosed: true });
 
-      const panelContent = getPanelContent();
-
-      expect(panelContent).toHaveAttribute('aria-hidden', 'true');
+      expect(panelContent).not.toHaveAttribute('hidden');
     });
 
     it('should have aria-hidden false when panel is open', () => {
-      const { getPanelContent } = renderPanel({ isClosed: false });
+      const { panelContent } = renderPanel({ isClosed: false });
 
-      const panelContent = getPanelContent();
-
-      expect(panelContent).toHaveAttribute('aria-hidden', 'false');
+      expect(panelContent).toHaveAttribute('hidden');
     });
   });
 });

--- a/packages/components/collapsible-panel/src/collapsible-panel.tsx
+++ b/packages/components/collapsible-panel/src/collapsible-panel.tsx
@@ -25,7 +25,10 @@ import CollapsiblePanelHeader from './collapsible-panel-header';
 
 const HeaderContainer = styled(AccessibleButton)``;
 
-const sequentialId = createSequentialId('panel-content-');
+const panelButtonSequentialId = createSequentialId('collapsible-panel-button-');
+const panelContentSequentialId = createSequentialId(
+  'collapsible-panel-content-'
+);
 
 export type TCollapsiblePanel = {
   /**
@@ -144,7 +147,8 @@ const defaultProps: Pick<
 // When `isClosed` is provided the component behaves as a controlled component,
 // otherwise it will behave like an uncontrolled component.
 const CollapsiblePanel = (props: TCollapsiblePanel) => {
-  const panelContentId = useFieldId(props.id, sequentialId);
+  const panelButtonId = useFieldId(props.id, panelButtonSequentialId);
+  const panelContentId = useFieldId(undefined, panelContentSequentialId);
   // Pass only `data-*` props
   const dataProps = filterDataAttributes(props);
   const scale = props.condensed ? 's' : 'm';
@@ -196,7 +200,7 @@ const CollapsiblePanel = (props: TCollapsiblePanel) => {
                 getHeaderContainerStyles(props, isOpen),
                 getThemeStyle(props.theme),
               ]}
-              id={props.id}
+              id={panelButtonId}
               label=""
               onClick={props.isDisabled ? undefined : toggle}
               isDisabled={props.isDisabled}
@@ -246,7 +250,9 @@ const CollapsiblePanel = (props: TCollapsiblePanel) => {
                 <Spacings.Inset scale={scale}>
                   <SectionContent
                     id={panelContentId}
-                    aria-hidden={isOpen ? 'false' : 'true'}
+                    role="region"
+                    aria-labelledby={panelButtonId}
+                    hidden={isOpen}
                   >
                     {props.children}
                   </SectionContent>
@@ -260,7 +266,10 @@ const CollapsiblePanel = (props: TCollapsiblePanel) => {
   );
 };
 
-CollapsiblePanel.getPanelContentId = sequentialId;
+/**
+ * @deprecated This function is no longer supported.
+ */
+CollapsiblePanel.getPanelContentId = () => '';
 CollapsiblePanel.displayName = 'CollapsiblePanel';
 CollapsiblePanel.defaultProps = defaultProps;
 CollapsiblePanel.Header = CollapsiblePanelHeader;

--- a/packages/components/collapsible-panel/src/collapsible-panel.tsx
+++ b/packages/components/collapsible-panel/src/collapsible-panel.tsx
@@ -252,7 +252,7 @@ const CollapsiblePanel = (props: TCollapsiblePanel) => {
                     id={panelContentId}
                     role="region"
                     aria-labelledby={panelButtonId}
-                    hidden={isOpen}
+                    hidden={!isOpen}
                   >
                     {props.children}
                   </SectionContent>

--- a/packages/components/collapsible-panel/src/collapsible-panel.tsx
+++ b/packages/components/collapsible-panel/src/collapsible-panel.tsx
@@ -1,9 +1,13 @@
 import { ReactNode } from 'react';
 import isNil from 'lodash/isNil';
-import uniqueId from 'lodash/uniqueId';
 import styled from '@emotion/styled';
-import { filterDataAttributes, warning } from '@commercetools-uikit/utils';
+import {
+  createSequentialId,
+  filterDataAttributes,
+  warning,
+} from '@commercetools-uikit/utils';
 import AccessibleButton from '@commercetools-uikit/accessible-button';
+import { useFieldId } from '@commercetools-uikit/hooks';
 import Spacings from '@commercetools-uikit/spacings';
 import Text from '@commercetools-uikit/text';
 import CollapsibleMotion from '@commercetools-uikit/collapsible-motion';
@@ -21,8 +25,7 @@ import CollapsiblePanelHeader from './collapsible-panel-header';
 
 const HeaderContainer = styled(AccessibleButton)``;
 
-const panelContentIdPrefix = 'panel-content-';
-const getPanelContentId = (id?: string) => panelContentIdPrefix + id;
+const sequentialId = createSequentialId('panel-content-');
 
 export type TCollapsiblePanel = {
   /**
@@ -125,14 +128,12 @@ export type TCollapsiblePanel = {
 
 const defaultProps: Pick<
   TCollapsiblePanel,
-  | 'id'
   | 'theme'
   | 'condensed'
   | 'isDisabled'
   | 'headerControlsAlignment'
   | 'horizontalConstraint'
 > = {
-  id: uniqueId(),
   theme: 'dark',
   condensed: false,
   isDisabled: false,
@@ -143,7 +144,7 @@ const defaultProps: Pick<
 // When `isClosed` is provided the component behaves as a controlled component,
 // otherwise it will behave like an uncontrolled component.
 const CollapsiblePanel = (props: TCollapsiblePanel) => {
-  const panelContentId = getPanelContentId(props.id);
+  const panelContentId = useFieldId(props.id, sequentialId);
   // Pass only `data-*` props
   const dataProps = filterDataAttributes(props);
   const scale = props.condensed ? 's' : 'm';
@@ -259,7 +260,7 @@ const CollapsiblePanel = (props: TCollapsiblePanel) => {
   );
 };
 
-CollapsiblePanel.getPanelContentId = getPanelContentId;
+CollapsiblePanel.getPanelContentId = sequentialId;
 CollapsiblePanel.displayName = 'CollapsiblePanel';
 CollapsiblePanel.defaultProps = defaultProps;
 CollapsiblePanel.Header = CollapsiblePanelHeader;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2536,6 +2536,7 @@ __metadata:
     "@commercetools-uikit/collapsible-motion": 15.0.0
     "@commercetools-uikit/constraints": 15.0.0
     "@commercetools-uikit/design-system": 15.0.0
+    "@commercetools-uikit/hooks": 15.0.0
     "@commercetools-uikit/icons": 15.0.0
     "@commercetools-uikit/spacings": 15.0.0
     "@commercetools-uikit/text": 15.0.0


### PR DESCRIPTION
### Summary

`CollapsiblePanel` component does not correctly autogenerate IDs. 

### Description

When the `CollapsiblePanel` component is used and no `id` property is provided, the autogenerated value is not correctly calculated so, if a consumer uses several instances of this component in the same view, they all will have the same ID in the rendered HTML.

I also found some room for improvements in the accessibility attributes of the component based of [this reference](https://w3c.github.io/aria-practices/examples/accordion/accordion.html).