### PR TITLE
PoC use `inherit` as an accepted value for `Text` components

### DIFF
--- a/packages/components/stamp/src/stamp.story.js
+++ b/packages/components/stamp/src/stamp.story.js
@@ -47,11 +47,15 @@ storiesOf('Components|Stamps', module)
                       color={themedValue(undefined, iconColorsMap[tone])}
                       size="medium"
                     />
-                    <Text.Detail>{'Hello'}</Text.Detail>
+                    <Text.Detail tone={themedValue('', 'inherit')}>
+                      {'Hello'}
+                    </Text.Detail>
                   </SpacingsInline>
                 </Stamp>
                 <Stamp tone={tone} isCondensed={boolean('isCondensed', false)}>
-                  <Text.Detail>{`tone="${tone}"`}</Text.Detail>
+                  <Text.Detail
+                    tone={themedValue('', 'inherit')}
+                  >{`tone="${tone}"`}</Text.Detail>
                 </Stamp>
               </SpacingsInline>
             );

--- a/packages/components/stamp/src/stamp.tsx
+++ b/packages/components/stamp/src/stamp.tsx
@@ -1,7 +1,6 @@
-// TODO: @redesign cleanup
 import type { ReactNode } from 'react';
 import { css } from '@emotion/react';
-import { designTokens, useTheme } from '@commercetools-uikit/design-system';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 type Tone =
   | 'critical'
