### PR TITLE
Fix icon displaced to far right when data table cell is expanded

### DIFF
--- a/.changeset/smooth-ears-drum.md
+++ b/.changeset/smooth-ears-drum.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table': patch
+---
+
+fix icon displaced to far right when data table cell is expanded

--- a/packages/components/data-table/src/cell.styles.tsx
+++ b/packages/components/data-table/src/cell.styles.tsx
@@ -29,20 +29,17 @@ const getHorizontalAlignmentStyle = (props: TCellInner) => {
     return css`
       text-align: center;
       justify-self: center;
-      justify-content: center;
     `;
   }
   if (props.horizontalCellAlignment === 'right') {
     return css`
       text-align: right;
       justify-self: flex-end;
-      justify-content: end;
     `;
   }
   return css`
     text-align: left;
     justify-self: flex-start;
-    jusify-content: start;
   `;
 };
 

--- a/packages/components/data-table/src/cell.styles.tsx
+++ b/packages/components/data-table/src/cell.styles.tsx
@@ -29,17 +29,20 @@ const getHorizontalAlignmentStyle = (props: TCellInner) => {
     return css`
       text-align: center;
       justify-self: center;
+      justify-content: center;
     `;
   }
   if (props.horizontalCellAlignment === 'right') {
     return css`
       text-align: right;
       justify-self: flex-end;
+      justify-content: end;
     `;
   }
   return css`
     text-align: left;
     justify-self: flex-start;
+    jusify-content: start;
   `;
 };
 

--- a/packages/components/data-table/src/header-cell.styles.tsx
+++ b/packages/components/data-table/src/header-cell.styles.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { designTokens } from '@commercetools-uikit/design-system';
 import { getCellInnerStyles } from './cell.styles';
+import { designTokens } from '@commercetools-uikit/design-system';
 import type { THeaderCell } from './header-cell';
 
 const getButtonStyle = () => css`
@@ -71,9 +71,7 @@ const HeaderCellInner = styled.div<THeaderCellInner>`
   box-sizing: border-box;
   display: flex;
   justify-content: space-between;
-  padding: 0
-    ${(props) =>
-      props.isCondensed ? designTokens.spacingS : designTokens.spacingM};
+  padding: 0 ${(props) => (props.isCondensed ? designTokens.spacingS : designTokens.spacingM)};
 
   ${getCellInnerStyles}
   ${(props) => (props.isSortable ? getSortableHeaderStyles(props) : '')};
@@ -126,7 +124,7 @@ const HeaderIconWrapper = styled.div`
   align-items: center;
   justify-content: center;
   margin-left: ${designTokens.spacingS};
-  padding: 0 ${designTokens.spacingXs};
+  vertical-align: middle;
 `;
 
 export {

--- a/packages/components/data-table/src/header-cell.styles.tsx
+++ b/packages/components/data-table/src/header-cell.styles.tsx
@@ -71,7 +71,9 @@ const HeaderCellInner = styled.div<THeaderCellInner>`
   box-sizing: border-box;
   display: flex;
   justify-content: space-between;
-  padding: 0 ${(props) => (props.isCondensed ? designTokens.spacingS : designTokens.spacingM)};
+  padding: 0
+    ${(props) =>
+      props.isCondensed ? designTokens.spacingS : designTokens.spacingM};
 
   ${getCellInnerStyles}
   ${(props) => (props.isSortable ? getSortableHeaderStyles(props) : '')};

--- a/packages/components/data-table/src/header-cell.tsx
+++ b/packages/components/data-table/src/header-cell.tsx
@@ -9,7 +9,6 @@ import {
   HeaderCellInner,
   HeaderIconWrapper,
   HeaderLabelWrapper,
-  HeaderContentWrapper,
 } from './header-cell.styles';
 import Resizer from './column-resizer';
 import ColumnResizingContext from './column-resizing-context';

--- a/packages/components/data-table/src/header-cell.tsx
+++ b/packages/components/data-table/src/header-cell.tsx
@@ -160,10 +160,12 @@ const HeaderCell = (props: THeaderCell) => {
         horizontalCellAlignment={props.horizontalCellAlignment}
         {...sortableHeaderProps}
       >
-        <HeaderLabelWrapper>{props.children}</HeaderLabelWrapper>
-        {props.iconComponent && (
-          <HeaderIconWrapper>{props.iconComponent}</HeaderIconWrapper>
-        )}
+        <HeaderLabelWrapper>
+          {props.children}
+          {props.iconComponent && (
+            <HeaderIconWrapper>{props.iconComponent}</HeaderIconWrapper>
+          )}
+        </HeaderLabelWrapper>
         {props.isSortable && (
           <>
             {/** conditional rendering of one of the icons at a time is handled by CSS. Checkout cell.styles */}

--- a/packages/components/data-table/src/header-cell.tsx
+++ b/packages/components/data-table/src/header-cell.tsx
@@ -9,6 +9,7 @@ import {
   HeaderCellInner,
   HeaderIconWrapper,
   HeaderLabelWrapper,
+  HeaderContentWrapper,
 } from './header-cell.styles';
 import Resizer from './column-resizer';
 import ColumnResizingContext from './column-resizing-context';


### PR DESCRIPTION
Fix icon displaced to far right when data table cell is expanded
Before: 
<img width="517" alt="image" src="https://user-images.githubusercontent.com/19975842/190599092-dc80d95f-13b0-4edd-8543-217e52455e11.png">

After:
<img width="671" alt="image (1)" src="https://user-images.githubusercontent.com/19975842/190599213-ad774737-0dd8-4bd5-8f68-264cd0042ecc.png">
