### PR TITLE
Fix `Link` component `font-size` value in the new theme

### DIFF
--- a/.changeset/light-oranges-design.md
+++ b/.changeset/light-oranges-design.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-uikit/link': patch
+'@commercetools-uikit/design-system': patch
+---
+
+Fix `font-size` for `Link` component in the new theme.

--- a/design-system/materials/internals/definition.yaml
+++ b/design-system/materials/internals/definition.yaml
@@ -1438,38 +1438,25 @@ decisionGroupsByTheme:
       prefix: font-size
       decisions:
         font-size-for-input:
-          description: ''
           choice: font-size-30
         font-size-for-text-as-h1:
-          description: ''
           choice: font-size-60
         font-size-for-text-as-h2:
-          description: ''
           choice: font-size-50
         font-size-for-text-as-h3:
-          description: ''
           choice: font-size-40
         font-size-for-text-as-h4:
-          description: ''
           choice: font-size-30
         font-size-for-text-as-h5:
-          description: ''
           choice: font-size-30
         font-size-for-text-as-body:
-          description: ''
           choice: font-size-30
         font-size-for-text-as-detail:
-          description: ''
           choice: font-size-20
         font-size-for-body:
-          description: ''
           choice: '16px'
         font-size-for-button:
-          description: ''
           choice: font-size-20
-        font-size-for-link:
-          description: ''
-          choice: 'inherit'
         font-size-for-stamp:
           choice: font-size-20
         font-size-for-view-switcher:

--- a/design-system/src/design-tokens.ts
+++ b/design-system/src/design-tokens.ts
@@ -615,7 +615,6 @@ export const themes = {
     fontSizeForTextAsDetail: '0.875rem',
     fontSizeForBody: '16px',
     fontSizeForButton: '0.875rem',
-    fontSizeForLink: 'inherit',
     fontSizeForStamp: '0.875rem',
     fontSizeForViewSwitcher: '0.875rem',
     fontSizeForTable: '0.875rem',

--- a/packages/components/link/src/link.tsx
+++ b/packages/components/link/src/link.tsx
@@ -10,7 +10,7 @@ import styled from '@emotion/styled';
 import { Link as ReactRouterLink } from 'react-router-dom';
 import { css } from '@emotion/react';
 import { FormattedMessage } from 'react-intl';
-import { designTokens } from '@commercetools-uikit/design-system';
+import { designTokens, useTheme } from '@commercetools-uikit/design-system';
 import { filterInvalidAttributes, warning } from '@commercetools-uikit/utils';
 import { ExternalLinkIcon } from '@commercetools-uikit/icons';
 
@@ -104,21 +104,28 @@ const getActiveColorValue = (tone: string = 'primary') => {
   return designTokens.fontColorForTextWhenInverted;
 };
 
-const getLinkStyles = (props: TLinkProps) => {
+const getLinkStyles = (props: TLinkProps & { isNewTheme: boolean }) => {
   const color = getTextColorValue(props.tone);
   const hoverColor = getActiveColorValue(props.tone);
 
-  return css`
-    font-family: inherit;
-    color: ${color};
-    font-size: ${designTokens.fontSizeForLink};
-    &:hover,
-    &:focus,
-    &:active {
-      color: ${hoverColor};
-    }
-    text-decoration: underline;
-  `;
+  return [
+    css`
+      font-family: inherit;
+      color: ${color};
+
+      &:hover,
+      &:focus,
+      &:active {
+        color: ${hoverColor};
+      }
+      text-decoration: underline;
+    `,
+    !props.isNewTheme
+      ? css`
+          font-size: ${designTokens.fontSizeForLink};
+        `
+      : null,
+  ];
 };
 
 const Wrapper = styled.span`
@@ -129,6 +136,7 @@ const Wrapper = styled.span`
 `;
 
 const Link = (props: TLinkProps) => {
+  const { isNewTheme } = useTheme();
   const remainingProps = filterInvalidAttributes(props);
 
   // `filterInvalidAttributes` strips off `intlMessage` and `children`
@@ -143,7 +151,7 @@ const Link = (props: TLinkProps) => {
     return (
       <Wrapper>
         <a
-          css={getLinkStyles(props)}
+          css={getLinkStyles({ ...props, isNewTheme })}
           href={props.to}
           target="_blank"
           rel="noopener noreferrer"
@@ -167,7 +175,7 @@ const Link = (props: TLinkProps) => {
 
   return (
     <ReactRouterLink
-      css={getLinkStyles(props)}
+      css={getLinkStyles({ ...props, isNewTheme })}
       to={props.to}
       {...remainingProps}
     >

--- a/packages/components/link/src/link.visualroute.jsx
+++ b/packages/components/link/src/link.visualroute.jsx
@@ -23,5 +23,10 @@ export const component = () => (
         An inverted label text
       </Link>
     </Spec>
+    <Spec label="Link respecting parent font-size">
+      <div style={{ fontSize: 24 }}>
+        <Link to="/">A label text</Link>
+      </div>
+    </Spec>
   </Suite>
 );


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Fix `Link` component `font-size` value in the new theme

## Description

We want the `font-size` of the `Link` component to be inherited from its parent in the new theme but it's currently not wroking.

We decided to use `font-size: inherit` for the new theme, but that's making the size to be inherited from the `body` element, not its parent.
