### PR TITLE
fix: enable deserialization of nested html markup

### DIFF
--- a/.changeset/healthy-rockets-pretend.md
+++ b/.changeset/healthy-rockets-pretend.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/rich-text-utils': patch
+---
+
+Fix `deserializeElement` function to cover deserialization of nested html markup

--- a/packages/components/inputs/rich-text-utils/src/html/html.spec.js
+++ b/packages/components/inputs/rich-text-utils/src/html/html.spec.js
@@ -100,6 +100,16 @@ describe('html', () => {
           );
         });
       });
+      describe('nested elements within text and unsupported element tags (table, img)', () => {
+        it('should properly serialize', () => {
+          const htmlValue =
+            '<ol><li><span style="font-weight: bold; font-family: &quot;Comic Sans MS&quot;;">Computermouse for <span style="text-decoration-line: underline;">controlling</span></span></li></ol><table class="table table-bordered"><tbody><tr><td>hello</td></tr><tr><td><p>world<img src="https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_10010937aj.jpg" style="width: 100%; float: right;" class="pull-right img-circle"></p></td></tr></tbody></table><ol><li><span style="font-weight: bold; font-family: &quot;Comic Sans MS&quot;;"><span style="text-decoration-line: underline;"><br></span></span></li></ol>';
+
+          expect(html.serialize(html.deserialize(htmlValue))).toEqual(
+            '<ol><li><strong>Computermouse for </strong><u><strong>controlling</strong></u></li></ol>hello<p>world</p><ol><li><u><strong></strong></u></li></ol>'
+          );
+        });
+      });
     });
   });
 });

--- a/packages/components/inputs/rich-text-utils/src/html/html.tsx
+++ b/packages/components/inputs/rich-text-utils/src/html/html.tsx
@@ -177,7 +177,7 @@ const mapper: TMapper = {
 
 const wrapWithParagraphIfRootElement = (
   el: HTMLElement | ChildNode,
-  textContent: TElement | TText
+  textContent: TElement | TText | (TElement | TText)[]
 ) =>
   el.parentNode?.nodeName === 'BODY' // root element, because body is eventually turned to React fragment
     ? jsx('element', { type: 'paragraph' }, textContent)
@@ -253,7 +253,15 @@ const deserializeElement = (
           jsx('element', { type: 'span' }, children)
         );
       }
-      return wrapWithParagraphIfRootElement(el, jsx('text', attrs, children));
+      return wrapWithParagraphIfRootElement(
+        el,
+        // children mapping to cover nested elements within text e.g. <span>Some <span>text</span></span>
+        children.map((child) =>
+          Text.isText(child)
+            ? jsx('text', attrs, child)
+            : jsx('element', attrs, child)
+        )
+      );
     }
   }
 

--- a/packages/components/inputs/rich-text-utils/src/is-empty/is-empty.spec.js
+++ b/packages/components/inputs/rich-text-utils/src/is-empty/is-empty.spec.js
@@ -11,12 +11,12 @@ describe('isEmpty', () => {
       expect(isEmpty('<h1></h1><ul><li></li></ul>')).toBeTruthy();
     });
   });
-  describe('when empty but has empty html tags', () => {
+  describe('when not empty', () => {
     it('should indicate that the value is not empty', () => {
       expect(isEmpty('<ol><li><em>Not empty</em></li></ol>')).toBeFalsy();
     });
   });
-  describe('when not empty', () => {
+  describe('when not empty and with malformed markup', () => {
     it('should indicate that the value is not empty', () => {
       expect(isEmpty('<H1>Okay</h1>')).toBeFalsy();
     });


### PR DESCRIPTION
#### Summary

Fixes regression in `@commercetools-uikit/rich-text-utils` related to deserialization of nested html markup
