### PR TITLE
fix(radio-input): radio input default hover area background color

### DIFF
--- a/.changeset/old-hounds-study.md
+++ b/.changeset/old-hounds-study.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/radio-input': patch
+---
+
+Set default hover area color to `transparent`

--- a/packages/components/inputs/radio-input/src/radio-option.styles.ts
+++ b/packages/components/inputs/radio-input/src/radio-option.styles.ts
@@ -154,7 +154,7 @@ const getNewThemeHoverAreaStyles = css`
   width: 26px;
   height: 26px;
   border-radius: 50%;
-  border: 4px solid ${designTokens.colorSurface};
+  border: 4px solid transparent;
 `;
 
 const RadioOptionContainer = styled.div<TStylesProps>`


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Before:
<img width="406" alt="Screenshot 2023-03-02 at 12 00 32" src="https://user-images.githubusercontent.com/49066275/222410167-6e1c5cee-e4e6-4cb7-95c2-b444e82eeee4.png">

After
<img width="271" alt="Screenshot 2023-03-02 at 11 54 16" src="https://user-images.githubusercontent.com/49066275/222410195-9ece6173-da09-473d-98f9-153649e79077.png">
