### PR TITLE
fix(toggle-input):  overflow when in focused or hovered state

### DIFF
--- a/.changeset/tall-shirts-roll.md
+++ b/.changeset/tall-shirts-roll.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/toggle-input': patch
+---
+
+Fix the issue with the focus indicator and the hover area overflow

--- a/packages/components/inputs/toggle-input/src/toggle-input.styles.ts
+++ b/packages/components/inputs/toggle-input/src/toggle-input.styles.ts
@@ -126,9 +126,14 @@ const getNewThemeFocusIndicator = (props: TStyledSpanProps) => css`
 `;
 
 const getNewThemeMargin = (props: TStyledLabelProps) =>
+  `calc(2px + ${props.themedThumb[props.size].hoverAreaWidth} + (${
+    props.themedThumb[props.size].diameter
+  } - ${props.themedTrack[props.size].height}) / 2)`;
+
+const getMargin = (props: TStyledLabelProps) =>
   css`
     margin: ${props.isNewTheme
-      ? `${props.size === 'big' ? '14px' : '9px'} !important`
+      ? `${getNewThemeMargin(props)} !important`
       : 'unset'};
   `;
 
@@ -137,7 +142,7 @@ const Label = styled.label<TStyledLabelProps>`
   display: inline-block;
   cursor: ${(props) => (props.isDisabled ? 'not-allowed' : 'pointer')};
   align-self: center;
-  ${getNewThemeMargin}
+  ${getMargin}
 
   ${labelSizeStyles}
 

--- a/packages/components/inputs/toggle-input/src/toggle-input.styles.ts
+++ b/packages/components/inputs/toggle-input/src/toggle-input.styles.ts
@@ -130,7 +130,10 @@ const Label = styled.label<TStyledLabelProps>`
   display: inline-block;
   cursor: ${(props) => (props.isDisabled ? 'not-allowed' : 'pointer')};
   align-self: center;
-  margin: ${(props) => (props.isNewTheme ? '14px !important' : 'unset')};
+  margin: ${(props) =>
+    props.isNewTheme
+      ? `${props.size === 'big' ? '14px' : '9px'} !important`
+      : 'unset'};
 
   ${labelSizeStyles}
 

--- a/packages/components/inputs/toggle-input/src/toggle-input.styles.ts
+++ b/packages/components/inputs/toggle-input/src/toggle-input.styles.ts
@@ -125,15 +125,19 @@ const getNewThemeFocusIndicator = (props: TStyledSpanProps) => css`
   }
 `;
 
+const getNewThemeMargin = (props: TStyledLabelProps) =>
+  css`
+    margin: ${props.isNewTheme
+      ? `${props.size === 'big' ? '14px' : '9px'} !important`
+      : 'unset'};
+  `;
+
 const Label = styled.label<TStyledLabelProps>`
   position: relative;
   display: inline-block;
   cursor: ${(props) => (props.isDisabled ? 'not-allowed' : 'pointer')};
   align-self: center;
-  margin: ${(props) =>
-    props.isNewTheme
-      ? `${props.size === 'big' ? '14px' : '9px'} !important`
-      : 'unset'};
+  ${getNewThemeMargin}
 
   ${labelSizeStyles}
 

--- a/packages/components/inputs/toggle-input/src/toggle-input.styles.ts
+++ b/packages/components/inputs/toggle-input/src/toggle-input.styles.ts
@@ -129,6 +129,8 @@ const Label = styled.label<TStyledLabelProps>`
   position: relative;
   display: inline-block;
   cursor: ${(props) => (props.isDisabled ? 'not-allowed' : 'pointer')};
+  align-self: center;
+  margin: ${(props) => (props.isNewTheme ? '14px !important' : 'unset')};
 
   ${labelSizeStyles}
 

--- a/packages/components/inputs/toggle-input/src/toggle.story.js
+++ b/packages/components/inputs/toggle-input/src/toggle.story.js
@@ -1,6 +1,12 @@
 import { Value } from 'react-value';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, boolean, select, text } from '@storybook/addon-knobs/react';
