### PR TITLE
Update `DataTableManager` settings selector to allow for long placeholders

### DIFF
--- a/.changeset/selfish-kangaroos-exist.md
+++ b/.changeset/selfish-kangaroos-exist.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table-manager': patch
+---
+
+Updated `DataTableManager` settings selector to keep same height for long placeholders (eg: german)

--- a/packages/components/data-table-manager/src/data-table-settings/data-table-settings.tsx
+++ b/packages/components/data-table-manager/src/data-table-settings/data-table-settings.tsx
@@ -125,7 +125,7 @@ export type TDataTableSettingsProps = {
 because the input is always empty, and therefore doesn't take any space by itself
 but we want to keep enough space for the placeholder to be readable */
 const SelectContainer = styled.div`
-  width: ${customProperties.constraint4};
+  min-width: ${customProperties.constraint4};
 `;
 
 const TopBarContainer = styled.div`


### PR DESCRIPTION
## Summary

Allow `DataTableManager` settings selector to use long placeholders keeping the same height.

Example of how it currently renders:

![Screenshot 2022-07-11 at 12 30 45](https://user-images.githubusercontent.com/97907068/178246734-b775e1e1-0168-4862-a860-b0f7882c11af.png)

## Description

The selector currently has a fixed of 184px (`constraint4` design token) width and we decided to change that to be a `min-width` since there are plenty available horizontal space.

This is how it will look like:

(_German_)
![image](https://user-images.githubusercontent.com/97907068/178247052-79970480-5023-44d3-9f52-3747609dffdc.png)

(_English_)

![Screenshot 2022-07-11 at 12 31 20](https://user-images.githubusercontent.com/97907068/178247179-6a512697-ed54-4b8d-bebe-9b720fbe441d.png)

