### PR TITLE
Export utility helpers to transform from design tokens to CSS vars

### DIFF
--- a/.changeset/few-toes-roll.md
+++ b/.changeset/few-toes-roll.md
@@ -1,0 +1,32 @@
+---
+'@commercetools-uikit/design-system': patch
+---
+
+New helper functions to transform from design tokens to CSS vars.
+
+Let's say we have an object with design tokens data like this:
+```
+{
+  colorPrimary: '#00b39e',
+}
+```
+
+We can transform the object to use CSS var names keys:
+```
+transformTokensToCssVarsValues(tokens);
+
+// Output
+{
+  '--color-primary': '#00b39e',
+}
+```
+
+We can also tranform the object to use CSS var references values:
+```
+transformTokensToCssVarsReferences(tokens);
+
+// Output
+{
+  'colorPrimary': 'var(--color-primary, #00b39e)',
+}
+```

--- a/design-system/src/index.ts
+++ b/design-system/src/index.ts
@@ -5,5 +5,6 @@ export {
   themes,
 } from './design-tokens';
 export { ThemeProvider, useTheme } from './theme-provider';
+export * from './utils';
 
 export { default as version } from './version';

--- a/design-system/src/theme-provider.tsx
+++ b/design-system/src/theme-provider.tsx
@@ -1,18 +1,13 @@
 import { useLayoutEffect, useState, useRef, useEffect } from 'react';
-import kebabCase from 'lodash/kebabCase';
 import isObject from 'lodash/isObject';
 import merge from 'lodash/merge';
 import isEqual from 'lodash/isEqual';
 import { themes } from './design-tokens';
+import { transformTokensToCssVarsValues } from './utils';
 
 const allThemesNames = Object.keys(themes);
 
 type ThemeName = keyof typeof themes;
-
-const toVars = (obj: Record<string, string>) =>
-  Object.fromEntries(
-    Object.entries(obj).map(([key, value]) => [`--${kebabCase(key)}`, value])
-  );
 
 // used to cover SSR builds (for instance in Gatsby)
 const isBrowser = typeof window !== 'undefined';
@@ -45,7 +40,7 @@ const applyTheme = ({
     );
   }
 
