### PR TITLE
Make `label` property type optional in `options` prop type of select inputs and select fields

### DIFF
--- a/.changeset/slow-steaks-rhyme.md
+++ b/.changeset/slow-steaks-rhyme.md
@@ -1,0 +1,8 @@
+---
+'@commercetools-uikit/creatable-select-field': patch
+'@commercetools-uikit/select-field': patch
+'@commercetools-uikit/creatable-select-input': patch
+'@commercetools-uikit/select-input': patch
+---
+
+Make `label` property optional in `options` prop

--- a/packages/components/fields/creatable-select-field/src/creatable-select-field.tsx
+++ b/packages/components/fields/creatable-select-field/src/creatable-select-field.tsx
@@ -31,7 +31,7 @@ type TCustomFormErrors<Values> = {
 };
 type TValue = {
   value: string;
-  label: ReactNode;
+  label?: ReactNode;
 };
 type TOptions = TValue[] | { options: TValue[] }[];
 

--- a/packages/components/fields/select-field/src/select-field.tsx
+++ b/packages/components/fields/select-field/src/select-field.tsx
@@ -22,7 +22,7 @@ import type { Props as ReactSelectProps } from 'react-select';
 type TErrorRenderer = (key: string, error?: boolean) => ReactNode;
 type TOption = {
   value: string;
-  label: ReactNode;
+  label?: ReactNode;
 };
 type TOptionObject = {
   options: TOption[];

--- a/packages/components/inputs/creatable-select-input/src/creatable-select-input.tsx
+++ b/packages/components/inputs/creatable-select-input/src/creatable-select-input.tsx
@@ -27,7 +27,7 @@ const customizedComponents = {
 
 type TValue = {
   value: string;
-  label: ReactNode;
+  label?: ReactNode;
 };
 
 type TOptions = TValue[] | { options: TValue[] }[];

--- a/packages/components/inputs/select-input/src/select-input.tsx
+++ b/packages/components/inputs/select-input/src/select-input.tsx
@@ -27,7 +27,7 @@ const customizedComponents = {
 
 type TOption = {
   value: string;
-  label: ReactNode;
+  label?: ReactNode;
 };
 
 type TOptionObject = {


### PR DESCRIPTION
#### Summary

Make `label` property type optional in `options` prop type of select inputs and select fields.

This is a follow-up of #2279.

## Description

We defined the `label` property to be from [ReactNode](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L230) Typescript type which would allow for an undefined value, but when auto-generating the prop-types it gets defined as a required property so we need to make it optional in Typescript.
Actually, this `label` value is not used internally in the components (it's more for their consumers) so it seems to be safe to type it like this.
