### PR TITLE
Fix design tokens not loading in production environment

### DIFF
--- a/docs/.storybook/configs/theme-context.js
+++ b/docs/.storybook/configs/theme-context.js
@@ -19,11 +19,15 @@ const themeParams = [
     name: 'Default Theme',
     props: { themeName: 'default' },
   },
-  {
+];
+
+// Do not show the new test theme in public environment
+if (process.env.VERCEL_ENV !== 'production') {
+  themeParams.push({
     name: 'Test Theme',
     props: { themeName: 'test' },
-  },
-];
+  });
+}
 
 const themeContext = {
   icon: 'box', // a icon displayed in the Storybook toolbar to control contextual props
@@ -32,8 +36,6 @@ const themeContext = {
   params: themeParams,
   options: {
     deep: true, // pass the `props` deeply into all wrapping components
-    // Disable only in the main production environment.
-    disable: process.env.VERCEL_ENV === 'production', // disable this contextual environment completely
     cancelable: false, // allow this contextual environment to be opt-out optionally in toolbar
   },
 };


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19f5r7Q03K8ENjeXiPU777K9OcwZ1ElOQ%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=lfZa2-D)

#### Summary

Design tokens are not loaded in Storybook production environment. 

## Description

Since we don't want to make public the testing theme, we are not rendering the Theme switcher in the production environment but, as that switcher is the one rendering the `ThemeProvider` component which deals with loading the design tokens in the document, no token is loaded.

This is a basic and fast solution where we render the switcher although we will only have one option available in production environment.
