### PR TITLE
Export missing prop in `Link` typescript type

### DIFF
--- a/.changeset/three-poets-rule.md
+++ b/.changeset/three-poets-rule.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/link': patch
+---
+
+Update `Link` component props typescript definition.

--- a/packages/components/link/README.md
+++ b/packages/components/link/README.md
@@ -51,3 +51,14 @@ export default Example;
 | `isExternal`  | `boolean`                                                      |          | `false`     | A flag to indicate if the Link points to an external source.&#xA;<bt />&#xA;If `true`, a regular `<a>` is rendered instead of the default `react-router`s `<Link />` |
 | `to`          | `union`<br/>Possible values:<br/>`string , LocationDescriptor` |    ✅    |             | The URL that the Link should point to.                                                                                                                               |
 | `tone`        | `union`<br/>Possible values:<br/>`'primary' , 'inverted'`      |          | `'primary'` | Color of the link                                                                                                                                                    |
+| `onClick`     | `Function`<br/>[See signature.](#signature-onClick)            |          |             | Handler when the link is clicked.                                                                                                                                    |
+
+## Signatures
+
+### Signature `onClick`
+
+```ts
+(
+  event: MouseEvent<HTMLLinkElement> | KeyboardEvent<HTMLLinkElement>
+) => void
+```

--- a/packages/components/link/src/link.spec.js
+++ b/packages/components/link/src/link.spec.js
@@ -19,6 +19,13 @@ describe('rendering', () => {
       const link = screen.getByText('Link');
       expect(link).toBeInTheDocument();
     });
+    it('should call "onClick" when link is clicked', () => {
+      const onClickMock = jest.fn();
+      const linkProps = { ...props, onClick: onClickMock };
+      render(<Link {...linkProps}>Link</Link>);
+      screen.getByText('Link').click();
+      expect(onClickMock).toHaveBeenCalled();
+    });
   });
   describe('when rendering an external link', () => {
     beforeEach(() => {
@@ -27,11 +34,18 @@ describe('rendering', () => {
         isFoo: 'bar',
       });
     });
-    it('should render a react router link', () => {
+    it('should render a native link', () => {
       render(<Link {...props}>Link</Link>);
       const link = screen.getByText('Link');
       expect(link).toBeInTheDocument();
       expect(link).toHaveProperty('href', props.to);
+    });
+    it('should call "onClick" when link is clicked', () => {
+      const onClickMock = jest.fn();
+      const linkProps = { ...props, onClick: onClickMock };
+      render(<Link {...linkProps}>Link</Link>);
+      screen.getByText('Link').click();
+      expect(onClickMock).toHaveBeenCalled();
     });
   });
   describe('when rendering a translated link', () => {

--- a/packages/components/link/src/link.tsx
+++ b/packages/components/link/src/link.tsx
@@ -1,6 +1,11 @@
 import type { LocationDescriptor } from 'history';
 import type { MessageDescriptor } from 'react-intl';
-import { Children, type ReactNode } from 'react';
+import {
+  Children,
+  type ReactNode,
+  type MouseEvent,
+  type KeyboardEvent,
+} from 'react';
 import styled from '@emotion/styled';
 import { Link as ReactRouterLink } from 'react-router-dom';
 import { css } from '@emotion/react';
@@ -38,6 +43,13 @@ type TLinkProps = {
    * Color of the link
    */
   tone?: 'primary' | 'inverted';
+
+  /**
+   * Handler when the link is clicked.
+   */
+  onClick?: (
+    event: MouseEvent<HTMLLinkElement> | KeyboardEvent<HTMLLinkElement>
+  ) => void;
 };
 type TIconColor = 'primary' | 'surface';
 


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1K2q1DTyiIPZTdgr7TmzzLpWGAS5DB53w%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=mcxXD_f)

#### Summary

`Link` component allows for the `onClick` prop but it is not defined in its props typescript type.

## Description

We just add the `onClick` to the `Link` component props typescript definition and also include a couple of tests to verify this prop is called when provided after clicking the component, both when we render a `react-router-dom` link or a native HTML one.
