### PR TITLE
fix(flat-button): use `font-size` consistent with `<Text.Body>`

### DIFF
--- a/.changeset/healthy-knives-carry.md
+++ b/.changeset/healthy-knives-carry.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/flat-button': patch
+---
+
+Fix `font-size` in the new theme

--- a/packages/components/buttons/flat-button/src/flat-button.tsx
+++ b/packages/components/buttons/flat-button/src/flat-button.tsx
@@ -11,6 +11,7 @@ import omit from 'lodash/omit';
 import { designTokens } from '@commercetools-uikit/design-system';
 import { filterInvalidAttributes } from '@commercetools-uikit/utils';
 import AccessibleButton from '@commercetools-uikit/accessible-button';
+import Text from '@commercetools-uikit/text';
 import { getTextColor, getButtonIconColor } from './flat-button.styles';
 
 const propsToOmit = ['type'];
@@ -121,7 +122,6 @@ const FlatButton = <TStringOrComponent extends ElementType = 'button'>(
       css={css`
         min-height: initial;
         align-items: center;
-        font-size: ${designTokens.fontSizeForTextAsBody};
         ${props.as && props.as !== 'button'
           ? `white-space: normal;
                display: inline-block;`
@@ -162,7 +162,7 @@ const FlatButton = <TStringOrComponent extends ElementType = 'button'>(
       {props.icon && props.iconPosition === 'left' && (
         <ButtonIcon<TStringOrComponent> {...props} />
       )}
-      <span>{props.label}</span>
+      <Text.Body as="span">{props.label}</Text.Body>
       {props.icon && props.iconPosition === 'right' && (
         <ButtonIcon<TStringOrComponent> {...props} />
       )}

--- a/packages/components/buttons/flat-button/src/flat-button.tsx
+++ b/packages/components/buttons/flat-button/src/flat-button.tsx
@@ -121,6 +121,7 @@ const FlatButton = <TStringOrComponent extends ElementType = 'button'>(
       css={css`
         min-height: initial;
         align-items: center;
+        font-size: ${designTokens.fontSizeForTextAsBody};
         ${props.as && props.as !== 'button'
           ? `white-space: normal;
                display: inline-block;`


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

This PR applies `<FlatButton>`'s `font-size` consistent with `<Text.body>` in the new theme.
