### PR TITLE
Adding the strikethrough property to text component

### DIFF
--- a/.changeset/warm-pigs-raise.md
+++ b/.changeset/warm-pigs-raise.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/text': major
+---
+
+Introduced a new prop 'isStrikethrough' for body and detail text components when needing a strikethrought text

--- a/packages/components/text/README.md
+++ b/packages/components/text/README.md
@@ -96,16 +96,17 @@ import Text from '@commercetools-uikit/text';
 
 ### Properties
 
-| Props         | Type             | Required | Values                                                                        | Default |                                                                        |
-| ------------- | ---------------- | :------: | ----------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------- |
-| `as`          | `String`         |    -     | `['p', 'span']`                                                               | -       |                                                                        |
-| `isBold`      | `Boolean`        |    -     | -                                                                             | `false` |                                                                        |
-| `isItalic`    | `Boolean`        |    -     | -                                                                             | `false` |                                                                        |
-| `tone`        | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative', 'inverted']` | -       |                                                                        |
-| `children`    | `PropTypes.node` | ✅ (\*)  | -                                                                             | -       |                                                                        |
-| `intlMessage` | `intl message`   | ✅ (\*)  | -                                                                             | -       | An `intl` message object that will be rendered with `FormattedMessage` |
-| `title`       | `String`         |    -     | -                                                                             | -       |                                                                        |
-| `truncate`    | `Bool`           |    -     | -                                                                             | `false` |                                                                        |
+| Props             | Type             | Required | Values                                                                        | Default |                                                                        |
+| ----------------- | ---------------- | :------: | ----------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------- |
+| `as`              | `String`         |    -     | `['p', 'span']`                                                               | -       |                                                                        |
+| `isBold`          | `Boolean`        |    -     | -                                                                             | `false` |                                                                        |
+| `isItalic`        | `Boolean`        |    -     | -                                                                             | `false` |                                                                        |
+| `isStrikethrough` | `Boolean`        |    -     | -                                                                             | `false` |                                                                        |
+| `tone`            | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative', 'inverted']` | -       |                                                                        |
+| `children`        | `PropTypes.node` | ✅ (\*)  | -                                                                             | -       |                                                                        |
+| `intlMessage`     | `intl message`   | ✅ (\*)  | -                                                                             | -       | An `intl` message object that will be rendered with `FormattedMessage` |
+| `title`           | `String`         |    -     | -                                                                             | -       |                                                                        |
+| `truncate`        | `Bool`           |    -     | -                                                                             | `false` |                                                                        |
 
 > `*`: `children` is required only if `intlMessage` is not provided
 
@@ -131,16 +132,17 @@ import Text from '@commercetools-uikit/text';
 
 ### Properties
 
-| Props         | Type             | Required | Values                                                                        | Default |                                                                        |
-| ------------- | ---------------- | :------: | ----------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------- |
-| `as`          | `string`         |    -     | `['small', 'span']` `[^]`                                                     | `false` |                                                                        |
-| `isBold`      | `Boolean`        |    -     | -                                                                             | `false` |                                                                        |
-| `isItalic`    | `Boolean`        |    -     | -                                                                             | `false` |                                                                        |
-| `tone`        | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative', 'warning'']` | -       |                                                                        |
-| `children`    | `PropTypes.node` | ✅ (\*)  | -                                                                             | -       |                                                                        |
-| `intlMessage` | `intl message`   | ✅ (\*)  | -                                                                             | -       | An `intl` message object that will be rendered with `FormattedMessage` |
-| `title`       | `String`         |    -     | -                                                                             | -       |                                                                        |
-| `truncate`    | `Bool`           |    -     | -                                                                             | `false` |                                                                        |
+| Props             | Type             | Required | Values                                                                        | Default |                                                                        |
+| ----------------- | ---------------- | :------: | ----------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------- |
+| `as`              | `string`         |    -     | `['small', 'span']` `[^]`                                                     | `false` |                                                                        |
+| `isBold`          | `Boolean`        |    -     | -                                                                             | `false` |                                                                        |
+| `isItalic`        | `Boolean`        |    -     | -                                                                             | `false` |                                                                        |
+| `isStrikethrough` | `Boolean`        |    -     | -                                                                             | `false` |                                                                        |
+| `tone`            | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative', 'warning'']` | -       |                                                                        |
+| `children`        | `PropTypes.node` | ✅ (\*)  | -                                                                             | -       |                                                                        |
+| `intlMessage`     | `intl message`   | ✅ (\*)  | -                                                                             | -       | An `intl` message object that will be rendered with `FormattedMessage` |
+| `title`           | `String`         |    -     | -                                                                             | -       |                                                                        |
+| `truncate`        | `Bool`           |    -     | -                                                                             | `false` |                                                                        |
 
 > `*`: `children` is required only if `intlMessage` is not provided.
 > `[^]`: Use `as` prop to render an inline element.

