### PR TITLE
Add new hook to use `MutationObserver` API

### DIFF
--- a/.changeset/hot-files-marry.md
+++ b/.changeset/hot-files-marry.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/design-system': patch
+---
+
+Use SSR compatible mutation observer

--- a/.changeset/nice-apricots-tan.md
+++ b/.changeset/nice-apricots-tan.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/hooks': minor
+---
+
+Add new `useMutationObserver`

--- a/design-system/package.json
+++ b/design-system/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@babel/runtime": "^7.19.0",
     "@babel/runtime-corejs3": "^7.19.1",
+    "@commercetools-uikit/hooks": "15.11.2",
     "@emotion/react": "^11.4.0",
     "lodash": "4.17.21",
     "prop-types": "15.8.1",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -22,7 +22,9 @@
     "@babel/runtime": "^7.19.0",
     "@babel/runtime-corejs3": "^7.19.1",
     "@commercetools-uikit/utils": "15.11.2",
-    "lodash": "4.17.21"
+    "@types/raf-schd": "^4.0.1",
+    "lodash": "4.17.21",
+    "raf-schd": "^4.0.3"
   },
   "devDependencies": {
     "@testing-library/react": "12.1.5",

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,6 +1,7 @@
 export { default as useToggleState } from './use-toggle-state';
 export { default as usePrevious } from './use-previous';
 export { default as useFieldId } from './use-field-id';
+export { default as useMutationObserver } from './use-mutation-observer';
 export { default as useRowSelection } from './use-row-selection';
 export { default as useSorting } from './use-sorting';
 export { default as usePaginationState } from './use-pagination-state';

--- a/packages/hooks/src/use-mutation-observer/index.ts
+++ b/packages/hooks/src/use-mutation-observer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './use-mutation-observer';

--- a/packages/hooks/src/use-mutation-observer/use-mutation-observer.ts
+++ b/packages/hooks/src/use-mutation-observer/use-mutation-observer.ts
@@ -1,0 +1,107 @@
+// NOTE: This React hook is essentially the same as the [@react-hook/intersection-observer](https://www.npmjs.com/package/@react-hook/intersection-observer)
+// except for the usage of `MutationObserver` instead of `IntersectionObserver`.
+import { useEffect, useLayoutEffect, useRef } from 'react';
+import rafSchd from 'raf-schd';
+
+type TUseMutationObserverCallback = (
+  mutationsList: MutationRecord[],
+  observer: MutationObserver
+) => void;
+
+let _mutationObserver: ReturnType<typeof createMutationObserver>;
+
+const useLatest = <T>(current: T) => {
+  const storedValue = useRef(current);
+  useEffect(() => {
+    storedValue.current = current;
+  });
+  return storedValue;
+};
+
+function createMutationObserver() {
+  const callbacks = new Map<Node, TUseMutationObserverCallback[]>();
+  const observer = new MutationObserver(
+    rafSchd((mutationsList, observer) => {
+      const mutationsByTarget = mutationsList.reduce<
+        Map<Node, MutationRecord[]>
+      >((_mutationsByTarget, mutation) => {
+        const callbacksForTarget =
+          _mutationsByTarget.get(mutation.target) ?? [];
+        callbacksForTarget.push(mutation);
+        _mutationsByTarget.set(mutation.target, callbacksForTarget);
+        return _mutationsByTarget;
+      }, new Map());
+
+      mutationsByTarget.forEach((mutations, target) => {
+        const targetCallbacks = callbacks.get(target);
+        targetCallbacks?.forEach((cb) => cb(mutations, observer));
+      });
+    })
+  );
+
+  return {
+    observer,
+    subscribe(
+      target: HTMLElement,
+      callback: TUseMutationObserverCallback,
+      options?: MutationObserverInit
+    ) {
+      observer.observe(target, options);
+      const targetCallbacks = callbacks.get(target) ?? [];
+      targetCallbacks.push(callback);
+      callbacks.set(target, targetCallbacks);
+    },
+    unsubscribe(target: HTMLElement, callback: TUseMutationObserverCallback) {
+      const targetCallbacks = callbacks.get(target) ?? [];
+      if (targetCallbacks.length === 1) {
+        observer.disconnect();
+        callbacks.delete(target);
+        return;
+      }
+      const tcIndex = targetCallbacks.indexOf(callback);
+      if (tcIndex !== -1) targetCallbacks.splice(tcIndex, 1);
+      callbacks.set(target, targetCallbacks);
+    },
+  };
+}
+
+const getMutationObserver = () =>
+  !_mutationObserver
+    ? (_mutationObserver = createMutationObserver())
+    : _mutationObserver;
+
+function useMutationObserver<T extends HTMLElement>(
+  target: React.RefObject<T> | T | null,
+  callback: TUseMutationObserverCallback,
+  options?: MutationObserverInit
+): MutationObserver {
+  const mutationObserver = getMutationObserver();
+  const storedCallback = useLatest(callback);
+  const storedOptions = useLatest(options);
+
+  useLayoutEffect(() => {
+    let didUnsubscribe = false;
+    const targetEl = target && 'current' in target ? target.current : target;
+    if (!targetEl) return () => {};
+
+    function cb(mutationsList: MutationRecord[], observer: MutationObserver) {
+      if (didUnsubscribe) return;
+      storedCallback.current(mutationsList, observer);
+    }
+
+    mutationObserver.subscribe(
+      targetEl as HTMLElement,
+      cb,
+      storedOptions.current
+    );
+
+    return () => {
+      didUnsubscribe = true;
+      mutationObserver.unsubscribe(targetEl as HTMLElement, cb);
+    };
+  }, [target, mutationObserver, storedCallback, storedOptions]);
+
+  return mutationObserver.observer;
+}
+
+export default useMutationObserver;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3470,6 +3470,7 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.19.0
     "@babel/runtime-corejs3": ^7.19.1
+    "@commercetools-uikit/hooks": 15.11.2
     "@emotion/react": ^11.4.0
     lodash: 4.17.21
     nodemon: ^2.0.20
@@ -3599,7 +3600,9 @@ __metadata:
     "@babel/runtime-corejs3": ^7.19.1
     "@commercetools-uikit/utils": 15.11.2
     "@testing-library/react": 12.1.5
+    "@types/raf-schd": ^4.0.1
     lodash: 4.17.21
+    raf-schd: ^4.0.3
     react: 17.0.2
   peerDependencies:
     react: 17.x
@@ -7384,6 +7387,13 @@ __metadata:
   version: 15.7.4
   resolution: "@types/prop-types@npm:15.7.4"
   checksum: ef6e1899e59b876c273811b1bd845022fc66d5a3d11cb38a25b6c566b30514ae38fe20a40f67622f362a4f4f7f9224e22d8da101cff3d6e97e11d7b4c307cfc1
+  languageName: node
+  linkType: hard
+
+"@types/raf-schd@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@types/raf-schd@npm:4.0.1"
+  checksum: 0babaa85541aadc6e5f8aa64ec79cd68bf67ea56abb7610c8daf3ca5f4b1a75d12e4e147a0b5434938a4031650ebddc733021ec4e7db4f11f7955390ec32c917
   languageName: node
   linkType: hard
 
@@ -17187,7 +17197,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"raf-schd@npm:^4.0.2":
+"raf-schd@npm:^4.0.2, raf-schd@npm:^4.0.3":
   version: 4.0.3
   resolution: "raf-schd@npm:4.0.3"
   checksum: 45514041c5ad31fa96aef3bb3c572a843b92da2f2cd1cb4a47c9ad58e48761d3a4126e18daa32b2bfa0bc2551a42d8f324a0e40e536cb656969929602b4e8b58


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18N7ccWKQq24UO8HEqZe8XsQLnPSSpcxzc%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=9Tthkrf)

#### Summary

Include a new hook to easily use [MutationObserver API](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) in components.

## Description

The new implementation has been copied from the `app-kit` [repository](https://github.com/commercetools/merchant-center-application-kit/blob/main/packages/application-components/src/hooks/use-mutation-observer/use-mutation-observer.ts).

There are two changes over the original implementation:
1. `observer` configuration is not passed to the mutation observer factory but to the `observe` function instead. The way it was, since we only have one `observer` instance, if we configure several observers, only the configuration from the first one is used. (_I think we should change this also in `app-kit`_)
2. Instead of calling the consumer callback with one mutation record at a time, we call it with a list of all mutations received by the observer to follow the [MutationObserver behaviour](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/MutationObserver#parameters).
