### PR TITLE
fix: add missing `label` property to `options` prop type of select inputs and select fields

### DIFF
--- a/.changeset/thirty-jars-argue.md
+++ b/.changeset/thirty-jars-argue.md
@@ -1,0 +1,8 @@
+---
+'@commercetools-uikit/creatable-select-field': patch
+'@commercetools-uikit/select-field': patch
+'@commercetools-uikit/creatable-select-input': patch
+'@commercetools-uikit/select-input': patch
+---
+
+Add missing `label` property to `options` prop type

--- a/packages/components/fields/creatable-select-field/src/creatable-select-field.tsx
+++ b/packages/components/fields/creatable-select-field/src/creatable-select-field.tsx
@@ -31,6 +31,7 @@ type TCustomFormErrors<Values> = {
 };
 type TValue = {
   value: string;
+  label: string;
 };
 type TOptions = TValue[] | { options: TValue[] }[];
 

--- a/packages/components/fields/select-field/src/select-field.tsx
+++ b/packages/components/fields/select-field/src/select-field.tsx
@@ -22,6 +22,7 @@ import type { Props as ReactSelectProps } from 'react-select';
 type TErrorRenderer = (key: string, error?: boolean) => ReactNode;
 type TOption = {
   value: string;
+  label: string;
 };
 type TOptionObject = {
   options: TOption[];

--- a/packages/components/inputs/creatable-select-input/src/creatable-select-input.tsx
+++ b/packages/components/inputs/creatable-select-input/src/creatable-select-input.tsx
@@ -27,6 +27,7 @@ const customizedComponents = {
 
 type TValue = {
   value: string;
+  label: string;
 };
 
 type TOptions = TValue[] | { options: TValue[] }[];

--- a/packages/components/inputs/select-input/src/select-input.tsx
+++ b/packages/components/inputs/select-input/src/select-input.tsx
@@ -27,6 +27,7 @@ const customizedComponents = {
 
 type TOption = {
   value: string;
+  label: string;
 };
 
 type TOptionObject = {


### PR DESCRIPTION
Fixes #2277