--- a/packages/components/text/src/text.story.js
+++ b/packages/components/text/src/text.story.js
@@ -73,6 +73,7 @@ storiesOf('Basics|Typography/Text', module)
         })}
         isBold={boolean('bold', false)}
         isItalic={boolean('italic', false)}
+        isStrikethrough={boolean('strikethrough', false)}
         tone={select('Text tone', {
           none: null,
           primary: 'primary',
@@ -98,6 +99,7 @@ storiesOf('Basics|Typography/Text', module)
         })}
         isBold={boolean('bold', false)}
         isItalic={boolean('italic', false)}
+        isStrikethrough={boolean('strikethrough', false)}
         tone={select('Text tone', {
           none: null,
           primary: 'primary',

--- a/packages/components/text/src/text.styles.ts
+++ b/packages/components/text/src/text.styles.ts
@@ -28,6 +28,10 @@ const italic = `
   font-style: italic;
 `;
 
+const strikethrough = `
+  text-decoration: line-through;
+`;
+
 const getTone = (tone: string) => {
   switch (tone) {
     case 'information':
@@ -72,6 +76,7 @@ export const bodyStyles = (props: TBodyProps) => css`
   font-size: 1rem;
   ${props.isBold && bold}
   ${props.isItalic && italic}
+  ${props.isStrikethrough && strikethrough}
   ${props.tone && getTone(props.tone)}
   ${props.truncate && truncate}
 `;
@@ -105,6 +110,7 @@ export const detailStyles = (props: TDetailProps) => css`
   font-size: 0.9231rem;
   ${props.isBold && bold}
   ${props.isItalic && italic}
+  ${props.isStrikethrough && strikethrough}
   ${props.tone && getTone(props.tone)}
   ${props.truncate && truncate}
 `;

--- a/packages/components/text/src/text.tsx
+++ b/packages/components/text/src/text.tsx
@@ -154,6 +154,7 @@ export type TBodyProps = {
   as?: 'span' | 'p';
   isBold?: boolean;
   isItalic?: boolean;
+  isStrikethrough?: boolean;
   tone?:
     | 'primary'
     | 'secondary'
@@ -198,6 +199,7 @@ export type TDetailProps = {
   id?: string;
   isBold?: boolean;
   isItalic?: boolean;
+  isStrikethrough?: boolean;
   as?: 'span' | 'small';
   tone?:
     | 'primary'

--- a/packages/components/text/src/text.visualroute.jsx
+++ b/packages/components/text/src/text.visualroute.jsx
@@ -91,6 +91,9 @@ export const component = () => (
     <Spec label="Body - italic">
       <Text.Body isItalic={true}>Body text italic</Text.Body>
     </Spec>
+    <Spec label="Body - strikethrough">
+      <Text.Body isStrikethrough={true}>Body text strikethrough</Text.Body>
+    </Spec>
     <Spec label="Body - tone - primary">
       <Text.Body tone="primary">Body text primary</Text.Body>
     </Spec>
@@ -125,6 +128,9 @@ export const component = () => (
     </Spec>
     <Spec label="Detail - italic">
       <Text.Detail isItalic={true}>Detail text italic</Text.Detail>
+    </Spec>
+    <Spec label="Detail - strikethrough">
+      <Text.Body isStrikethrough={true}>Detail text strikethrough</Text.Body>
     </Spec>
     <Spec label="Detail - tone - primary">
       <Text.Detail tone="primary">Detail text primary</Text.Detail>

--- a/packages/components/text/src/text.visualroute.jsx
+++ b/packages/components/text/src/text.visualroute.jsx
@@ -130,7 +130,7 @@ export const component = () => (
       <Text.Detail isItalic={true}>Detail text italic</Text.Detail>
     </Spec>
     <Spec label="Detail - strikethrough">
-      <Text.Body isStrikethrough={true}>Detail text strikethrough</Text.Body>
+      <Text.Detail isStrikethrough={true}>Detail text strikethrough</Text.Detail>
     </Spec>
     <Spec label="Detail - tone - primary">
       <Text.Detail tone="primary">Detail text primary</Text.Detail>


### PR DESCRIPTION
#### Summary

Since teams are using the custom styling to achieve the strikethrough text in the Merchant center, I introduced a new prop `strikethrough` for body and detail text components.


![Screenshot 2022-10-11 at 13 13 13](https://user-images.githubusercontent.com/52276952/195320709-733372f8-e433-4daf-a4e1-0c5e01a76605.png)


Open issue: https://github.com/commercetools/ui-kit/issues/2217
