### PR TITLE
Extend design tokens naming rules

### DIFF
--- a/design-system/scripts/generate-design-tokens.js
+++ b/design-system/scripts/generate-design-tokens.js
@@ -38,13 +38,13 @@ const designTokens = {};
       + background-color-for-tag
     - <attribute>-for-<component-group>-when-<state>-
       + background-color-for-button-when-disabled
-    - <attribute>-for-<component-group>-as-<state>-
+    - <attribute>-for-<component-group>-as-<variant>-
       + border-radius-for-button-as-big
-    - <attribute>-for-<component-group>-as-<state>-when-<state>
-      + border-for-button-as-secondary-when-hovered
-    - <attribute>-for-<component-group>-as-<state>-as-<state>-
-      + border-radius-for-button-as-icon-as-small
-    - <attribute>-for-<component-group>-as-<state>-as-<state>-when-<state>-
+    - <attribute>-for-<component-group>-as-<variant>-when-<state>
+    + border-for-button-as-secondary-when-hovered
+    - <attribute>-for-<component-group>-as-<variant>-as-<variant>-
+    + border-radius-for-button-as-icon-as-small
+    - <attribute>-for-<component-group>-as-<variant>-as-<variant>-when-<state>-
       + border-radius-for-button-as-icon-as-small-when-disabled
 */
 function parseToken(token) {
@@ -94,7 +94,7 @@ function parseToken(token) {
     2. variants (might have several of this)
     3. state
 
-  Eg: <attribute>-for-<component-group>-as-<state>-when-<state>
+  Eg: <attribute>-for-<component-group>-as-<variant>-when-<state>
 */
 function isValidTokenName(tokenName, tokenParts) {
   const componentGroupIndex = tokenName.indexOf(tokenParts.componentGroup);

--- a/design-system/scripts/generate-design-tokens.js
+++ b/design-system/scripts/generate-design-tokens.js
@@ -21,13 +21,98 @@ const endProgram = (message) => {
   process.exit(1);
 };
 
-const TOKEN_REGEX =
-  /^(\w+(?:-\w+)(?:-\w+)?)(?:-for-(\w+(?:-\w+)?))?(?:-when-([\w-]+?))?(?:-on-([\w-]+?))?$/i;
+const ALLOWED_CSS_VALUES_IN_CHOICES = /px|none|hsla/;
+
+const isAllowedCssChoice = (choice) =>
+  choice.match(ALLOWED_CSS_VALUES_IN_CHOICES) !== null;
 
 const supportedStates = Object.keys(definitions.states);
 const supportedComponentGroups = Object.keys(definitions.componentGroups);
+const supportedVariants = Object.keys(definitions.variants || {});
 
 const designTokens = {};
+
+/*
+  Allowed patterns with examples:
+    - <attribute>-for-<component-group>
+      + background-color-for-tag
+    - <attribute>-for-<component-group>-when-<state>-
+      + background-color-for-button-when-disabled
+    - <attribute>-for-<component-group>-as-<state>-
+      + border-radius-for-button-as-big
+    - <attribute>-for-<component-group>-as-<state>-when-<state>
+      + border-for-button-as-secondary-when-hovered
+    - <attribute>-for-<component-group>-as-<state>-as-<state>-
+      + border-radius-for-button-as-icon-as-small
+    - <attribute>-for-<component-group>-as-<state>-as-<state>-when-<state>-
+      + border-radius-for-button-as-icon-as-small-when-disabled
+*/
+function parseToken(token) {
+  const parts = token.split('-');
+  let partType = 'cssRule';
+  let newVariant = false;
+  return parts.reduce(
+    (agg, part) => {
+      if (['for', 'as', 'when'].includes(part)) {
+        partType = part;
+        if (part === 'as') newVariant = true;
+        return agg;
+      }
+
+      if (partType === 'for') {
+        agg.componentGroup = `${agg.componentGroup}${
+          !!agg.componentGroup ? '-' : ''
+        }${part}`;
+      } else if (partType === 'when') {
+        agg.state = `${agg.state}${!!agg.state ? '-' : ''}${part}`;
+      } else if (partType === 'as') {
+        if (newVariant) {
+          agg.variants.push(part);
+          newVariant = false;
+        } else {
+          const lastIndex = agg.variants.length - 1;
+          agg.variants[lastIndex] = `${agg.variants[lastIndex]}-${part}`;
+        }
+      } else {
+        agg.cssRule = `${agg.cssRule}${!!agg.cssRule ? '-' : ''}${part}`;
+      }
+
+      return agg;
+    },
+    {
+      cssRule: '',
+      componentGroup: '',
+      variants: [],
+      state: '',
+    }
+  );
+}
+
+/*
+  We make sure the order of the token parts is
+    1. component group
+    2. variants (might have several of this)
+    3. state
+
+  Eg: <attribute>-for-<component-group>-as-<state>-when-<state>
+*/
+function isValidTokenName(tokenName, tokenParts) {
+  const componentGroupIndex = tokenName.indexOf(tokenParts.componentGroup);
+  const variantsIndexes = tokenParts.variants.map((variant) =>
+    tokenName.indexOf(variant)
+  );
+  const stateIndex = tokenName.indexOf(tokenParts.state) || Number.MAX_VALUE;
+
+  return (
+    (variantsIndexes.length === 0 ||
+      variantsIndexes.every(
+        (variantIndex) => variantIndex > componentGroupIndex
+      )) &&
+    componentGroupIndex < stateIndex &&
+    (variantsIndexes.length === 0 ||
+      variantsIndexes.every((variantIndex) => variantIndex < stateIndex))
+  );
+}
 
 Object.keys(definitions.choiceGroupsByTheme).forEach((themeName) => {
   if (!designTokens[themeName]) {
@@ -67,41 +152,53 @@ Object.entries(definitions.decisionGroupsByTheme).forEach(
         }
         if (
           !designTokens[themeName][decision.choice] &&
-          !designTokens.default[decision.choice]
+          !designTokens.default[decision.choice] &&
+          !isAllowedCssChoice(decision.choice)
         ) {
           endProgram(`Choice called "${decision.choice}" was not found!`);
         }
-        // TODO parse token name and warn when invalid name was given and token
-        // is not deprecated
 
-        const match = key.match(TOKEN_REGEX);
+        const tokenParts = parseToken(key);
 
-        if (match) {
-          const componentGroup = match[2];
-          const state = match[3];
-
-          if (
-            componentGroup &&
-            !supportedComponentGroups.includes(componentGroup)
-          )
-            endProgram(
-              `Token "${key}" uses unsupported component group "${componentGroup}"!`
-            );
-
-          if (state && !supportedStates.includes(state))
-            endProgram(`Token "${key}" uses unsupported state "${state}"!`);
-        } else if (!decision.deprecated) {
+        if (
+          tokenParts.componentGroup &&
+          !supportedComponentGroups.includes(tokenParts.componentGroup)
+        )
           endProgram(
-            `Token "${key}" does not follow <attribute>-for-<component-group>-when-<state>-on-<theme> naming scheme! Tokens not following this scheme must use "deprecated" flag.`
+            `Token "${key}" uses unsupported component group "${tokenParts.componentGroup}"!`
+          );
+
+        if (tokenParts.state && !supportedStates.includes(tokenParts.state))
+          endProgram(
+            `Token "${key}" uses unsupported state "${tokenParts.state}"!`
+          );
+
+        const invalidVariants = tokenParts.variants.find(
+          (variant) => !supportedVariants.includes(variant)
+        );
+        if (invalidVariants?.length > 0)
+          endProgram(
+            `Token "${key}" uses unsupported variants "${invalidVariants}"!`
+          );
+
+        if (
+          tokenParts.componentGroup &&
+          !decision.deprecated &&
+          !isValidTokenName(key, tokenParts)
+        ) {
+          endProgram(
+            `Token "${key}" does not follow <attribute>-for-<component-group>-as-<variant>-when-<state> naming scheme! Tokens not following this scheme must use "deprecated" flag.`
           );
         }
+
         if (!designTokens[themeName]) {
           designTokens[themeName] = {};
         }
 
-        designTokens[themeName][key] =
-          designTokens[themeName][decision.choice] ||
-          designTokens.default[decision.choice];
+        designTokens[themeName][key] = isAllowedCssChoice(decision.choice)
+          ? decision.choice
+          : designTokens[themeName][decision.choice] ||
+            designTokens.default[decision.choice];
       });
     });
   }
@@ -204,3 +301,5 @@ fs.writeFileSync(
     parser: 'typescript',
   })
 );
+
+console.log('\nDesign tokens built!\n');


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX181Ihoct2AUlIvW3Xnkp4wQi8aQU1jy4%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=9-mOGm8)
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Extend design tokens naming so we can support more use cases.

## Description

While working with the designs for the new theme and making our components compatible with both current and new UI we-re finding finding some restrictions in tokens naming that it seems we need to extend.
So now the naming pattern we allow is like this:
```
<attribute>-for-<component-group>(-[when|as]-[<variant|state>])?
```

This pattern allows for this token names:
```
background-color-for-tag
font-color-for-text-when-inverted
font-size-for-text-as-h1
```

What we are missing is:
* ability to combine variants with states: `<attribute>-for-<component-group>-as-<variant>-when-<state>` (eg: `border-for-button-as-secondary-when-hovered`)
* ability to combine variants with variants: `<attribute>-for-<component-group>-as-<variant>-as-<variant>` (eg: `border-radius-for-button-as-icon-as-small`)
  * In this case both icon and small are treated as variants for buttons
