### PR TITLE
Remove `Stamp` breaking warning

### DIFF
--- a/.changeset/seven-guests-raise.md
+++ b/.changeset/seven-guests-raise.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/stamp': patch
+---
+
+Remove warning which throws an error in local development

--- a/packages/components/stamp/src/stamp.tsx
+++ b/packages/components/stamp/src/stamp.tsx
@@ -4,7 +4,6 @@ import { css } from '@emotion/react';
 import { designTokens, useTheme } from '@commercetools-uikit/design-system';
 import Text from '@commercetools-uikit/text';
 import SpacingsInline from '@commercetools-uikit/spacings-inline';
-import { warning } from '@commercetools-uikit/utils';
 
 type Tone =
   | 'critical'
@@ -154,11 +153,6 @@ const Stamp = (props: Props) => {
       size: 'medium',
       color: getIconColor(props, overrideTextColor),
     });
-
-  warning(
-    !props.children,
-    'Stamp: The `children` prop has been deprecated. Please use the `label` and `icon` prop to render the content.'
-  );
 
   return (
     <div


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Remove `Stamp` breaking warning

## Description

We updated the `Stamp` component to use inline props instead of `children` for the text to render and, while we temporary allow for both (`children` is ignored if new inline props are provided) to make transition easier, we added a `warning` to let users know about this change that actually throws an error in development mode.

In this PR we remove that `warning` and we will think on a better solution to let users know about this change.
