### PR TITLE
feat(design-system): export `resets.css` styles

### DIFF
--- a/.changeset/purple-flowers-provide.md
+++ b/.changeset/purple-flowers-provide.md
@@ -1,0 +1,9 @@
+---
+'@commercetools-uikit/design-system': minor
+---
+
+Expose global reset styles from `/materials` entry point.
+
+```js
+import '@commercetools-uikit/design-system/materials/resets.css';
+```

--- a/design-system/materials/resets.css
+++ b/design-system/materials/resets.css
@@ -1,0 +1,40 @@
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  box-sizing: border-box;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+}
+
+button {
+  cursor: pointer;
+}
+
+a {
+  color: var(--color-primary);
+  cursor: pointer;
+  text-decoration: none;
+  transition: color 0.2s ease-in;
+}
+
+p {
+  color: var(--font-color-for-text);
+  margin: 0;
+}

--- a/design-system/materials/resets.css
+++ b/design-system/materials/resets.css
@@ -6,6 +6,8 @@
 
 html,
 body {
+  color: var(--font-color-for-text);
+  font-family: var(--font-family);
   margin: 0;
   padding: 0;
 }
@@ -35,6 +37,5 @@ a {
 }
 
 p {
-  color: var(--font-color-for-text);
   margin: 0;
 }

--- a/docs/.storybook/config.js
+++ b/docs/.storybook/config.js
@@ -1,3 +1,4 @@
+import '@commercetools-uikit/design-system/materials/resets.css';
 import { addParameters, configure, addDecorator } from '@storybook/react';
 import { withContexts } from '@storybook/addon-contexts/react';
 import { addReadme } from 'storybook-readme';

--- a/docs/.storybook/preview-head.html
+++ b/docs/.storybook/preview-head.html
@@ -7,8 +7,6 @@
     color: var(--font-color-for-text);
     font-family: var(--font-family);
     font-size: var(--font-size-for-body);
-    margin: 0;
-    padding: 0;
   }
 
   body {

--- a/docs/.storybook/preview-head.html
+++ b/docs/.storybook/preview-head.html
@@ -4,8 +4,6 @@
 <style>
   html,
   body {
-    color: var(--font-color-for-text);
-    font-family: var(--font-family);
     font-size: var(--font-size-for-body);
   }
 

--- a/docs/.storybook/webpack.config.js
+++ b/docs/.storybook/webpack.config.js
@@ -65,6 +65,19 @@ module.exports = ({ config }) => {
         },
       ],
     },
+    {
+      test: /\.css$/,
+      sideEffects: true,
+      use: [
+        require.resolve('style-loader'),
+        {
+          loader: require.resolve('css-loader'),
+          options: {
+            importLoaders: 1,
+          },
+        },
+      ],
+    },
     // Storybook uses a plugin to load and render markdown files.
     {
       test: /\.md$/,

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,6 +23,7 @@
     "@storybook/react": "5.3.21",
     "@storybook/theming": "5.3.21",
     "babel-loader": "8.2.5",
+    "css-loader": "5.2.7",
     "html-loader": "1.3.2",
     "markdown-loader": "7.0.0",
     "moment": "2.29.4",
@@ -31,6 +32,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "storybook-readme": "5.0.9",
+    "style-loader": "2.0.0",
     "yaml": "1.10.2",
     "yaml-loader": "0.8.0"
   },

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -3087,6 +3087,7 @@ __metadata:
     "@storybook/react": 5.3.21
     "@storybook/theming": 5.3.21
     babel-loader: 8.2.5
+    css-loader: 5.2.7
     html-loader: 1.3.2
     markdown-loader: 7.0.0
     moment: 2.29.4
@@ -3096,6 +3097,7 @@ __metadata:
     react: 17.0.2
     react-dom: 17.0.2
     storybook-readme: 5.0.9
+    style-loader: 2.0.0
     webpack: 4.46.0
     yaml: 1.10.2
     yaml-loader: 0.8.0
@@ -7057,6 +7059,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css-loader@npm:5.2.7":
+  version: 5.2.7
+  resolution: "css-loader@npm:5.2.7"
+  dependencies:
+    icss-utils: ^5.1.0
+    loader-utils: ^2.0.0
+    postcss: ^8.2.15
+    postcss-modules-extract-imports: ^3.0.0
+    postcss-modules-local-by-default: ^4.0.0
+    postcss-modules-scope: ^3.0.0
+    postcss-modules-values: ^4.0.0
+    postcss-value-parser: ^4.1.0
+    schema-utils: ^3.0.0
+    semver: ^7.3.5
+  peerDependencies:
+    webpack: ^4.27.0 || ^5.0.0
+  checksum: fb0742b30ac0919f94b99a323bdefe6d48ae46d66c7d966aae59031350532f368f8bba5951fcd268f2e053c5e6e4655551076268e9073ccb58e453f98ae58f8e
+  languageName: node
+  linkType: hard
+
 "css-loader@npm:^3.0.0":
   version: 3.6.0
   resolution: "css-loader@npm:3.6.0"
