### PR TITLE
Update `CollapsiblePanel` header styles

### DIFF
--- a/.changeset/hot-points-flow.md
+++ b/.changeset/hot-points-flow.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/collapsible-panel': patch
+---
+
+Update `CollapsiblePanel` header vertical padding in collapsed mode (`4px` -> `8px`).

--- a/packages/components/collapsible-panel/src/collapsible-panel.styles.tsx
+++ b/packages/components/collapsible-panel/src/collapsible-panel.styles.tsx
@@ -33,7 +33,7 @@ const getHeaderContainerStyles = (
       ? 'flex-start'
       : 'space-between'};
     padding: ${props.condensed
-      ? `${vars.spacingXs} ${vars.spacingS}`
+      ? `${vars.spacingS} ${vars.spacingS}`
       : `${vars.spacingS} ${vars.spacingM}`};
   `;
 

--- a/packages/components/collapsible-panel/src/collapsible-panel.styles.tsx
+++ b/packages/components/collapsible-panel/src/collapsible-panel.styles.tsx
@@ -33,7 +33,7 @@ const getHeaderContainerStyles = (
       ? 'flex-start'
       : 'space-between'};
     padding: ${props.condensed
-      ? `${vars.spacingS} ${vars.spacingS}`
+      ? `${vars.spacingS}`
       : `${vars.spacingS} ${vars.spacingM}`};
   `;
 


### PR DESCRIPTION
#### Summary

Increase header vertical padding in `condensed` mode.

## Description

Updated vertical padding of panel header from `4px` to `8px` when `condensed` property is used.

closes #2275 