### PR TITLE
Fix `label` property type in `options prop` type of select inputs and select fields

### DIFF
--- a/.changeset/heavy-parrots-hear.md
+++ b/.changeset/heavy-parrots-hear.md
@@ -1,0 +1,8 @@
+---
+'@commercetools-uikit/creatable-select-field': patch
+'@commercetools-uikit/select-field': patch
+'@commercetools-uikit/creatable-select-input': patch
+'@commercetools-uikit/select-input': patch
+---
+
+Fix `label` property type in `options` prop

--- a/packages/components/fields/creatable-select-field/src/creatable-select-field.tsx
+++ b/packages/components/fields/creatable-select-field/src/creatable-select-field.tsx
@@ -31,7 +31,7 @@ type TCustomFormErrors<Values> = {
 };
 type TValue = {
   value: string;
-  label: string;
+  label: ReactNode;
 };
 type TOptions = TValue[] | { options: TValue[] }[];
 

--- a/packages/components/fields/select-field/src/select-field.tsx
+++ b/packages/components/fields/select-field/src/select-field.tsx
@@ -22,7 +22,7 @@ import type { Props as ReactSelectProps } from 'react-select';
 type TErrorRenderer = (key: string, error?: boolean) => ReactNode;
 type TOption = {
   value: string;
-  label: string;
+  label: ReactNode;
 };
 type TOptionObject = {
   options: TOption[];

--- a/packages/components/inputs/creatable-select-input/src/creatable-select-input.tsx
+++ b/packages/components/inputs/creatable-select-input/src/creatable-select-input.tsx
@@ -27,7 +27,7 @@ const customizedComponents = {
 
 type TValue = {
   value: string;
-  label: string;
+  label: ReactNode;
 };
 
 type TOptions = TValue[] | { options: TValue[] }[];

--- a/packages/components/inputs/select-input/src/select-input.tsx
+++ b/packages/components/inputs/select-input/src/select-input.tsx
@@ -27,7 +27,7 @@ const customizedComponents = {
 
 type TOption = {
   value: string;
-  label: string;
+  label: ReactNode;
 };
 
 type TOptionObject = {


### PR DESCRIPTION
#### Summary

Fixes the type of options `label` property to allow more types than a string.

## Description

When providing the value for the `label` property of the options, users might use not only strings but other types as well (ex: an element for a rich label).
We widen the type of that property to support different use cases.