@@ -9194,6 +9216,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"icss-utils@npm:^5.0.0, icss-utils@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "icss-utils@npm:5.1.0"
+  peerDependencies:
+    postcss: ^8.1.0
+  checksum: 5c324d283552b1269cfc13a503aaaa172a280f914e5b81544f3803bc6f06a3b585fb79f66f7c771a2c052db7982c18bf92d001e3b47282e3abbbb4c4cc488d68
+  languageName: node
+  linkType: hard
+
 "ieee754@npm:^1.1.4":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
@@ -11014,6 +11045,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.4":
+  version: 3.3.4
+  resolution: "nanoid@npm:3.3.4"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 2fddd6dee994b7676f008d3ffa4ab16035a754f4bb586c61df5a22cf8c8c94017aadd360368f47d653829e0569a92b129979152ff97af23a558331e47e37cd9c
+  languageName: node
+  linkType: hard
+
 "nanomatch@npm:^1.2.9":
   version: 1.2.13
   resolution: "nanomatch@npm:1.2.13"
@@ -11911,6 +11951,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-modules-extract-imports@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "postcss-modules-extract-imports@npm:3.0.0"
+  peerDependencies:
+    postcss: ^8.1.0
+  checksum: 4b65f2f1382d89c4bc3c0a1bdc5942f52f3cb19c110c57bd591ffab3a5fee03fcf831604168205b0c1b631a3dce2255c70b61aaae3ef39d69cd7eb450c2552d2
+  languageName: node
+  linkType: hard
+
 "postcss-modules-local-by-default@npm:^3.0.2":
   version: 3.0.3
   resolution: "postcss-modules-local-by-default@npm:3.0.3"
@@ -11920,6 +11969,19 @@ __metadata:
     postcss-selector-parser: ^6.0.2
     postcss-value-parser: ^4.1.0
   checksum: 0267633eaf80e72a3abf391b6e34c5b344a1bdfb1421543d3ed43fc757e053e0fcc1a2eb06d959a8f435776e8dc80288b59bfc34d61e5e021d47b747c417c5a1
+  languageName: node
+  linkType: hard
+
+"postcss-modules-local-by-default@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "postcss-modules-local-by-default@npm:4.0.0"
+  dependencies:
+    icss-utils: ^5.0.0
+    postcss-selector-parser: ^6.0.2
+    postcss-value-parser: ^4.1.0
+  peerDependencies:
+    postcss: ^8.1.0
+  checksum: 6cf570badc7bc26c265e073f3ff9596b69bb954bc6ac9c5c1b8cba2995b80834226b60e0a3cbb87d5f399dbb52e6466bba8aa1d244f6218f99d834aec431a69d
   languageName: node
   linkType: hard
 
@@ -11933,6 +11995,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-modules-scope@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "postcss-modules-scope@npm:3.0.0"
+  dependencies:
+    postcss-selector-parser: ^6.0.4
+  peerDependencies:
+    postcss: ^8.1.0
+  checksum: 330b9398dbd44c992c92b0dc612c0626135e2cc840fee41841eb61247a6cfed95af2bd6f67ead9dd9d0bb41f5b0367129d93c6e434fa3e9c58ade391d9a5a138
+  languageName: node
+  linkType: hard
+
 "postcss-modules-values@npm:^3.0.0":
   version: 3.0.0
   resolution: "postcss-modules-values@npm:3.0.0"
@@ -11943,6 +12016,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-modules-values@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "postcss-modules-values@npm:4.0.0"
+  dependencies:
+    icss-utils: ^5.0.0
+  peerDependencies:
+    postcss: ^8.1.0
+  checksum: f7f2cdf14a575b60e919ad5ea52fed48da46fe80db2733318d71d523fc87db66c835814940d7d05b5746b0426e44661c707f09bdb83592c16aea06e859409db6
+  languageName: node
+  linkType: hard
+
 "postcss-selector-parser@npm:^6.0.0, postcss-selector-parser@npm:^6.0.2":
   version: 6.0.6
   resolution: "postcss-selector-parser@npm:6.0.6"
@@ -11950,6 +12034,16 @@ __metadata:
     cssesc: ^3.0.0
     util-deprecate: ^1.0.2
   checksum: 3602758798048bffbd6a97d6f009b32a993d6fd2cc70775bb59593e803d7fa8738822ecffb2fafc745edf7fad297dad53c30d2cfe78446a7d3f4a4a258cb15b2
