### PR TITLE
Acccessibility button: display role attribute when SecondaryButton component is disabled

### DIFF
--- a/.changeset/curvy-worms-invite.md
+++ b/.changeset/curvy-worms-invite.md
@@ -2,4 +2,4 @@
 '@commercetools-uikit/accessible-button': patch
 ---
 
-keep role attribute of the accessibility button even when disabled
+fix a bug with accessibility attributes when using the `as` property

--- a/.changeset/curvy-worms-invite.md
+++ b/.changeset/curvy-worms-invite.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/accessible-button': patch
+---
+
+keep role attribute of the accessibility button even when disabled

--- a/packages/components/buttons/accessible-button/src/accessible-button.spec.js
+++ b/packages/components/buttons/accessible-button/src/accessible-button.spec.js
@@ -102,5 +102,16 @@ describe('rendering', () => {
         '0'
       );
     });
+    it('should render a div element with accessibility attributes when disabled', () => {
+      render(<AccessibleButton {...props} as="div" isDisabled={true} />);
+      expect(screen.getByLabelText('test-button')).toHaveAttribute(
+        'role',
+        'button'
+      );
+      expect(screen.getByLabelText('test-button')).toHaveAttribute(
+        'tabindex',
+        '0'
+      );
+    });
   });
 });

--- a/packages/components/buttons/accessible-button/src/accessible-button.tsx
+++ b/packages/components/buttons/accessible-button/src/accessible-button.tsx
@@ -143,14 +143,10 @@ const AccessibleButton = forwardRef<HTMLButtonElement, TAccessibleButtonProps>(
         type: props.type,
       };
     } else {
-      if (!props.isDisabled) {
-        buttonProps = {
-          onKeyPress: handleKeyPress,
-        };
-      }
       buttonProps = {
         role: 'button',
         tabIndex: '0',
+        onKeyPress: handleKeyPress,
       };
     }
 

--- a/packages/components/buttons/accessible-button/src/accessible-button.tsx
+++ b/packages/components/buttons/accessible-button/src/accessible-button.tsx
@@ -142,7 +142,7 @@ const AccessibleButton = forwardRef<HTMLButtonElement, TAccessibleButtonProps>(
       buttonProps = {
         type: props.type,
       };
-    } else if (!props.isDisabled) {
+    } else {
       buttonProps = {
         role: 'button',
         tabIndex: '0',

--- a/packages/components/buttons/accessible-button/src/accessible-button.tsx
+++ b/packages/components/buttons/accessible-button/src/accessible-button.tsx
@@ -143,10 +143,14 @@ const AccessibleButton = forwardRef<HTMLButtonElement, TAccessibleButtonProps>(
         type: props.type,
       };
     } else {
+      if (!props.isDisabled) {
+        buttonProps = {
+          onKeyPress: handleKeyPress,
+        };
+      }
       buttonProps = {
         role: 'button',
         tabIndex: '0',
-        onKeyPress: handleKeyPress,
       };
     }
 


### PR DESCRIPTION
SecondaryButton components rendered as` a` tags lose their role attribute when disabled. We should still see the role attribute even if the component is disabled.