### PR TITLE
fix(MoneyInput): mixed up styles when disabled and readonly are true

### DIFF
--- a/.changeset/seven-deers-repeat.md
+++ b/.changeset/seven-deers-repeat.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/money-input': patch
+---
+
+Fixed MoneyInput component styles when isDisabled and isReadOnly props are true at the same time

--- a/packages/components/inputs/money-input/src/money-input.tsx
+++ b/packages/components/inputs/money-input/src/money-input.tsx
@@ -148,6 +148,7 @@ const createCurrencySelectStyles: TCreateCurrencySelectStyles = ({
         return 'pointer';
       })(),
       backgroundColor: (() => {
+        if (isDisabled) return base.backgroundColor;
         if (isReadOnly) return designTokens.backgroundColorForInput;
         return base.backgroundColor;
       })(),


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

<!-- provide a short summary of your changes -->

Fixes MoneyInput component styles when isDisabled and isReadOnly props are true at the same time

## Description

<!-- provide some context -->

Generated `currencySelectStyles` inside the `MoneyInput` component has a wrong `backgroundColor` when  `isDisabled` and `isReadOnly` props are true at the same time.

![Screenshot 2023-02-22 at 15 28 37](https://user-images.githubusercontent.com/13467563/220654949-66feee40-12f4-4620-af77-cbf4dacdfc0a.png)