+  languageName: node
+  linkType: hard
+
+"postcss-selector-parser@npm:^6.0.4":
+  version: 6.0.10
+  resolution: "postcss-selector-parser@npm:6.0.10"
+  dependencies:
+    cssesc: ^3.0.0
+    util-deprecate: ^1.0.2
+  checksum: 46afaa60e3d1998bd7adf6caa374baf857cc58d3ff944e29459c9a9e4680a7fe41597bd5b755fc81d7c388357e9bf67c0251d047c640a09f148e13606b8a8608
   languageName: node
   linkType: hard
 
@@ -11967,6 +12061,17 @@ __metadata:
     picocolors: ^0.2.1
     source-map: ^0.6.1
   checksum: 4ac793f506c23259189064bdc921260d869a115a82b5e713973c5af8e94fbb5721a5cc3e1e26840500d7e1f1fa42a209747c5b1a151918a9bc11f0d7ed9048e3
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.2.15":
+  version: 8.4.19
+  resolution: "postcss@npm:8.4.19"
+  dependencies:
+    nanoid: ^3.3.4
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: 62782723a385f92b7525f66d29614624de7c5643855423db3a5efd9287e677650300192749adddbbb6734cea9b1d5f5fd4f6ea00ca3f9a95dbbb88f835f5ca64
   languageName: node
   linkType: hard
 
@@ -13708,6 +13813,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map-js@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "source-map-js@npm:1.0.2"
+  checksum: c049a7fc4deb9a7e9b481ae3d424cc793cb4845daa690bc5a05d428bf41bf231ced49b4cf0c9e77f9d42fdb3d20d6187619fc586605f5eabe995a316da8d377c
+  languageName: node
+  linkType: hard
+
 "source-map-resolve@npm:^0.5.0":
   version: 0.5.3
   resolution: "source-map-resolve@npm:0.5.3"
@@ -14072,6 +14184,18 @@ __metadata:
   dependencies:
     min-indent: ^1.0.0
   checksum: 18f045d57d9d0d90cd16f72b2313d6364fd2cb4bf85b9f593523ad431c8720011a4d5f08b6591c9d580f446e78855c5334a30fb91aa1560f5d9f95ed1b4a0530
+  languageName: node
+  linkType: hard
+
+"style-loader@npm:2.0.0":
+  version: 2.0.0
+  resolution: "style-loader@npm:2.0.0"
+  dependencies:
+    loader-utils: ^2.0.0
+    schema-utils: ^3.0.0
+  peerDependencies:
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: 21425246a5a8f14d1625a657a3a56f8a323193fa341a71af818a2ed2a429efa2385a328b4381cf2f12c2d0e6380801eb9e0427ed9c3a10ff95c86e383184d632
   languageName: node
   linkType: hard
 

--- a/visual-testing-app/index.html
+++ b/visual-testing-app/index.html
@@ -10,17 +10,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:slnt,wght@-10,400;-10,500;0,400;0,500;0,600;0,700&family=Open+Sans:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
     <title>UI-Kit | Visual testing app</title>
-    <style>
-      html,
-      body {
-        color: var(--font-color-for-text);
-        font-family: var(--font-family);
-        font-size: var(--font-size-for-body);
-        margin: 0;
-        padding: 0;
-        height: 100vh;
-      }
-    </style>
   </head>
   <body>
     <div id="app"></div>

--- a/visual-testing-app/src/App.jsx
+++ b/visual-testing-app/src/App.jsx
@@ -1,3 +1,4 @@
+import './globals.css';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import { ThemeProvider } from '@commercetools-uikit/design-system';
 

--- a/visual-testing-app/src/globals.css
+++ b/visual-testing-app/src/globals.css
@@ -1,0 +1,9 @@
+@import '@commercetools-uikit/design-system/materials/resets.css';
+
+html,
+body {
+  color: var(--font-color-for-text);
+  font-family: var(--font-family);
+  font-size: var(--font-size-for-body);
+  height: 100vh;
+}

--- a/visual-testing-app/src/globals.css
+++ b/visual-testing-app/src/globals.css
@@ -2,8 +2,6 @@
 
 html,
 body {
-  color: var(--font-color-for-text);
-  font-family: var(--font-family);
   font-size: var(--font-size-for-body);
   height: 100vh;
 }


### PR DESCRIPTION
Extracting some of the changes from #2324 

Most of the resets styles are currently [defined in App Kit](https://github.com/commercetools/merchant-center-application-kit/blob/87853f778b03fc86363333e7c1bc1953a7728ef4/packages/application-shell/src/components/application-shell/global-styles.tsx#L53-L98). However, some of them are tightly related to basic styles which are more a concern of the design system.

This PR proposes to expose a `resets.css` file from the `design-system` package that can be used by the consumers of the UI Kit. This should make it easier to manage basic changes in one place.

Happy to hear your thoughts and if this makes sense or not.