### PR TITLE
Fix `useTheme` hook

### DIFF
--- a/.changeset/heavy-hornets-pretend.md
+++ b/.changeset/heavy-hornets-pretend.md
@@ -2,4 +2,4 @@
 '@commercetools-uikit/design-system': patch
 ---
 
-Fix `useHook` to keep the returned current selected theme name in sync with the provider.
+Fix `useTheme` hook to keep the returned current selected theme name in sync with the provider.

--- a/.changeset/heavy-hornets-pretend.md
+++ b/.changeset/heavy-hornets-pretend.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/design-system': patch
+---
+
+Fix `useHook` to keep the returned current selected theme name in sync with the provider.

--- a/.changeset/nasty-ears-deliver.md
+++ b/.changeset/nasty-ears-deliver.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/tag': patch
+---
+
+Refactor `useHook` usage.

--- a/design-system/src/theme-provider.tsx
+++ b/design-system/src/theme-provider.tsx
@@ -93,7 +93,7 @@ ThemeProvider.defaultProps = {
 };
 
 type TUseThemeResult = {
-  currentTheme: ThemeName;
+  theme: ThemeName;
 };
 const useTheme = (parentSelector = defaultParentSelector): TUseThemeResult => {
   const [theme, setTheme] = useState<ThemeName>('default');
@@ -135,7 +135,7 @@ const useTheme = (parentSelector = defaultParentSelector): TUseThemeResult => {
     return () => observer.disconnect();
   }, []);
 
-  return { currentTheme: theme };
+  return { theme };
 };
 
 export { ThemeProvider, useTheme };

