### PR TITLE
Example links not working as expected

### DIFF
--- a/packages/components/grid/src/grid.story.js
+++ b/packages/components/grid/src/grid.story.js
@@ -89,7 +89,7 @@ storiesOf('Components|Grid', module)
                 'In the Knobs section on the right panel, you can see all the supported CSS Grid properties, both for the parent container and for the children elements (items).'
               }
             </Text.Body>
-            <LinkTo kind="Examples|Components/Grid" story="Grid layouts">
+            <LinkTo kind="Examples/Components/Grid" story="With-fixed-columns">
               <Text.Body tone="primary">
                 {
                   'Check out the Grid examples to build some basic grid layouts!'

--- a/packages/components/inputs/creatable-select-input/src/creatable-select-input.story.js
+++ b/packages/components/inputs/creatable-select-input/src/creatable-select-input.story.js
@@ -154,7 +154,10 @@ storiesOf('Components|Inputs/SelectInputs', module)
           />
         </Section>
         <Section>
-          <LinkTo kind="Examples|Forms/Inputs" story="CreatableSelectInput">
+          <LinkTo
+            kind="Examples/Forms/Inputs/SelectInputs"
+            story="CreatableSelectInput"
+          >
             See form example
           </LinkTo>
         </Section>

--- a/packages/components/inputs/select-input/src/select-input.story.js
+++ b/packages/components/inputs/select-input/src/select-input.story.js
@@ -147,7 +147,7 @@ storiesOf('Components|Inputs/SelectInputs', module)
           />
         </Section>
         <Section>
-          <LinkTo kind="Examples|Forms/Inputs" story="SelectInput">
+          <LinkTo kind="Examples/Forms/Inputs/SelectInputs" story="SelectInput">
             See form example
           </LinkTo>
         </Section>


### PR DESCRIPTION

#### Summary

The Example links in the UI Kit Storybook are not working as expected and clicking on them did nothing. So I checked and fixed it for grid and input components.

![Screenshot 2022-10-05 at 11 31 26](https://user-images.githubusercontent.com/52276952/194050411-f81f9cd2-7d45-4065-bdde-f1581fbc33b2.png)

Opened issue: https://github.com/commercetools/ui-kit/issues/2213