@@ -21,7 +20,6 @@ type Props = {
    */
   isCondensed: boolean;
   children: ReactNode;
-  overrideTextColor?: boolean;
 };
 
 export const availableTones: Tone[] = [
@@ -32,6 +30,40 @@ export const availableTones: Tone[] = [
   'primary',
   'secondary',
 ];
+
+const tonesStylesMap = {
+  critical: {
+    backgroundColor: designTokens.colorError95,
+    borderColor: designTokens.borderColorForStampWhenError,
+    color: designTokens.colorError40,
+  },
+  warning: {
+    backgroundColor: designTokens.colorWarning95,
+    borderColor: designTokens.borderColorForStampWhenWarning,
+    color: designTokens.colorWarning40,
+  },
+  positive: {
+    backgroundColor: designTokens.backgroundColorForStampAsPositive,
+    borderColor: designTokens.borderColorForStampAsPositive,
+    color: designTokens.colorPrimary25,
+  },
+  information: {
+    backgroundColor: designTokens.colorInfo95,
+    borderColor: designTokens.borderColorForStampAsInformation,
+    color: designTokens.colorInfo40,
+  },
+  primary: {
+    backgroundColor: designTokens.colorPrimary95,
+    borderColor: designTokens.borderColorForStampAsPrimary,
+    color: designTokens.colorPrimary25,
+  },
+  secondary: {
+    backgroundColor: designTokens.colorNeutral95,
+    borderColor: designTokens.borderColorForStampAsSecondary,
+    color: designTokens.colorNeutral40,
+  },
+};
+
 const getPaddingStyle = (props: Props) => {
   if (props.isCondensed)
     return css`
@@ -43,108 +75,32 @@ const getPaddingStyle = (props: Props) => {
 };
 
 const getToneStyles = (props: Props) => {
-  switch (props.tone) {
-    case 'critical': {
-      return css`
-        background-color: ${designTokens.colorError95};
-        border: 1px solid ${designTokens.borderColorForStampWhenError};
-        &,
-        & * {
-          color: ${props.overrideTextColor
-            ? designTokens.colorError40 + '!important'
-            : 'inherit'};
-        }
-      `;
-    }
-    case 'warning': {
-      return css`
-        background-color: ${designTokens.colorWarning95};
-        border: 1px solid ${designTokens.borderColorForStampWhenWarning};
-        &,
-        & * {
-          color: ${props.overrideTextColor
-            ? designTokens.colorWarning40 + '!important'
-            : 'inherit'};
-        }
-      `;
-    }
-    case 'positive': {
-      return css`
-        background-color: ${designTokens.backgroundColorForStampAsPositive};
-        border: 1px solid ${designTokens.borderColorForStampAsPositive};
-        &,
-        & * {
-          color: ${props.overrideTextColor
-            ? designTokens.colorPrimary25 + '!important'
-            : 'inherit'};
-        }
-      `;
-    }
-    case 'information': {
-      return css`
-        background-color: ${designTokens.colorInfo95};
-        border: 1px solid ${designTokens.borderColorForStampAsInformation};
-        &,
-        & * {
-          color: ${props.overrideTextColor
-            ? designTokens.colorInfo40 + '!important'
-            : 'inherit'};
-        }
-      `;
-    }
-    case 'primary': {
-      return css`
-        background-color: ${designTokens.colorPrimary95};
-        border: 1px solid ${designTokens.borderColorForStampAsPrimary};
-        &,
-        & * {
-          color: ${props.overrideTextColor
-            ? designTokens.colorPrimary25 + '!important'
-            : 'inherit'};
-        }
-      `;
-    }
-    case 'secondary': {
-      return css`
-        background-color: ${designTokens.colorNeutral95};
-        border: 1px solid ${designTokens.borderColorForStampAsSecondary};
-        &,
-        & * {
-          color: ${props.overrideTextColor
-            ? designTokens.colorNeutral40 + '!important'
-            : 'inherit'};
-        }
-      `;
-    }
-    default:
-      return css``;
+  if (!props.tone || !tonesStylesMap[props.tone]) {
+    return css``;
   }
+
+  const toneStyles = tonesStylesMap[props.tone || ''];
+  return css`
+    background-color: ${toneStyles.backgroundColor};
+    border: 1px solid ${toneStyles.borderColor};
+    color: ${toneStyles.color};
+  `;
 };
 
-const getStampStyles = (props: Props) => {
+const getStampStyles = () => {
   return css`
-    color: ${props.overrideTextColor ? 'inherit' : designTokens.colorSolid};
+    color: ${designTokens.colorSolid};
     font-size: ${designTokens.fontSizeForStamp};
     border-radius: ${designTokens.borderRadiusForStamp};
   `;
 };
 
-const Stamp = (props: Props) => {
-  const { themedValue } = useTheme();
-  const overrideTextColor = props.overrideTextColor ?? themedValue(false, true);
+const Stamp = (props: Props) => (
+  <div css={[getStampStyles(), getToneStyles(props), getPaddingStyle(props)]}>
+    {props.children}
+  </div>
+);
 
-  return (
-    <div
-      css={[
-        getStampStyles({ ...props, overrideTextColor }),
-        getToneStyles({ ...props, overrideTextColor }),
-        getPaddingStyle(props),
-      ]}
-    >
-      {props.children}
-    </div>
-  );
-};
 const defaultProps: Pick<Props, 'isCondensed'> = {
   isCondensed: false,
 };

--- a/packages/components/text/src/text.styles.ts
+++ b/packages/components/text/src/text.styles.ts
@@ -50,6 +50,8 @@ const getTone = (tone: string) => {
       return `color: ${designTokens.colorWarning};`;
     case 'critical':
       return `color: ${designTokens.colorError40};`;
+    case 'inherit':
+      return 'color: inherit;';
     default:
       return ``;
   }

--- a/packages/components/text/src/text.tsx
+++ b/packages/components/text/src/text.tsx
@@ -11,6 +11,15 @@ import {
   wrapStyles,
 } from './text.styles';
 
+type Tone =
+  | 'primary'
+  | 'secondary'
+  | 'information'
+  | 'positive'
+  | 'negative'
+  | 'critical'
+  | 'inherit';
+
 type TBasicTextProps = {
   id?: string;
   intlMessage?: MessageDescriptor & {
@@ -111,13 +120,7 @@ export type TSubheadlineProps = {
   as?: 'h4' | 'h5';
   truncate?: boolean;
   isBold?: boolean;
-  tone?:
-    | 'primary'
-    | 'secondary'
-    | 'information'
-    | 'positive'
-    | 'negative'
-    | 'critical';
+  tone?: Tone;
 } & TBasicTextProps &
   TBasicHeadlineProps;
 
@@ -174,14 +177,7 @@ export type TBodyProps = {
   isBold?: boolean;
   isItalic?: boolean;
   isStrikethrough?: boolean;
-  tone?:
-    | 'primary'
-    | 'secondary'
-    | 'information'
-    | 'positive'
-    | 'negative'
-    | 'inverted'
-    | 'critical';
+  tone?: Tone | 'inverted';
   truncate?: boolean;
 } & TBasicTextProps &
   TBasicHeadlineProps;
@@ -222,15 +218,7 @@ export type TDetailProps = {
   isItalic?: boolean;
   isStrikethrough?: boolean;
   as?: 'span' | 'small';
-  tone?:
-    | 'primary'
-    | 'secondary'
-    | 'information'
-    | 'positive'
-    | 'negative'
-    | 'warning'
-    | 'inverted'
-    | 'critical';
+  tone?: Tone | 'warning' | 'inverted';
   truncate?: boolean;
   'aria-labelledby'?: string;
 } & TBasicTextProps &


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19zADBqKxv4qPNaEov1hu0zqQRDXCn48to%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=WpbrS6e)

#### Summary

PoC use `inherit` as an accepted value for `Text` components

## Description

Currently we are CSS overwriting the colors of `Stamp` component children (usually `Text` instances) in the new theme to comply with the new color requirement.

Searching for more clean implementation we had the idea for the `Text` component `tone` property to accept a new value (`inherit`) so the rendered text would not set a color but it would use its parent's.

This works fine but it will enforce a change in all `Stamp` consumers to add the `tone="inherit"` prop in their code.
I think it's best for us to keep this change for the moment we start the `Stamp` refactor we talked about (inline text and icon properties) so we can better use what we want for the future (use the `inherit` tone in `Text` component) while keeping backwards compatibility for a while.
