### PR TITLE
fix(radio-input): option label alignment

### DIFF
--- a/.changeset/chilled-boxes-yell.md
+++ b/.changeset/chilled-boxes-yell.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/radio-input': patch
+---
+
+Fix `RadioInput.Option` label alignment

--- a/packages/components/fields/radio-field/src/radio-field.story.js
+++ b/packages/components/fields/radio-field/src/radio-field.story.js
@@ -10,7 +10,6 @@ import {
 } from '@storybook/addon-knobs/react';
 import Constraints from '@commercetools-uikit/constraints';
 import { Value } from 'react-value';
-import Spacings from '@commercetools-uikit/spacings';
 import RadioInput from '@commercetools-uikit/radio-input';
 import Section from '../../../../../docs/.storybook/decorators/section';
 import Readme from '../README.md';
@@ -109,10 +108,8 @@ storiesOf('Components|Fields', module)
                 isHovered={boolean('isHovered #1', false, radioOption1)}
                 additionalContent={text('additionalContent', '', radioOption1)}
               >
-                <Spacings.Inline scale="xs" alignItems="center">
-                  <div>{'🍎'}</div>
-                  <div>{text('label #1', 'Apple', radioOption1)}</div>
-                </Spacings.Inline>
+                <div>{'🍎'}</div>
+                <div>{text('label #1', 'Apple', radioOption1)}</div>
               </RadioInput.Option>
               <RadioInput.Option
                 value={text('value #2', 'banana', radioOption2)}
@@ -124,10 +121,8 @@ storiesOf('Components|Fields', module)
                 isHovered={boolean('isHovered #2', false, radioOption2)}
                 additionalContent={text('additionalContent', '', radioOption2)}
               >
-                <Spacings.Inline scale="xs" alignItems="center">
-                  <div>{'🍌'}</div>
-                  <div>{text('label #2', 'Banana', radioOption2)}</div>
-                </Spacings.Inline>
+                <div>{'🍌'}</div>
+                <div>{text('label #2', 'Banana', radioOption2)}</div>
               </RadioInput.Option>
               <RadioInput.Option
                 value={text('value #3', 'pineapple', radioOption3)}
@@ -139,10 +134,8 @@ storiesOf('Components|Fields', module)
                 isHovered={boolean('isHovered #3', false, radioOption3)}
                 additionalContent={text('additionalContent', '', radioOption3)}
               >
-                <Spacings.Inline scale="xs" alignItems="center">
-                  <div>{'🍍'}</div>
-                  <div>{text('label #3', 'Pineapple', radioOption3)}</div>
-                </Spacings.Inline>
+                <div>{'🍍'}</div>
+                <div>{text('label #3', 'Pineapple', radioOption3)}</div>
               </RadioInput.Option>
             </RadioField>
           );

--- a/packages/components/inputs/radio-input/src/radio-input.story.js
+++ b/packages/components/inputs/radio-input/src/radio-input.story.js
@@ -3,7 +3,6 @@ import { action } from '@storybook/addon-actions';
 import { withKnobs, boolean, text, select } from '@storybook/addon-knobs/react';
 import Constraints from '@commercetools-uikit/constraints';
 import { Value } from 'react-value';
-import Spacings from '@commercetools-uikit/spacings';
 import Section from '../../../../../docs/.storybook/decorators/section';
 import Readme from '../README.md';
 import RadioInput from '.';
@@ -75,10 +74,8 @@ storiesOf('Components|Inputs', module)
               isHovered={boolean('isHovered #1', false, radioOption1)}
               additionalContent={text('additionalContent', '', radioOption1)}
             >
-              <Spacings.Inline scale="xs" alignItems="center">
-                <div>{'🍎'}</div>
-                {text('label #1', 'Apple', radioOption1)}
-              </Spacings.Inline>
+              <div>{'🍎'}</div>
+              {text('label #1', 'Apple', radioOption1)}
             </RadioInput.Option>
             <RadioInput.Option
               value={text('value #2', 'banana', radioOption2)}
@@ -90,10 +87,8 @@ storiesOf('Components|Inputs', module)
               isHovered={boolean('isHovered #2', false, radioOption2)}
               additionalContent={text('additionalContent', '', radioOption2)}
             >
-              <Spacings.Inline scale="xs" alignItems="center">
-                <div>{'🍌'}</div>
-                {text('label #2', 'Banana', radioOption2)}
-              </Spacings.Inline>
+              <div>{'🍌'}</div>
+              {text('label #2', 'Banana', radioOption2)}
             </RadioInput.Option>
             <RadioInput.Option
               value={text('value #3', 'pineapple', radioOption3)}
@@ -105,10 +100,8 @@ storiesOf('Components|Inputs', module)
               isHovered={boolean('isHovered #3', false, radioOption3)}
               additionalContent={text('additionalContent', '', radioOption3)}
             >
-              <Spacings.Inline scale="xs" alignItems="center">
-                <div>{'🍍'}</div>
-                {text('label #3', 'Pineapple', radioOption3)}
-              </Spacings.Inline>
+              <div>{'🍍'}</div>
+              {text('label #3', 'Pineapple', radioOption3)}
             </RadioInput.Option>
           </RadioInput.Group>
         )}

--- a/packages/components/inputs/radio-input/src/radio-option.styles.ts
+++ b/packages/components/inputs/radio-input/src/radio-option.styles.ts
@@ -18,6 +18,7 @@ const LabelTextWrapper = styled.div<TStylesProps>`
   font-size: 1rem;
   font-family: inherit;
   display: flex;
+  align-items: center;
   ${(props) => getDefaultThemeLabelColor(props)}
 `;
 


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Before:
<img width="347" alt="Screenshot 2023-03-09 at 16 49 32" src="https://user-images.githubusercontent.com/49066275/224078838-5514b2aa-299a-4b8e-8a56-85f2ace05532.png">

After:
<img width="826" alt="Screenshot 2023-03-09 at 16 03 29" src="https://user-images.githubusercontent.com/49066275/224069058-2591572d-a77b-4a56-9bcf-997f84f0572f.png">

In `RadioInput` and `RadioField` components' stories we define `Option` label alignment in the stories ([ref](https://github.com/commercetools/ui-kit/blob/29964960c78206aa7b766b2a173f46f0743d8b5c/packages/components/fields/radio-field/src/radio-field.story.js#L112), [ref2](https://github.com/commercetools/ui-kit/blob/29964960c78206aa7b766b2a173f46f0743d8b5c/packages/components/inputs/radio-input/src/radio-input.story.js#L78)). Recent changes in styles and adding `Flexbox` to the label container without specifying the vertical alignment caused some misalignment of the label for the new theme. We missed that unfortunately.

Perhaps adding a ` <Spacings.Inline scale="xs" alignItems="center">` as the `Option`'s children is not the most fortunate decision. We don't show the label normally with an icon in the MC, and here we are forcing the alignment. This is prone to regressions in the future.

So, although it's less visually appealing, my suggestion would be to change our stories to render just text:
```tsx
<RadioInput.Option
 // ...
>
  {text('label #1', 'Banana', radioOption)}
</RadioInput.Option>
```
instead of:
```
<RadioInput.Option
  // ...
>
  <Spacings.Inline scale="xs" alignItems="center">
    <div>{'🍌'}</div>
    {text('label #1', 'Banana', radioOption1)}
  </Spacings.Inline>
</RadioInput.Option>
```