-  const vars = toVars(
+  const vars = transformTokensToCssVarsValues(
     merge(
       {},
       themes.default,

--- a/design-system/src/utils.spec.ts
+++ b/design-system/src/utils.spec.ts
@@ -1,0 +1,62 @@
+import {
+  transformTokensToCssVarsValues,
+  transformTokensToCssVarsDefinitions,
+} from './utils';
+
+describe('Utils', () => {
+  const tokens = {
+    colorPrimary: '#00b39e',
+    borderRadius4: '4px',
+    borderForButtonAsSecondary: '1px solid var(--color-neutral)',
+    paddingForCard: `var(--spacing-m, 16px) var(--spacing-xl, 32px)`,
+  };
+
+  describe('transformTokensToCssVarsValues', () => {
+    it('should transform tokens to css var values', () => {
+      const transformed = transformTokensToCssVarsValues(tokens);
+
+      expect(transformed).toMatchInlineSnapshot(`
+        {
+          "--border-for-button-as-secondary": "1px solid var(--color-neutral)",
+          "--border-radius-4": "4px",
+          "--color-primary": "#00b39e",
+          "--padding-for-card": "var(--spacing-m, 16px) var(--spacing-xl, 32px)",
+        }
+      `);
+    });
+  });
+
+  describe('transformTokensToCssVarsDefinitions', () => {
+    describe('with includeDefaultValue default value (true)', () => {
+      it('should transform tokens to css var definitions', () => {
+        const transformed = transformTokensToCssVarsDefinitions(tokens);
+
+        expect(transformed).toMatchInlineSnapshot(`
+          {
+            "borderForButtonAsSecondary": "var(--border-for-button-as-secondary, 1px solid var(--color-neutral))",
+            "borderRadius4": "var(--border-radius-4, 4px)",
+            "colorPrimary": "var(--color-primary, #00b39e)",
+            "paddingForCard": "var(--padding-for-card, var(--spacing-m, 16px) var(--spacing-xl, 32px))",
+          }
+        `);
+      });
+    });
+
+    describe('with includeDefaultValue default value set to false', () => {
+      it('should transform tokens to css var definitions', () => {
+        const transformed = transformTokensToCssVarsDefinitions(tokens, {
+          includeDefaultValue: false,
+        });
+
+        expect(transformed).toMatchInlineSnapshot(`
+          {
+            "borderForButtonAsSecondary": "var(--border-for-button-as-secondary)",
+            "borderRadius4": "var(--border-radius-4)",
+            "colorPrimary": "var(--color-primary)",
+            "paddingForCard": "var(--padding-for-card)",
+          }
+        `);
+      });
+    });
+  });
+});

--- a/design-system/src/utils.spec.ts
+++ b/design-system/src/utils.spec.ts
@@ -1,6 +1,6 @@
 import {
   transformTokensToCssVarsValues,
-  transformTokensToCssVarsDefinitions,
+  transformTokensToCssVarsReferences,
 } from './utils';
 
 describe('Utils', () => {
@@ -26,10 +26,10 @@ describe('Utils', () => {
     });
   });
 
-  describe('transformTokensToCssVarsDefinitions', () => {
+  describe('transformTokensToCssVarsReferences', () => {
     describe('with includeDefaultValue default value (true)', () => {
       it('should transform tokens to css var definitions', () => {
-        const transformed = transformTokensToCssVarsDefinitions(tokens);
+        const transformed = transformTokensToCssVarsReferences(tokens);
 
         expect(transformed).toMatchInlineSnapshot(`
           {
@@ -44,7 +44,7 @@ describe('Utils', () => {
 
     describe('with includeDefaultValue default value set to false', () => {
       it('should transform tokens to css var definitions', () => {
-        const transformed = transformTokensToCssVarsDefinitions(tokens, {
+        const transformed = transformTokensToCssVarsReferences(tokens, {
           includeDefaultValue: false,
         });
 

--- a/design-system/src/utils.ts
+++ b/design-system/src/utils.ts
@@ -35,7 +35,7 @@ function transformTokensToCssVarsValues(
     borderRadius4: 'var(--border-radius-4, 4px)',
   }
 */
-function transformTokensToCssVarsDefinitions(
+function transformTokensToCssVarsReferences(
   tokens: Record<string, string>,
   { includeDefaultValue } = { includeDefaultValue: true }
 ): Record<string, string> {
@@ -47,4 +47,4 @@ function transformTokensToCssVarsDefinitions(
   );
 }
 
-export { transformTokensToCssVarsValues, transformTokensToCssVarsDefinitions };
+export { transformTokensToCssVarsValues, transformTokensToCssVarsReferences };

--- a/design-system/src/utils.ts
+++ b/design-system/src/utils.ts
@@ -1,0 +1,50 @@
+import kebabCase from 'lodash/kebabCase';
+
+/*
+  This will transform a map of tokens names/values to
+  a map of css var names/values
+
+  Example input:
+  {
+    borderRadius4: '4px',
+  }
+  Example output:
+  {
+     '--border-radius-4': '4px',
+  }
+*/
+function transformTokensToCssVarsValues(
+  tokens: Record<string, string>
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(tokens).map(([key, value]) => [`--${kebabCase(key)}`, value])
+  );
+}
+
+/*
+  This will transform a map of tokens names/values to
+  a map of token names/css var definitions.
+  Including default css value in the definition is optional (true by default)
+
+  Example input:
+  {
+    borderRadius4: '4px',
+  }
+  Example output:
+  {
+    borderRadius4: 'var(--border-radius-4, 4px)',
+  }
+*/
+function transformTokensToCssVarsDefinitions(
+  tokens: Record<string, string>,
+  { includeDefaultValue } = { includeDefaultValue: true }
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(tokens).map(([key, value]) => [
+      key,
+      `var(--${kebabCase(key)}${includeDefaultValue ? ', ' + value : ''})`,
+    ])
+  );
+}
+
+export { transformTokensToCssVarsValues, transformTokensToCssVarsDefinitions };


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX17xWMWk5e7c8strlZy0Ke7ZNR66J8EMQg%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=ZwmdL-5)

### Summary

Export utility helpers to transform from design tokens to CSS vars

## Description

We realized there are a couple of consumer repositories that are implementing transformer utilities to convert from design tokens map to CSS vars.

Having an input design tokens map like this:
```
{
  colorPrimary: '#00b39e',
  borderRadius4: '4px',
}
```

We might want to transform that object to be a map where keys are CSS var names and values are the CSS values:
```
{
  '--color-primary': '#00b39e',
  '--border-radius-4': '4px',
}
```

Another option would be the transform the values to be CSS var references to be used:
```
{
  colorPrimary: 'var(--color-primary, #00b39e)',
  borderRadius4: 'var(--border-radius-4, 4px)',
}
```