### PR TITLE
Fix info button arrangement in the data table component

### DIFF
--- a/.changeset/slimy-walls-worry.md
+++ b/.changeset/slimy-walls-worry.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-uikit/data-table': minor
+---
+
+Fix arrangement of data-table info button.
+
+The optional info button which can be set in the table header cell is placed left to the label. This causes a bad looking alignment with the rest of the table cells and due to the size, the padding of the header cell seems to be ignored.

--- a/.changeset/slimy-walls-worry.md
+++ b/.changeset/slimy-walls-worry.md
@@ -1,7 +1,5 @@
 ---
-'@commercetools-uikit/data-table': minor
+'@commercetools-uikit/data-table': patch
 ---
 
-Fix arrangement of data-table info button.
-
-The optional info button which can be set in the table header cell is placed left to the label. This causes a bad looking alignment with the rest of the table cells and due to the size, the padding of the header cell seems to be ignored.
+Fix position of header cell icon to the right of the text.

--- a/packages/components/data-table/src/data-table.story.js
+++ b/packages/components/data-table/src/data-table.story.js
@@ -181,7 +181,7 @@ const initialColumnsState = [
       <IconButton
         icon={<InformationIcon />}
         label="Custom Column Information"
-        size="medium"
+        size="small"
         onClick={() =>
           alert(
             'This Column can be customized using the controls at the bottom of this page!'

--- a/packages/components/data-table/src/header-cell.styles.tsx
+++ b/packages/components/data-table/src/header-cell.styles.tsx
@@ -123,8 +123,8 @@ const HeaderIconWrapper = styled.div`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  margin-right: ${vars.spacingS};
-  padding: ${vars.spacingXs} 0;
+  margin-left: ${vars.spacingS};
+  padding: 0 ${vars.spacingXs};
 `;
 
 export {

--- a/packages/components/data-table/src/header-cell.tsx
+++ b/packages/components/data-table/src/header-cell.tsx
@@ -160,10 +160,10 @@ const HeaderCell = (props: THeaderCell) => {
         horizontalCellAlignment={props.horizontalCellAlignment}
         {...sortableHeaderProps}
       >
+        <HeaderLabelWrapper>{props.children}</HeaderLabelWrapper>
         {props.iconComponent && (
           <HeaderIconWrapper>{props.iconComponent}</HeaderIconWrapper>
         )}
-        <HeaderLabelWrapper>{props.children}</HeaderLabelWrapper>
         {props.isSortable && (
           <>
             {/** conditional rendering of one of the icons at a time is handled by CSS. Checkout cell.styles */}


### PR DESCRIPTION
This PR fixes the issue opened regarding data-table info button arrangement. 
![image](https://user-images.githubusercontent.com/19975842/189948898-7f6a7d1e-6317-4af8-825a-b18746439399.png)

Fixes #2283