+import {
+  Spacings,
+  Text,
+  IconButton,
+  InformationIcon,
+} from '@commercetools-frontend/ui-kit';
 import { action } from '@storybook/addon-actions';
 import Section from '../../../../../docs/.storybook/decorators/section';
 import Readme from '../README.md';
@@ -19,17 +25,29 @@ storiesOf('Components|Inputs', module)
       <Value
         defaultValue={false}
         render={(value, onChange) => (
-          <Toggle
-            id={text('id', 'toggle-id')}
-            name={text('name', '')}
-            size={select('size', ['small', 'big'], 'big')}
-            isDisabled={boolean('isDisabled', false)}
-            isChecked={value}
-            onChange={(event) => {
-              action('onChange')(event);
-              onChange(event.target.checked);
-            }}
-          />
+          <>
+            <Text.Detail>{'This is some content 👆'}</Text.Detail>
+            <Spacings.Inline alignItems="center">
+              <Text.Detail>{'This is a label'}</Text.Detail>
+              <Toggle
+                id={text('id', 'toggle-id')}
+                name={text('name', '')}
+                size={select('size', ['small', 'big'], 'big')}
+                isDisabled={boolean('isDisabled', false)}
+                isChecked={value}
+                onChange={(event) => {
+                  action('onChange')(event);
+                  onChange(event.target.checked);
+                }}
+              />
+              <IconButton
+                icon={<InformationIcon />}
+                label="A label text"
+                onClick={() => {}}
+              />
+            </Spacings.Inline>
+            <Text.Detail>{'This is some content 👇'}</Text.Detail>
+          </>
         )}
       />
     </Section>

--- a/packages/components/inputs/toggle-input/src/toggle.story.js
+++ b/packages/components/inputs/toggle-input/src/toggle.story.js
@@ -1,12 +1,6 @@
 import { Value } from 'react-value';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, boolean, select, text } from '@storybook/addon-knobs/react';
-import {
-  Spacings,
-  Text,
-  IconButton,
-  InformationIcon,
-} from '@commercetools-frontend/ui-kit';
 import { action } from '@storybook/addon-actions';
 import Section from '../../../../../docs/.storybook/decorators/section';
 import Readme from '../README.md';
@@ -25,29 +19,17 @@ storiesOf('Components|Inputs', module)
       <Value
         defaultValue={false}
         render={(value, onChange) => (
-          <>
-            <Text.Detail>{'This is some content 👆'}</Text.Detail>
-            <Spacings.Inline alignItems="center">
-              <Text.Detail>{'This is a label'}</Text.Detail>
-              <Toggle
-                id={text('id', 'toggle-id')}
-                name={text('name', '')}
-                size={select('size', ['small', 'big'], 'big')}
-                isDisabled={boolean('isDisabled', false)}
-                isChecked={value}
-                onChange={(event) => {
-                  action('onChange')(event);
-                  onChange(event.target.checked);
-                }}
-              />
-              <IconButton
-                icon={<InformationIcon />}
-                label="A label text"
-                onClick={() => {}}
-              />
-            </Spacings.Inline>
-            <Text.Detail>{'This is some content 👇'}</Text.Detail>
-          </>
+          <Toggle
+            id={text('id', 'toggle-id')}
+            name={text('name', '')}
+            size={select('size', ['small', 'big'], 'big')}
+            isDisabled={boolean('isDisabled', false)}
+            isChecked={value}
+            onChange={(event) => {
+              action('onChange')(event);
+              onChange(event.target.checked);
+            }}
+          />
         )}
       />
     </Section>


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

`<ToggleInput>` used within `<Spacings.Inline>` in the MC:
<img width="431" alt="Screenshot 2023-03-13 at 14 12 45" src="https://user-images.githubusercontent.com/49066275/224711901-8eb2142a-f8ed-48b3-b41c-41910021f443.png">


