### PR TITLE
[`TimeInput`] Adjust clear icon visibility

### DIFF
--- a/.changeset/gorgeous-snails-sip.md
+++ b/.changeset/gorgeous-snails-sip.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/time-input': patch
+---
+
+Hide the clear icon when there's not value in the input.

--- a/packages/components/inputs/time-input/src/time-input-body.tsx
+++ b/packages/components/inputs/time-input/src/time-input-body.tsx
@@ -78,7 +78,7 @@ const TimeInputBody = forwardRef<HTMLInputElement, TTimeInputBodyProps>(
               : {})}
           />
 
-          {!props.isDisabled && !props.isReadOnly && (
+          {!props.isDisabled && !props.isReadOnly && Boolean(props.value) && (
             <ClearSection
               isDisabled={props.isDisabled}
               hasError={props.hasError}

--- a/packages/components/inputs/time-input/src/time-input.tsx
+++ b/packages/components/inputs/time-input/src/time-input.tsx
@@ -4,6 +4,7 @@ import {
   useRef,
   type FocusEventHandler,
   type ChangeEventHandler,
+  type ChangeEvent,
 } from 'react';
 import { useIntl } from 'react-intl';
 import Constraints from '@commercetools-uikit/constraints';
@@ -143,6 +144,7 @@ const TimeInput = (props: TTimeInputProps) => {
   const id = useFieldId(props.id, sequentialId);
   const intl = useIntl();
   const element = useRef<HTMLInputElement>(null);
+  const { onChange } = props;
 
   if (!props.isReadOnly) {
     warning(
@@ -166,7 +168,8 @@ const TimeInput = (props: TTimeInputProps) => {
     if (element.current) {
       dispatchReactChangeEvent(element.current, '');
     }
-  }, []);
+    onChange?.({ target: { value: '' } } as ChangeEvent<HTMLInputElement>);
+  }, [onChange]);
 
   // if locale has changed trigger a new change event
   useEffect(() => {
@@ -185,7 +188,7 @@ const TimeInput = (props: TTimeInputProps) => {
         name={props.name}
         autoComplete={props.autoComplete}
         value={props.value}
-        onChange={props.onChange}
+        onChange={onChange}
         onBlur={handleBlur}
         onFocus={props.onFocus}
         isAutofocussed={props.isAutofocussed}


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

We don't want to display the clear icon when there is no value in the input.

## Description

Here is an example of the new behavior:

[Components _ Inputs - TimeInput ⋅ Storybook.webm](https://user-images.githubusercontent.com/97907068/217501168-85176e67-a306-4be1-ab41-374466c9a9a4.webm)
