### PR TITLE
Remove unnecessary helper from theming React hook

### DIFF
--- a/design-system/src/theme-provider.spec.js
+++ b/design-system/src/theme-provider.spec.js
@@ -1,5 +1,6 @@
 /* eslint-disable testing-library/no-wait-for-multiple-assertions */
-import { useTheme, customProperties } from '@commercetools-uikit/design-system';
+import { useState } from 'react';
+import { customProperties } from '@commercetools-uikit/design-system';
 import PropTypes from 'prop-types';
 import { screen, render, fireEvent, waitFor } from '../../test/test-utils';
 import { ThemeProvider } from './theme-provider';
@@ -23,18 +24,25 @@ const globalParentSelector = () => document.body;
 const localParentSelector = () => document.getElementById('localParent');
 
 const TestComponentWithThemeProvider = () => {
-  const { applyTheme: applyGlobalTheme } = useTheme(globalParentSelector);
-  const { applyTheme: applyLocalTheme } = useTheme(localParentSelector);
+  const [globalTheme, setGlobalTheme] = useState({
+    name: 'default',
+    overrides: {},
+  });
+  const [localTheme, setLocalTheme] = useState({
+    name: 'default',
+    overrides: {},
+  });
+
   return (
     <>
       <button
         onClick={() => {
-          applyGlobalTheme({
-            themeOverrides: {
+          setGlobalTheme({
+            name: 'dark',
+            overrides: {
               colorSolid: 'red',
               colorSurface: 'yellow',
             },
-            newTheme: 'dark',
           });
         }}
       >
@@ -42,22 +50,30 @@ const TestComponentWithThemeProvider = () => {
       </button>
       <button
         onClick={() => {
-          applyLocalTheme({
-            themeOverrides: {
+          setLocalTheme({
+            name: 'dark',
+            overrides: {
               colorSolid: 'green',
               colorSurface: 'tomato',
               customColor: '#BADA55',
             },
-            newTheme: 'dark',
           });
         }}
       >
         change local theme
       </button>
-      <ThemeProvider parentSelector={globalParentSelector} />
+      <ThemeProvider
+        theme={globalTheme.name}
+        themeOverrides={globalTheme.overrides}
+        parentSelector={globalParentSelector}
+      />
       <TestComponent text="global" />
       <div id="localParent">
-        <ThemeProvider parentSelector={localParentSelector} />
+        <ThemeProvider
+          theme={localTheme.name}
+          themeOverrides={localTheme.overrides}
+          parentSelector={localParentSelector}
+        />
         <TestComponent text="local" />
       </div>
     </>

--- a/design-system/src/theme-provider.tsx
+++ b/design-system/src/theme-provider.tsx
@@ -88,21 +88,7 @@ const useTheme = (parentSelector = defaultParentSelector) => {
     setTheme(parentSelectorRef.current()?.dataset.theme || 'default');
   }, []);
 
-  // So consumers don't have to provide 'parentSelector' again as
-  // they already provided it in the hook call
-  const updateTheme = useRef(
-    ({ newTheme, themeOverrides }: Omit<TApplyTheme, 'parentSelector'>) => {
-      applyTheme({
-        newTheme,
-        parentSelector: parentSelectorRef.current,
-        themeOverrides,
-      });
-      setTheme(newTheme || 'default');
-    }
-  );
-  return useMemo(() => {
-    return { theme, applyTheme: updateTheme.current };
-  }, [theme]);
+  return useMemo(() => theme, [theme]);
 };
 
 export { ThemeProvider, useTheme };

--- a/design-system/src/theme-provider.tsx
+++ b/design-system/src/theme-provider.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useMemo, useState, useRef, useEffect } from 'react';
+import { useLayoutEffect, useState, useRef, useEffect } from 'react';
 import kebabCase from 'lodash/kebabCase';
 import isObject from 'lodash/isObject';
 import merge from 'lodash/merge';
@@ -88,7 +88,7 @@ const useTheme = (parentSelector = defaultParentSelector) => {
     setTheme(parentSelectorRef.current()?.dataset.theme || 'default');
   }, []);
 
-  return useMemo(() => theme, [theme]);
+  return theme;
 };
 
 export { ThemeProvider, useTheme };

--- a/design-system/src/theme-provider.visualroute.jsx
+++ b/design-system/src/theme-provider.visualroute.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useTheme, customProperties } from '@commercetools-uikit/design-system';
 import { Switch, Route } from 'react-router';
 import kebabCase from 'lodash/kebabCase';
@@ -15,7 +16,7 @@ export const routePath = '/theme-provider';
 const parentSelector = (id) => () => document.getElementById(id);
 
 const DummyComponent = (props) => {
-  const { theme } = useTheme(parentSelector(props.parentId));
+  const theme = useTheme(parentSelector(props.parentId));
 
   return (
     <h1
@@ -135,15 +136,16 @@ TestComponent.propTypes = {
 const localThemeParentSelector = () => document.getElementById('local');
 
 const InteractiveRoute = () => {
-  const { applyTheme: applyGlobalTheme } = useTheme();
-  const { applyTheme: applyLocalTheme } = useTheme(localThemeParentSelector);
+  const [globalTheme, setGlobalTheme] = useState({ name: 'default', overrides: {} });
+  const [localTheme, setLocalTheme] = useState({ name: 'default', overrides: {} });
+
   return (
     <>
       <button
         onClick={() => {
-          applyGlobalTheme({
-            newTheme: 'dark',
-            themeOverrides: {
+          setGlobalTheme({
+            name: 'dark',
+            overrides: {
               colorSolid: 'red',
               colorSurface: 'yellow',
               customColor: '#BADA55',
@@ -155,18 +157,24 @@ const InteractiveRoute = () => {
       </button>
       <button
         onClick={() => {
-          applyLocalTheme({
-            newTheme: 'dark',
-            themeOverrides: { colorSolid: 'green', colorSurface: 'tomato' },
+          setLocalTheme({
+            name: 'dark',
+            overrides: { colorSolid: 'green', colorSurface: 'tomato' },
           });
         }}
       >
         change local theme
       </button>
-      <ThemeProvider />
+      <ThemeProvider
+        theme={globalTheme.name}
+        themeOverrides={globalTheme.overrides}
+      />
       <TestComponent text="global" />
       <div id="local">
-        <ThemeProvider parentSelector={localThemeParentSelector} />
+        <ThemeProvider
+          theme={localTheme.name}
+          themeOverrides={localTheme.overrides}
+          parentSelector={localThemeParentSelector} />
         <TestComponent text="local" />
       </div>
     </>


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX128lVqpOwrffDpRNHsoxrRgNT0r5z644%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=QALXUDg)
### Summary

Remove `applyTheme` from `useTheme` hook since we don't see the need for it.

## Description

We expect users to handle the current theme on their side and provide it to the `ThemeProvider` as a prop.
When they'll need to change it, they would just provide a new value in the `theme` prop of the provider.

`useTheme` hook will only return a string with the current provider theme.