--- a/design-system/src/theme-provider.tsx
+++ b/design-system/src/theme-provider.tsx
@@ -117,7 +117,7 @@ const useTheme = (parentSelector = defaultParentSelector): TUseThemeResult => {
 
     if (themeDomNode) {
       // We need to read the current theme after the provider is rendered
-      // to have the actual selected theme (calulated client-side) in the
+      // to have the actual selected theme (calculated client-side) in the
       // hook local state
       setTheme((themeDomNode.dataset.theme as ThemeName) || 'default');
 

--- a/design-system/src/theme-provider.tsx
+++ b/design-system/src/theme-provider.tsx
@@ -119,7 +119,10 @@ const useTheme = (parentSelector = defaultParentSelector): TUseThemeResult => {
       // We need to read the current theme after the provider is rendered
       // to have the actual selected theme (calculated client-side) in the
       // hook local state
-      setTheme((themeDomNode.dataset.theme as ThemeName) || 'default');
+      const nextTheme = themeDomNode.dataset.theme as ThemeName;
+      if (nextTheme) {
+        setTheme(nextTheme);
+      }
 
       // We observe the theme DOM node for changes in its `data-theme`
       // attribute, which is the one we update in the `applyTheme` function

--- a/design-system/src/theme-provider.visualroute.jsx
+++ b/design-system/src/theme-provider.visualroute.jsx
@@ -16,7 +16,7 @@ export const routePath = '/theme-provider';
 const parentSelector = (id) => () => document.getElementById(id);
 
 const DummyComponent = (props) => {
-  const theme = useTheme(parentSelector(props.parentId));
+  const { currentTheme } = useTheme(parentSelector(props.parentId));
 
   return (
     <h1
@@ -30,7 +30,7 @@ const DummyComponent = (props) => {
     >
       {props.title ?? (
         <>
-          Title with {theme} theme <i>colorSolid</i> design token
+          Title with {currentTheme} theme <i>colorSolid</i> design token
         </>
       )}
     </h1>

--- a/design-system/src/theme-provider.visualroute.jsx
+++ b/design-system/src/theme-provider.visualroute.jsx
@@ -16,7 +16,7 @@ export const routePath = '/theme-provider';
 const parentSelector = (id) => () => document.getElementById(id);
 
 const DummyComponent = (props) => {
-  const { currentTheme } = useTheme(
+  const { theme } = useTheme(
     props.parentId
       ? parentSelector(props.parentId)
       : undefined
@@ -34,7 +34,7 @@ const DummyComponent = (props) => {
     >
       {props.title ?? (
         <>
-          Title with {currentTheme} theme <i>colorSolid</i> design token
+          Title with {theme} theme <i>colorSolid</i> design token
         </>
       )}
     </h1>

--- a/design-system/src/theme-provider.visualroute.jsx
+++ b/design-system/src/theme-provider.visualroute.jsx
@@ -16,7 +16,11 @@ export const routePath = '/theme-provider';
 const parentSelector = (id) => () => document.getElementById(id);
 
 const DummyComponent = (props) => {
-  const { currentTheme } = useTheme(parentSelector(props.parentId));
+  const { currentTheme } = useTheme(
+    props.parentId
+      ? parentSelector(props.parentId)
+      : () => document.documentElement
+  );
 
   return (
     <h1

--- a/design-system/src/theme-provider.visualroute.jsx
+++ b/design-system/src/theme-provider.visualroute.jsx
@@ -19,7 +19,7 @@ const DummyComponent = (props) => {
   const { currentTheme } = useTheme(
     props.parentId
       ? parentSelector(props.parentId)
-      : () => document.documentElement
+      : undefined
   );
 
   return (

--- a/packages/components/tag/src/tag-body.tsx
+++ b/packages/components/tag/src/tag-body.tsx
@@ -72,11 +72,11 @@ const getContentWrapperStyles = (props: TTagBodyProps) => {
 };
 
 const TagBody = (props: TTagBodyProps) => {
-  const { currentTheme } = useTheme();
+  const { theme } = useTheme();
   const textTone = props.isDisabled ? 'secondary' : undefined;
   // TODO: This is a temporary solution due to theme migration. After the new
   // theme is published, we must remove this and just use the `Text.Body` component
-  const TextComponent = currentTheme === 'default' ? Text.Detail : Text.Body;
+  const TextComponent = theme === 'default' ? Text.Detail : Text.Body;
 
   return (
     <Body

--- a/packages/components/tag/src/tag-body.tsx
+++ b/packages/components/tag/src/tag-body.tsx
@@ -72,7 +72,7 @@ const getContentWrapperStyles = (props: TTagBodyProps) => {
 };
 
 const TagBody = (props: TTagBodyProps) => {
-  const currentTheme = useTheme();
+  const { currentTheme } = useTheme();
   const textTone = props.isDisabled ? 'secondary' : undefined;
   // TODO: This is a temporary solution due to theme migration. After the new
   // theme is published, we must remove this and just use the `Text.Body` component


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1q4bxywP8JWXyyl0TMBaOo3CB7WWR4ud0%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=a27jD5v)

#### Summary

`useTheme` hook returns the selected theme but the value gets out of sync if it's changed.

## Description

Initially we thought the theme would not needed to be changed for the purpose of the migration but as we started working on it, we realized it's quite useful and also that's something we would like to have in the future (if we support official themes).

The current selected theme is not stored in a context state but in the DOM element where we set the design tokens up.
The `useHook` was just reading that value after first render so consumers can access to that value, but if the theme is changed, the hook keeps the old value.

We didn't realize about this problem as we weren't using the hook in our components yet, but as we start needing it to refactor the code of some components to adjust its UI for the new theme, we now see the problem.
Actually, the current problem is that the theme returned from the hook never changes, so the components using the hook does not get re-rendered when the theme changes in the page.

Since the value is stored in an HTML DOM node, I opted for using a [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) to get a notification whenever the attribute where we store the theme value is modified.

Also, I decided to change the return type of the hook: instead of returning a string with the current theme name, we now return an object containing a property with that value. This would make potential hook updates easier to digest by its consumers (currently we are using it almost nowhere, so this is a good time to do it).
