### PR TITLE
[POC] Fix proposal for Percy related issues with CSS vars

### DIFF
--- a/design-system/scripts/generate-custom-properties.js
+++ b/design-system/scripts/generate-custom-properties.js
@@ -157,7 +157,7 @@ let _canUseCssVars: Boolean | null = null;
 const canUseCssVars = (): Boolean => {
   if (_canUseCssVars === null) {
     _canUseCssVars =
-      Boolean(document.querySelector('meta[name="ui-kit-vrt-environment"]'));
+      !Boolean(document.querySelector('meta[name="ui-kit-vrt-environment"]'));
   }
   return _canUseCssVars;
 };
@@ -167,8 +167,8 @@ const proxyHandler = {
     name: keyof typeof customProperties
   ) => {
     return canUseCssVars()
-      ? themes.default[name]
-      : target[name];
+    ? target[name]
+    : themes.default[name];
   },
 };
 

--- a/design-system/scripts/generate-custom-properties.js
+++ b/design-system/scripts/generate-custom-properties.js
@@ -151,7 +151,28 @@ const printCustomProperties = (data) => {
 */
 export const themes = ${JSON.stringify(themes, null, 2)} as const;
 
-export default ${JSON.stringify(variables, null, 2)} as const;
+const customProperties = ${JSON.stringify(variables, null, 2)} as const;
+
+let _canUseCssVars: Boolean | null = null;
+const canUseCssVars = (): Boolean => {
+  if (_canUseCssVars === null) {
+    _canUseCssVars =
+      Boolean(document.querySelector('meta[name="ui-kit-vrt-environment"]'));
+  }
+  return _canUseCssVars;
+};
+const proxyHandler = {
+  get: (
+    target: typeof customProperties,
+    name: keyof typeof customProperties
+  ) => {
+    return canUseCssVars()
+      ? themes.default[name]
+      : target[name];
+  },
+};
+
+export default new Proxy(customProperties, proxyHandler);
 `;
 };
 

--- a/design-system/src/custom-properties.ts
+++ b/design-system/src/custom-properties.ts
@@ -253,7 +253,7 @@ export const themes = {
   },
 } as const;
 
-export default {
+const customProperties = {
   colorPrimary: 'var(--color-primary, #00b39e)',
   colorPrimary25: 'var(--color-primary-25, hsl(172.9608938547486, 100%, 25%))',
   colorPrimary40: 'var(--color-primary-40, hsl(172.9608938547486, 100%, 40%))',
@@ -402,3 +402,23 @@ export default {
   sizeHeightTag: 'var(--size-height-tag, 26px)',
   standardInputHeight: 'var(--standard-input-height, 32px)',
 } as const;
+
+let _canUseCssVars: Boolean | null = null;
+const canUseCssVars = (): Boolean => {
+  if (_canUseCssVars === null) {
+    _canUseCssVars = Boolean(
+      document.querySelector('meta[name="ui-kit-vrt-environment"]')
+    );
+  }
+  return _canUseCssVars;
+};
+const proxyHandler = {
+  get: (
+    target: typeof customProperties,
+    name: keyof typeof customProperties
+  ) => {
+    return canUseCssVars() ? themes.default[name] : target[name];
+  },
+};
+
+export default new Proxy(customProperties, proxyHandler);

--- a/design-system/src/custom-properties.ts
+++ b/design-system/src/custom-properties.ts
@@ -406,7 +406,7 @@ const customProperties = {
 let _canUseCssVars: Boolean | null = null;
 const canUseCssVars = (): Boolean => {
   if (_canUseCssVars === null) {
-    _canUseCssVars = Boolean(
+    _canUseCssVars = !Boolean(
       document.querySelector('meta[name="ui-kit-vrt-environment"]')
     );
   }
@@ -417,7 +417,7 @@ const proxyHandler = {
     target: typeof customProperties,
     name: keyof typeof customProperties
   ) => {
-    return canUseCssVars() ? themes.default[name] : target[name];
+    return canUseCssVars() ? target[name] : themes.default[name];
   },
 };
 

--- a/visual-testing-app/index.html
+++ b/visual-testing-app/index.html
@@ -6,6 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, viewport-fit=cover"
     />
+    <meta name="ui-kit-vrt-environment">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i' rel='stylesheet' type='text/css'>
     <title>UI-Kit | Visual testing app</title>
     <style>


### PR DESCRIPTION
### Summary

This PR includes a proposal fix for the problem we found when implementing Theming support with Percy snapshot testing.

## Description

It seems Percy does not support using CSS vars the way we want to use them (CSS in JS).

Since our components use the `custom-properties.ts` file to get access to design tokens values which we want to be CSS vars in the new version but that does not seem to be working with Percy snapshot testing, following their recommendation (not to use CSS vars), in this proposal we add a marker in the visual testing app document (the one we use for snapshot testing) and use it in the mentioned file to not return a CSS var but the fixed default value when rendering in that environment.
