### PR TITLE
Update css tokens imports

### DIFF
--- a/design-system/materials/internals/tokens.story.js
+++ b/design-system/materials/internals/tokens.story.js
@@ -4,7 +4,8 @@ import { storiesOf } from '@storybook/react';
 import styled from '@emotion/styled';
 import TextInput from '@commercetools-uikit/text-input';
 import merge from 'lodash/merge';
-import customProperties from '../custom-properties.json';
+// import customProperties from '../custom-properties.json';
+import { designTokens } from '@commercetools-uikit/design-system';
 import Readme from './TOKENS.md';
 import definition from './definition.yaml';
 import deprecatedTokens from './deprecated-tokens';
@@ -34,8 +35,8 @@ const Table = styled.table`
 
 const Background = styled.div`
   background-color: rgba(0, 0, 0, 0.01);
-  font-family: ${customProperties['--font-family-default']};
-  color: ${customProperties['--color-solid']};
+  font-family: ${designTokens.fontFamilyDefault};
+  color: ${designTokens.colorSolid}
   margin: 10px;
   > * + * {
     margin: 16px 0 0 0;
@@ -207,6 +208,7 @@ ChoiceGroup.defaultProps = {
 };
 
 const DecisionGroup = (props) => {
+  console.log('DecisionGroup#', { props });
   const decisions = filterDecisionGroupValues(
     props.decisionGroup.decisions,
     props.searchText
@@ -259,7 +261,10 @@ DecisionGroup.propTypes = {
   decisionGroup: PropTypes.shape({
     label: PropTypes.string.isRequired,
     prefix: PropTypes.string.isRequired,
-    decisions: PropTypes.objectOf(PropTypes.string),
+    decisions: PropTypes.shape({
+      choice: PropTypes.string.isRequired,
+      description: PropTypes.string,
+    }),
   }).isRequired,
   renderSample: PropTypes.func.isRequired,
 };

--- a/design-system/materials/internals/tokens.story.js
+++ b/design-system/materials/internals/tokens.story.js
@@ -4,7 +4,6 @@ import { storiesOf } from '@storybook/react';
 import styled from '@emotion/styled';
 import TextInput from '@commercetools-uikit/text-input';
 import merge from 'lodash/merge';
-// import customProperties from '../custom-properties.json';
 import { designTokens } from '@commercetools-uikit/design-system';
 import Readme from './TOKENS.md';
 import definition from './definition.yaml';
@@ -208,7 +207,6 @@ ChoiceGroup.defaultProps = {
 };
 
 const DecisionGroup = (props) => {
-  console.log('DecisionGroup#', { props });
   const decisions = filterDecisionGroupValues(
     props.decisionGroup.decisions,
     props.searchText

--- a/design-system/src/theme-provider.spec.js
+++ b/design-system/src/theme-provider.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable testing-library/no-wait-for-multiple-assertions */
 import { useState } from 'react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import PropTypes from 'prop-types';
 import { screen, render, fireEvent, waitFor } from '../../test/test-utils';
 import { ThemeProvider } from './theme-provider';
@@ -8,8 +8,8 @@ import { ThemeProvider } from './theme-provider';
 const TestComponent = (props) => (
   <div
     style={{
-      color: customProperties.colorSolid,
-      backgroundColor: customProperties.colorSurface,
+      color: designTokens.colorSolid,
+      backgroundColor: designTokens.colorSurface,
     }}
     data-testid={props.text}
   >

--- a/design-system/src/theme-provider.visualroute.jsx
+++ b/design-system/src/theme-provider.visualroute.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useTheme, customProperties } from '@commercetools-uikit/design-system';
+import { useTheme, designTokens } from '@commercetools-uikit/design-system';
 import { Switch, Route } from 'react-router';
 import kebabCase from 'lodash/kebabCase';
 import PropTypes from 'prop-types';
@@ -23,8 +23,8 @@ const DummyComponent = (props) => {
       style={{
         color: props.color
           ? `var(--${kebabCase(props.color)})`
-          : customProperties.colorSolid,
-        backgroundColor: customProperties.colorSurface,
+          : designTokens.colorSolid,
+        backgroundColor: designTokens.colorSurface,
         margin: 0,
       }}
     >
@@ -122,8 +122,8 @@ const DefaultRoute = () => (
 const TestComponent = (props) => (
   <div
     style={{
-      color: customProperties.colorSolid,
-      backgroundColor: customProperties.colorSurface,
+      color: designTokens.colorSolid,
+      backgroundColor: designTokens.colorSurface,
     }}
   >
     {props.text}

--- a/docs/.storybook/configs/theme-context.js
+++ b/docs/.storybook/configs/theme-context.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
-import { customProperties, ThemeProvider } from '../../../design-system';
+import { designTokens, ThemeProvider } from '../../../design-system';
 
-const defaultTheme = customProperties;
+const defaultTheme = designTokens;
 
 const customTheme = {
   colorSolid: '#fff',

--- a/docs/.storybook/decorators/section/section.js
+++ b/docs/.storybook/decorators/section/section.js
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 const Section = (props) => {
   return (
     <div
       css={css`
-        background-color: ${customProperties.colorSurface};
+        background-color: ${designTokens.colorSurface};
         padding: 16px;
       `}
     >

--- a/packages/calendar-utils/src/calendar-body/calendar-body.styles.ts
+++ b/packages/calendar-utils/src/calendar-body/calendar-body.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { getInputStyles } from '@commercetools-uikit/input-utils';
 import type { TCalendarBody } from './calendar-body';
 
@@ -12,13 +12,13 @@ const getClearSectionStyles = () => {
     align-items: center;
     box-sizing: border-box;
     display: flex;
-    margin-right: ${customProperties.spacingXs};
+    margin-right: ${designTokens.spacingXs};
     cursor: pointer;
-    transition: color ${customProperties.transitionStandard},
-      border-color ${customProperties.transitionStandard};
+    transition: color ${designTokens.transitionStandard},
+      border-color ${designTokens.transitionStandard};
 
     &:hover svg * {
-      fill: ${customProperties.colorWarning};
+      fill: ${designTokens.colorWarning};
     }
   `;
 };
@@ -29,35 +29,35 @@ type TState = {
 
 const getIconBorderColor = (props: TCalendarBody, state: TState) => {
   if (props.isDisabled) {
-    return customProperties.borderColorForInputWhenDisabled;
+    return designTokens.borderColorForInputWhenDisabled;
   }
   if (props.hasError) {
-    return customProperties.borderColorForInputWhenError;
+    return designTokens.borderColorForInputWhenError;
   }
   if (props.hasWarning) {
-    return customProperties.borderColorForInputWhenWarning;
+    return designTokens.borderColorForInputWhenWarning;
   }
   if (props.isReadOnly) {
-    return customProperties.borderColorForInputWhenReadonly;
+    return designTokens.borderColorForInputWhenReadonly;
   }
   if (props.isOpen || state.isFocused) {
-    return customProperties.borderColorForInputWhenFocused;
+    return designTokens.borderColorForInputWhenFocused;
   }
-  return customProperties.borderColorForInput;
+  return designTokens.borderColorForInput;
 };
 
 const getIconFontColor = (props: TCalendarBody) => {
   if (props.isDisabled) {
-    return customProperties.fontColorForInputWhenDisabled;
+    return designTokens.fontColorForInputWhenDisabled;
   }
   if (props.hasError) {
-    return customProperties.fontColorForInputWhenError;
+    return designTokens.fontColorForInputWhenError;
   }
   if (props.hasWarning) {
-    return customProperties.fontColorForInputWhenWarning;
+    return designTokens.fontColorForInputWhenWarning;
   }
   if (props.isReadOnly) {
-    return customProperties.fontColorForInputWhenReadonly;
+    return designTokens.fontColorForInputWhenReadonly;
   }
   return 'initial';
 };
@@ -71,84 +71,83 @@ const getCalendarIconContainerStyles = (
     box-sizing: border-box;
     background: none;
     border: 0;
-    border-left: 1px solid ${customProperties.borderColorForInput};
-    border-top-right-radius: ${customProperties.borderRadiusForInput};
-    border-bottom-right-radius: ${customProperties.borderRadiusForInput};
+    border-left: 1px solid ${designTokens.borderColorForInput};
+    border-top-right-radius: ${designTokens.borderRadiusForInput};
+    border-bottom-right-radius: ${designTokens.borderRadiusForInput};
     border-color: ${getIconBorderColor(props, state)};
     color: ${getIconFontColor(props)};
     cursor: ${props.isDisabled ? 'not-allowed' : 'default'};
     height: 100%;
     display: flex;
-    padding: ${customProperties.spacingXs};
+    padding: ${designTokens.spacingXs};
     outline: 0;
-    transition: color ${customProperties.transitionStandard},
-      border-color ${customProperties.transitionStandard};
+    transition: color ${designTokens.transitionStandard},
+      border-color ${designTokens.transitionStandard};
     &:active,
     &:hover:not(:disabled)&:not(:read-only),
     &:focus {
-      border-color: ${customProperties.borderColorForInputWhenFocused};
+      border-color: ${designTokens.borderColorForInputWhenFocused};
     }
   `;
 };
 
 const getInputBorderColor = (props: TCalendarBody, state: TState) => {
   if (props.isDisabled) {
-    return customProperties.borderColorForInputWhenDisabled;
+    return designTokens.borderColorForInputWhenDisabled;
   }
   if (props.hasError) {
-    return customProperties.borderColorForInputWhenError;
+    return designTokens.borderColorForInputWhenError;
   }
   if (props.hasWarning) {
-    return customProperties.borderColorForInputWhenWarning;
+    return designTokens.borderColorForInputWhenWarning;
   }
   if (props.isReadOnly) {
-    return customProperties.borderColorForInputWhenReadonly;
+    return designTokens.borderColorForInputWhenReadonly;
   }
   if ((props.isOpen || state.isFocused) && !props.isReadOnly) {
-    return customProperties.borderColorForInputWhenFocused;
+    return designTokens.borderColorForInputWhenFocused;
   }
-  return customProperties.borderColorForInput;
+  return designTokens.borderColorForInput;
 };
 const getInputFontColor = (props: TCalendarBody) => {
   if (props.isDisabled) {
-    return customProperties.fontColorForInputWhenDisabled;
+    return designTokens.fontColorForInputWhenDisabled;
   }
   if (props.hasError) {
-    return customProperties.fontColorForInputWhenError;
+    return designTokens.fontColorForInputWhenError;
   }
   if (props.hasWarning) {
-    return customProperties.fontColorForInputWhenWarning;
+    return designTokens.fontColorForInputWhenWarning;
   }
   if (props.isReadOnly) {
-    return customProperties.fontColorForInputWhenReadonly;
+    return designTokens.fontColorForInputWhenReadonly;
   }
-  return customProperties.fontColorForInput;
+  return designTokens.fontColorForInput;
 };
 const getInputContainerStyles = (props: TCalendarBody, state: TState) => {
   return css`
     appearance: none;
     background-color: ${props.isDisabled
-      ? customProperties.backgroundColorForInputWhenDisabled
-      : customProperties.backgroundColorForInput};
+      ? designTokens.backgroundColorForInputWhenDisabled
+      : designTokens.backgroundColorForInput};
     border: 1px solid ${getInputBorderColor(props, state)};
-    border-radius: ${customProperties.borderRadiusForInput};
+    border-radius: ${designTokens.borderRadiusForInput};
     box-sizing: border-box;
     color: ${getInputFontColor(props)};
     cursor: ${props.isDisabled ? 'not-allowed' : 'default'};
     width: 100%;
-    height: ${customProperties.sizeHeightInput};
+    height: ${designTokens.sizeHeightInput};
     align-items: center;
     display: flex;
-    font-size: ${customProperties.fontSizeDefault};
+    font-size: ${designTokens.fontSizeDefault};
     font-family: inherit;
-    min-width: ${customProperties.constraint5};
-    transition: border-color ${customProperties.transitionStandard},
-      box-shadow ${customProperties.transitionStandard};
+    min-width: ${designTokens.constraint5};
+    transition: border-color ${designTokens.transitionStandard},
+      box-shadow ${designTokens.transitionStandard};
 
     &:focus-within {
-      border-color: ${customProperties.borderColorForInputWhenFocused};
-      box-shadow: inset 0 0 0 2px
-        ${customProperties.borderColorForInputWhenFocused};
+      border-color: ${designTokens.borderColorForInputWhenFocused};
+      box-shadow: inset 0 0 0 2px ${designTokens.borderColorForInputWhenFocused};
     }
     &:focus,
     &:hover {
@@ -158,7 +157,7 @@ const getInputContainerStyles = (props: TCalendarBody, state: TState) => {
       props.isReadOnly ||
       ((props.isOpen || state.isFocused) && !props.isReadOnly)
         ? ''
-        : customProperties.borderColorForInputWhenFocused};
+        : designTokens.borderColorForInputWhenFocused};
     }
   `;
 };

--- a/packages/calendar-utils/src/calendar-day/calendar-day.tsx
+++ b/packages/calendar-utils/src/calendar-day/calendar-day.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 type TCalendarDay = {
   children?: ReactNode;
@@ -20,47 +20,47 @@ const getStyles = (props: TCalendarDay) => {
   if (!['heading', 'spacing'].includes(props.type || '')) {
     styles.push(css`
       text-align: center;
-      padding: ${customProperties.spacingS} 0;
+      padding: ${designTokens.spacingS} 0;
       cursor: default;
-      border-radius: ${customProperties.borderRadius4};
+      border-radius: ${designTokens.borderRadius4};
     `);
   }
   if (['heading', 'spacing'].includes(props.type || '')) {
     styles.push(css`
       text-align: center;
-      padding: ${customProperties.spacingS} 0;
+      padding: ${designTokens.spacingS} 0;
       cursor: default;
-      color: ${customProperties.colorNeutral60};
+      color: ${designTokens.colorNeutral60};
     `);
   }
   if (props.isHighlighted) {
     styles.push(
       css`
-        background-color: ${customProperties.colorNeutral90};
+        background-color: ${designTokens.colorNeutral90};
       `
     );
   }
   if (props.isSelected) {
     styles.push(
       css`
-        background-color: ${customProperties.colorPrimary};
-        color: ${customProperties.colorSurface};
+        background-color: ${designTokens.colorPrimary};
+        color: ${designTokens.colorSurface};
       `
     );
   }
   if (props.isRangeStart || props.isRangeEnd) {
     styles.push(
       css`
-        background-color: ${customProperties.colorPrimary40};
-        color: ${customProperties.colorSurface};
+        background-color: ${designTokens.colorPrimary40};
+        color: ${designTokens.colorSurface};
       `
     );
   }
   if (props.isRangeBetween) {
     styles.push(
       css`
-        background-color: ${customProperties.colorNeutral90};
-        color: ${customProperties.fontColorForInput};
+        background-color: ${designTokens.colorNeutral90};
+        color: ${designTokens.fontColorForInput};
       `
     );
   }
@@ -71,14 +71,14 @@ const getStyles = (props: TCalendarDay) => {
     props.isToday
   ) {
     styles.push(css`
-      color: ${customProperties.colorInfo};
+      color: ${designTokens.colorInfo};
       font-weight: bold;
     `);
   }
 
   if (props.disabled) {
     styles.push(css`
-      color: ${customProperties.fontColorForInputWhenDisabled};
+      color: ${designTokens.fontColorForInputWhenDisabled};
       cursor: not-allowed;
     `);
   }

--- a/packages/calendar-utils/src/calendar-header/calendar-header.tsx
+++ b/packages/calendar-utils/src/calendar-header/calendar-header.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useIntl } from 'react-intl';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import SecondaryIconButton from '@commercetools-uikit/secondary-icon-button';
 import {
   AngleLeftIcon,
@@ -43,9 +43,9 @@ const CalendarHeader = (props: TCalendarHeader) => {
       css={css`
         display: flex;
         padding: 10px 2% 6px;
-        margin-bottom: ${customProperties.spacingXs};
+        margin-bottom: ${designTokens.spacingXs};
         justify-content: space-between;
-        border-bottom: 1px solid ${customProperties.colorNeutral90};
+        border-bottom: 1px solid ${designTokens.colorNeutral90};
       `}
     >
       <Inline scale="xs" alignItems="center">

--- a/packages/calendar-utils/src/calendar-menu/calendar-menu.tsx
+++ b/packages/calendar-utils/src/calendar-menu/calendar-menu.tsx
@@ -1,6 +1,6 @@
 import { Component, ReactNode } from 'react';
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 type TCalendarMenu = {
   children: ReactNode;
@@ -21,17 +21,17 @@ export default class CalendarMenu extends Component<TCalendarMenu> {
         css={[
           css`
             overflow-y: scroll;
-            color: ${customProperties.colorSolid};
+            color: ${designTokens.colorSolid};
             font-family: inherit;
-            border: 1px solid ${customProperties.borderColorForInputWhenFocused};
-            border-radius: ${customProperties.borderRadiusForInput};
-            margin-top: ${customProperties.spacingXs};
-            font-size: ${customProperties.fontSizeDefault};
+            border: 1px solid ${designTokens.borderColorForInputWhenFocused};
+            border-radius: ${designTokens.borderRadiusForInput};
+            margin-top: ${designTokens.spacingXs};
+            font-size: ${designTokens.fontSizeDefault};
             position: absolute;
             box-sizing: border-box;
             width: 100%;
-            background-color: ${customProperties.colorSurface};
-            min-width: ${customProperties.constraint5};
+            background-color: ${designTokens.colorSurface};
+            min-width: ${designTokens.constraint5};
             z-index: 99999; /* copied from flatpickr */
           `,
           !hasFooter &&
@@ -40,11 +40,11 @@ export default class CalendarMenu extends Component<TCalendarMenu> {
             `,
           hasError &&
             css`
-              border-color: ${customProperties.borderColorForInputWhenError};
+              border-color: ${designTokens.borderColorForInputWhenError};
             `,
           hasWarning &&
             css`
-              border-color: ${customProperties.borderColorForInputWhenWarning};
+              border-color: ${designTokens.borderColorForInputWhenWarning};
             `,
         ]}
       >

--- a/packages/components/avatar/src/avatar.tsx
+++ b/packages/components/avatar/src/avatar.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { filterDataAttributes } from '@commercetools-uikit/utils';
 
 export type TAvatarProps = {
@@ -120,10 +120,10 @@ const Avatar = (props: TAvatarProps) => (
   <div
     css={css`
       align-items: center;
-      background-color: ${customProperties.colorNeutral60};
+      background-color: ${designTokens.colorNeutral60};
       border-radius: 100%;
-      font-size: ${customProperties.fontSizeDefault};
-      color: ${customProperties.colorSurface};
+      font-size: ${designTokens.fontSizeDefault};
+      color: ${designTokens.colorSurface};
       display: flex;
       justify-content: center;
       overflow: hidden;
@@ -133,7 +133,7 @@ const Avatar = (props: TAvatarProps) => (
       width: ${avatarSizes[props.size].width};
 
       ${props.isHighlighted
-        ? `background-color: ${customProperties.colorNeutral};`
+        ? `background-color: ${designTokens.colorNeutral};`
         : ''}
     `}
     {...filterDataAttributes(props)}

--- a/packages/components/buttons/accessible-button/src/accessible-button.tsx
+++ b/packages/components/buttons/accessible-button/src/accessible-button.tsx
@@ -12,7 +12,7 @@ import {
 import { isValidElementType } from 'react-is';
 import omit from 'lodash/omit';
 import { filterAriaAttributes, warning } from '@commercetools-uikit/utils';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { normalizedButtonStyles } from './accessible-button.styles';
@@ -160,7 +160,7 @@ const AccessibleButton = forwardRef<HTMLButtonElement, TAccessibleButtonProps>(
         css={css`
           ${normalizedButtonStyles}
           display: inline-flex;
-          font-size: ${customProperties.fontSizeDefault};
+          font-size: ${designTokens.fontSizeDefault};
           cursor: ${props.isDisabled ? 'not-allowed' : 'pointer'};
           &:disabled {
             cursor: not-allowed;

--- a/packages/components/buttons/flat-button/src/flat-button.styles.ts
+++ b/packages/components/buttons/flat-button/src/flat-button.styles.ts
@@ -1,4 +1,4 @@
-import type { TFlatButtonProps, CustomProperties } from './flat-button';
+import type { TFlatButtonProps, TDesignTokens } from './flat-button';
 
 export const getButtonIconColor = (
   props: Pick<TFlatButtonProps, 'isDisabled' | 'tone'>
@@ -13,17 +13,15 @@ export const getButtonIconColor = (
 export const getTextColor = (
   tone: TFlatButtonProps['tone'],
   isHover: boolean = false,
-  customProperties: CustomProperties
+  designTokens: TDesignTokens
 ): string => {
   switch (tone) {
     case 'primary':
-      return isHover
-        ? customProperties.colorPrimary25
-        : customProperties.colorPrimary;
+      return isHover ? designTokens.colorPrimary25 : designTokens.colorPrimary;
     case 'secondary':
-      return customProperties.colorSolid;
+      return designTokens.colorSolid;
     case 'inverted':
-      return customProperties.fontColorForTextWhenInverted;
+      return designTokens.fontColorForTextWhenInverted;
     default:
       return 'inherit';
   }

--- a/packages/components/buttons/flat-button/src/flat-button.tsx
+++ b/packages/components/buttons/flat-button/src/flat-button.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react';
 import { css } from '@emotion/react';
 import omit from 'lodash/omit';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { filterInvalidAttributes } from '@commercetools-uikit/utils';
 import Text from '@commercetools-uikit/text';
 import AccessibleButton from '@commercetools-uikit/accessible-button';
@@ -16,7 +16,7 @@ import { getTextColor, getButtonIconColor } from './flat-button.styles';
 
 const propsToOmit = ['type'];
 
-export type CustomProperties = typeof customProperties;
+export type TDesignTokens = typeof designTokens;
 
 export type TFlatButtonProps<
   TStringOrComponent extends ElementType = 'button'
@@ -132,19 +132,19 @@ const FlatButton = <TStringOrComponent extends ElementType = 'button'>(
 
         span {
           color: ${props.isDisabled
-            ? customProperties.colorNeutral
-            : getTextColor(props.tone, false, customProperties)};
+            ? designTokens.colorNeutral
+            : getTextColor(props.tone, false, designTokens)};
         }
 
         svg * {
           fill: ${props.isDisabled
-            ? customProperties.colorNeutral
-            : getTextColor(props.tone, false, customProperties)};
+            ? designTokens.colorNeutral
+            : getTextColor(props.tone, false, designTokens)};
         }
 
         * + span,
         * + svg {
-          margin-left: ${customProperties.spacingXs};
+          margin-left: ${designTokens.spacingXs};
         }
 
         ${!props.isDisabled
@@ -152,10 +152,10 @@ const FlatButton = <TStringOrComponent extends ElementType = 'button'>(
             &:hover,
             &:focus {
               span {
-                color: ${getTextColor(props.tone, true, customProperties)};
+                color: ${getTextColor(props.tone, true, designTokens)};
               }
               svg * {
-                fill: ${getTextColor(props.tone, true, customProperties)};
+                fill: ${getTextColor(props.tone, true, designTokens)};
               }
             }`
           : ''}

--- a/packages/components/buttons/icon-button/src/icon-button.styles.ts
+++ b/packages/components/buttons/icon-button/src/icon-button.styles.ts
@@ -1,5 +1,5 @@
 import { warning } from '@commercetools-uikit/utils';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { css } from '@emotion/react';
 import type { TIconButtonProps } from './icon-button';
 
@@ -39,9 +39,9 @@ const getStateStyles = (
 ) => {
   if (isDisabled) {
     const disabledStyle = css`
-      background-color: ${customProperties.colorAccent98};
-      border-color: ${customProperties.colorNeutral};
-      color: ${customProperties.colorNeutral60};
+      background-color: ${designTokens.colorAccent98};
+      border-color: ${designTokens.colorNeutral};
+      color: ${designTokens.colorNeutral60};
       box-shadow: none;
     `;
     switch (theme) {
@@ -50,8 +50,8 @@ const getStateStyles = (
           disabledStyle,
           css`
             &:hover {
-              border-color: ${customProperties.colorInfo85};
-              background-color: ${customProperties.colorInfo85};
+              border-color: ${designTokens.colorInfo85};
+              background-color: ${designTokens.colorInfo85};
             }
           `,
         ];
@@ -60,8 +60,8 @@ const getStateStyles = (
           disabledStyle,
           css`
             &:hover {
-              border-color: ${customProperties.colorPrimary85};
-              background-color: ${customProperties.colorPrimary85};
+              border-color: ${designTokens.colorPrimary85};
+              background-color: ${designTokens.colorPrimary85};
             }
           `,
         ];
@@ -71,13 +71,13 @@ const getStateStyles = (
   }
   if (isActive) {
     const activeStyle = css`
-      box-shadow: ${customProperties.shadow9};
-      background-color: ${customProperties.colorSurface};
-      border-color: ${customProperties.colorSurface};
+      box-shadow: ${designTokens.shadow9};
+      background-color: ${designTokens.colorSurface};
+      border-color: ${designTokens.colorSurface};
       &:hover {
-        box-shadow: ${customProperties.shadow9};
-        background-color: ${customProperties.colorNeutral95};
-        border-color: ${customProperties.colorNeutral95};
+        box-shadow: ${designTokens.shadow9};
+        background-color: ${designTokens.colorNeutral95};
+        border-color: ${designTokens.colorNeutral95};
       }
     `;
     switch (theme) {
@@ -88,18 +88,18 @@ const getStateStyles = (
             // When the button is active and somehow is disabled it should have
             // a different color to indicate that it's active but can't receive any actions
             css`
-              background-color: ${customProperties.colorInfo85};
-              border-color: ${customProperties.colorInfo85};
-              color: ${customProperties.colorSurface};
-              box-shadow: ${customProperties.shadow9};
+              background-color: ${designTokens.colorInfo85};
+              border-color: ${designTokens.colorInfo85};
+              color: ${designTokens.colorSurface};
+              box-shadow: ${designTokens.shadow9};
             `,
           css`
-            background-color: ${customProperties.colorInfo};
-            border-color: ${customProperties.colorInfo};
-            color: ${customProperties.colorSurface};
+            background-color: ${designTokens.colorInfo};
+            border-color: ${designTokens.colorInfo};
+            color: ${designTokens.colorSurface};
             &:hover {
-              background-color: ${customProperties.colorInfo85};
-              border-color: ${customProperties.colorInfo85};
+              background-color: ${designTokens.colorInfo85};
+              border-color: ${designTokens.colorInfo85};
             }
           `,
         ];
@@ -110,18 +110,18 @@ const getStateStyles = (
           // a different color to indicate that it's active but can't receive any actions
           isDisabled &&
             css`
-              background-color: ${customProperties.colorPrimary85};
-              border-color: ${customProperties.colorPrimary85};
-              color: ${customProperties.colorSurface};
-              box-shadow: ${customProperties.shadow9};
+              background-color: ${designTokens.colorPrimary85};
+              border-color: ${designTokens.colorPrimary85};
+              color: ${designTokens.colorSurface};
+              box-shadow: ${designTokens.shadow9};
             `,
 
           css`
-            background-color: ${customProperties.colorPrimary};
-            color: ${customProperties.colorSurface};
+            background-color: ${designTokens.colorPrimary};
+            color: ${designTokens.colorSurface};
             &:hover {
-              background-color: ${customProperties.colorPrimary85};
-              border-color: ${customProperties.colorPrimary85};
+              background-color: ${designTokens.colorPrimary85};
+              border-color: ${designTokens.colorPrimary85};
             }
           `,
         ];
@@ -131,12 +131,12 @@ const getStateStyles = (
   }
   return css`
     &:hover {
-      box-shadow: ${customProperties.shadow8};
+      box-shadow: ${designTokens.shadow8};
     }
     &:active {
-      box-shadow: ${customProperties.shadow9};
-      background-color: ${customProperties.colorSurface};
-      border-color: ${customProperties.colorSurface};
+      box-shadow: ${designTokens.shadow9};
+      background-color: ${designTokens.colorSurface};
+      border-color: ${designTokens.colorSurface};
     }
   `;
 };
@@ -154,15 +154,15 @@ const getShapeStyles = (
       switch (size) {
         case 'small':
           return css`
-            border-radius: ${customProperties.borderRadius2};
+            border-radius: ${designTokens.borderRadius2};
           `;
         case 'medium':
           return css`
-            border-radius: ${customProperties.borderRadius4};
+            border-radius: ${designTokens.borderRadius4};
           `;
         case 'big':
           return css`
-            border-radius: ${customProperties.borderRadius6};
+            border-radius: ${designTokens.borderRadius6};
           `;
         default:
           return css``;
@@ -201,17 +201,17 @@ const getThemeStyles = (theme: TIconButtonProps['theme']) => {
     case 'primary':
       return css`
         &:hover {
-          background-color: ${customProperties.colorPrimary};
-          border-color: ${customProperties.colorPrimary};
-          color: ${customProperties.colorSurface};
+          background-color: ${designTokens.colorPrimary};
+          border-color: ${designTokens.colorPrimary};
+          color: ${designTokens.colorSurface};
         }
       `;
     case 'info':
       return css`
         &:hover {
-          background-color: ${customProperties.colorInfo};
-          border-color: ${customProperties.colorInfo};
-          color: ${customProperties.colorSurface};
+          background-color: ${designTokens.colorInfo};
+          border-color: ${designTokens.colorInfo};
+          color: ${designTokens.colorSurface};
         }
       `;
     default: {
@@ -233,7 +233,7 @@ const getHoverStyles = (
   return css`
     &:hover {
       * {
-        fill: ${customProperties.colorSurface};
+        fill: ${designTokens.colorSurface};
       }
     }
   `;

--- a/packages/components/buttons/icon-button/src/icon-button.tsx
+++ b/packages/components/buttons/icon-button/src/icon-button.tsx
@@ -7,7 +7,7 @@ import {
   cloneElement,
 } from 'react';
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { filterInvalidAttributes, warning } from '@commercetools-uikit/utils';
 import AccessibleButton from '@commercetools-uikit/accessible-button';
 import {
@@ -119,11 +119,11 @@ const IconButton = <TStringOrComponent extends ElementType = 'button'>(
           display: flex;
           align-items: center;
           justify-content: center;
-          border: 1px solid ${customProperties.colorSurface};
-          background-color: ${customProperties.colorSurface};
-          box-shadow: ${customProperties.shadow7};
-          color: ${customProperties.colorSolid};
-          transition: background-color ${customProperties.transitionLinear80Ms},
+          border: 1px solid ${designTokens.colorSurface};
+          background-color: ${designTokens.colorSurface};
+          box-shadow: ${designTokens.shadow7};
+          color: ${designTokens.colorSolid};
+          transition: background-color ${designTokens.transitionLinear80Ms},
             box-shadow 150ms ease-in-out;
         `,
         getStateStyles(props.isDisabled, isActive, props.theme),

--- a/packages/components/buttons/link-button/src/link-button.tsx
+++ b/packages/components/buttons/link-button/src/link-button.tsx
@@ -4,7 +4,7 @@ import { cloneElement, ReactElement, useEffect } from 'react';
 import { Link as ReactRouterLink } from 'react-router-dom';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import {
   warnDeprecatedComponent,
   filterInvalidAttributes,
@@ -51,11 +51,11 @@ const hoverStyles = css`
   &:focus,
   &:active {
     span {
-      color: ${customProperties.colorPrimary25};
+      color: ${designTokens.colorPrimary25};
     }
 
     svg * {
-      fill: ${customProperties.colorPrimary25};
+      fill: ${designTokens.colorPrimary25};
     }
   }
 `;
@@ -74,9 +74,7 @@ const StyledExternalLink = styled.a<
 
   span {
     color: ${(props) =>
-      props.isDisabled
-        ? customProperties.colorNeutral
-        : customProperties.colorPrimary};
+      props.isDisabled ? designTokens.colorNeutral : designTokens.colorPrimary};
   }
 
   cursor: ${(props) => (props.isDisabled ? 'not-allowed' : 'pointer')};

--- a/packages/components/buttons/primary-button/src/primary-button.styles.ts
+++ b/packages/components/buttons/primary-button/src/primary-button.styles.ts
@@ -1,22 +1,22 @@
 /* eslint-disable import/prefer-default-export */
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import type { TPrimaryButtonProps } from './primary-button';
 
 const getSizeStyles = (size: TPrimaryButtonProps['size']) => {
   switch (size) {
     case 'small':
       return css`
-        border-radius: ${customProperties.borderRadius4};
-        padding: 0 ${customProperties.spacingS} 0 ${customProperties.spacingS};
-        height: ${customProperties.smallButtonHeight};
+        border-radius: ${designTokens.borderRadius4};
+        padding: 0 ${designTokens.spacingS} 0 ${designTokens.spacingS};
+        height: ${designTokens.smallButtonHeight};
       `;
 
     case 'big':
       return css`
-        padding: 0 ${customProperties.spacingM} 0 ${customProperties.spacingM};
-        height: ${customProperties.bigButtonHeight};
-        border-radius: ${customProperties.borderRadius6};
+        padding: 0 ${designTokens.spacingM} 0 ${designTokens.spacingM};
+        height: ${designTokens.bigButtonHeight};
+        border-radius: ${designTokens.borderRadius6};
       `;
 
     default:
@@ -32,9 +32,9 @@ const getButtonStyles = (
 ) => {
   const baseStyles = css`
     align-items: center;
-    color: ${customProperties.colorSurface};
-    transition: background-color ${customProperties.transitionLinear80Ms};
-    font-size: ${customProperties.fontSizeDefault};
+    color: ${designTokens.colorSurface};
+    transition: background-color ${designTokens.transitionLinear80Ms};
+    font-size: ${designTokens.fontSizeDefault};
     ${getSizeStyles(size)}
   `;
   // "disabled" takes precendece over "active"
@@ -45,9 +45,9 @@ const getButtonStyles = (
         &,
         &:active,
         &:hover {
-          background-color: ${customProperties.colorAccent98};
-          color: ${customProperties.colorNeutral60};
-          box-shadow: 0 0 0 1px ${customProperties.colorNeutral} inset;
+          background-color: ${designTokens.colorAccent98};
+          color: ${designTokens.colorNeutral60};
+          box-shadow: 0 0 0 1px ${designTokens.colorNeutral} inset;
         }
       `,
     ];
@@ -56,10 +56,10 @@ const getButtonStyles = (
     const baseActiveStyles = [
       baseStyles,
       css`
-        box-shadow: ${customProperties.shadow9};
+        box-shadow: ${designTokens.shadow9};
         &:hover,
         &:focus {
-          box-shadow: ${customProperties.shadow8};
+          box-shadow: ${designTokens.shadow8};
         }
       `,
     ];
@@ -68,13 +68,13 @@ const getButtonStyles = (
         return [
           baseActiveStyles,
           css`
-            background-color: ${customProperties.colorPrimary};
+            background-color: ${designTokens.colorPrimary};
             &:focus,
             &:hover {
-              background-color: ${customProperties.colorPrimary25};
+              background-color: ${designTokens.colorPrimary25};
             }
             &:active {
-              background-color: ${customProperties.colorPrimary};
+              background-color: ${designTokens.colorPrimary};
             }
           `,
         ];
@@ -82,13 +82,13 @@ const getButtonStyles = (
         return [
           baseActiveStyles,
           css`
-            background-color: ${customProperties.colorWarning};
+            background-color: ${designTokens.colorWarning};
             &:focus,
             &:hover {
-              background-color: ${customProperties.colorWarning};
+              background-color: ${designTokens.colorWarning};
             }
             &:active {
-              background-color: ${customProperties.colorWarning};
+              background-color: ${designTokens.colorWarning};
             }
           `,
         ];
@@ -99,13 +99,13 @@ const getButtonStyles = (
   const baseDefaultStyles = [
     baseStyles,
     css`
-      box-shadow: ${customProperties.shadow7};
+      box-shadow: ${designTokens.shadow7};
       &:hover,
       &:focus {
-        box-shadow: ${customProperties.shadow8};
+        box-shadow: ${designTokens.shadow8};
       }
       &:active {
-        box-shadow: ${customProperties.shadow9};
+        box-shadow: ${designTokens.shadow9};
       }
     `,
   ];
@@ -114,13 +114,13 @@ const getButtonStyles = (
       return [
         baseDefaultStyles,
         css`
-          background-color: ${customProperties.colorPrimary};
+          background-color: ${designTokens.colorPrimary};
           &:focus,
           &:hover {
-            background-color: ${customProperties.colorPrimary25};
+            background-color: ${designTokens.colorPrimary25};
           }
           &:active {
-            background-color: ${customProperties.colorPrimary};
+            background-color: ${designTokens.colorPrimary};
           }
         `,
       ];
@@ -128,13 +128,13 @@ const getButtonStyles = (
       return [
         baseDefaultStyles,
         css`
-          background-color: ${customProperties.colorWarning};
+          background-color: ${designTokens.colorWarning};
           &:focus,
           &:hover {
-            background-color: ${customProperties.colorPrimary25};
+            background-color: ${designTokens.colorPrimary25};
           }
           &:active {
-            background-color: ${customProperties.colorWarning};
+            background-color: ${designTokens.colorWarning};
           }
         `,
       ];

--- a/packages/components/buttons/primary-button/src/primary-button.tsx
+++ b/packages/components/buttons/primary-button/src/primary-button.tsx
@@ -9,7 +9,7 @@ import {
 import omit from 'lodash/omit';
 import { css } from '@emotion/react';
 import Inline from '@commercetools-uikit/spacings-inline';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { filterInvalidAttributes } from '@commercetools-uikit/utils';
 import AccessibleButton from '@commercetools-uikit/accessible-button';
 import { getButtonStyles } from './primary-button.styles';
@@ -110,7 +110,7 @@ const PrimaryButton = <TStringOrComponent extends ElementType = 'button'>(
         {Boolean(props.iconLeft) && (
           <span
             css={css`
-              margin: 0 ${customProperties.spacingXs} 0 0;
+              margin: 0 ${designTokens.spacingXs} 0 0;
               display: flex;
               align-items: center;
               justify-content: center;

--- a/packages/components/buttons/secondary-button/src/secondary-button.styles.ts
+++ b/packages/components/buttons/secondary-button/src/secondary-button.styles.ts
@@ -2,7 +2,7 @@ import type { Theme } from '@emotion/react';
 
 import { warning } from '@commercetools-uikit/utils';
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 const getStateStyles = (
   isDisabled: boolean,
@@ -11,18 +11,18 @@ const getStateStyles = (
 ) => {
   if (isDisabled) {
     const baseDisabledStyles = css`
-      box-shadow: 0 0 0 1px ${customProperties.colorNeutral} inset;
-      background-color: ${customProperties.colorAccent98};
-      color: ${customProperties.colorNeutral60};
+      box-shadow: 0 0 0 1px ${designTokens.colorNeutral} inset;
+      background-color: ${designTokens.colorAccent98};
+      color: ${designTokens.colorNeutral60};
     `;
     switch (theme) {
       case 'info':
         return [
           baseDisabledStyles,
           css`
-            color: ${customProperties.colorNeutral60};
+            color: ${designTokens.colorNeutral60};
           `,
-          isActive && `color: ${customProperties.colorInfo};`,
+          isActive && `color: ${designTokens.colorInfo};`,
         ];
       default:
         return baseDisabledStyles;
@@ -31,18 +31,18 @@ const getStateStyles = (
   if (isActive) {
     const baseActiveStyles = [
       css`
-        box-shadow: ${customProperties.shadow9};
-        background-color: ${customProperties.colorSurface};
+        box-shadow: ${designTokens.shadow9};
+        background-color: ${designTokens.colorSurface};
         &:focus,
         &:hover {
-          background-color: ${customProperties.colorNeutral95};
+          background-color: ${designTokens.colorNeutral95};
         }
       `,
       isDisabled &&
         css`
-          box-shadow: 0 0 0 1px ${customProperties.colorNeutral} inset;
-          background-color: ${customProperties.colorAccent98};
-          color: ${customProperties.colorNeutral60};
+          box-shadow: 0 0 0 1px ${designTokens.colorNeutral} inset;
+          background-color: ${designTokens.colorAccent98};
+          color: ${designTokens.colorNeutral60};
         `,
     ];
     switch (theme) {
@@ -50,7 +50,7 @@ const getStateStyles = (
         return [
           baseActiveStyles,
           css`
-            color: ${customProperties.colorInfo};
+            color: ${designTokens.colorInfo};
           `,
         ];
       default:
@@ -60,11 +60,11 @@ const getStateStyles = (
   return css`
     &:focus,
     &:hover {
-      box-shadow: ${customProperties.shadow8};
+      box-shadow: ${designTokens.shadow8};
     }
     &:active {
-      box-shadow: ${customProperties.shadow9};
-      background-color: ${customProperties.colorSurface};
+      box-shadow: ${designTokens.shadow9};
+      background-color: ${designTokens.colorSurface};
     }
   `;
 };
@@ -79,10 +79,10 @@ const getThemeStyles = (theme: Theme) => {
       return css`
         &:focus,
         &:hover {
-          color: ${customProperties.colorInfo};
+          color: ${designTokens.colorInfo};
 
           * {
-            fill: ${customProperties.colorInfo};
+            fill: ${designTokens.colorInfo};
           }
         }
       `;
@@ -94,11 +94,11 @@ const getThemeStyles = (theme: Theme) => {
       return css`
         &:focus,
         &:hover {
-          box-shadow: ${customProperties.shadow8};
+          box-shadow: ${designTokens.shadow8};
         }
         &:active {
-          box-shadow: ${customProperties.shadow9};
-          background-color: ${customProperties.colorSurface};
+          box-shadow: ${designTokens.shadow9};
+          background-color: ${designTokens.colorSurface};
         }
       `;
     }

--- a/packages/components/buttons/secondary-button/src/secondary-button.tsx
+++ b/packages/components/buttons/secondary-button/src/secondary-button.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react';
 import { Link } from 'react-router-dom';
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import Inline from '@commercetools-uikit/spacings-inline';
 import { filterInvalidAttributes, warning } from '@commercetools-uikit/utils';
 import AccessibleButton from '@commercetools-uikit/accessible-button';
@@ -114,18 +114,18 @@ export const SecondaryButton = <
     css`
       display: flex;
       align-items: center;
-      padding: 0 ${customProperties.spacingM};
-      height: ${customProperties.bigButtonHeight};
+      padding: 0 ${designTokens.spacingM};
+      height: ${designTokens.bigButtonHeight};
     `,
     css`
       display: inline-flex;
-      background-color: ${customProperties.colorSurface};
-      border-radius: ${customProperties.borderRadius6};
-      box-shadow: ${customProperties.shadow7};
-      color: ${customProperties.colorSolid};
-      font-size: ${customProperties.fontSizeDefault};
-      transition: background-color ${customProperties.transitionLinear80Ms},
-        box-shadow ${customProperties.transitionEaseinout150Ms};
+      background-color: ${designTokens.colorSurface};
+      border-radius: ${designTokens.borderRadius6};
+      box-shadow: ${designTokens.shadow7};
+      color: ${designTokens.colorSolid};
+      font-size: ${designTokens.fontSizeDefault};
+      transition: background-color ${designTokens.transitionLinear80Ms},
+        box-shadow ${designTokens.transitionEaseinout150Ms};
     `,
     getStateStyles(props.isDisabled, isActive, props.theme),
     getThemeStyles(props.theme),
@@ -147,7 +147,7 @@ export const SecondaryButton = <
         {Boolean(props.iconLeft) && (
           <span
             css={css`
-              margin: 0 ${customProperties.spacingXs} 0 0;
+              margin: 0 ${designTokens.spacingXs} 0 0;
               display: flex;
               align-items: center;
               justify-content: center;

--- a/packages/components/buttons/secondary-icon-button/src/secondary-icon-button.styles.ts
+++ b/packages/components/buttons/secondary-icon-button/src/secondary-icon-button.styles.ts
@@ -1,12 +1,12 @@
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import type { TSecondaryButtonProps } from './secondary-icon-button';
 
 const getDisabledStyle = () => {
   /* By using the css 'disabled' selector directly, we don't need additional logic to check the isDisabled prop */
   return css`
     &:disabled svg {
-      fill: ${customProperties.colorNeutral60};
+      fill: ${designTokens.colorNeutral60};
     }
   `;
 };
@@ -16,27 +16,27 @@ const getColorStyle = (props: Pick<TSecondaryButtonProps, 'color'>) => {
     case 'solid':
       return css`
         & svg {
-          fill: ${customProperties.colorSolid};
+          fill: ${designTokens.colorSolid};
         }
         &:focus,
         &:hover svg {
-          fill: ${customProperties.colorPrimary};
+          fill: ${designTokens.colorPrimary};
         }
       `;
     case 'primary':
       return css`
         & svg {
-          fill: ${customProperties.colorPrimary};
+          fill: ${designTokens.colorPrimary};
         }
         &:focus,
         &:hover svg {
-          fill: ${customProperties.colorPrimary25};
+          fill: ${designTokens.colorPrimary25};
         }
       `;
     default:
       return css`
         svg {
-          fill: ${customProperties.colorSolid};
+          fill: ${designTokens.colorSolid};
         }
       `;
   }

--- a/packages/components/card/src/card.tsx
+++ b/packages/components/card/src/card.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { filterDataAttributes } from '@commercetools-uikit/utils';
 import Inset from '@commercetools-uikit/spacings-inset';
 
@@ -34,13 +34,11 @@ const Card = (props: TCardProps) => (
       box-sizing: border-box;
       width: 100%;
       font-size: 1rem;
-      box-shadow: ${props.type === 'raised'
-        ? customProperties.shadow1
-        : 'none'};
-      border-radius: ${customProperties.borderRadius6};
+      box-shadow: ${props.type === 'raised' ? designTokens.shadow1 : 'none'};
+      border-radius: ${designTokens.borderRadius6};
       background: ${props.theme === 'dark'
-        ? customProperties.colorNeutral95
-        : customProperties.colorSurface};
+        ? designTokens.colorNeutral95
+        : designTokens.colorSurface};
     `}
     // Allow to override the styles by passing a `className` prop.
     // Custom styles can also be passed using the `css` prop from emotion.

--- a/packages/components/collapsible-panel/src/collapsible-panel.styles.tsx
+++ b/packages/components/collapsible-panel/src/collapsible-panel.styles.tsx
@@ -1,16 +1,16 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import type { TCollapsiblePanel } from './collapsible-panel';
 
 function getThemeStyle(theme?: TCollapsiblePanel['theme']) {
   if (theme === 'light') {
     return css`
-      background-color: ${customProperties.colorSurface};
+      background-color: ${designTokens.colorSurface};
     `;
   }
   return css`
-    background-color: ${customProperties.colorNeutral95};
+    background-color: ${designTokens.colorNeutral95};
   `;
 }
 
@@ -23,8 +23,8 @@ const getHeaderContainerStyles = (
 ) => {
   const baseStyles = css`
     position: relative;
-    border-top-left-radius: ${customProperties.borderRadius6};
-    border-top-right-radius: ${customProperties.borderRadius6};
+    border-top-left-radius: ${designTokens.borderRadius6};
+    border-top-right-radius: ${designTokens.borderRadius6};
     display: flex;
     flex: 1;
     align-items: center;
@@ -33,8 +33,8 @@ const getHeaderContainerStyles = (
       ? 'flex-start'
       : 'space-between'};
     padding: ${props.condensed
-      ? `${customProperties.spacingXs} ${customProperties.spacingS}`
-      : `${customProperties.spacingS} ${customProperties.spacingM}`};
+      ? `${designTokens.spacingXs} ${designTokens.spacingS}`
+      : `${designTokens.spacingS} ${designTokens.spacingM}`};
   `;
 
   return [
@@ -49,13 +49,13 @@ const getHeaderContainerStyles = (
         z-index: 1;
         position: sticky;
         top: 0;
-        border-top-right-radius: ${customProperties.borderRadius6};
-        border-top-left-radius: ${customProperties.borderRadius6};
+        border-top-right-radius: ${designTokens.borderRadius6};
+        border-top-left-radius: ${designTokens.borderRadius6};
       `,
     !props.condensed &&
       // To understand why this min-height see: https://github.com/commercetools/ui-kit/pull/616
       css`
-        min-height: ${customProperties.bigButtonHeight};
+        min-height: ${designTokens.bigButtonHeight};
         box-sizing: content-box; /* makes the padding extend beyond the min-height */
       `,
   ];
@@ -63,19 +63,19 @@ const getHeaderContainerStyles = (
 
 const baseContainerStyles = css`
   position: relative;
-  min-width: ${customProperties.constraint6};
+  min-width: ${designTokens.constraint6};
   padding: 0;
   display: flex;
   flex-direction: column;
-  box-shadow: ${customProperties.shadow1};
-  border-radius: ${customProperties.borderRadius6};
-  color: ${customProperties.colorSolid};
+  box-shadow: ${designTokens.shadow1};
+  border-radius: ${designTokens.borderRadius6};
+  color: ${designTokens.colorSolid};
   font-family: inherit;
-  font-size: ${customProperties.fontSizeDefault};
+  font-size: ${designTokens.fontSizeDefault};
 `;
 
 const HeaderControlsWrapper = styled.div`
-  margin-left: ${customProperties.spacingM};
+  margin-left: ${designTokens.spacingM};
   display: flex;
   align-items: center;
 
@@ -91,7 +91,7 @@ const SectionContent = styled.div`
 `;
 
 const SectionWrapper = styled.div`
-  border-top: 1px solid ${customProperties.colorNeutral60};
+  border-top: 1px solid ${designTokens.colorNeutral60};
 `;
 
 export {

--- a/packages/components/collapsible-panel/src/header-icon.tsx
+++ b/packages/components/collapsible-panel/src/header-icon.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { AngleDownIcon, AngleRightIcon } from '@commercetools-uikit/icons';
 
 const sizeIconContainer = '22px';
@@ -24,8 +24,8 @@ type THeaderIcon = {
 const HeaderIcon = (props: THeaderIcon) => {
   const backgroundColor =
     props.tone === 'urgent'
-      ? customProperties.colorWarning
-      : customProperties.colorSurface;
+      ? designTokens.colorWarning
+      : designTokens.colorSurface;
   return (
     <div
       css={[
@@ -41,15 +41,15 @@ const HeaderIcon = (props: THeaderIcon) => {
             : sizeIconContainer};
           border-radius: 50%;
           flex-shrink: 0;
-          box-shadow: ${customProperties.shadow7};
+          box-shadow: ${designTokens.shadow7};
           background-color: ${backgroundColor};
           border: 1px solid ${backgroundColor};
         `,
         props.isDisabled &&
           css`
             box-shadow: none;
-            border: 1px solid ${customProperties.colorNeutral};
-            background-color: ${customProperties.colorAccent98};
+            border: 1px solid ${designTokens.colorNeutral};
+            background-color: ${designTokens.colorAccent98};
           `,
       ]}
     >

--- a/packages/components/constraints/src/helpers.ts
+++ b/packages/components/constraints/src/helpers.ts
@@ -1,10 +1,11 @@
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
+
+type TDesignTokenName = keyof typeof designTokens;
 
 // `null` is derived from `getMaxPropEquivalent`
 const getMaxPropTokenValue = (max: number | string | null) => {
   if (!max) return null;
-  // @ts-expect-error
-  return customProperties[`constraint${max}`];
+  return designTokens[`constraint${max}` as TDesignTokenName];
 };
 
 // Generates an array of accepted values for the max prop, given a min and max

--- a/packages/components/constraints/src/helpers.ts
+++ b/packages/components/constraints/src/helpers.ts
@@ -5,7 +5,11 @@ type TDesignTokenName = keyof typeof designTokens;
 // `null` is derived from `getMaxPropEquivalent`
 const getMaxPropTokenValue = (max: number | string | null) => {
   if (!max) return null;
-  return designTokens[`constraint${max}` as TDesignTokenName];
+  const tokenName = `constraint${max}`;
+  if (tokenName in designTokens) {
+    return designTokens[tokenName as TDesignTokenName];
+  }
+  return null;
 };
 
 // Generates an array of accepted values for the max prop, given a min and max

--- a/packages/components/constraints/src/horizontal/horizontal.story.js
+++ b/packages/components/constraints/src/horizontal/horizontal.story.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import styled from '@emotion/styled';
 import Horizontal from './horizontal';
 import { getAcceptedMaxPropValues, getMaxPropTokenValue } from '../helpers';
@@ -11,9 +11,9 @@ const ColouredRow = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  border-radius: ${customProperties.borderRadius6};
-  color: ${customProperties.colorSurface};
-  background-color: ${customProperties.colorPrimary};
+  border-radius: ${designTokens.borderRadius6};
+  color: ${designTokens.colorSurface};
+  background-color: ${designTokens.colorPrimary};
 `;
 
 const Stack = styled.div`
@@ -24,7 +24,7 @@ const Stack = styled.div`
 
 const Wrapper = styled.div`
   position: relative;
-  padding-top: ${customProperties.spacingXl};
+  padding-top: ${designTokens.spacingXl};
 `;
 
 const ColumnsContainer = styled.div`
@@ -36,8 +36,8 @@ const ColumnsContainer = styled.div`
 `;
 const Column = styled.div`
   display: inline-block;
-  width: ${customProperties.constraint2};
-  margin-right: ${customProperties.spacingM};
+  width: ${designTokens.constraint2};
+  margin-right: ${designTokens.spacingM};
   height: 100%;
   text-align: center;
   background-color: rgba(241, 109, 14, 0.3);

--- a/packages/components/data-table-manager/src/column-settings-manager/column-settings-manager.tsx
+++ b/packages/components/data-table-manager/src/column-settings-manager/column-settings-manager.tsx
@@ -13,7 +13,7 @@ import { DragDropContext, type DropResult } from 'react-beautiful-dnd';
 import debounce from 'debounce-promise';
 import differenceWith from 'lodash/differenceWith';
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import AsyncSelectInput from '@commercetools-uikit/async-select-input';
 import FieldLabel from '@commercetools-uikit/field-label';
 import Spacings from '@commercetools-uikit/spacings';
@@ -64,7 +64,7 @@ type TDroppableContainerProps = {
 const DroppableContainer = styled.div<TDroppableContainerProps>`
   width: 100%;
   position: relative;
-  max-width: ${customProperties.constraint10};
+  max-width: ${designTokens.constraint10};
   cursor: ${(props) => (props.isDragging ? 'grabbing' : 'auto')};
 `;
 

--- a/packages/components/data-table-manager/src/data-table-settings/data-table-settings.tsx
+++ b/packages/components/data-table-manager/src/data-table-settings/data-table-settings.tsx
@@ -6,7 +6,7 @@ import AccessibleHidden from '@commercetools-uikit/accessible-hidden';
 import SelectInput from '@commercetools-uikit/select-input';
 import { TableIcon } from '@commercetools-uikit/icons';
 import Spacings from '@commercetools-uikit/spacings';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { UPDATE_ACTIONS, COLUMN_MANAGER, DISPLAY_SETTINGS } from '../constants';
 import DisplaySettingsManager, {
   DENSITY_COMPACT,
@@ -125,7 +125,7 @@ export type TDataTableSettingsProps = {
 because the input is always empty, and therefore doesn't take any space by itself
 but we want to keep enough space for the placeholder to be readable */
 const SelectContainer = styled.div`
-  min-width: ${customProperties.constraint4};
+  min-width: ${designTokens.constraint4};
 `;
 
 const TopBarContainer = styled.div`

--- a/packages/components/data-table-manager/src/display-settings-manager/display-settings-manager.tsx
+++ b/packages/components/data-table-manager/src/display-settings-manager/display-settings-manager.tsx
@@ -10,7 +10,7 @@ import Grid from '@commercetools-uikit/grid';
 import RadioInput from '@commercetools-uikit/radio-input';
 import Spacings from '@commercetools-uikit/spacings';
 import AccessibleHiden from '@commercetools-uikit/accessible-hidden';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import SettingsContainer from '../settings-container';
 import messages from './messages';
 import {
@@ -52,7 +52,7 @@ const DensityManager = (props: TDensityManagerProps) => {
       containerTheme={props.managerTheme}
     >
       <Grid
-        gridGap={customProperties.spacingM}
+        gridGap={designTokens.spacingM}
         gridTemplateColumns="repeat(2, 1fr)"
       >
         <Grid.Item>

--- a/packages/components/data-table-manager/src/droppable-panel/tag-container-editable.tsx
+++ b/packages/components/data-table-manager/src/droppable-panel/tag-container-editable.tsx
@@ -1,13 +1,12 @@
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 const TagContainerEditable = styled.div`
-  background-color: ${customProperties.backgroundColorForInput};
-  border: ${customProperties.borderRadius1} solid
-    ${customProperties.colorNeutral60};
-  border-radius: ${customProperties.borderRadius6};
-  padding: ${customProperties.spacingS};
-  height: ${customProperties.constraint7};
+  background-color: ${designTokens.backgroundColorForInput};
+  border: ${designTokens.borderRadius1} solid ${designTokens.colorNeutral60};
+  border-radius: ${designTokens.borderRadius6};
+  padding: ${designTokens.spacingS};
+  height: ${designTokens.constraint7};
   overflow: auto;
 `;
 

--- a/packages/components/data-table/src/cell.styles.tsx
+++ b/packages/components/data-table/src/cell.styles.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import AccessibleButton from '@commercetools-uikit/accessible-button';
 import type { TDataCell } from './cell';
 
@@ -17,10 +17,10 @@ type TCellInner = {
 const getPaddingStyle = (props: TCellInner) => {
   if (props.isCondensed)
     return css`
-      padding: ${customProperties.spacingS};
+      padding: ${designTokens.spacingS};
     `;
   return css`
-    padding: ${customProperties.spacingM};
+    padding: ${designTokens.spacingM};
   `;
 };
 
@@ -125,10 +125,10 @@ type TBaseCell = {
 const BaseCell = styled.td<TBaseCell>`
   position: relative;
   display: flex;
-  background-color: ${customProperties.colorSurface};
+  background-color: ${designTokens.colorSurface};
   border-bottom: ${(props) =>
     props.shouldRenderBottomBorder
-      ? `1px solid ${customProperties.colorNeutral90};`
+      ? `1px solid ${designTokens.colorNeutral90};`
       : 'none'};
   ${(props) =>
     props.shouldClipContent
@@ -155,9 +155,9 @@ const BaseFooterCell = styled.td<TBaseFooterCell>`
   left: 0;
   bottom: 0;
   grid-column: 1 / ${(props) => props.numberOfColumns};
-  background-color: ${customProperties.colorSurface};
-  border-bottom: 1px solid ${customProperties.colorNeutral90};
-  border-top: 1px solid ${customProperties.colorNeutral90};
+  background-color: ${designTokens.colorSurface};
+  border-bottom: 1px solid ${designTokens.colorNeutral90};
+  border-top: 1px solid ${designTokens.colorNeutral90};
 
   /* makes the footer top border overlap the border of the last data row: */
   margin-top: -1px;

--- a/packages/components/data-table/src/column-resizer.tsx
+++ b/packages/components/data-table/src/column-resizer.tsx
@@ -1,6 +1,6 @@
 import type { MouseEvent } from 'react';
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 type TColumnResizer = {
   onMouseDown?: (event: MouseEvent) => void;
@@ -10,7 +10,7 @@ type TColumnResizer = {
 const ResizerIndicator = styled.div<TColumnResizer>`
   height: 100%;
   width: 3px;
-  background: ${customProperties.colorInfo};
+  background: ${designTokens.colorInfo};
   visibility: hidden;
   cursor: col-resize;
 

--- a/packages/components/data-table/src/data-table.styles.tsx
+++ b/packages/components/data-table/src/data-table.styles.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { RowExpandCollapseButton } from './cell.styles';
 import convertNumericDimensionToPixelValue from './utils/convert-numeric-dimension-to-pixel-value';
 import type { TDataTableProps } from './data-table';
@@ -14,7 +14,7 @@ const getClickableRowStyle = (props: TGetClickableRowStyleProps) => {
     return css`
       cursor: pointer;
       &:hover td {
-        background: ${customProperties.backgroundColorForInputWhenHovered};
+        background: ${designTokens.backgroundColorForInputWhenHovered};
       }
     `;
   }

--- a/packages/components/data-table/src/footer.tsx
+++ b/packages/components/data-table/src/footer.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { getPaddingStyle, getHorizontalAlignmentStyle } from './cell.styles';
 
 type TFooter = {
@@ -19,9 +19,9 @@ const Footer = styled.div<TFooter>`
   display: block;
   ${getPaddingStyle}
   ${getHorizontalAlignmentStyle}
-  background-color: ${customProperties.colorSurface};
-  border-top: 1px solid ${customProperties.colorNeutral90};
-  border-bottom: 1px solid ${customProperties.colorNeutral90};
+  background-color: ${designTokens.colorSurface};
+  border-top: 1px solid ${designTokens.colorNeutral90};
+  border-bottom: 1px solid ${designTokens.colorNeutral90};
   ${(props) =>
     props.resizedTotalWidth ? `max-width: ${props.resizedTotalWidth}px;` : ''}
 `;

--- a/packages/components/data-table/src/header-cell.styles.tsx
+++ b/packages/components/data-table/src/header-cell.styles.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { getCellInnerStyles } from './cell.styles';
 import type { THeaderCell } from './header-cell';
 
@@ -13,7 +13,7 @@ const getButtonStyle = () => css`
   text-decoration: none;
   color: inherit;
   font: inherit;
-  font-size: ${customProperties.fontSizeDefault};
+  font-size: ${designTokens.fontSizeDefault};
   font-family: inherit;
 `;
 
@@ -37,7 +37,7 @@ const getSortableHeaderStyles = (props: TGetSortableHeaderStyles) => css`
 
   svg[data-icon-state='inactive'],
   svg[data-icon-state='active'] {
-    margin-left: ${customProperties.spacingS};
+    margin-left: ${designTokens.spacingS};
     flex-shrink: 0;
   }
   svg[data-icon-state='inactive'] {
@@ -55,7 +55,7 @@ const getSortableHeaderStyles = (props: TGetSortableHeaderStyles) => css`
     svg[data-icon-state='active'] {
       display: inline-block;
       * {
-        fill: ${customProperties.colorNeutral};
+        fill: ${designTokens.colorNeutral};
       }
     }
   }
@@ -73,9 +73,7 @@ const HeaderCellInner = styled.div<THeaderCellInner>`
   justify-content: space-between;
   padding: 0
     ${(props) =>
-      props.isCondensed
-        ? customProperties.spacingS
-        : customProperties.spacingM};
+      props.isCondensed ? designTokens.spacingS : designTokens.spacingM};
 
   ${getCellInnerStyles}
   ${(props) => (props.isSortable ? getSortableHeaderStyles(props) : '')};
@@ -88,8 +86,8 @@ type TBaseHeaderCell = {
   shouldClipContent?: boolean;
 };
 const BaseHeaderCell = styled.th<TBaseHeaderCell>`
-  color: ${customProperties.colorSurface};
-  background-color: ${customProperties.colorAccent};
+  color: ${designTokens.colorSurface};
+  background-color: ${designTokens.colorAccent};
 
   position: ${(props) =>
     props.disableHeaderStickiness ? 'relative' : 'sticky'};
@@ -101,7 +99,7 @@ const BaseHeaderCell = styled.th<TBaseHeaderCell>`
   font-weight: normal;
 
   /* right border that doesn't count towards the column width */
-  box-shadow: inset -1px 0 ${customProperties.colorNeutral90};
+  box-shadow: inset -1px 0 ${designTokens.colorNeutral90};
 
   /* this ensures that, when dragging this header's column resizer
      it remains above the rest of the headers, preventing accidental hovers/flickering */
@@ -119,7 +117,7 @@ const HeaderLabelWrapper = styled.div`
   /* ensure height stays the same even if label is empty
      1.4em = default line-height */
   min-height: 1.4em;
-  margin: ${customProperties.spacingS} 0;
+  margin: ${designTokens.spacingS} 0;
   flex: 1;
 `;
 
@@ -127,8 +125,8 @@ const HeaderIconWrapper = styled.div`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  margin-right: ${customProperties.spacingS};
-  padding: ${customProperties.spacingXs} 0;
+  margin-right: ${designTokens.spacingS};
+  padding: ${designTokens.spacingXs} 0;
 `;
 
 export {

--- a/packages/components/grid/src/grid.example.story.js
+++ b/packages/components/grid/src/grid.example.story.js
@@ -1,7 +1,7 @@
 import { storiesOf } from '@storybook/react';
 import { withKnobs, select, number } from '@storybook/addon-knobs/react';
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import Spacings from '@commercetools-uikit/spacings';
 import Text from '@commercetools-uikit/text';
 import Section from '../../../../docs/.storybook/decorators/section';
@@ -16,7 +16,7 @@ const Placeholder = styled.div`
   align-items: center;
   justify-content: center;
   background-color: pink;
-  padding: ${customProperties.spacingM};
+  padding: ${designTokens.spacingM};
 `;
 
 const renderGridElements = () => {

--- a/packages/components/grid/src/grid.visualroute.jsx
+++ b/packages/components/grid/src/grid.visualroute.jsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import Grid from '@commercetools-uikit/grid';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { Suite, Spec } from '../../../../test/percy';
 
 export const routePath = '/grid';
@@ -15,7 +15,7 @@ const Placeholder = styled.div`
   background-color: pink;
   padding: 16px;
   font-size: 16px;
-  font-family: ${customProperties.fontFamilyDefault};
+  font-family: ${designTokens.fontFamilyDefault};
 `;
 
 export const component = () => (

--- a/packages/components/icons/src/generated/AngleDownReact.tsx
+++ b/packages/components/icons/src/generated/AngleDownReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/AngleLeftReact.tsx
+++ b/packages/components/icons/src/generated/AngleLeftReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/AngleRightReact.tsx
+++ b/packages/components/icons/src/generated/AngleRightReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/AngleThinLeftReact.tsx
+++ b/packages/components/icons/src/generated/AngleThinLeftReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/AngleThinRightReact.tsx
+++ b/packages/components/icons/src/generated/AngleThinRightReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/AngleUpDownReact.tsx
+++ b/packages/components/icons/src/generated/AngleUpDownReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/AngleUpReact.tsx
+++ b/packages/components/icons/src/generated/AngleUpReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ArrowDownReact.tsx
+++ b/packages/components/icons/src/generated/ArrowDownReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ArrowLeftReact.tsx
+++ b/packages/components/icons/src/generated/ArrowLeftReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ArrowLongDownReact.tsx
+++ b/packages/components/icons/src/generated/ArrowLongDownReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ArrowRightReact.tsx
+++ b/packages/components/icons/src/generated/ArrowRightReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ArrowTriangleDownReact.tsx
+++ b/packages/components/icons/src/generated/ArrowTriangleDownReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ArrowTriangleUpReact.tsx
+++ b/packages/components/icons/src/generated/ArrowTriangleUpReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ArrowUpReact.tsx
+++ b/packages/components/icons/src/generated/ArrowUpReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ArrowsReact.tsx
+++ b/packages/components/icons/src/generated/ArrowsReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/BackReact.tsx
+++ b/packages/components/icons/src/generated/BackReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/BidirectionalArrowReact.tsx
+++ b/packages/components/icons/src/generated/BidirectionalArrowReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/BinFilledReact.tsx
+++ b/packages/components/icons/src/generated/BinFilledReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/BinLinearReact.tsx
+++ b/packages/components/icons/src/generated/BinLinearReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/BoxReact.tsx
+++ b/packages/components/icons/src/generated/BoxReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/BrainReact.tsx
+++ b/packages/components/icons/src/generated/BrainReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/CalendarReact.tsx
+++ b/packages/components/icons/src/generated/CalendarReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/CameraReact.tsx
+++ b/packages/components/icons/src/generated/CameraReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/CaretDownReact.tsx
+++ b/packages/components/icons/src/generated/CaretDownReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/CaretUpReact.tsx
+++ b/packages/components/icons/src/generated/CaretUpReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/CartReact.tsx
+++ b/packages/components/icons/src/generated/CartReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ChainBrokenReact.tsx
+++ b/packages/components/icons/src/generated/ChainBrokenReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ChainReact.tsx
+++ b/packages/components/icons/src/generated/ChainReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/CheckActiveReact.tsx
+++ b/packages/components/icons/src/generated/CheckActiveReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/CheckBoldReact.tsx
+++ b/packages/components/icons/src/generated/CheckBoldReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/CheckInactiveReact.tsx
+++ b/packages/components/icons/src/generated/CheckInactiveReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/CheckThinReact.tsx
+++ b/packages/components/icons/src/generated/CheckThinReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/CircleReact.tsx
+++ b/packages/components/icons/src/generated/CircleReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ClipboardReact.tsx
+++ b/packages/components/icons/src/generated/ClipboardReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ClockReact.tsx
+++ b/packages/components/icons/src/generated/ClockReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ClockWithArrowReact.tsx
+++ b/packages/components/icons/src/generated/ClockWithArrowReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/CloseBoldReact.tsx
+++ b/packages/components/icons/src/generated/CloseBoldReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/CloseReact.tsx
+++ b/packages/components/icons/src/generated/CloseReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/CodeViewReact.tsx
+++ b/packages/components/icons/src/generated/CodeViewReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/CoinsReact.tsx
+++ b/packages/components/icons/src/generated/CoinsReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ColumnsReact.tsx
+++ b/packages/components/icons/src/generated/ColumnsReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ConnectedSquareReact.tsx
+++ b/packages/components/icons/src/generated/ConnectedSquareReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ConnectedTriangleReact.tsx
+++ b/packages/components/icons/src/generated/ConnectedTriangleReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/CopyReact.tsx
+++ b/packages/components/icons/src/generated/CopyReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/CubeReact.tsx
+++ b/packages/components/icons/src/generated/CubeReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/CubesReact.tsx
+++ b/packages/components/icons/src/generated/CubesReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/DotReact.tsx
+++ b/packages/components/icons/src/generated/DotReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/DownloadReact.tsx
+++ b/packages/components/icons/src/generated/DownloadReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/DragDropReact.tsx
+++ b/packages/components/icons/src/generated/DragDropReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/DragReact.tsx
+++ b/packages/components/icons/src/generated/DragReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/EditReact.tsx
+++ b/packages/components/icons/src/generated/EditReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ErrorReact.tsx
+++ b/packages/components/icons/src/generated/ErrorReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ExpandReact.tsx
+++ b/packages/components/icons/src/generated/ExpandReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ExportReact.tsx
+++ b/packages/components/icons/src/generated/ExportReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ExternalLinkReact.tsx
+++ b/packages/components/icons/src/generated/ExternalLinkReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/EyeCrossedReact.tsx
+++ b/packages/components/icons/src/generated/EyeCrossedReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/EyeReact.tsx
+++ b/packages/components/icons/src/generated/EyeReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/FilterAndListReact.tsx
+++ b/packages/components/icons/src/generated/FilterAndListReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/FilterReact.tsx
+++ b/packages/components/icons/src/generated/FilterReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/FlagFilledReact.tsx
+++ b/packages/components/icons/src/generated/FlagFilledReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/FlagLinearReact.tsx
+++ b/packages/components/icons/src/generated/FlagLinearReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/FlameReact.tsx
+++ b/packages/components/icons/src/generated/FlameReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/FractionDigitsReact.tsx
+++ b/packages/components/icons/src/generated/FractionDigitsReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/GearReact.tsx
+++ b/packages/components/icons/src/generated/GearReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/GraduationCapReact.tsx
+++ b/packages/components/icons/src/generated/GraduationCapReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/GraphReact.tsx
+++ b/packages/components/icons/src/generated/GraphReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/GridReact.tsx
+++ b/packages/components/icons/src/generated/GridReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/HeartReact.tsx
+++ b/packages/components/icons/src/generated/HeartReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ImportReact.tsx
+++ b/packages/components/icons/src/generated/ImportReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/InfoReact.tsx
+++ b/packages/components/icons/src/generated/InfoReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/InformationReact.tsx
+++ b/packages/components/icons/src/generated/InformationReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ListReact.tsx
+++ b/packages/components/icons/src/generated/ListReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ListWithSearchReact.tsx
+++ b/packages/components/icons/src/generated/ListWithSearchReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/LockReact.tsx
+++ b/packages/components/icons/src/generated/LockReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/LogoutReact.tsx
+++ b/packages/components/icons/src/generated/LogoutReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/MailReact.tsx
+++ b/packages/components/icons/src/generated/MailReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/MinimizeReact.tsx
+++ b/packages/components/icons/src/generated/MinimizeReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/NestedViewReact.tsx
+++ b/packages/components/icons/src/generated/NestedViewReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/OperationsReact.tsx
+++ b/packages/components/icons/src/generated/OperationsReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/PageGearReact.tsx
+++ b/packages/components/icons/src/generated/PageGearReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/PagesReact.tsx
+++ b/packages/components/icons/src/generated/PagesReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/PaperBillInvertedReact.tsx
+++ b/packages/components/icons/src/generated/PaperBillInvertedReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/PaperclipReact.tsx
+++ b/packages/components/icons/src/generated/PaperclipReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/PinFilledReact.tsx
+++ b/packages/components/icons/src/generated/PinFilledReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/PinGearReact.tsx
+++ b/packages/components/icons/src/generated/PinGearReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/PinLinearReact.tsx
+++ b/packages/components/icons/src/generated/PinLinearReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/PluginReact.tsx
+++ b/packages/components/icons/src/generated/PluginReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/PlusBoldReact.tsx
+++ b/packages/components/icons/src/generated/PlusBoldReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/PlusThinReact.tsx
+++ b/packages/components/icons/src/generated/PlusThinReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/RefreshReact.tsx
+++ b/packages/components/icons/src/generated/RefreshReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/RestoreReact.tsx
+++ b/packages/components/icons/src/generated/RestoreReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/RevertReact.tsx
+++ b/packages/components/icons/src/generated/RevertReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ReviewReact.tsx
+++ b/packages/components/icons/src/generated/ReviewReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/RightTriangleFilledReact.tsx
+++ b/packages/components/icons/src/generated/RightTriangleFilledReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/RightTriangleLinearReact.tsx
+++ b/packages/components/icons/src/generated/RightTriangleLinearReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/RocketReact.tsx
+++ b/packages/components/icons/src/generated/RocketReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ScreenGearReact.tsx
+++ b/packages/components/icons/src/generated/ScreenGearReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ScreenUserReact.tsx
+++ b/packages/components/icons/src/generated/ScreenUserReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/SearchReact.tsx
+++ b/packages/components/icons/src/generated/SearchReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/SortingReact.tsx
+++ b/packages/components/icons/src/generated/SortingReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/SpeechBubbleReact.tsx
+++ b/packages/components/icons/src/generated/SpeechBubbleReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/SpeedometerReact.tsx
+++ b/packages/components/icons/src/generated/SpeedometerReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/SplitReact.tsx
+++ b/packages/components/icons/src/generated/SplitReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/StackReact.tsx
+++ b/packages/components/icons/src/generated/StackReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/StarReact.tsx
+++ b/packages/components/icons/src/generated/StarReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/SubdirectoryArrowReact.tsx
+++ b/packages/components/icons/src/generated/SubdirectoryArrowReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/SupportReact.tsx
+++ b/packages/components/icons/src/generated/SupportReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/SwitcherReact.tsx
+++ b/packages/components/icons/src/generated/SwitcherReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/TableReact.tsx
+++ b/packages/components/icons/src/generated/TableReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/TagMultiReact.tsx
+++ b/packages/components/icons/src/generated/TagMultiReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/TagReact.tsx
+++ b/packages/components/icons/src/generated/TagReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/TagStackedReact.tsx
+++ b/packages/components/icons/src/generated/TagStackedReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/TerminalReact.tsx
+++ b/packages/components/icons/src/generated/TerminalReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/TreeStructureReact.tsx
+++ b/packages/components/icons/src/generated/TreeStructureReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/TruckReact.tsx
+++ b/packages/components/icons/src/generated/TruckReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/UserFilledReact.tsx
+++ b/packages/components/icons/src/generated/UserFilledReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/UserLinearReact.tsx
+++ b/packages/components/icons/src/generated/UserLinearReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/VerifiedReact.tsx
+++ b/packages/components/icons/src/generated/VerifiedReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/ViewGridPlusReact.tsx
+++ b/packages/components/icons/src/generated/ViewGridPlusReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/WarningReact.tsx
+++ b/packages/components/icons/src/generated/WarningReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/generated/WorldReact.tsx
+++ b/packages/components/icons/src/generated/WorldReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/icons/src/icon.story.js
+++ b/packages/components/icons/src/icon.story.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, select } from '@storybook/addon-knobs/react';
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import Grid from '@commercetools-uikit/grid';
 import Spacings from '@commercetools-uikit/spacings';
 import {
@@ -130,11 +130,11 @@ const InlineSvgPage = (props) => {
               style={{
                 height: '100%',
                 backgroundColor:
-                  color === 'surface' ? customProperties.colorSolid : 'inherit',
+                  color === 'surface' ? designTokens.colorSolid : 'inherit',
               }}
             >
               <Grid
-                gridGap={customProperties.spacingS}
+                gridGap={designTokens.spacingS}
                 gridAutoColumns="1fr"
                 gridTemplateColumns={`repeat(${colorValues.length}, 1fr)`}
                 alignItems="center"

--- a/packages/components/icons/src/icons.visualroute.jsx
+++ b/packages/components/icons/src/icons.visualroute.jsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { Switch, Route } from 'react-router-dom';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import * as icons from '@commercetools-uikit/icons';
 import InlineSvg from '@commercetools-uikit/icons/inline-svg';
 import Text from '@commercetools-uikit/text';
@@ -106,7 +106,7 @@ export const component = () => (
                       height: '100%',
                       backgroundColor:
                         color === 'surface'
-                          ? customProperties.colorSolid
+                          ? designTokens.colorSolid
                           : 'inherit',
                     }}
                     key={`${size}-${color}`}

--- a/packages/components/icons/src/templates/icon.styles.tsx
+++ b/packages/components/icons/src/templates/icon.styles.tsx
@@ -2,7 +2,7 @@
 import { warning } from '@commercetools-uikit/utils';
 // @ts-ignore
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 export type Props = {
   color?:
@@ -59,28 +59,28 @@ const getColor = (color: Props['color']) => {
   let iconColor;
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
     default:
       break;

--- a/packages/components/inputs/checkbox-input/src/checkbox-input.styles.ts
+++ b/packages/components/inputs/checkbox-input/src/checkbox-input.styles.ts
@@ -1,16 +1,16 @@
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import type { TCheckboxProps } from './checkbox-input';
 
 const getSvgBorderStroke = (props: TCheckboxProps) => {
   if (props.isDisabled) {
-    return customProperties.borderColorForInputWhenDisabled;
+    return designTokens.borderColorForInputWhenDisabled;
   }
   if (props.hasError) {
-    return customProperties.borderColorForInputWhenError;
+    return designTokens.borderColorForInputWhenError;
   }
   if (props.isReadOnly) {
-    return customProperties.borderColorForInputWhenReadonly;
+    return designTokens.borderColorForInputWhenReadonly;
   }
   if (
     props.isHovered &&
@@ -18,22 +18,22 @@ const getSvgBorderStroke = (props: TCheckboxProps) => {
     !props.isDisabled &&
     !props.hasError
   ) {
-    return customProperties.borderColorForInputWhenFocused;
+    return designTokens.borderColorForInputWhenFocused;
   }
-  return customProperties.borderColorForInput;
+  return designTokens.borderColorForInput;
 };
 
 const getSvgContentFill = (props: TCheckboxProps) => {
   if (props.isDisabled) {
-    return customProperties.fontColorForInputWhenDisabled;
+    return designTokens.fontColorForInputWhenDisabled;
   }
   if (props.hasError) {
-    return customProperties.fontColorForInputWhenError;
+    return designTokens.fontColorForInputWhenError;
   }
   if (props.isReadOnly) {
-    return customProperties.fontColorForInputWhenReadonly;
+    return designTokens.fontColorForInputWhenReadonly;
   }
-  return customProperties.borderColorForInputWhenFocused;
+  return designTokens.borderColorForInputWhenFocused;
 };
 
 const getCheckboxWrapperStyles = (props: TCheckboxProps) => {
@@ -47,7 +47,7 @@ const getCheckboxWrapperStyles = (props: TCheckboxProps) => {
     align-items: center;
     svg *[data-style='checkbox__border'] {
       stroke: ${getSvgBorderStroke(props)};
-      fill: ${customProperties.backgroundColorForInput};
+      fill: ${designTokens.backgroundColorForInput};
     }
     svg *[data-style='checkbox__content'] {
       fill: ${getSvgContentFill(props)};

--- a/packages/components/inputs/checkbox-input/src/checkbox-input.tsx
+++ b/packages/components/inputs/checkbox-input/src/checkbox-input.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEventHandler, ReactNode } from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import {
   createSequentialId,
   filterDataAttributes,
@@ -84,7 +84,7 @@ const hoverStyles = (props: TLabelProps) => {
   if (!props.hasError && !props.readOnly && !props.disabled) {
     return css`
       &:hover svg *[data-style='checkbox__border'] {
-        stroke: ${customProperties.borderColorForInputWhenFocused};
+        stroke: ${designTokens.borderColorForInputWhenFocused};
       }
     `;
   }
@@ -92,9 +92,9 @@ const hoverStyles = (props: TLabelProps) => {
 };
 
 const LabelTextWrapper = styled.div`
-  margin-left: ${customProperties.spacingS};
+  margin-left: ${designTokens.spacingS};
   outline: none;
-  border-radius: ${customProperties.borderRadiusForTag};
+  border-radius: ${designTokens.borderRadiusForTag};
 `;
 
 const Label = styled.label<TLabelProps>`
@@ -110,7 +110,7 @@ const Label = styled.label<TLabelProps>`
   ${hoverStyles}
 
   &:focus-within div {
-    box-shadow: 0 0 0 2px ${customProperties.borderColorForInputWhenFocused};
+    box-shadow: 0 0 0 2px ${designTokens.borderColorForInputWhenFocused};
   }
 `;
 

--- a/packages/components/inputs/checkbox-input/src/checkbox.tsx
+++ b/packages/components/inputs/checkbox-input/src/checkbox.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, useCallback, ChangeEventHandler } from 'react';
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { accessibleHiddenInputStyles } from '@commercetools-uikit/input-utils';
 import {
   filterAriaAttributes,
@@ -10,7 +10,7 @@ import type { TCheckboxProps } from './checkbox-input';
 
 const Input = styled.input`
   &:focus + div > svg *[data-style='checkbox__border'] {
-    stroke: ${customProperties.borderColorForInputWhenFocused};
+    stroke: ${designTokens.borderColorForInputWhenFocused};
   }
 `;
 

--- a/packages/components/inputs/checkbox-input/src/icons/generated/CheckedReact.tsx
+++ b/packages/components/inputs/checkbox-input/src/icons/generated/CheckedReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/inputs/checkbox-input/src/icons/generated/IndeterminateReact.tsx
+++ b/packages/components/inputs/checkbox-input/src/icons/generated/IndeterminateReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/inputs/checkbox-input/src/icons/generated/UncheckedReact.tsx
+++ b/packages/components/inputs/checkbox-input/src/icons/generated/UncheckedReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/inputs/date-time-input/src/time-input.tsx
+++ b/packages/components/inputs/date-time-input/src/time-input.tsx
@@ -1,23 +1,23 @@
 /// <reference types="@emotion/react/types/css-prop" />
 import type { KeyboardEventHandler, RefObject } from 'react';
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import type { TDateTimeInputProps } from './date-time-input';
 
 const getInputStyles = () => css`
   width: 100%;
   text-align: center;
   border: 0;
-  border-top: 1px solid ${customProperties.colorNeutral90};
+  border-top: 1px solid ${designTokens.colorNeutral90};
   padding: 10px 0;
   outline: 0;
-  font-size: ${customProperties.fontSizeDefault};
-  margin-top: ${customProperties.spacingS};
-  color: ${customProperties.colorSolid};
+  font-size: ${designTokens.fontSizeDefault};
+  margin-top: ${designTokens.spacingS};
+  color: ${designTokens.colorSolid};
 
   :disabled {
     /* Fixes background color in Firefox */
-    background-color: ${customProperties.colorSurface};
+    background-color: ${designTokens.colorSurface};
   }
 `;
 

--- a/packages/components/inputs/input-utils/src/multiline-input/multiline-input.styles.ts
+++ b/packages/components/inputs/input-utils/src/multiline-input/multiline-input.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { getInputStyles } from '../styles';
 import type { TMultiLineInputProps } from './multiline-input';
 
@@ -14,7 +14,7 @@ const getTextareaStyles = (props: TMultiLineInputProps) => {
   const baseStyles = [
     getInputStyles(props),
     css`
-      padding: ${customProperties.spacingXs} ${customProperties.spacingS};
+      padding: ${designTokens.spacingXs} ${designTokens.spacingS};
       line-height: ${sizeInputLineHeight};
       flex: auto;
       word-break: break-word;

--- a/packages/components/inputs/input-utils/src/styles.ts
+++ b/packages/components/inputs/input-utils/src/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 type TInputProps = {
   isDisabled?: boolean;
@@ -12,76 +12,75 @@ type TInputProps = {
 
 const getInputBorderColor = (props: TInputProps) => {
   if (props.isDisabled || props.disabled) {
-    return customProperties.borderColorForInputWhenDisabled;
+    return designTokens.borderColorForInputWhenDisabled;
   }
   if (props.hasError) {
-    return customProperties.borderColorForInputWhenError;
+    return designTokens.borderColorForInputWhenError;
   }
   if (props.hasWarning) {
-    return customProperties.borderColorForInputWhenWarning;
+    return designTokens.borderColorForInputWhenWarning;
   }
   if (props.isReadOnly || props.readOnly) {
-    return customProperties.borderColorForInputWhenReadonly;
+    return designTokens.borderColorForInputWhenReadonly;
   }
-  return customProperties.borderColorForInput;
+  return designTokens.borderColorForInput;
 };
 
 const getInputFontColor = (props: TInputProps) => {
   if (props.isDisabled || props.disabled) {
-    return customProperties.fontColorForInputWhenDisabled;
+    return designTokens.fontColorForInputWhenDisabled;
   }
   if (props.hasError) {
-    return customProperties.fontColorForInputWhenError;
+    return designTokens.fontColorForInputWhenError;
   }
   if (props.hasWarning) {
-    return customProperties.fontColorForInputWhenWarning;
+    return designTokens.fontColorForInputWhenWarning;
   }
   if (props.isReadOnly || props.readOnly) {
-    return customProperties.fontColorForInputWhenReadonly;
+    return designTokens.fontColorForInputWhenReadonly;
   }
-  return customProperties.fontColorForInput;
+  return designTokens.fontColorForInput;
 };
 
 const getInputStyles = (props: TInputProps) => {
   return css`
     appearance: none;
     background-color: ${props.isDisabled || props.disabled
-      ? customProperties.backgroundColorForInputWhenDisabled
-      : customProperties.backgroundColorForInput};
+      ? designTokens.backgroundColorForInputWhenDisabled
+      : designTokens.backgroundColorForInput};
     border: 1px solid ${getInputBorderColor(props)};
-    border-radius: ${customProperties.borderRadiusForInput};
+    border-radius: ${designTokens.borderRadiusForInput};
     box-sizing: border-box;
     color: ${getInputFontColor(props)};
     cursor: ${props.isDisabled ? 'not-allowed' : 'default'};
     display: flex;
     flex: 1;
     font-family: inherit;
-    font-size: ${customProperties.fontSizeForInput};
-    height: ${customProperties.sizeHeightInput};
-    min-height: ${customProperties.sizeHeightInput};
+    font-size: ${designTokens.fontSizeForInput};
+    height: ${designTokens.sizeHeightInput};
+    min-height: ${designTokens.sizeHeightInput};
     opacity: ${props.isDisabled || props.disabled
       ? '1'
       : 'unset'}; /* fix for mobile safari */
     outline: none;
     overflow: hidden;
-    padding: 0 ${customProperties.spacingS};
-    transition: border-color ${customProperties.transitionStandard},
-      background-color ${customProperties.transitionStandard},
-      color ${customProperties.transitionStandard},
-      box-shadow ${customProperties.transitionStandard};
+    padding: 0 ${designTokens.spacingS};
+    transition: border-color ${designTokens.transitionStandard},
+      background-color ${designTokens.transitionStandard},
+      color ${designTokens.transitionStandard},
+      box-shadow ${designTokens.transitionStandard};
     width: 100%;
 
     &::placeholder {
-      color: ${customProperties.placeholderFontColorForInput};
+      color: ${designTokens.placeholderFontColorForInput};
     }
     :active,
     :focus,
     :hover:not(:disabled):not(:read-only) {
-      border-color: ${customProperties.borderColorForInputWhenFocused};
+      border-color: ${designTokens.borderColorForInputWhenFocused};
     }
     :focus {
-      box-shadow: inset 0 0 0 2px
-        ${customProperties.borderColorForInputWhenFocused};
+      box-shadow: inset 0 0 0 2px ${designTokens.borderColorForInputWhenFocused};
     }
   `;
 };

--- a/packages/components/inputs/localized-multiline-text-input/src/translation-input.styles.ts
+++ b/packages/components/inputs/localized-multiline-text-input/src/translation-input.styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 // NOTE: order is important here
 // * a disabled-field currently does not display warning/error-states so it takes precedence
@@ -29,19 +29,18 @@ const getLanguageLabelStyles = (_props: TTranslationInputStylesProps) => {
   return css`
     /* avoid wrapping label onto new lines */
     flex: 1 0 auto;
-    color: ${customProperties.fontColorForInputWhenDisabled};
+    color: ${designTokens.fontColorForInputWhenDisabled};
     line-height: calc(
-      ${customProperties.sizeHeightInput} - 2 *
-        ${customProperties.borderRadius1}
+      ${designTokens.sizeHeightInput} - 2 * ${designTokens.borderRadius1}
     );
-    background-color: ${customProperties.backgroundColorForInputWhenDisabled};
-    border-top-left-radius: ${customProperties.borderRadiusForInput};
-    border-bottom-left-radius: ${customProperties.borderRadiusForInput};
-    border: 1px ${customProperties.borderColorForInputWhenDisabled} solid;
-    padding: 0 ${customProperties.spacingS};
-    transition: border-color ${customProperties.transitionStandard},
-      background-color ${customProperties.transitionStandard},
-      color ${customProperties.transitionStandard};
+    background-color: ${designTokens.backgroundColorForInputWhenDisabled};
+    border-top-left-radius: ${designTokens.borderRadiusForInput};
+    border-bottom-left-radius: ${designTokens.borderRadiusForInput};
+    border: 1px ${designTokens.borderColorForInputWhenDisabled} solid;
+    padding: 0 ${designTokens.spacingS};
+    transition: border-color ${designTokens.transitionStandard},
+      background-color ${designTokens.transitionStandard},
+      color ${designTokens.transitionStandard};
     border-right: 0;
     box-shadow: none;
     appearance: none;

--- a/packages/components/inputs/localized-multiline-text-input/src/translation-input.tsx
+++ b/packages/components/inputs/localized-multiline-text-input/src/translation-input.tsx
@@ -11,7 +11,7 @@ import FlatButton from '@commercetools-uikit/flat-button';
 import { AngleUpIcon } from '@commercetools-uikit/icons';
 import Stack from '@commercetools-uikit/spacings-stack';
 import { filterDataAttributes, warning } from '@commercetools-uikit/utils';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import Text from '@commercetools-uikit/text';
 import {
   MultilineInput,
@@ -229,7 +229,7 @@ const TranslationInput = (props: TranslationInputProps) => {
                       position: absolute;
                       top: 0;
                       right: 0;
-                      margin-top: ${customProperties.spacingXs};
+                      margin-top: ${designTokens.spacingXs};
                     `,
                 ]}
               >

--- a/packages/components/inputs/localized-rich-text-input/src/editor.styles.ts
+++ b/packages/components/inputs/localized-rich-text-input/src/editor.styles.ts
@@ -1,23 +1,23 @@
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import type { TEditorProps } from './editor';
 
 const EditorLanguageLabel = styled.label`
   /* avoid wrapping label onto new lines */
   white-space: nowrap;
   flex: 0;
-  color: ${customProperties.fontColorForInputWhenDisabled};
+  color: ${designTokens.fontColorForInputWhenDisabled};
   line-height: calc(
-    ${customProperties.sizeHeightInput} - 2 * ${customProperties.borderRadius1}
+    ${designTokens.sizeHeightInput} - 2 * ${designTokens.borderRadius1}
   );
-  background-color: ${customProperties.backgroundColorForInputWhenDisabled};
-  border-top-left-radius: ${customProperties.borderRadiusForInput};
-  border-bottom-left-radius: ${customProperties.borderRadiusForInput};
-  border: 1px ${customProperties.borderColorForInputWhenDisabled} solid;
-  padding: 0 ${customProperties.spacingS};
-  transition: border-color ${customProperties.transitionStandard},
-    background-color ${customProperties.transitionStandard},
-    color ${customProperties.transitionStandard};
+  background-color: ${designTokens.backgroundColorForInputWhenDisabled};
+  border-top-left-radius: ${designTokens.borderRadiusForInput};
+  border-bottom-left-radius: ${designTokens.borderRadiusForInput};
+  border: 1px ${designTokens.borderColorForInputWhenDisabled} solid;
+  padding: 0 ${designTokens.spacingS};
+  transition: border-color ${designTokens.transitionStandard},
+    background-color ${designTokens.transitionStandard},
+    color ${designTokens.transitionStandard};
   border-right: 0;
   box-shadow: none;
   appearance: none;

--- a/packages/components/inputs/localized-rich-text-input/src/editor.tsx
+++ b/packages/components/inputs/localized-rich-text-input/src/editor.tsx
@@ -15,7 +15,7 @@ import {
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useIntl } from 'react-intl';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { warning, filterDataAttributes } from '@commercetools-uikit/utils';
 import CollapsibleMotion from '@commercetools-uikit/collapsible-motion';
 import Stack from '@commercetools-uikit/spacings-stack';
@@ -165,10 +165,10 @@ const Editor = forwardRef((props: TEditorProps, forwardedRef) => {
     },
     [editor, props.language]
   );
-  /* 
+  /*
   Resetting the editor requires access to `editor` object returned from `useSlate` hook.
-  Therefore, `reset` function is attached to the passed `ref` object via `useImperativeHandle` 
-  to be called from the parent component. 
+  Therefore, `reset` function is attached to the passed `ref` object via `useImperativeHandle`
+  to be called from the parent component.
   e.g. <button onMouseDown={() => ref.current?.resetValue("<p><strong>Value after reset</strong></p>")}>Reset</button>
   */
   useImperativeHandle(forwardedRef, () => {
@@ -178,13 +178,13 @@ const Editor = forwardRef((props: TEditorProps, forwardedRef) => {
   });
 
   const shouldToggleButtonTakeSpace =
-    /* 
+    /*
       - if hasLanguagesControl and there are no errors/warnings to display
       - then the toggleButton is absolutely positioned
       This is because the toggle button is placed next to the LocalizedInputToggle without being siblings in the DOM.
       If there is a error or warning showing,
       then it can be placed statically because it will then be a sibling to the error/warning message
-      and LocalizedInputToggle is placed below the errors/warnings. 
+      and LocalizedInputToggle is placed below the errors/warnings.
     */
 
     (renderToggleButton && !props.hasLanguagesControl) ||
@@ -321,7 +321,7 @@ const Editor = forwardRef((props: TEditorProps, forwardedRef) => {
                           position: absolute;
                           top: 0;
                           right: 0;
-                          margin-top: ${customProperties.spacingXs};
+                          margin-top: ${designTokens.spacingXs};
                         `,
                     ]}
                   >

--- a/packages/components/inputs/localized-text-input/src/localized-text-input.styles.ts
+++ b/packages/components/inputs/localized-text-input/src/localized-text-input.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 // NOTE: order is important here
 // * a disabled-field currently does not display warning/error-states so it takes precedence
@@ -19,17 +19,17 @@ const getLanguageLabelStyles = (_props: unknown) => {
     /* avoid wrapping label onto new lines */
     flex: 1 0 auto;
     box-sizing: border-box;
-    color: ${customProperties.fontColorForInputWhenDisabled};
-    height: ${customProperties.sizeHeightInput};
-    line-height: ${customProperties.sizeHeightInput};
-    background-color: ${customProperties.backgroundColorForInputWhenDisabled};
-    border-top-left-radius: ${customProperties.borderRadiusForInput};
-    border-bottom-left-radius: ${customProperties.borderRadiusForInput};
-    border: 1px ${customProperties.borderColorForInputWhenDisabled} solid;
-    padding: 0 ${customProperties.spacingS};
-    transition: border-color ${customProperties.transitionStandard},
-      background-color ${customProperties.transitionStandard},
-      color ${customProperties.transitionStandard};
+    color: ${designTokens.fontColorForInputWhenDisabled};
+    height: ${designTokens.sizeHeightInput};
+    line-height: ${designTokens.sizeHeightInput};
+    background-color: ${designTokens.backgroundColorForInputWhenDisabled};
+    border-top-left-radius: ${designTokens.borderRadiusForInput};
+    border-bottom-left-radius: ${designTokens.borderRadiusForInput};
+    border: 1px ${designTokens.borderColorForInputWhenDisabled} solid;
+    padding: 0 ${designTokens.spacingS};
+    transition: border-color ${designTokens.transitionStandard},
+      background-color ${designTokens.transitionStandard},
+      color ${designTokens.transitionStandard};
     border-right: 0;
     box-shadow: none;
     appearance: none;

--- a/packages/components/inputs/money-input/src/money-input.styles.ts
+++ b/packages/components/inputs/money-input/src/money-input.styles.ts
@@ -1,19 +1,19 @@
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { getInputStyles } from '@commercetools-uikit/input-utils';
 import type { TInputProps } from './money-input';
 
 const getCurrencyLabelStyles = () => css`
   display: flex;
-  color: ${customProperties.fontColorForInputWhenDisabled};
-  background-color: ${customProperties.backgroundColorForInputWhenDisabled};
-  border-top-left-radius: ${customProperties.borderRadiusForInput};
-  border-bottom-left-radius: ${customProperties.borderRadiusForInput};
-  border: 1px ${customProperties.borderColorForInputWhenDisabled} solid;
+  color: ${designTokens.fontColorForInputWhenDisabled};
+  background-color: ${designTokens.backgroundColorForInputWhenDisabled};
+  border-top-left-radius: ${designTokens.borderRadiusForInput};
+  border-bottom-left-radius: ${designTokens.borderRadiusForInput};
+  border: 1px ${designTokens.borderColorForInputWhenDisabled} solid;
   border-right: 0;
-  padding: 0 ${customProperties.spacingS};
+  padding: 0 ${designTokens.spacingS};
   align-items: center;
-  font-size: ${customProperties.fontSizeForInput};
+  font-size: ${designTokens.fontSizeForInput};
   box-sizing: border-box;
 `;
 
@@ -28,7 +28,7 @@ const getAmountInputStyles = (props: TGetAmountInputStyles) => [
     margin-left: 0;
 
     &::placeholder {
-      color: ${customProperties.placeholderFontColorForInput};
+      color: ${designTokens.placeholderFontColorForInput};
     }
   `,
 ];
@@ -43,7 +43,7 @@ const getHighPrecisionWrapperStyles = ({
   position: absolute;
   top: 0;
   right: 0;
-  margin-right: ${customProperties.spacingXs};
+  margin-right: ${designTokens.spacingXs};
   height: 100%;
   display: flex;
   align-items: center;

--- a/packages/components/inputs/money-input/src/money-input.tsx
+++ b/packages/components/inputs/money-input/src/money-input.tsx
@@ -9,7 +9,7 @@ import Select, {
 import { useIntl } from 'react-intl';
 import { css, type Theme } from '@emotion/react';
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import {
   warning,
   isNumberish,
@@ -118,13 +118,13 @@ const createCurrencySelectStyles: TCreateCurrencySelectStyles = ({
       minWidth: '72px',
       borderColor: (() => {
         if (isDisabled)
-          return `${customProperties.borderColorForInputWhenDisabled} !important`;
-        if (hasError) return customProperties.borderColorForInputWhenError;
-        if (hasWarning) return customProperties.borderColorForInputWhenWarning;
-        if (hasFocus) return customProperties.borderColorForInputWhenFocused;
+          return `${designTokens.borderColorForInputWhenDisabled} !important`;
+        if (hasError) return designTokens.borderColorForInputWhenError;
+        if (hasWarning) return designTokens.borderColorForInputWhenWarning;
+        if (hasFocus) return designTokens.borderColorForInputWhenFocused;
         if (isReadOnly)
-          return `${customProperties.borderColorForInputWhenReadonly} !important`;
-        return customProperties.borderColorForInput;
+          return `${designTokens.borderColorForInputWhenReadonly} !important`;
+        return designTokens.borderColorForInput;
       })(),
       cursor: (() => {
         if (isDisabled) return 'not-allowed';
@@ -132,7 +132,7 @@ const createCurrencySelectStyles: TCreateCurrencySelectStyles = ({
         return 'pointer';
       })(),
       backgroundColor: (() => {
-        if (isReadOnly) return customProperties.backgroundColorForInput;
+        if (isReadOnly) return designTokens.backgroundColorForInput;
         return base.backgroundColor;
       })(),
     }),
@@ -141,15 +141,15 @@ const createCurrencySelectStyles: TCreateCurrencySelectStyles = ({
       marginLeft: 0,
       maxWidth: 'initial',
       color: (() => {
-        if (isDisabled) return customProperties.fontColorForInputWhenDisabled;
-        if (hasError) return customProperties.fontColorForInputWhenError;
-        if (hasWarning) return customProperties.fontColorForInputWhenWarning;
-        if (isReadOnly) return customProperties.fontColorForInputWhenReadonly;
+        if (isDisabled) return designTokens.fontColorForInputWhenDisabled;
+        if (hasError) return designTokens.fontColorForInputWhenError;
+        if (hasWarning) return designTokens.fontColorForInputWhenWarning;
+        if (isReadOnly) return designTokens.fontColorForInputWhenReadonly;
         return base.color;
       })(),
     }),
     dropdownIndicator: () => ({
-      fill: isReadOnly ? customProperties.fontColorForInputWhenReadonly : '',
+      fill: isReadOnly ? designTokens.fontColorForInputWhenReadonly : '',
     }),
   };
 };
@@ -815,7 +815,7 @@ const MoneyInput = (props: TMoneyInputProps) => {
               props.hasHighPrecisionBadge &&
                 isHighPrecision &&
                 css`
-                  padding-right: ${customProperties.spacingL};
+                  padding-right: ${designTokens.spacingL};
                 `,
             ]}
             placeholder={props.placeholder}
@@ -846,7 +846,7 @@ const MoneyInput = (props: TMoneyInputProps) => {
                   // so that the tooltip is flush with the component
                   styles={{
                     body: {
-                      margin: `${customProperties.spacingS} -${customProperties.spacingXs} ${customProperties.spacingS} 0`,
+                      margin: `${designTokens.spacingS} -${designTokens.spacingXs} ${designTokens.spacingS} 0`,
                     },
                   }}
                   title={intl.formatMessage(messages.highPrecision)}

--- a/packages/components/inputs/radio-input/src/icons/generated/RadioOptionCheckedReact.tsx
+++ b/packages/components/inputs/radio-input/src/icons/generated/RadioOptionCheckedReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/inputs/radio-input/src/icons/generated/RadioOptionUncheckedReact.tsx
+++ b/packages/components/inputs/radio-input/src/icons/generated/RadioOptionUncheckedReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/inputs/radio-input/src/radio-option.styles.ts
+++ b/packages/components/inputs/radio-input/src/radio-option.styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { TOptionProps } from './radio-option';
 
 type TStylesProps = Pick<
@@ -10,24 +10,24 @@ type TStylesProps = Pick<
 
 const LabelTextWrapper = styled.div<TStylesProps>`
   grid-area: label;
-  margin-left: ${customProperties.spacingS};
+  margin-left: ${designTokens.spacingS};
   font-size: 1rem;
   font-family: inherit;
   color: ${(props) =>
     props.isDisabled
-      ? customProperties.fontColorForInputWhenDisabled
-      : customProperties.fontColorForInput};
+      ? designTokens.fontColorForInputWhenDisabled
+      : designTokens.fontColorForInput};
 `;
 
 const AdditionalTextWrapper = styled.div<TStylesProps>`
   grid-area: content;
-  margin-left: ${customProperties.spacingXs};
+  margin-left: ${designTokens.spacingXs};
   font-size: 1rem;
   font-family: inherit;
   color: ${(props) =>
     props.isDisabled
-      ? customProperties.fontColorForInputWhenDisabled
-      : customProperties.fontColorForInput};
+      ? designTokens.fontColorForInputWhenDisabled
+      : designTokens.fontColorForInput};
 `;
 
 const RadioOptionsWrapper = styled.div<TStylesProps>`
@@ -41,37 +41,37 @@ const RadioOptionsWrapper = styled.div<TStylesProps>`
 
 const getSvgContainerBorderStroke = (props: TStylesProps) => {
   if (props.isDisabled) {
-    return customProperties.borderColorForInputWhenDisabled;
+    return designTokens.borderColorForInputWhenDisabled;
   }
   if (props.hasError) {
-    return customProperties.borderColorForInputWhenError;
+    return designTokens.borderColorForInputWhenError;
   }
   if (props.hasWarning) {
-    return customProperties.borderColorForInputWhenWarning;
+    return designTokens.borderColorForInputWhenWarning;
   }
   if (props.isHovered && !props.isDisabled) {
-    return customProperties.borderColorForInputWhenFocused;
+    return designTokens.borderColorForInputWhenFocused;
   }
   if (props.isReadOnly) {
-    return customProperties.borderColorForInputWhenReadonly;
+    return designTokens.borderColorForInputWhenReadonly;
   }
-  return customProperties.borderColorForInput;
+  return designTokens.borderColorForInput;
 };
 
 const getSvgContainerContentFill = (props: TStylesProps) => {
   if (props.isDisabled) {
-    return customProperties.fontColorForInputWhenDisabled;
+    return designTokens.fontColorForInputWhenDisabled;
   }
   if (props.hasError) {
-    return customProperties.fontColorForInputWhenError;
+    return designTokens.fontColorForInputWhenError;
   }
   if (props.hasWarning) {
-    return customProperties.fontColorForInputWhenWarning;
+    return designTokens.fontColorForInputWhenWarning;
   }
   if (props.isReadOnly) {
-    return customProperties.fontColorForInputWhenReadonly;
+    return designTokens.fontColorForInputWhenReadonly;
   }
-  return customProperties.borderColorForInputWhenFocused;
+  return designTokens.borderColorForInputWhenFocused;
 };
 
 const getContainerStyles = (props: TOptionProps) => css`
@@ -80,8 +80,8 @@ const getContainerStyles = (props: TOptionProps) => css`
   grid-area: radio;
   svg {
     fill: ${props.isDisabled
-      ? customProperties.backgroundColorForInputWhenDisabled
-      : customProperties.backgroundColorForInput};
+      ? designTokens.backgroundColorForInputWhenDisabled
+      : designTokens.backgroundColorForInput};
   }
 
   svg *[data-style='radio-option__border'] {
@@ -94,34 +94,34 @@ const getContainerStyles = (props: TOptionProps) => css`
 
 const getSvgLabelBorderStroke = (props: TStylesProps) => {
   if (props.isDisabled) {
-    return customProperties.borderColorForInputWhenDisabled;
+    return designTokens.borderColorForInputWhenDisabled;
   }
   if (props.hasError) {
-    return customProperties.borderColorForInputWhenError;
+    return designTokens.borderColorForInputWhenError;
   }
   if (props.hasWarning) {
-    return customProperties.borderColorForInputWhenWarning;
+    return designTokens.borderColorForInputWhenWarning;
   }
   if (props.isReadOnly) {
-    return customProperties.borderColorForInputWhenReadonly;
+    return designTokens.borderColorForInputWhenReadonly;
   }
-  return customProperties.borderColorForInputWhenFocused;
+  return designTokens.borderColorForInputWhenFocused;
 };
 
 const getLabelColor = (props: TStylesProps) => {
   if (props.isDisabled) {
-    return customProperties.fontColorForInputWhenDisabled;
+    return designTokens.fontColorForInputWhenDisabled;
   }
   if (props.hasError) {
-    return customProperties.fontColorForInputWhenError;
+    return designTokens.fontColorForInputWhenError;
   }
   if (props.hasWarning) {
-    return customProperties.fontColorForInputWhenWarning;
+    return designTokens.fontColorForInputWhenWarning;
   }
   if (props.isReadOnly) {
-    return customProperties.fontColorForInputWhenReadonly;
+    return designTokens.fontColorForInputWhenReadonly;
   }
-  return customProperties.fontColorForInput;
+  return designTokens.fontColorForInput;
 };
 const getLabelCursor = (props: TStylesProps) => {
   if (props.isDisabled) {
@@ -143,7 +143,7 @@ const getLabelStyles = (props: TStylesProps) => css`
     stroke: ${getSvgLabelBorderStroke(props)};
   }
   :focus-within ${LabelTextWrapper} {
-    outline: auto 2px ${customProperties.borderColorForInputWhenFocused};
+    outline: auto 2px ${designTokens.borderColorForInputWhenFocused};
     outline-offset: 3px;
   }
 `;

--- a/packages/components/inputs/radio-input/src/radio-option.tsx
+++ b/packages/components/inputs/radio-input/src/radio-option.tsx
@@ -6,7 +6,7 @@ import {
   isValidElement,
 } from 'react';
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import {
   filterDataAttributes,
   filterInvalidAttributes,
@@ -25,7 +25,7 @@ import SpacingsInset from '@commercetools-uikit/spacings-inset';
 
 const Input = styled.input`
   &:focus + div > svg *[data-style='radio-option__border'] {
-    stroke: ${customProperties.borderColorForInputWhenFocused};
+    stroke: ${designTokens.borderColorForInputWhenFocused};
   }
 `;
 

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/divider.ts
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/divider.ts
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 const Divider = styled.span`
   width: 1px;
-  height: ${customProperties.spacingL};
-  background: ${customProperties.colorNeutral};
-  margin: 0 ${customProperties.spacingXs};
+  height: ${designTokens.spacingL};
+  background: ${designTokens.colorNeutral};
+  margin: 0 ${designTokens.spacingXs};
 `;
 
 export default Divider;

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/dropdown.styles.tsx
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/dropdown.styles.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 type TDropdownStylesProps = {
   isSelected?: boolean;
@@ -16,69 +16,67 @@ const DropdownItem = styled.button<TDropdownStylesProps>`
   border: 0;
   font-size: 1rem;
   cursor: pointer;
-  padding: ${customProperties.spacingXs} ${customProperties.spacingS};
-  font-family: ${customProperties.fontFamilyDefault};
+  padding: ${designTokens.spacingXs} ${designTokens.spacingS};
+  font-family: ${designTokens.fontFamilyDefault};
   display: block;
   background-color: ${(props) =>
-    props.isSelected
-      ? customProperties.colorAccent95
-      : customProperties.colorSurface};
+    props.isSelected ? designTokens.colorAccent95 : designTokens.colorSurface};
 
   &:focus,
   &:hover {
     outline: none;
-    background-color: ${customProperties.colorNeutral90};
+    background-color: ${designTokens.colorNeutral90};
   }
 `;
 
 const getButtonStyles = (props: TDropdownStylesProps) => [
   css`
     border: 0;
-    font-family: ${customProperties.fontFamilyDefault};
-    border-radius: ${customProperties.borderRadius4};
+    font-family: ${designTokens.fontFamilyDefault};
+    border-radius: ${designTokens.borderRadius4};
     cursor: pointer;
-    font-size: ${customProperties.fontSizeForInput};
-    color: ${customProperties.colorSolid};
+    font-size: ${designTokens.fontSizeForInput};
+    color: ${designTokens.colorSolid};
     display: flex;
     justify-content: center;
     align-items: center;
     padding: ${props.isStyleButton
-      ? `calc(${customProperties.spacingXs} - 1px) ${customProperties.spacingS}`
-      : customProperties.spacingXs};
+      ? `calc(${designTokens.spacingXs} - 1px) ${designTokens.spacingS}`
+      : designTokens.spacingXs};
 
     &:hover {
-      background-color: ${customProperties.colorNeutral90};
+      background-color: ${designTokens.colorNeutral90};
     }
   `,
   props.isIndeterminate &&
     css`
-      background-color: ${customProperties.colorAccent95};
+      background-color: ${designTokens.colorAccent95};
     `,
   props.isOpen &&
     css`
       &:not(:hover) {
-        background-color: ${customProperties.colorAccent30};
-        color: ${customProperties.colorSurface};
+        background-color: ${designTokens.colorAccent30};
+        color: ${designTokens.colorSurface};
 
         svg {
-          fill: ${customProperties.colorSurface};
+          fill: ${designTokens.colorSurface};
         }
       }
     `,
   props.isReadOnly &&
     css`
-      color: ${customProperties.colorNeutral60};
+      color: ${designTokens.colorNeutral60};
 
       svg {
-        fill: ${customProperties.colorNeutral60};
+        fill: ${designTokens.colorNeutral60};
       }
     `,
   props.isDisabled &&
     css`
-      color: ${customProperties.colorNeutral60};
+      color: ${designTokens.colorNeutral60};
 
       svg {
-        fill: ${customProperties.colorNeutral60};
+        fill: ${designTokens.colorNeutral60};
       }
     `,
 ];
@@ -86,16 +84,16 @@ const getButtonStyles = (props: TDropdownStylesProps) => [
 const DropdownContainer = styled.div`
   position: absolute;
   cursor: pointer;
-  font-size: ${customProperties.fontSizeForInput};
-  top: ${customProperties.spacingXs};
-  margin-top: ${customProperties.spacingXs};
+  font-size: ${designTokens.fontSizeForInput};
+  top: ${designTokens.spacingXs};
+  margin-top: ${designTokens.spacingXs};
   left: 0;
   white-space: nowrap;
-  background: ${customProperties.colorSurface};
+  background: ${designTokens.colorSurface};
   overflow: hidden;
   z-index: 9999;
-  border: 1px solid ${customProperties.colorPrimary};
-  border-radius: ${customProperties.borderRadius6};
+  border: 1px solid ${designTokens.colorPrimary};
+  border-radius: ${designTokens.borderRadius6};
 `;
 
 export { DropdownContainer, DropdownItem, getButtonStyles };

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/BoldReact.tsx
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/BoldReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/ExpandFullReact.tsx
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/ExpandFullReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/ItalicReact.tsx
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/ItalicReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/MoreStylesReact.tsx
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/MoreStylesReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/OrderedListReact.tsx
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/OrderedListReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/RedoReact.tsx
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/RedoReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/StrikethroughReact.tsx
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/StrikethroughReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/SubscriptReact.tsx
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/SubscriptReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/SuperscriptReact.tsx
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/SuperscriptReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/UnderlineReact.tsx
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/UnderlineReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/UndoReact.tsx
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/UndoReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/UnorderedListReact.tsx
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/icons/generated/UnorderedListReact.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { warning } from '@commercetools-uikit/utils';
 import { css, ClassNames } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 export type Props = {
   color?:
     | 'solid'
@@ -77,35 +77,35 @@ const getColor = (color: Props['color']) => {
 
   switch (color) {
     case 'solid':
-      iconColor = customProperties.colorSolid;
+      iconColor = designTokens.colorSolid;
       break;
 
     case 'neutral60':
-      iconColor = customProperties.colorNeutral60;
+      iconColor = designTokens.colorNeutral60;
       break;
 
     case 'surface':
-      iconColor = customProperties.colorSurface;
+      iconColor = designTokens.colorSurface;
       break;
 
     case 'info':
-      iconColor = customProperties.colorInfo;
+      iconColor = designTokens.colorInfo;
       break;
 
     case 'primary':
-      iconColor = customProperties.colorPrimary;
+      iconColor = designTokens.colorPrimary;
       break;
 
     case 'primary40':
-      iconColor = customProperties.colorPrimary40;
+      iconColor = designTokens.colorPrimary40;
       break;
 
     case 'warning':
-      iconColor = customProperties.colorWarning;
+      iconColor = designTokens.colorWarning;
       break;
 
     case 'error':
-      iconColor = customProperties.colorError;
+      iconColor = designTokens.colorError;
       break;
 
     default:

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/rich-text-body-button.tsx
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/rich-text-body-button.tsx
@@ -1,6 +1,6 @@
 import omit from 'lodash/omit';
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import type { ReactNode, MouseEvent, KeyboardEvent } from 'react';
 
 type TRichTextBodyButtonProps = {
@@ -17,8 +17,8 @@ type TRichTextBodyButtonProps = {
 const propsToOmit = ['isActive', 'label', 'isDisabled', 'isReadOnly'];
 
 function getFillColor(props: TRichTextBodyButtonProps) {
-  if (props.isActive) return customProperties.colorSurface;
-  return customProperties.colorSolid;
+  if (props.isActive) return designTokens.colorSurface;
+  return designTokens.colorSolid;
 }
 
 const RichTextBodyButton = (props: TRichTextBodyButtonProps) => {
@@ -37,13 +37,13 @@ const RichTextBodyButton = (props: TRichTextBodyButtonProps) => {
           border: 0;
           cursor: pointer;
           background: ${props.isActive
-            ? customProperties.colorAccent30
+            ? designTokens.colorAccent30
             : 'transparent'};
           display: flex;
           justify-content: center;
           align-items: center;
-          border-radius: ${customProperties.spacingXs};
-          padding: ${customProperties.spacingXs};
+          border-radius: ${designTokens.spacingXs};
+          padding: ${designTokens.spacingXs};
 
           &:focus {
             outline: none;
@@ -52,8 +52,8 @@ const RichTextBodyButton = (props: TRichTextBodyButtonProps) => {
           &:hover,
           &:focus {
             background: ${props.isActive
-              ? customProperties.colorAccent30
-              : customProperties.colorNeutral90};
+              ? designTokens.colorAccent30
+              : designTokens.colorNeutral90};
           }
 
           svg {
@@ -63,14 +63,14 @@ const RichTextBodyButton = (props: TRichTextBodyButtonProps) => {
           &:disabled {
             pointer-events: none;
             svg {
-              fill: ${customProperties.colorNeutral60};
+              fill: ${designTokens.colorNeutral60};
             }
           }
         `,
         props.isReadOnly &&
           css`
             svg {
-              fill: ${customProperties.colorNeutral60};
+              fill: ${designTokens.colorNeutral60};
             }
           `,
       ]}

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/rich-text-body.styles.ts
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/rich-text-body.styles.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import type { TRichTextEditorBody } from './rich-text-body';
 
 type TRichTextBodyStylesProps = Pick<
@@ -11,37 +11,37 @@ type TRichTextBodyStylesProps = Pick<
 const getBorderColor = (props: TRichTextBodyStylesProps) => {
   if (props.isDisabled) {
     return css`
-      border-color: ${customProperties.borderColorForInputWhenDisabled};
+      border-color: ${designTokens.borderColorForInputWhenDisabled};
     `;
   }
   if (props.hasError) {
     return css`
-      border-color: ${customProperties.borderColorForInputWhenError};
+      border-color: ${designTokens.borderColorForInputWhenError};
     `;
   }
   if (props.hasWarning) {
     return css`
-      border-color: ${customProperties.borderColorForInputWhenWarning};
+      border-color: ${designTokens.borderColorForInputWhenWarning};
     `;
   }
   if (props.isReadOnly) {
     return css`
-      border-color: ${customProperties.borderColorForInputWhenReadonly};
+      border-color: ${designTokens.borderColorForInputWhenReadonly};
     `;
   }
   return css`
-    border-color: ${customProperties.borderColorForInput};
+    border-color: ${designTokens.borderColorForInput};
   `;
 };
 
 const getBackgroundColor = (props: TRichTextBodyStylesProps) => {
   if (props.isDisabled) {
     return css`
-      background-color: ${customProperties.backgroundColorForInputWhenDisabled};
+      background-color: ${designTokens.backgroundColorForInputWhenDisabled};
     `;
   }
   return css`
-    background-color: ${customProperties.backgroundColorForInput};
+    background-color: ${designTokens.backgroundColorForInput};
   `;
 };
 
@@ -61,12 +61,11 @@ export const ToolbarRightControls = styled.div``;
 export const Toolbar = styled.div`
   display: flex;
   flex-wrap: wrap;
-  font-family: ${customProperties.fontFamilyDefault};
-  border-radius: ${customProperties.borderRadiusForInput};
+  font-family: ${designTokens.fontFamilyDefault};
+  border-radius: ${designTokens.borderRadiusForInput};
   border-bottom: 0;
-  padding: ${customProperties.spacingXs}
-    calc(${customProperties.spacingS} - 1px);
-  padding-left: calc(${customProperties.spacingXs} - 1px);
+  padding: ${designTokens.spacingXs} calc(${designTokens.spacingS} - 1px);
+  padding-left: calc(${designTokens.spacingXs} - 1px);
   align-items: flex-start;
   align-content: stretch;
 
@@ -75,9 +74,9 @@ export const Toolbar = styled.div`
   &::after {
     position: absolute;
     content: '';
-    width: calc(100% - ${customProperties.spacingS});
+    width: calc(100% - ${designTokens.spacingS});
     height: 1px;
-    background: ${customProperties.colorNeutral};
+    background: ${designTokens.colorNeutral};
     left: 50%;
     transform: translateX(-50%);
     bottom: -1px;
@@ -105,29 +104,29 @@ const reset = (props: TRichTextBodyStylesProps) => [
   `,
   props.isReadOnly &&
     css`
-      color: ${customProperties.fontColorForInputWhenReadonly};
+      color: ${designTokens.fontColorForInputWhenReadonly};
     `,
 
   props.isDisabled &&
     css`
-      color: ${customProperties.fontColorForInputWhenDisabled};
+      color: ${designTokens.fontColorForInputWhenDisabled};
     `,
 ];
 
 export const EditorContainer = styled.div<TRichTextBodyStylesProps>`
-  padding: 4px ${customProperties.spacingS};
+  padding: 4px ${designTokens.spacingS};
   padding-top: 6px;
-  border-radius: ${customProperties.borderRadiusForInput};
-  font-family: ${customProperties.fontFamilyDefault};
+  border-radius: ${designTokens.borderRadiusForInput};
+  font-family: ${designTokens.fontFamilyDefault};
   ${getBorderColor}
   overflow-y: scroll;
   ${reset}
 `;
 
 export const Container = styled.div<TRichTextBodyStylesProps>`
-  border-radius: ${customProperties.borderRadiusForInput};
-  border: 1px solid ${customProperties.borderColorForInput};
-  transition: ${customProperties.transitionStandard};
+  border-radius: ${designTokens.borderRadiusForInput};
+  border: 1px solid ${designTokens.borderColorForInput};
+  transition: ${designTokens.transitionStandard};
   ${getBorderColor}
   ${getBackgroundColor}
   pointer-events: ${(props) =>
@@ -135,31 +134,29 @@ export const Container = styled.div<TRichTextBodyStylesProps>`
   position: relative;
 
   &:hover {
-    border-color: ${customProperties.borderColorForInputWhenFocused};
+    border-color: ${designTokens.borderColorForInputWhenFocused};
   }
   &:focus {
     outline: none;
-    box-shadow: inset 0 0 0 2px
-      ${customProperties.borderColorForInputWhenFocused};
+    box-shadow: inset 0 0 0 2px ${designTokens.borderColorForInputWhenFocused};
   }
 
   ${Toolbar} {
-    border-radius: ${customProperties.borderRadiusForInput};
+    border-radius: ${designTokens.borderRadiusForInput};
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
-    border-color: ${customProperties.borderColorForInput};
+    border-color: ${designTokens.borderColorForInput};
   }
 
   &:focus-within {
-    border-color: ${customProperties.borderColorForInputWhenFocused};
-    box-shadow: inset 0 0 0 2px
-      ${customProperties.borderColorForInputWhenFocused};
+    border-color: ${designTokens.borderColorForInputWhenFocused};
+    box-shadow: inset 0 0 0 2px ${designTokens.borderColorForInputWhenFocused};
     ${Toolbar} {
-      border-color: ${customProperties.borderColorForInputWhenFocused};
+      border-color: ${designTokens.borderColorForInputWhenFocused};
     }
 
     ${EditorContainer} {
-      border-color: ${customProperties.borderColorForInputWhenFocused};
+      border-color: ${designTokens.borderColorForInputWhenFocused};
     }
   }
 `;

--- a/packages/components/inputs/search-select-input/src/search-select-input.styles.ts
+++ b/packages/components/inputs/search-select-input/src/search-select-input.styles.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import type { TSearchSelectInputProps } from './search-select-input';
 
 const SearchSelectInputWrapper = styled.div<
@@ -15,7 +15,7 @@ const SearchSelectInputWrapper = styled.div<
         div[class$='indicatorContainer' i] {
           cursor: pointer;
           svg * {
-            fill: ${customProperties.colorSolid};
+            fill: ${designTokens.colorSolid};
           }
         }
       }`

--- a/packages/components/inputs/select-utils/src/clear-indicator/clear-indicator.tsx
+++ b/packages/components/inputs/select-utils/src/clear-indicator/clear-indicator.tsx
@@ -2,7 +2,7 @@ import type { CSSProperties, LegacyRef } from 'react';
 import type { ClearIndicatorProps } from 'react-select';
 import { css } from '@emotion/react';
 import { useIntl } from 'react-intl';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { CloseIcon } from '@commercetools-uikit/icons';
 import messages from './messages';
 
@@ -31,7 +31,7 @@ const ClearIndicator = (props: TClearIndicator) => {
         box-sizing: border-box;
         text-decoration: none;
         :hover svg * {
-          fill: ${customProperties.colorWarning};
+          fill: ${designTokens.colorWarning};
         }
       `}
       style={getStyles('clearIndicator', props) as CSSProperties}

--- a/packages/components/inputs/select-utils/src/create-select-styles.ts
+++ b/packages/components/inputs/select-utils/src/create-select-styles.ts
@@ -8,7 +8,7 @@
   Always check all affected components when making changes here!
 */
 import { ReactNode } from 'react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 type TProps = {
   isDisabled?: boolean;
@@ -42,44 +42,40 @@ type TState = {
 const controlStyles = (props: TProps) => (base: TBase, state: TState) => {
   return {
     ...base,
-    fontSize: customProperties.fontSizeForInput,
+    fontSize: designTokens.fontSizeForInput,
     backgroundColor: props.isDisabled
-      ? customProperties.backgroundColorForInputWhenDisabled
-      : customProperties.backgroundColorForInput,
+      ? designTokens.backgroundColorForInputWhenDisabled
+      : designTokens.backgroundColorForInput,
     borderColor: (() => {
-      if (props.isDisabled)
-        return customProperties.borderColorForInputWhenDisabled;
-      if (state.isFocused)
-        return customProperties.borderColorForInputWhenFocused;
-      if (props.hasError) return customProperties.borderColorForInputWhenError;
-      if (props.hasWarning)
-        return customProperties.borderColorForInputWhenWarning;
-      if (props.isReadOnly)
-        return customProperties.borderColorForInputWhenReadonly;
-      return customProperties.borderColorForInput;
+      if (props.isDisabled) return designTokens.borderColorForInputWhenDisabled;
+      if (state.isFocused) return designTokens.borderColorForInputWhenFocused;
+      if (props.hasError) return designTokens.borderColorForInputWhenError;
+      if (props.hasWarning) return designTokens.borderColorForInputWhenWarning;
+      if (props.isReadOnly) return designTokens.borderColorForInputWhenReadonly;
+      return designTokens.borderColorForInput;
     })(),
-    borderRadius: customProperties.borderRadiusForInput,
-    minHeight: customProperties.sizeHeightInput,
+    borderRadius: designTokens.borderRadiusForInput,
+    minHeight: designTokens.sizeHeightInput,
     cursor: (() => {
       if (props.isDisabled) return 'not-allowed';
       if (props.isReadOnly) return 'default';
       return 'pointer';
     })(),
-    padding: `0 ${customProperties.spacingS}`,
-    transition: `border-color ${customProperties.transitionStandard},
-    box-shadow ${customProperties.transitionStandard}`,
+    padding: `0 ${designTokens.spacingS}`,
+    transition: `border-color ${designTokens.transitionStandard},
+    box-shadow ${designTokens.transitionStandard}`,
     outline: 0,
     boxShadow: 'none',
 
     '&:focus-within': {
       boxShadow: (() => {
         if (!props.isDisabled)
-          return `inset 0 0 0 2px ${customProperties.borderColorForInputWhenFocused}`;
+          return `inset 0 0 0 2px ${designTokens.borderColorForInputWhenFocused}`;
         return null;
       })(),
       borderColor: (() => {
         if (!props.isDisabled)
-          return customProperties.borderColorForInputWhenFocused;
+          return designTokens.borderColorForInputWhenFocused;
         return null;
       })(),
     },
@@ -87,14 +83,14 @@ const controlStyles = (props: TProps) => (base: TBase, state: TState) => {
     '&:hover': {
       borderColor: (() => {
         if (!props.isDisabled && !props.isReadOnly)
-          return customProperties.borderColorForInputWhenFocused;
+          return designTokens.borderColorForInputWhenFocused;
         return null;
       })(),
     },
     pointerEvents: 'auto',
     color:
       props.isDisabled || props.isReadOnly
-        ? customProperties.fontColorForInputWhenDisabled
+        ? designTokens.fontColorForInputWhenDisabled
         : base.fontColorForInput,
   };
 };
@@ -102,17 +98,16 @@ const controlStyles = (props: TProps) => (base: TBase, state: TState) => {
 const menuStyles = (props: TProps) => (base: TBase) => {
   return {
     ...base,
-    border: `1px ${customProperties.borderColorForInputWhenFocused} solid`,
-    borderRadius: customProperties.borderRadiusForInput,
-    backgroundColor: customProperties.backgroundColorForInput,
-    boxShadow: customProperties.shadow7,
-    fontSize: customProperties.fontSizeForInput,
+    border: `1px ${designTokens.borderColorForInputWhenFocused} solid`,
+    borderRadius: designTokens.borderRadiusForInput,
+    backgroundColor: designTokens.backgroundColorForInput,
+    boxShadow: designTokens.shadow7,
+    fontSize: designTokens.fontSizeForInput,
     fontFamily: 'inherit',
-    margin: `${customProperties.spacingXs} 0 0 0`,
+    margin: `${designTokens.spacingXs} 0 0 0`,
     borderColor: (() => {
-      if (props.hasError) return customProperties.borderColorForInputWhenError;
-      if (props.hasWarning)
-        return customProperties.borderColorForInputWhenWarning;
+      if (props.hasError) return designTokens.borderColorForInputWhenError;
+      if (props.hasWarning) return designTokens.borderColorForInputWhenWarning;
       return base.borderColorForInput;
     })(),
   };
@@ -124,20 +119,20 @@ const indicatorSeparatorStyles = () => (base: TBase) => {
     display: 'none',
     margin: '0',
     padding: '0',
-    marginLeft: customProperties.spacingXs,
+    marginLeft: designTokens.spacingXs,
   };
 };
 
 const dropdownIndicatorStyles = (props: TProps) => (base: TBase) => {
   return {
     ...base,
-    color: customProperties.fontColorForInput,
+    color: designTokens.fontColorForInput,
     margin: '0',
     padding: '0',
-    marginLeft: customProperties.spacingXs,
+    marginLeft: designTokens.spacingXs,
     fill:
       props.isDisabled || props.isReadOnly
-        ? customProperties.fontColorForInputWhenDisabled
+        ? designTokens.fontColorForInputWhenDisabled
         : base.fontColorForInput,
   };
 };
@@ -152,38 +147,38 @@ const menuListStyles = () => (base: TBase) => {
   return {
     ...base,
     padding: '0',
-    borderRadius: customProperties.borderRadiusForInput,
-    backgroundColor: customProperties.backgroundColorForInput,
+    borderRadius: designTokens.borderRadiusForInput,
+    backgroundColor: designTokens.backgroundColorForInput,
   };
 };
 
 const optionStyles = () => (base: TBase, state: TState) => {
   return {
     ...base,
-    transition: `border-color ${customProperties.transitionStandard},
-      background-color ${customProperties.transitionStandard},
-      color ${customProperties.transitionStandard}`,
-    paddingLeft: customProperties.spacingS,
-    paddingRight: customProperties.spacingS,
+    transition: `border-color ${designTokens.transitionStandard},
+      background-color ${designTokens.transitionStandard},
+      color ${designTokens.transitionStandard}`,
+    paddingLeft: designTokens.spacingS,
+    paddingRight: designTokens.spacingS,
     color: (() => {
-      if (!state.isDisabled) return customProperties.fontColorForInput;
-      if (state.isSelected) return customProperties.fontColorForInput;
+      if (!state.isDisabled) return designTokens.fontColorForInput;
+      if (state.isSelected) return designTokens.fontColorForInput;
       return base.color;
     })(),
     backgroundColor: (() => {
       if (state.isSelected)
-        return customProperties.backgroundColorForInputWhenSelected;
+        return designTokens.backgroundColorForInputWhenSelected;
       if (state.isFocused)
-        return customProperties.backgroundColorForInputWhenHovered;
+        return designTokens.backgroundColorForInputWhenHovered;
       return base.backgroundColor;
     })(),
 
     '&:active': {
       color: (() => {
-        if (!state.isDisabled) return customProperties.fontColorForInput;
+        if (!state.isDisabled) return designTokens.fontColorForInput;
         return base.color;
       })(),
-      backgroundColor: customProperties.backgroundColorForInputWhenSelected,
+      backgroundColor: designTokens.backgroundColorForInputWhenSelected,
     },
   };
 };
@@ -191,14 +186,14 @@ const optionStyles = () => (base: TBase, state: TState) => {
 const placeholderStyles = (props: TProps) => (base: TBase) => {
   return {
     ...base,
-    color: customProperties.placeholderFontColorForInput,
+    color: designTokens.placeholderFontColorForInput,
     width: '100%',
     overflow: 'hidden',
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
     fill:
       props.isDisabled || props.isReadOnly
-        ? customProperties.fontColorForInputWhenDisabled
+        ? designTokens.fontColorForInputWhenDisabled
         : base.fontColorForInput,
   };
 };
@@ -218,7 +213,7 @@ const valueContainerStyles = (props: TProps) => (base: TBase) => {
         : 'grid',
     fill:
       props.isDisabled || props.isReadOnly
-        ? customProperties.fontColorForInputWhenDisabled
+        ? designTokens.fontColorForInputWhenDisabled
         : base.fontColorForInput,
   };
 };
@@ -228,12 +223,12 @@ const singleValueStyles = (props: TProps) => (base: TBase) => {
     ...base,
     color: (() => {
       if (props.isDisabled) {
-        return customProperties.fontColorForInputWhenDisabled;
+        return designTokens.fontColorForInputWhenDisabled;
       }
       if (props.isReadOnly) {
-        return customProperties.fontColorForInputWhenReadonly;
+        return designTokens.fontColorForInputWhenReadonly;
       }
-      return customProperties.fontColorForInput;
+      return designTokens.fontColorForInput;
     })(),
   };
 };
@@ -244,7 +239,7 @@ const groupStyles = (props: TProps) => (base: TBase) => {
     padding: 0,
     '&:not(:first-of-type)': {
       borderTop: props.showOptionGroupDivider
-        ? `1px solid ${customProperties.colorNeutral}`
+        ? `1px solid ${designTokens.colorNeutral}`
         : base.borderTop,
     },
   };
@@ -253,12 +248,12 @@ const groupStyles = (props: TProps) => (base: TBase) => {
 const groupHeadingStyles = () => (base: TBase) => {
   return {
     ...base,
-    color: customProperties.fontColorForInputWhenReadonly,
-    fontSize: customProperties.fontSizeSmall,
+    color: designTokens.fontColorForInputWhenReadonly,
+    fontSize: designTokens.fontSizeSmall,
     textTransform: 'none',
     fontWeight: 'bold',
-    margin: `0 ${customProperties.spacingXs}`,
-    padding: `${customProperties.spacingS} ${customProperties.spacingXs}`,
+    margin: `0 ${designTokens.spacingXs}`,
+    padding: `${designTokens.spacingS} ${designTokens.spacingXs}`,
     '&:empty': {
       padding: 0,
     },
@@ -269,10 +264,10 @@ const containerStyles = () => (base: TBase, state: TState) => {
   return {
     ...base,
     fontFamily: 'inherit',
-    minHeight: customProperties.sizeHeightInput,
-    borderRadius: customProperties.borderRadiusForInput,
+    minHeight: designTokens.sizeHeightInput,
+    borderRadius: designTokens.borderRadiusForInput,
     borderColor: state.isFocused
-      ? customProperties.borderColorForInputWhenFocused
+      ? designTokens.borderColorForInputWhenFocused
       : base.borderColor,
 
     boxShadow: state.isFocused ? 'none' : base.boxShadow,
@@ -293,8 +288,8 @@ const menuPortalStyles = (props: TProps) => (base: TBase) => ({
 const multiValueStyles = () => (base: TBase) => {
   return {
     ...base,
-    height: customProperties.sizeHeightTag,
-    backgroundColor: customProperties.backgroundColorForTag,
+    height: designTokens.sizeHeightTag,
+    backgroundColor: designTokens.backgroundColorForTag,
     padding: '0',
   };
 };
@@ -302,21 +297,19 @@ const multiValueStyles = () => (base: TBase) => {
 const multiValueLabelStyles = (props: TProps) => (base: TBase) => {
   return {
     ...base,
-    fontSize: customProperties.fontSizeSmall,
+    fontSize: designTokens.fontSizeSmall,
     color: (() => {
-      if (props.isDisabled)
-        return customProperties.fontColorForInputWhenDisabled;
-      if (props.isReadOnly)
-        return customProperties.fontColorForInputWhenReadonly;
+      if (props.isDisabled) return designTokens.fontColorForInputWhenDisabled;
+      if (props.isReadOnly) return designTokens.fontColorForInputWhenReadonly;
       return base.color;
     })(),
-    padding: `${customProperties.spacingXs} ${customProperties.spacingS}`,
-    borderRadius: `${customProperties.borderRadiusForTag} 0 0 ${customProperties.borderRadiusForTag}`,
-    border: `1px ${customProperties.borderColorForTag} solid`,
+    padding: `${designTokens.spacingXs} ${designTokens.spacingS}`,
+    borderRadius: `${designTokens.borderRadiusForTag} 0 0 ${designTokens.borderRadiusForTag}`,
+    border: `1px ${designTokens.borderColorForTag} solid`,
     borderWidth: '1px 0 1px 1px',
 
     '&:last-child': {
-      borderRadius: customProperties.borderRadiusForTag,
+      borderRadius: designTokens.borderRadiusForTag,
       borderWidth: '1px',
     },
   };
@@ -326,27 +319,27 @@ const multiValueRemoveStyles =
   (props: TProps) => (base: TBase, state: TState) => {
     return {
       ...base,
-      borderColor: customProperties.borderColorForTag,
-      padding: `0 ${customProperties.spacingXs}`,
-      borderRadius: `0 ${customProperties.borderRadiusForTag} ${customProperties.borderRadiusForTag} 0`,
+      borderColor: designTokens.borderColorForTag,
+      padding: `0 ${designTokens.spacingXs}`,
+      borderRadius: `0 ${designTokens.borderRadiusForTag} ${designTokens.borderRadiusForTag} 0`,
       borderStyle: 'solid',
       borderWidth: '1px',
       pointerEvents:
         state.isDisabled || props.isReadOnly ? 'none' : base.pointerEvents,
-      backgroundColor: customProperties.backgroundColorForTag,
+      backgroundColor: designTokens.backgroundColorForTag,
 
       'svg *': {
         fill: props.isReadOnly
-          ? customProperties.fontColorForInputWhenReadonly
+          ? designTokens.fontColorForInputWhenReadonly
           : '',
       },
 
       '&:hover, &:focus': {
-        borderColor: customProperties.borderColorForTagWarning,
-        backgroundColor: customProperties.backgroundColorForTag,
+        borderColor: designTokens.borderColorForTagWarning,
+        backgroundColor: designTokens.backgroundColorForTag,
 
         'svg *': {
-          fill: customProperties.borderColorForTagWarning,
+          fill: designTokens.borderColorForTagWarning,
         },
       },
     };

--- a/packages/components/inputs/select-utils/src/wrapper-with-icon/wrapper-with-icon.tsx
+++ b/packages/components/inputs/select-utils/src/wrapper-with-icon/wrapper-with-icon.tsx
@@ -1,6 +1,6 @@
 import { cloneElement, type ReactElement } from 'react';
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import {
   components as defaultComponents,
   type SingleValueProps,
@@ -63,8 +63,7 @@ const WrapperWithIcon = <Type extends 'singleValue' | 'placeholder'>(
         // the icon has a fixed size of 24px (== SpacingsXl), therefore we can use a fixed margin
         // spacingsXs is the margin between the icon and value
         css={css`
-          margin-left: ${customProperties.spacingXl +
-          customProperties.spacingXs};
+          margin-left: ${designTokens.spacingXl + designTokens.spacingXs};
         `}
       >
         {/* @ts-ignore */}

--- a/packages/components/inputs/time-input/src/time-input-body.styles.ts
+++ b/packages/components/inputs/time-input/src/time-input-body.styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { getInputStyles } from '@commercetools-uikit/input-utils';
 import { type TTimeInputProps } from './time-input';
 
@@ -13,38 +13,38 @@ const getClearSectionStyles = () => {
     align-items: center;
     box-sizing: border-box;
     display: flex;
-    margin: ${customProperties.spacingXs};
+    margin: ${designTokens.spacingXs};
     cursor: pointer;
 
     &:hover svg * {
-      fill: ${customProperties.colorWarning};
+      fill: ${designTokens.colorWarning};
     }
   `;
 };
 
 const getClockIconContainerColor = (props: TTimeInputProps) => {
   if (props.isDisabled) {
-    return customProperties.borderColorForInputWhenDisabled;
+    return designTokens.borderColorForInputWhenDisabled;
   }
   if (props.hasError) {
-    return customProperties.borderColorForInputWhenError;
+    return designTokens.borderColorForInputWhenError;
   }
   if (props.isReadOnly) {
-    return customProperties.borderColorForInputWhenReadonly;
+    return designTokens.borderColorForInputWhenReadonly;
   }
-  return customProperties.borderColorForInput;
+  return designTokens.borderColorForInput;
 };
 const getClockIconContainerFontColor = (props: TTimeInputProps) => {
   if (props.isDisabled) {
-    return customProperties.fontColorForInputWhenDisabled;
+    return designTokens.fontColorForInputWhenDisabled;
   }
   if (props.hasError) {
-    return customProperties.fontColorForInputWhenError;
+    return designTokens.fontColorForInputWhenError;
   }
   if (props.isReadOnly) {
-    return customProperties.fontColorForInputWhenReadonly;
+    return designTokens.fontColorForInputWhenReadonly;
   }
-  return customProperties.fontColorForInput;
+  return designTokens.fontColorForInput;
 };
 const getClockIconContainerStyles = (props: TTimeInputProps) => {
   return css`
@@ -52,87 +52,86 @@ const getClockIconContainerStyles = (props: TTimeInputProps) => {
     box-sizing: border-box;
     background: none;
     background-color: ${props.isDisabled
-      ? customProperties.backgroundColorForInputWhenDisabled
+      ? designTokens.backgroundColorForInputWhenDisabled
       : 'none'};
     border: 0;
-    border-left: 1px solid ${customProperties.borderColorForInput};
-    border-top-right-radius: ${customProperties.borderRadiusForInput};
-    border-bottom-right-radius: ${customProperties.borderRadiusForInput};
+    border-left: 1px solid ${designTokens.borderColorForInput};
+    border-top-right-radius: ${designTokens.borderRadiusForInput};
+    border-bottom-right-radius: ${designTokens.borderRadiusForInput};
     border-color: ${getClockIconContainerColor(props)};
     color: ${getClockIconContainerFontColor(props)};
     cursor: ${props.isDisabled ? 'not-allowed' : 'default'};
     height: 100%;
     display: flex;
-    padding: ${customProperties.spacingXs};
+    padding: ${designTokens.spacingXs};
     outline: 0;
-    transition: color ${customProperties.transitionStandard},
-      border-color ${customProperties.transitionStandard};
+    transition: color ${designTokens.transitionStandard},
+      border-color ${designTokens.transitionStandard};
     &:hover:not(:disabled):not(:read-only),
     &:focus {
-      border-color: ${customProperties.borderColorForInputWhenFocused};
+      border-color: ${designTokens.borderColorForInputWhenFocused};
     }
   `;
 };
 
 const getInputContainerBorderColor = (props: TTimeInputProps) => {
   if (props.isDisabled) {
-    return customProperties.borderColorForInputWhenDisabled;
+    return designTokens.borderColorForInputWhenDisabled;
   }
   if (props.hasError) {
-    return customProperties.borderColorForInputWhenError;
+    return designTokens.borderColorForInputWhenError;
   }
   if (props.isReadOnly) {
-    return customProperties.borderColorForInputWhenReadonly;
+    return designTokens.borderColorForInputWhenReadonly;
   }
-  return customProperties.borderColorForInput;
+  return designTokens.borderColorForInput;
 };
 const getInputContainerFontColor = (props: TTimeInputProps) => {
   if (props.isDisabled) {
-    return customProperties.fontColorForInputWhenDisabled;
+    return designTokens.fontColorForInputWhenDisabled;
   }
   if (props.hasError) {
-    return customProperties.fontColorForInputWhenError;
+    return designTokens.fontColorForInputWhenError;
   }
   if (props.isReadOnly) {
-    return customProperties.fontColorForInputWhenReadonly;
+    return designTokens.fontColorForInputWhenReadonly;
   }
-  return customProperties.fontColorForInput;
+  return designTokens.fontColorForInput;
 };
 const getInputContainerStyles = (props: TTimeInputProps) => {
   return css`
     appearance: none;
     background-color: ${props.isDisabled
-      ? customProperties.backgroundColorForInputWhenDisabled
-      : customProperties.backgroundColorForInput};
+      ? designTokens.backgroundColorForInputWhenDisabled
+      : designTokens.backgroundColorForInput};
     border: 1px solid ${getInputContainerBorderColor(props)};
-    border-radius: ${customProperties.borderRadiusForInput};
+    border-radius: ${designTokens.borderRadiusForInput};
     box-sizing: border-box;
     color: ${getInputContainerFontColor(props)};
     cursor: ${props.isDisabled ? 'not-allowed' : 'default'};
     width: 100%;
-    height: ${customProperties.sizeHeightInput};
+    height: ${designTokens.sizeHeightInput};
     align-items: center;
     display: flex;
-    font-size: ${customProperties.fontSizeDefault};
+    font-size: ${designTokens.fontSizeDefault};
     font-family: inherit;
-    transition: border-color ${customProperties.transitionStandard},
-      box-shadow ${customProperties.transitionStandard};
+    transition: border-color ${designTokens.transitionStandard},
+      box-shadow ${designTokens.transitionStandard};
 
     svg {
       fill: ${props.isReadOnly
-        ? customProperties.fontColorForInputWhenReadonly
+        ? designTokens.fontColorForInputWhenReadonly
         : 'inherit'};
     }
 
     &:focus-within {
-      border-color: ${customProperties.borderColorForInputWhenFocused};
-      box-shadow: inset 0 0 0 2px
-        ${customProperties.borderColorForInputWhenFocused};
+      border-color: ${designTokens.borderColorForInputWhenFocused};
+      box-shadow: inset 0 0 0 2px ${designTokens.borderColorForInputWhenFocused};
     }
 
     :hover:not(:disabled):not(:read-only),
     :focus {
-      border-color: ${customProperties.borderColorForInputWhenFocused};
+      border-color: ${designTokens.borderColorForInputWhenFocused};
     }
   `;
 };
@@ -159,7 +158,7 @@ const StyledInputContainer = styled.div`
     ${StyledClockIconContainer},
     &:focus-within
     ${StyledClockIconContainer} {
-    border-color: ${customProperties.borderColorForInputWhenFocused};
+    border-color: ${designTokens.borderColorForInputWhenFocused};
   }
 `;
 

--- a/packages/components/inputs/toggle-input/src/toggle-input.tsx
+++ b/packages/components/inputs/toggle-input/src/toggle-input.tsx
@@ -1,7 +1,7 @@
 import { ChangeEventHandler } from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import {
   filterDataAttributes,
   filterAriaAttributes,
@@ -58,12 +58,12 @@ export const defaultProps: Pick<
 const labelSizeStyles = (props: TStyledLabelProps) => {
   if (props.size === 'small')
     return css`
-      height: calc(${customProperties.standardInputHeight} / 2);
-      width: calc(${customProperties.standardInputHeight});
+      height: calc(${designTokens.standardInputHeight} / 2);
+      width: calc(${designTokens.standardInputHeight});
     `;
   return css`
-    height: calc(${customProperties.standardInputHeight});
-    width: calc(${customProperties.standardInputHeight} * 2);
+    height: calc(${designTokens.standardInputHeight});
+    width: calc(${designTokens.standardInputHeight} * 2);
   `;
 };
 
@@ -75,7 +75,7 @@ const Label = styled.label<TStyledLabelProps>`
   ${labelSizeStyles}
 
   &:focus-within {
-    outline: auto 2px ${customProperties.borderColorForInputWhenFocused};
+    outline: auto 2px ${designTokens.borderColorForInputWhenFocused};
     outline-offset: 3px;
   }
 `;
@@ -85,8 +85,8 @@ const Span = styled.span<TStyledSpanProps>`
 
   &::before {
     border-radius: 16px;
-    box-shadow: ${customProperties.shadow9};
-    background-color: ${customProperties.colorNeutral60};
+    box-shadow: ${designTokens.shadow9};
+    background-color: ${designTokens.colorNeutral60};
     left: 0;
     top: 50%;
     transition: background 0.2s ease-in-out;
@@ -108,8 +108,8 @@ const Span = styled.span<TStyledSpanProps>`
       props.size === 'small' ? thumbSmallSize : thumbBigSize};
     width: ${(props) =>
       props.size === 'small' ? thumbSmallSize : thumbBigSize};
-    background-color: ${customProperties.colorSurface};
-    box-shadow: ${customProperties.shadow7};
+    background-color: ${designTokens.colorSurface};
+    box-shadow: ${designTokens.shadow7};
     border-radius: 50%;
     z-index: 1;
     transition: transform 0.2s ease, background 0.2s ease;
@@ -120,7 +120,7 @@ const getInputStyles = (props: TToggleInputProps) => css`
   /* when checked */
   &:checked {
     + span::before {
-      background: ${customProperties.colorPrimary};
+      background: ${designTokens.colorPrimary};
     }
     & + span::after {
       transform: ${props.size === 'small'
@@ -132,11 +132,11 @@ const getInputStyles = (props: TToggleInputProps) => css`
   /* when disabled */
   &:disabled {
     & + span::before {
-      background: ${customProperties.colorNeutral};
+      background: ${designTokens.colorNeutral};
       box-shadow: none;
     }
     & + span::after {
-      background: ${customProperties.colorAccent95};
+      background: ${designTokens.colorAccent95};
       box-shadow: none;
     }
   }
@@ -144,16 +144,16 @@ const getInputStyles = (props: TToggleInputProps) => css`
   /* when disabled and checked */
   &:disabled&:checked {
     & + span::before {
-      background: ${customProperties.colorPrimary25};
+      background: ${designTokens.colorPrimary25};
     }
     & + span::after {
-      background: ${customProperties.colorNeutral};
+      background: ${designTokens.colorNeutral};
     }
   }
 
   :not(:disabled)&:hover + span::after,
   :not(:disabled)&:focus + span::after {
-    box-shadow: ${customProperties.shadow16};
+    box-shadow: ${designTokens.shadow16};
   }
 `;
 

--- a/packages/components/label/src/required-indicator.tsx
+++ b/packages/components/label/src/required-indicator.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 const RequiredIndicator = () => (
   <em
     css={css`
-      color: ${customProperties.colorWarning};
+      color: ${designTokens.colorWarning};
     `}
   >
     {'*'}

--- a/packages/components/link/src/link.tsx
+++ b/packages/components/link/src/link.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import { Link as ReactRouterLink } from 'react-router-dom';
 import { css } from '@emotion/react';
 import { FormattedMessage } from 'react-intl';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { filterInvalidAttributes, warning } from '@commercetools-uikit/utils';
 import { ExternalLinkIcon } from '@commercetools-uikit/icons';
 
@@ -70,10 +70,10 @@ const defaultProps: Pick<TLinkProps, 'tone' | 'isExternal'> = {
 
 const getTextColorValue = (tone: TLinkProps['tone'] = 'primary') => {
   if (tone === 'primary') {
-    return customProperties.colorPrimary;
+    return designTokens.colorPrimary;
   }
 
-  return customProperties.fontColorForTextWhenInverted;
+  return designTokens.fontColorForTextWhenInverted;
 };
 const getIconColorValue = (
   tone: TLinkProps['tone'] = 'primary'
@@ -86,10 +86,10 @@ const getIconColorValue = (
 };
 const getActiveColorValue = (tone: string = 'primary') => {
   if (tone === 'primary') {
-    return customProperties.colorPrimary25;
+    return designTokens.colorPrimary25;
   }
 
-  return customProperties.fontColorForTextWhenInverted;
+  return designTokens.fontColorForTextWhenInverted;
 };
 
 const getLinkStyles = (props: TLinkProps) => {
@@ -99,7 +99,7 @@ const getLinkStyles = (props: TLinkProps) => {
   return css`
     font-family: inherit;
     color: ${color};
-    font-size: ${customProperties.fontSizeDefault};
+    font-size: ${designTokens.fontSizeDefault};
     &:hover,
     &:focus,
     &:active {
@@ -111,7 +111,7 @@ const getLinkStyles = (props: TLinkProps) => {
 
 const Wrapper = styled.span`
   > svg {
-    margin: 0 0 0 ${customProperties.spacingXs} !important;
+    margin: 0 0 0 ${designTokens.spacingXs} !important;
     vertical-align: bottom;
   }
 `;

--- a/packages/components/loading-spinner/src/loading-spinner.tsx
+++ b/packages/components/loading-spinner/src/loading-spinner.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useState, useEffect } from 'react';
 import { css, keyframes } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import Text from '@commercetools-uikit/text';
 import Inline from '@commercetools-uikit/spacings-inline';
 
@@ -78,7 +78,7 @@ const LoadingSpinner = (props: TLoadingSpinnerProps) => {
         >
           <path
             css={css`
-              fill: ${customProperties.colorAccent};
+              fill: ${designTokens.colorAccent};
               opacity: 0.2;
             `}
             d={circlePath}
@@ -86,7 +86,7 @@ const LoadingSpinner = (props: TLoadingSpinnerProps) => {
           <path
             css={css`
               animation: ${spin} 0.5s infinite linear;
-              fill: ${customProperties.colorAccent};
+              fill: ${designTokens.colorAccent};
               transform-origin: ${positionOrigin} ${positionOrigin} 0;
             `}
             d={pointerPath}

--- a/packages/components/notifications/src/content-notification/content-notification.tsx
+++ b/packages/components/notifications/src/content-notification/content-notification.tsx
@@ -3,7 +3,7 @@ import type { MessageDescriptor } from 'react-intl';
 import { Children, ReactNode } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import {
   ErrorIcon,
   WarningIcon,
@@ -60,13 +60,13 @@ const warnIfMissingContent = (props: TContentNotificationProps) => {
 const getIconContainerBackgroundColour = (props: TContentNotificationProps) => {
   switch (props.type) {
     case 'error':
-      return customProperties.colorError;
+      return designTokens.colorError;
     case 'info':
-      return customProperties.colorInfo;
+      return designTokens.colorInfo;
     case 'warning':
-      return customProperties.colorWarning;
+      return designTokens.colorWarning;
     case 'success':
-      return customProperties.colorPrimary;
+      return designTokens.colorPrimary;
     default:
       return '';
   }
@@ -93,10 +93,10 @@ const NotificationIcon = (props: TContentNotificationProps) => {
       css={css`
         display: flex;
         align-items: center;
-        border-radius: ${customProperties.borderRadius6} 0 0
-          ${customProperties.borderRadius6};
+        border-radius: ${designTokens.borderRadius6} 0 0
+          ${designTokens.borderRadius6};
         border-width: 0;
-        padding: ${customProperties.spacingS} ${customProperties.spacingM};
+        padding: ${designTokens.spacingS} ${designTokens.spacingM};
         background-color: ${getIconContainerBackgroundColour(props)};
         svg {
           margin: 0 -3px;
@@ -112,13 +112,13 @@ NotificationIcon.displayName = 'NotificationIcon';
 const getContentBorderColor = (props: TContentNotificationProps) => {
   switch (props.type) {
     case 'error':
-      return customProperties.colorError;
+      return designTokens.colorError;
     case 'info':
-      return customProperties.colorInfo;
+      return designTokens.colorInfo;
     case 'warning':
-      return customProperties.colorWarning;
+      return designTokens.colorWarning;
     case 'success':
-      return customProperties.colorPrimary;
+      return designTokens.colorPrimary;
     default:
       return '';
   }
@@ -136,8 +136,8 @@ const ContentNotification = (props: TContentNotificationProps) => {
         text-align: left;
         word-break: break-word;
         hyphens: auto;
-        font-size: ${customProperties.fontSizeDefault};
-        color: ${customProperties.colorSolid};
+        font-size: ${designTokens.fontSizeDefault};
+        color: ${designTokens.colorSolid};
         font-family: inherit;
       `}
     >
@@ -147,10 +147,10 @@ const ContentNotification = (props: TContentNotificationProps) => {
           flex-grow: 1;
           display: flex;
           align-items: center;
-          padding: ${customProperties.spacingS};
-          background: ${customProperties.colorSurface};
-          border-radius: 0 ${customProperties.borderRadius6}
-            ${customProperties.borderRadius6} 0;
+          padding: ${designTokens.spacingS};
+          background: ${designTokens.colorSurface};
+          border-radius: 0 ${designTokens.borderRadius6}
+            ${designTokens.borderRadius6} 0;
           border-width: 1px;
           border-style: solid;
           border-color: ${getContentBorderColor(props)};

--- a/packages/components/primary-action-dropdown/src/option.tsx
+++ b/packages/components/primary-action-dropdown/src/option.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { css } from '@emotion/react';
 import AccessibleButton from '@commercetools-uikit/accessible-button';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 type TOption = {
   /**
@@ -32,23 +32,23 @@ const Option = (props: TOption) => (
         display: block;
         text-align: left;
         width: 100%;
-        padding: ${customProperties.spacingS};
-        background-color: ${customProperties.colorSurface};
+        padding: ${designTokens.spacingS};
+        background-color: ${designTokens.colorSurface};
         &:first-of-type {
-          border-radius: ${customProperties.borderRadius6}
-            ${customProperties.borderRadius6} 0 0;
+          border-radius: ${designTokens.borderRadius6}
+            ${designTokens.borderRadius6} 0 0;
         }
         &:last-of-type {
-          border-radius: 0 0 ${customProperties.borderRadius6}
-            ${customProperties.borderRadius6};
+          border-radius: 0 0 ${designTokens.borderRadius6}
+            ${designTokens.borderRadius6};
         }
         &:hover {
-          background-color: ${customProperties.colorNeutral95};
+          background-color: ${designTokens.colorNeutral95};
         }
       `,
       props.isDisabled &&
         css`
-          color: ${customProperties.colorNeutral};
+          color: ${designTokens.colorNeutral};
         `,
     ]}
   >

--- a/packages/components/primary-action-dropdown/src/primary-action-dropdown.tsx
+++ b/packages/components/primary-action-dropdown/src/primary-action-dropdown.tsx
@@ -14,7 +14,7 @@ import {
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import AccessibleButton from '@commercetools-uikit/accessible-button';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import Text from '@commercetools-uikit/text';
 import { warning } from '@commercetools-uikit/utils';
 import { CaretUpIcon, CaretDownIcon } from '@commercetools-uikit/icons';
@@ -24,28 +24,28 @@ const getButtonStyles = (isDisabled: boolean) => {
   const baseButtonStyles = css`
     display: flex;
     align-items: center;
-    height: ${customProperties.bigButtonHeight};
+    height: ${designTokens.bigButtonHeight};
   `;
   if (isDisabled) {
     return [
       baseButtonStyles,
       css`
         box-shadow: none;
-        background-color: ${customProperties.colorAccent98};
+        background-color: ${designTokens.colorAccent98};
       `,
     ];
   }
   return [
     baseButtonStyles,
     css`
-      background-color: ${customProperties.colorSurface};
-      box-shadow: ${customProperties.shadow7};
+      background-color: ${designTokens.colorSurface};
+      box-shadow: ${designTokens.shadow7};
       &:hover {
-        box-shadow: ${customProperties.shadow8};
+        box-shadow: ${designTokens.shadow8};
       }
       &:active {
-        box-shadow: ${customProperties.shadow9};
-        background-color: ${customProperties.colorNeutral95};
+        box-shadow: ${designTokens.shadow9};
+        background-color: ${designTokens.colorNeutral95};
       }
     `,
   ];
@@ -74,15 +74,15 @@ const DropdownHead = (props: TDropdownHead) => (
       css={[
         ...getButtonStyles(props.isDisabled),
         css`
-          padding: 0 ${customProperties.spacingS};
-          border-radius: ${customProperties.borderRadius6} 0 0
-            ${customProperties.borderRadius6};
+          padding: 0 ${designTokens.spacingS};
+          border-radius: ${designTokens.borderRadius6} 0 0
+            ${designTokens.borderRadius6};
         `,
       ]}
     >
       <span
         css={css`
-          margin: 0 ${customProperties.spacingXs} 0 0;
+          margin: 0 ${designTokens.spacingXs} 0 0;
           display: flex;
           align-items: center;
           justify-content: center;
@@ -95,7 +95,7 @@ const DropdownHead = (props: TDropdownHead) => (
       </span>
       <span
         css={css`
-          margin: 0 ${customProperties.spacingXs} 0 0;
+          margin: 0 ${designTokens.spacingXs} 0 0;
           display: flex;
           align-items: center;
           justify-content: center;
@@ -127,10 +127,10 @@ const DropdownChevron = forwardRef<HTMLButtonElement, TDropdownChevron>(
       css={[
         ...getButtonStyles(props.isDisabled),
         css`
-          padding: 0 ${customProperties.spacingXs};
-          border-left: 1px solid ${customProperties.colorNeutral};
-          border-radius: 0 ${customProperties.borderRadius6}
-            ${customProperties.borderRadius6} 0;
+          padding: 0 ${designTokens.spacingXs};
+          border-left: 1px solid ${designTokens.colorNeutral};
+          border-radius: 0 ${designTokens.borderRadius6}
+            ${designTokens.borderRadius6} 0;
         `,
       ]}
     >
@@ -170,11 +170,11 @@ const Options = styled.div`
   position: absolute;
   z-index: 5;
   width: 100%;
-  top: calc(${customProperties.spacingS} + ${customProperties.bigButtonHeight});
+  top: calc(${designTokens.spacingS} + ${designTokens.bigButtonHeight});
   left: 0;
-  border: 1px solid ${customProperties.colorNeutral};
-  border-radius: ${customProperties.borderRadius6};
-  box-shadow: ${customProperties.shadow1};
+  border: 1px solid ${designTokens.colorNeutral};
+  border-radius: ${designTokens.borderRadius6};
+  box-shadow: ${designTokens.shadow1};
 `;
 
 /*

--- a/packages/components/spacings/spacings-inline/src/inline.styles.ts
+++ b/packages/components/spacings/spacings-inline/src/inline.styles.ts
@@ -1,7 +1,7 @@
 import type { TAlignItem, TProps, TScale } from './inline';
 
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 // @TODO remove this when we deprecate `flexStart`/`flexEnd`
 const getAlignItem = (alignment?: TAlignItem) => {
@@ -18,15 +18,15 @@ const getAlignItem = (alignment?: TAlignItem) => {
 const getMargin = (scale?: TScale): string | number => {
   switch (scale) {
     case 'xs':
-      return customProperties.spacingXs;
+      return designTokens.spacingXs;
     case 's':
-      return customProperties.spacingS;
+      return designTokens.spacingS;
     case 'm':
-      return customProperties.spacingM;
+      return designTokens.spacingM;
     case 'l':
-      return customProperties.spacingL;
+      return designTokens.spacingL;
     case 'xl':
-      return customProperties.spacingXl;
+      return designTokens.spacingXl;
     default:
       return 0;
   }

--- a/packages/components/spacings/spacings-inset-squish/src/inset-squish.tsx
+++ b/packages/components/spacings/spacings-inset-squish/src/inset-squish.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { filterDataAttributes } from '@commercetools-uikit/utils';
 
 type TScale = 's' | 'm' | 'l';
@@ -12,11 +12,11 @@ type TProps = {
 const getPadding = (scale?: TScale) => {
   switch (scale) {
     case 's':
-      return `${customProperties.spacingXs} ${customProperties.spacingS}`;
+      return `${designTokens.spacingXs} ${designTokens.spacingS}`;
     case 'm':
-      return `${customProperties.spacingS} ${customProperties.spacingM}`;
+      return `${designTokens.spacingS} ${designTokens.spacingM}`;
     case 'l':
-      return `${customProperties.spacingM} ${customProperties.spacingXl}`;
+      return `${designTokens.spacingM} ${designTokens.spacingXl}`;
     default:
       return 0;
   }

--- a/packages/components/spacings/spacings-inset/src/inset.tsx
+++ b/packages/components/spacings/spacings-inset/src/inset.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { filterDataAttributes } from '@commercetools-uikit/utils';
 
 export type TScale = 'xs' | 's' | 'm' | 'l' | 'xl';
@@ -8,15 +8,15 @@ export type TScale = 'xs' | 's' | 'm' | 'l' | 'xl';
 const getPadding = (scale?: TScale) => {
   switch (scale) {
     case 'xs':
-      return customProperties.spacingXs;
+      return designTokens.spacingXs;
     case 's':
-      return customProperties.spacingS;
+      return designTokens.spacingS;
     case 'm':
-      return customProperties.spacingM;
+      return designTokens.spacingM;
     case 'l':
-      return customProperties.spacingL;
+      return designTokens.spacingL;
     case 'xl':
-      return customProperties.spacingXl;
+      return designTokens.spacingXl;
     default:
       return 0;
   }

--- a/packages/components/spacings/spacings-stack/src/stack.styles.ts
+++ b/packages/components/spacings/spacings-stack/src/stack.styles.ts
@@ -1,7 +1,7 @@
 import type { TAlignItem, TScale, TProps } from './stack';
 
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 const getAlignItem = (alignment?: TAlignItem) => {
   switch (alignment) {
@@ -17,15 +17,15 @@ const getAlignItem = (alignment?: TAlignItem) => {
 const getMargin = (scale?: TScale) => {
   switch (scale) {
     case 'xs':
-      return customProperties.spacingXs;
+      return designTokens.spacingXs;
     case 's':
-      return customProperties.spacingS;
+      return designTokens.spacingS;
     case 'm':
-      return customProperties.spacingM;
+      return designTokens.spacingM;
     case 'l':
-      return customProperties.spacingL;
+      return designTokens.spacingL;
     case 'xl':
-      return customProperties.spacingXl;
+      return designTokens.spacingXl;
     default:
       return 0;
   }

--- a/packages/components/stamp/src/stamp.tsx
+++ b/packages/components/stamp/src/stamp.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 type Tone =
   | 'critical'
@@ -33,10 +33,10 @@ export const availableTones: Tone[] = [
 const getPaddingStyle = (props: Props) => {
   if (props.isCondensed)
     return css`
-      padding: 1px ${customProperties.spacingXs};
+      padding: 1px ${designTokens.spacingXs};
     `;
   return css`
-    padding: ${customProperties.spacingXs} ${customProperties.spacingS};
+    padding: ${designTokens.spacingXs} ${designTokens.spacingS};
   `;
 };
 
@@ -44,38 +44,38 @@ const getToneStyles = (props: Props) => {
   switch (props.tone) {
     case 'critical': {
       return css`
-        background-color: ${customProperties.colorError95};
-        border: 1px solid ${customProperties.colorError};
+        background-color: ${designTokens.colorError95};
+        border: 1px solid ${designTokens.colorError};
       `;
     }
     case 'warning': {
       return css`
-        background-color: ${customProperties.colorWarning95};
-        border: 1px solid ${customProperties.colorWarning};
+        background-color: ${designTokens.colorWarning95};
+        border: 1px solid ${designTokens.colorWarning};
       `;
     }
     case 'positive': {
       return css`
-        background-color: ${customProperties.colorPrimary85};
-        border: 1px solid ${customProperties.colorPrimary40};
+        background-color: ${designTokens.colorPrimary85};
+        border: 1px solid ${designTokens.colorPrimary40};
       `;
     }
     case 'information': {
       return css`
-        background-color: ${customProperties.colorInfo95};
-        border: 1px solid ${customProperties.colorInfo};
+        background-color: ${designTokens.colorInfo95};
+        border: 1px solid ${designTokens.colorInfo};
       `;
     }
     case 'primary': {
       return css`
-        background-color: ${customProperties.colorPrimary95};
-        border: 1px solid ${customProperties.colorPrimary25};
+        background-color: ${designTokens.colorPrimary95};
+        border: 1px solid ${designTokens.colorPrimary25};
       `;
     }
     case 'secondary': {
       return css`
-        background-color: ${customProperties.colorNeutral90};
-        border: 1px solid ${customProperties.colorNeutral60};
+        background-color: ${designTokens.colorNeutral90};
+        border: 1px solid ${designTokens.colorNeutral60};
       `;
     }
     default:
@@ -85,9 +85,9 @@ const getToneStyles = (props: Props) => {
 
 const getStampStyles = (_props: Props) => {
   return css`
-    color: ${customProperties.colorSolid};
-    font-size: ${customProperties.fontSizeDefault};
-    border-radius: ${customProperties.borderRadius2};
+    color: ${designTokens.colorSolid};
+    font-size: ${designTokens.fontSizeDefault};
+    border-radius: ${designTokens.borderRadius2};
   `;
 };
 

--- a/packages/components/tag/src/tag-body.tsx
+++ b/packages/components/tag/src/tag-body.tsx
@@ -3,7 +3,7 @@ import type { TTagProps } from './tag';
 import { ReactNode } from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import Text from '@commercetools-uikit/text';
 import { Link } from 'react-router-dom';
 
@@ -32,15 +32,15 @@ const getClickableContentWrapperStyles = (type: TTagBodyProps['type']) => {
     : [
         css`
           &:hover {
-            border-color: ${customProperties.borderColorForTagWhenFocused};
+            border-color: ${designTokens.borderColorForTagWhenFocused};
           }
         `,
       ];
 };
 
 const getTextDetailColor = (isDisabled: TTagBodyProps['isDisabled']) => {
-  if (isDisabled) return customProperties.fontColorForTagWhenDisabled;
-  return customProperties.fontColorForTag;
+  if (isDisabled) return designTokens.fontColorForTagWhenDisabled;
+  return designTokens.fontColorForTag;
 };
 
 const getContentWrapperStyles = (props: TTagBodyProps) => {
@@ -49,8 +49,8 @@ const getContentWrapperStyles = (props: TTagBodyProps) => {
     display: flex;
     box-sizing: border-box;
     align-items: center;
-    border-radius: ${customProperties.borderRadiusForTag};
-    padding: 5px ${customProperties.spacingS};
+    border-radius: ${designTokens.borderRadiusForTag};
+    padding: 5px ${designTokens.spacingS};
     white-space: normal;
     text-align: left;
     min-width: 0;
@@ -59,8 +59,8 @@ const getContentWrapperStyles = (props: TTagBodyProps) => {
     border-style: solid;
     border-width: 1px;
     border-color: ${props.type === 'warning'
-      ? customProperties.borderColorForTagWarning
-      : customProperties.borderColorForTag};
+      ? designTokens.borderColorForTagWarning
+      : designTokens.borderColorForTag};
 
     /* fixing things for IE11 ... */
     width: 100%;
@@ -81,7 +81,7 @@ const TagBody = (props: TTagBodyProps) => {
         getContentWrapperStyles(props),
         Boolean(props.onRemove) &&
           css`
-            padding-right: ${customProperties.spacingS};
+            padding-right: ${designTokens.spacingS};
             border-right: 0;
             border-top-right-radius: 0;
             border-bottom-right-radius: 0;
@@ -93,12 +93,12 @@ const TagBody = (props: TTagBodyProps) => {
           Boolean(props.onClick) &&
           css`
             &:hover {
-              box-shadow: ${customProperties.shadowBoxTagWhenHovered};
+              box-shadow: ${designTokens.shadowBoxTagWhenHovered};
               &::after {
                 position: absolute;
                 right: -1px;
                 content: '';
-                background-color: ${customProperties.borderColorForTagWhenFocused};
+                background-color: ${designTokens.borderColorForTagWhenFocused};
                 width: 1px;
                 height: 100%;
               }

--- a/packages/components/tag/src/tag.tsx
+++ b/packages/components/tag/src/tag.tsx
@@ -3,7 +3,7 @@ import type { LocationDescriptor } from 'history';
 import { ReactNode, MouseEvent, KeyboardEvent } from 'react';
 import { css, type SerializedStyles } from '@emotion/react';
 import { Link } from 'react-router-dom';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import Constraints from '@commercetools-uikit/constraints';
 import AccessibleButton from '@commercetools-uikit/accessible-button';
 import { CloseBoldIcon } from '@commercetools-uikit/icons';
@@ -88,8 +88,8 @@ const Tag = (props: TTagProps) => {
           min-width: 0;
           display: flex;
           background-color: ${props.type === 'warning'
-            ? customProperties.backgroundColorForTagWarning
-            : customProperties.backgroundColorForTag};
+            ? designTokens.backgroundColorForTagWarning
+            : designTokens.backgroundColorForTag};
         `}
       >
         <TagBody
@@ -111,11 +111,11 @@ const Tag = (props: TTagProps) => {
             css={[
               css`
                 border-color: ${props.type === 'warning'
-                  ? customProperties.borderColorForTagWarning
-                  : customProperties.borderColorForTag};
-                padding: 0 ${customProperties.spacingXs};
-                border-radius: 0 ${customProperties.borderRadiusForTag}
-                  ${customProperties.borderRadiusForTag} 0;
+                  ? designTokens.borderColorForTagWarning
+                  : designTokens.borderColorForTag};
+                padding: 0 ${designTokens.spacingXs};
+                border-radius: 0 ${designTokens.borderRadiusForTag}
+                  ${designTokens.borderRadiusForTag} 0;
                 display: flex;
                 align-items: center;
                 background: inherit;
@@ -123,17 +123,17 @@ const Tag = (props: TTagProps) => {
                 border-width: 1px 1px 1px 1px;
                 :not(:disabled)&:hover,
                 :not(:disabled)&:focus {
-                  border-color: ${customProperties.borderColorForTagWarning};
+                  border-color: ${designTokens.borderColorForTagWarning};
 
                   > svg * {
-                    fill: ${customProperties.borderColorForTagWarning};
+                    fill: ${designTokens.borderColorForTagWarning};
                   }
                 }
                 > svg * {
-                  fill: ${customProperties.fontColorForTag};
+                  fill: ${designTokens.fontColorForTag};
                 }
                 &:disabled > svg * {
-                  fill: ${customProperties.fontColorForTagWhenDisabled};
+                  fill: ${designTokens.fontColorForTagWhenDisabled};
                 }
               `,
             ]}

--- a/packages/components/text/src/text.styles.ts
+++ b/packages/components/text/src/text.styles.ts
@@ -6,11 +6,11 @@ import type {
 } from './text';
 
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 const getBaseStyles = () => {
   return `
-   color: ${customProperties.colorSolid};
+   color: ${designTokens.colorSolid};
 `;
 };
 
@@ -31,19 +31,19 @@ const italic = `
 const getTone = (tone: string) => {
   switch (tone) {
     case 'information':
-      return `color: ${customProperties.colorInfo};`;
+      return `color: ${designTokens.colorInfo};`;
     case 'secondary':
-      return `color: ${customProperties.colorNeutral60};`;
+      return `color: ${designTokens.colorNeutral60};`;
     case 'positive':
-      return `color: ${customProperties.colorPrimary25};`;
+      return `color: ${designTokens.colorPrimary25};`;
     case 'primary':
-      return `color: ${customProperties.colorPrimary};`;
+      return `color: ${designTokens.colorPrimary};`;
     case 'negative':
-      return `color: ${customProperties.colorError};`;
+      return `color: ${designTokens.colorError};`;
     case 'inverted':
-      return `color: ${customProperties.colorSurface};`;
+      return `color: ${designTokens.colorSurface};`;
     case 'warning':
-      return `color: ${customProperties.colorWarning};`;
+      return `color: ${designTokens.colorWarning};`;
     default:
       return ``;
   }

--- a/packages/components/tooltip/src/tooltip.styles.ts
+++ b/packages/components/tooltip/src/tooltip.styles.ts
@@ -1,17 +1,19 @@
 import { CSSProperties } from 'react';
 import styled from '@emotion/styled';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import type { TTooltipProps } from './tooltip';
+
+type TDesignTokenName = keyof typeof designTokens;
 
 const getOffsetMargin = ({ placement }: { placement: string }) => {
   const position = (placement && placement.split('-')[0]) || '';
   switch (position) {
     case 'left':
     case 'right':
-      return `0 ${customProperties.spacingXs}`;
+      return `0 ${designTokens.spacingXs}`;
     case 'top':
     case 'bottom':
-      return `${customProperties.spacingXs} 0`;
+      return `${designTokens.spacingXs} 0`;
     default:
       return '';
   }
@@ -19,14 +21,14 @@ const getOffsetMargin = ({ placement }: { placement: string }) => {
 
 export const Body = styled.div`
   font-family: inherit;
-  border-radius: ${customProperties.borderRadius6};
-  padding: ${customProperties.spacingXs} ${customProperties.spacingS};
+  border-radius: ${designTokens.borderRadius6};
+  padding: ${designTokens.spacingXs} ${designTokens.spacingS};
   border: 'none';
-  box-shadow: ${customProperties.shadow15};
+  box-shadow: ${designTokens.shadow15};
   font-size: 0.857rem;
   opacity: 0.95;
-  color: ${customProperties.colorSurface};
-  background-color: ${customProperties.colorAccent};
+  color: ${designTokens.colorSurface};
+  background-color: ${designTokens.colorAccent};
 `;
 
 // here we use object styles so we can spread these
@@ -44,9 +46,7 @@ export const getBodyStyles = ({
   return {
     fontFamily: 'inherit',
     margin: `${getOffsetMargin({ placement })} !important`,
-    maxWidth: (customProperties as Record<string, string>)[
-      `constraint${constraint}`
-    ],
+    maxWidth: designTokens[`constraint${constraint}` as TDesignTokenName],
     // so hovering over the tooltip when the tooltip overlaps the component
     pointerEvents: 'none',
     width: constraint === 'auto' ? 'auto' : undefined,

--- a/packages/components/tooltip/src/tooltip.styles.ts
+++ b/packages/components/tooltip/src/tooltip.styles.ts
@@ -43,10 +43,14 @@ export const getBodyStyles = ({
   placement: string;
   customStyles?: CSSProperties;
 }): CSSProperties => {
+  const constraintTokenName = `constraint${constraint}`;
   return {
     fontFamily: 'inherit',
     margin: `${getOffsetMargin({ placement })} !important`,
-    maxWidth: designTokens[`constraint${constraint}` as TDesignTokenName],
+    maxWidth:
+      constraintTokenName in designTokens
+        ? designTokens[constraintTokenName as TDesignTokenName]
+        : 'auto',
     // so hovering over the tooltip when the tooltip overlaps the component
     pointerEvents: 'none',
     width: constraint === 'auto' ? 'auto' : undefined,

--- a/packages/components/view-switcher/src/view-switcher-button.tsx
+++ b/packages/components/view-switcher/src/view-switcher-button.tsx
@@ -6,7 +6,7 @@ import {
 } from 'react';
 import { css } from '@emotion/react';
 import AccessibleButton from '@commercetools-uikit/accessible-button';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import { getButtonStyles } from './view-switcher.styles';
 
 export type TViewSwitcherButtonProps = {
@@ -39,7 +39,7 @@ const ViewSwitcherButton = (props: TViewSwitcherButtonProps) => (
     {props.icon && (
       <span
         css={css`
-          margin: 0 ${customProperties.spacingXs} 0 0;
+          margin: 0 ${designTokens.spacingXs} 0 0;
           display: flex;
           align-items: center;
           justify-content: center;

--- a/packages/components/view-switcher/src/view-switcher.styles.ts
+++ b/packages/components/view-switcher/src/view-switcher.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { customProperties } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 import type { TViewSwitcherButtonProps } from './view-switcher-button';
 
 const getSizeStyles = (
@@ -7,14 +7,14 @@ const getSizeStyles = (
 ) => {
   if (isCondensed) {
     return css`
-      padding: 0 ${customProperties.spacingS} 0 ${customProperties.spacingS};
-      height: ${customProperties.smallButtonHeight};
+      padding: 0 ${designTokens.spacingS} 0 ${designTokens.spacingS};
+      height: ${designTokens.smallButtonHeight};
     `;
   }
 
   return css`
-    padding: 0 ${customProperties.spacingM} 0 ${customProperties.spacingM};
-    height: ${customProperties.bigButtonHeight};
+    padding: 0 ${designTokens.spacingM} 0 ${designTokens.spacingM};
+    height: ${designTokens.bigButtonHeight};
   `;
 };
 
@@ -25,42 +25,40 @@ export const getButtonStyles = (
   isFirstButton?: TViewSwitcherButtonProps['isFirstButton'],
   isLastButton?: TViewSwitcherButtonProps['isLastButton']
 ) => {
-  const borderRadius = `${
-    isFirstButton ? customProperties.borderRadius6 : '0'
-  } ${
+  const borderRadius = `${isFirstButton ? designTokens.borderRadius6 : '0'} ${
     isLastButton
-      ? `${customProperties.borderRadius6} ${customProperties.borderRadius6}`
+      ? `${designTokens.borderRadius6} ${designTokens.borderRadius6}`
       : '0 0'
-  } ${isFirstButton ? customProperties.borderRadius6 : '0'}`;
+  } ${isFirstButton ? designTokens.borderRadius6 : '0'}`;
 
   return [
     css`
       align-items: center;
-      color: ${customProperties.colorSolid};
-      transition: background-color ${customProperties.transitionLinear80Ms};
-      font-size: ${customProperties.fontSizeDefault};
+      color: ${designTokens.colorSolid};
+      transition: background-color ${designTokens.transitionLinear80Ms};
+      font-size: ${designTokens.fontSizeDefault};
       border-radius: ${borderRadius};
       box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.24),
         0 -1px 1px 0 rgba(0, 0, 0, 0.12);
       &:hover {
-        background-color: ${customProperties.colorNeutral90};
+        background-color: ${designTokens.colorNeutral90};
       }
       &:active {
-        background-color: ${customProperties.colorNeutral95};
+        background-color: ${designTokens.colorNeutral95};
       }
       ${getSizeStyles(isCondensed)}
     `,
     isActive &&
       css`
-        background-color: ${customProperties.colorNeutral95};
-        box-shadow: ${customProperties.shadow9};
+        background-color: ${designTokens.colorNeutral95};
+        box-shadow: ${designTokens.shadow9};
       `,
     isDisabled &&
       css`
-        background-color: ${customProperties.colorAccent98};
-        color: ${customProperties.colorNeutral60};
+        background-color: ${designTokens.colorAccent98};
+        color: ${designTokens.colorNeutral60};
         &:hover {
-          background-color: ${customProperties.colorAccent98};
+          background-color: ${designTokens.colorAccent98};
         }
       `,
   ];

--- a/packages/index.bundlespec.js
+++ b/packages/index.bundlespec.js
@@ -1,8 +1,17 @@
-import { customProperties, version } from '@commercetools-frontend/ui-kit';
+import {
+  customProperties,
+  designTokens,
+  version,
+} from '@commercetools-frontend/ui-kit';
 
 describe('exports', () => {
+  // This field has been deprecated
   it('should export custom-properties', () => {
     expect(customProperties).toBeTruthy();
+  });
+
+  it('should export design-tokens', () => {
+    expect(designTokens).toBeTruthy();
   });
 
   describe('version', () => {

--- a/presets/ui-kit/src/index.ts
+++ b/presets/ui-kit/src/index.ts
@@ -51,6 +51,9 @@ export {
   useDataTableSortingState,
 } from '@commercetools-uikit/hooks';
 
-export { customProperties } from '@commercetools-uikit/design-system';
+export {
+  customProperties,
+  designTokens,
+} from '@commercetools-uikit/design-system';
 
 export { default as version } from './version';

--- a/test/percy/spec.jsx
+++ b/test/percy/spec.jsx
@@ -2,7 +2,7 @@ import { Children, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import pick from 'lodash/pick';
-import { customProperties } from '../../design-system';
+import { designTokens } from '../../design-system';
 
 const SpecContainer = styled.div`
   display: flex;
@@ -16,41 +16,41 @@ const SpecContainer = styled.div`
 `;
 
 const Label = styled.div`
-  font-family: ${customProperties.fontFamilyDefault};
+  font-family: ${designTokens.fontFamilyDefault};
   font-weight: bold;
   box-sizing: border-box;
   background-color: #774caf;
   padding: 5px;
-  color: ${customProperties.colorSurface};
-  font-size: ${customProperties.fontSizeDefault};
+  color: ${designTokens.colorSurface};
+  font-size: ${designTokens.fontSizeDefault};
 `;
 
 const PropList = styled.div`
-  font-family: ${customProperties.fontFamilyDefault};
+  font-family: ${designTokens.fontFamilyDefault};
   background-color: #894ac3;
   padding: 5px;
   box-sizing: border-box;
   font-size: 8pt;
   font-family: monospace;
-  color: ${customProperties.colorSurface};
+  color: ${designTokens.colorSurface};
 `;
 
 const PropLabel = styled.span`
   font-weight: bold;
-  padding: 0 ${customProperties.spacingXs};
+  padding: 0 ${designTokens.spacingXs};
   min-width: 140px;
   display: inline-block;
   box-sizing: border-box;
 `;
 
 const PropValue = styled.span`
-  padding: 0 ${customProperties.spacingXs};
+  padding: 0 ${designTokens.spacingXs};
   box-sizing: border-box;
 `;
 
 const Box = styled.div`
   background-color: ${(props) =>
-    props.backgroundColor ?? customProperties.colorSurface};
+    props.backgroundColor ?? designTokens.colorSurface};
   }};
 `;
 


### PR DESCRIPTION
#### Summary

Update design tokens imports to use the new exported object from the `@commercetools-uikit/design-token` package.

## Description

This is a follow-up PR for #2271.

We change imports to use the new exported property from mentioned package.

```js
// Before
import { customProperties } from '@commercetools-uikit/design-system';

// After
import { designTokens } from '@commercetools-uikit/design-system';
```
