### PR TITLE
Fix `Tag` component design tokens values in new theme

### DIFF
--- a/.changeset/rotten-moons-peel.md
+++ b/.changeset/rotten-moons-peel.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-uikit/design-system': patch
+'@commercetools-uikit/tag': patch
+---
+
+Fix `Tag` component design tokens

--- a/design-system/materials/internals/definition.yaml
+++ b/design-system/materials/internals/definition.yaml
@@ -591,12 +591,6 @@ decisionGroupsByTheme:
           choice: '#E7680D' # color-warning with 5% black opacity
         background-color-for-button-when-disabled:
           choice: color-neutral-95
-        background-color-for-tag:
-          description: ''
-          choice: color-warning-95
-        background-color-for-tag-warning:
-          description: ''
-          choice: color-neutral-95
 
     borders:
       label: Borders

--- a/design-system/src/design-tokens.ts
+++ b/design-system/src/design-tokens.ts
@@ -240,8 +240,6 @@ export const themes = {
     backgroundColorForButtonAsUrgentWhenActive: '#DC630A',
     backgroundColorForButtonAsUrgentWhenHovered: '#E7680D',
     backgroundColorForButtonWhenDisabled: 'hsl(0, 0%, 95%)',
-    backgroundColorForTag: 'hsl(25.110132158590307, 89.0196078431%, 95%)',
-    backgroundColorForTagWarning: 'hsl(0, 0%, 95%)',
     borderForButtonAsSecondary: '1px solid var(--color-neutral)',
     borderForButtonAsSecondaryWhenHovered: '1px solid var(--color-neutral)',
     borderForButtonAsSecondaryWhenActive: '1px solid var(--color-neutral)',

--- a/packages/components/tag/src/tag-body.tsx
+++ b/packages/components/tag/src/tag-body.tsx
@@ -99,6 +99,9 @@ const TagBody = (props: TTagBodyProps) => {
                 right: -1px;
                 content: '';
                 background-color: ${designTokens.borderColorForTagWhenFocused};
+                background-color: ${props.type === 'warning'
+                  ? designTokens.borderColorForTagWarning
+                  : designTokens.borderColorForTagWhenFocused};
                 width: 1px;
                 height: 100%;
               }

--- a/packages/components/tag/src/tag-body.tsx
+++ b/packages/components/tag/src/tag-body.tsx
@@ -98,7 +98,6 @@ const TagBody = (props: TTagBodyProps) => {
                 position: absolute;
                 right: -1px;
                 content: '';
-                background-color: ${designTokens.borderColorForTagWhenFocused};
                 background-color: ${props.type === 'warning'
                   ? designTokens.borderColorForTagWarning
                   : designTokens.borderColorForTagWhenFocused};


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18wttyCCnTnBQif6FHI2uESuuflMfBOMbE%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=SI3CGuH)

## Summary

Fix `Tag` component design tokens values in new theme

## Description

The values for the background color used in the new theme were invalid. Actually, the background color should not change by theme.

Also, I found a visual bug with the right border of the component when using type warning, onClick and the mouse over the component:
### Before
![image](https://user-images.githubusercontent.com/97907068/203355974-d2475572-9b1e-4de6-a8dc-d2c5a29c0fee.png)

### After
![image](https://user-images.githubusercontent.com/97907068/203356157-c01e6580-42b1-4559-a583-bf5bbc168549.png)

