### PR TITLE
refactor(VRTs): enable showcasing components in the new theme

### DIFF
--- a/design-system/src/theme-provider.visualroute.jsx
+++ b/design-system/src/theme-provider.visualroute.jsx
@@ -17,9 +17,7 @@ const parentSelector = (id) => () => document.getElementById(id);
 
 const DummyComponent = (props) => {
   const { theme } = useTheme(
-    props.parentId
-      ? parentSelector(props.parentId)
-      : undefined
+    props.parentId ? parentSelector(props.parentId) : undefined
   );
 
   return (
@@ -48,11 +46,11 @@ DummyComponent.propTypes = {
 
 const DefaultRoute = () => (
   <Suite>
-    <Spec label="use global default theme">
+    <Spec label="use global default theme" testedThemes={[]}>
       <DummyComponent />
     </Spec>
 
-    <Spec label="use local default theme">
+    <Spec label="use local default theme" testedThemes={[]}>
       <LocalThemeProvider
         parentId="local-1"
         parentSelector={parentSelector('local-1')}
@@ -61,7 +59,7 @@ const DefaultRoute = () => (
       </LocalThemeProvider>
     </Spec>
 
-    <Spec label="use local dark theme">
+    <Spec label="use local dark theme" testedThemes={[]}>
       <LocalDarkThemeProvider
         theme="dark"
         parentId="local-2"
@@ -71,7 +69,7 @@ const DefaultRoute = () => (
       </LocalDarkThemeProvider>
     </Spec>
 
-    <Spec label="repeat local default theme">
+    <Spec label="repeat local default theme" testedThemes={[]}>
       <LocalThemeProvider
         parentId="local-3"
         parentSelector={parentSelector('local-3')}
@@ -80,7 +78,7 @@ const DefaultRoute = () => (
       </LocalThemeProvider>
     </Spec>
 
-    <Spec label="repeat local dark theme">
+    <Spec label="repeat local dark theme" testedThemes={[]}>
       <LocalDarkThemeProvider
         theme="dark"
         parentId="local-4"
@@ -90,7 +88,7 @@ const DefaultRoute = () => (
       </LocalDarkThemeProvider>
     </Spec>
 
-    <Spec label="overridden local default theme">
+    <Spec label="overridden local default theme" testedThemes={[]}>
       <LocalThemeProvider
         themeOverrides={{ colorSolid: 'red' }}
         parentId="local-5"
@@ -107,7 +105,7 @@ const DefaultRoute = () => (
       </LocalThemeProvider>
     </Spec>
 
-    <Spec label="custom property added to default theme">
+    <Spec label="custom property added to default theme" testedThemes={[]}>
       <LocalThemeProvider
         themeOverrides={{ customColor: 'tomato' }}
         parentId="local-6"
@@ -140,8 +138,14 @@ TestComponent.propTypes = {
 const localThemeParentSelector = () => document.getElementById('local');
 
 const InteractiveRoute = () => {
-  const [globalTheme, setGlobalTheme] = useState({ name: 'default', overrides: {} });
-  const [localTheme, setLocalTheme] = useState({ name: 'default', overrides: {} });
+  const [globalTheme, setGlobalTheme] = useState({
+    name: 'default',
+    overrides: {},
+  });
+  const [localTheme, setLocalTheme] = useState({
+    name: 'default',
+    overrides: {},
+  });
 
   return (
     <>
@@ -178,7 +182,8 @@ const InteractiveRoute = () => {
         <ThemeProvider
           theme={localTheme.name}
           themeOverrides={localTheme.overrides}
-          parentSelector={localThemeParentSelector} />
+          parentSelector={localThemeParentSelector}
+        />
         <TestComponent text="local" />
       </div>
     </>

--- a/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input-open.visualroute.jsx
+++ b/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input-open.visualroute.jsx
@@ -13,7 +13,7 @@ export const routePath = '/async-creatable-select-input-open';
 
 export const component = () => (
   <Suite>
-    <Spec label="minimal" testedTheme="old">
+    <Spec label="minimal" testedThemes={['new']}>
       <AsyncCreatableSelectInput
         value={value}
         onChange={() => {}}

--- a/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input-open.visualroute.jsx
+++ b/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input-open.visualroute.jsx
@@ -13,7 +13,7 @@ export const routePath = '/async-creatable-select-input-open';
 
 export const component = () => (
   <Suite>
-    <Spec label="minimal">
+    <Spec label="minimal" testedTheme="old">
       <AsyncCreatableSelectInput
         value={value}
         onChange={() => {}}

--- a/packages/components/inputs/async-select-input/src/async-select-input-open.visualroute.jsx
+++ b/packages/components/inputs/async-select-input/src/async-select-input-open.visualroute.jsx
@@ -13,7 +13,7 @@ export const routePath = '/async-select-input-open';
 
 export const component = () => (
   <Suite>
-    <Spec label="minimal" testedTheme="old">
+    <Spec label="minimal" testedThemes={['new']}>
       <AsyncSelectInput
         value={value}
         onChange={() => {}}

--- a/packages/components/inputs/async-select-input/src/async-select-input-open.visualroute.jsx
+++ b/packages/components/inputs/async-select-input/src/async-select-input-open.visualroute.jsx
@@ -13,7 +13,7 @@ export const routePath = '/async-select-input-open';
 
 export const component = () => (
   <Suite>
-    <Spec label="minimal">
+    <Spec label="minimal" testedTheme="old">
       <AsyncSelectInput
         value={value}
         onChange={() => {}}

--- a/packages/components/inputs/date-input/src/date-input-open.visualroute.jsx
+++ b/packages/components/inputs/date-input/src/date-input-open.visualroute.jsx
@@ -7,7 +7,11 @@ export const routePath = '/date-input-open';
 
 export const component = () => (
   <Suite>
-    <Spec label="minimal" propsToList={['value', 'horizontalConstraint']}>
+    <Spec
+      label="minimal"
+      propsToList={['value', 'horizontalConstraint']}
+      testedTheme="old"
+    >
       <DateInput
         id="date-input"
         data-testid="date-input"

--- a/packages/components/inputs/date-input/src/date-input-open.visualroute.jsx
+++ b/packages/components/inputs/date-input/src/date-input-open.visualroute.jsx
@@ -10,7 +10,7 @@ export const component = () => (
     <Spec
       label="minimal"
       propsToList={['value', 'horizontalConstraint']}
-      testedTheme="old"
+      testedThemes={['new']}
     >
       <DateInput
         id="date-input"

--- a/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.visualroute.jsx
+++ b/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.visualroute.jsx
@@ -69,7 +69,7 @@ const InteractiveRoute = () => {
   }, []);
   return (
     <Suite>
-      <Spec label="Interactive Rich Text" omitPropsList>
+      <Spec label="Interactive Rich Text" omitPropsList testedTheme="old">
         <div>
           <label htmlFor="reset-button">Reset value to lorem ipsum</label>
           <button

--- a/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.visualroute.jsx
+++ b/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.visualroute.jsx
@@ -69,7 +69,7 @@ const InteractiveRoute = () => {
   }, []);
   return (
     <Suite>
-      <Spec label="Interactive Rich Text" omitPropsList testedTheme="old">
+      <Spec label="Interactive Rich Text" omitPropsList testedThemes={['new']}>
         <div>
           <label htmlFor="reset-button">Reset value to lorem ipsum</label>
           <button

--- a/packages/components/inputs/rich-text-input/src/rich-text-input.visualroute.jsx
+++ b/packages/components/inputs/rich-text-input/src/rich-text-input.visualroute.jsx
@@ -30,7 +30,7 @@ const InteractiveRoute = () => {
 
   return (
     <Suite>
-      <Spec label="minimal" omitPropsList testedTheme="old">
+      <Spec label="minimal" omitPropsList testedThemes={['new']}>
         <div>
           <label htmlFor="reset-button">Reset value to Hello World</label>
           <button

--- a/packages/components/inputs/rich-text-input/src/rich-text-input.visualroute.jsx
+++ b/packages/components/inputs/rich-text-input/src/rich-text-input.visualroute.jsx
@@ -30,7 +30,7 @@ const InteractiveRoute = () => {
 
   return (
     <Suite>
-      <Spec label="minimal" omitPropsList>
+      <Spec label="minimal" omitPropsList testedTheme="old">
         <div>
           <label htmlFor="reset-button">Reset value to Hello World</label>
           <button

--- a/packages/components/inputs/search-select-input/src/search-select-input-open.visualroute.jsx
+++ b/packages/components/inputs/search-select-input/src/search-select-input-open.visualroute.jsx
@@ -13,7 +13,7 @@ export const routePath = '/search-select-input-open';
 
 export const component = () => (
   <Suite>
-    <Spec label="minimal">
+    <Spec label="minimal" testedTheme="old">
       <SearchSelectInput
         value={value}
         onChange={() => {}}

--- a/packages/components/inputs/search-select-input/src/search-select-input-open.visualroute.jsx
+++ b/packages/components/inputs/search-select-input/src/search-select-input-open.visualroute.jsx
@@ -13,7 +13,7 @@ export const routePath = '/search-select-input-open';
 
 export const component = () => (
   <Suite>
-    <Spec label="minimal" testedTheme="old">
+    <Spec label="minimal" testedThemes={['new']}>
       <SearchSelectInput
         value={value}
         onChange={() => {}}

--- a/test/percy/README.md
+++ b/test/percy/README.md
@@ -194,6 +194,9 @@ A `Spec` should render your component in a specific state.
 You may use the prop `propsToList` to specify which props you want to display within the snapshot. Ideally, these should be the ones which you are testing. If `propsToList` is not defined, every prop will be displayed.
 If don't want to display any props at all, use `omitPropsList`.
 
+You may use the `testedThemes` prop to specify which themes will be used to showcase the component. By default, the component is rendered in both the default theme of the application and a local `ThemeProvider` context is created to showcase the component in the `new` theme. In order to only use the default (`old`) or the `new` theme context use `testedThemes={["old"]}` or `testedThemes={["new"]}` respectively.
+For specific use cases, like testing `ThemeProvider`, you may want to use `testedThemes={[]}` which will use the global theming context and not show any theme label.
+
 If you want to display the props of a nested component which is wrapped by the direct child of your `Spec`, use `listPropsOfChild`. This can be useful if you need to wrap your component in a `ThemeProvider`.
 
 You can use multiple specs within a `Suite`.

--- a/test/percy/spec.jsx
+++ b/test/percy/spec.jsx
@@ -3,9 +3,8 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import pick from 'lodash/pick';
-import { createSequentialId } from '@commercetools-uikit/utils';
-import { useFieldId } from '@commercetools-uikit/hooks';
-import { designTokens, ThemeProvider, useTheme } from '../../design-system';
+import { designTokens } from '../../design-system';
+import { LocalThemeProvider } from './local-theme-provider';
 
 const SpecContainer = styled.div`
   display: flex;
@@ -52,22 +51,12 @@ const PropValue = styled.span`
 `;
 
 const Box = (props) => {
-  const { isNewTheme } = useTheme(
-    props.boxId ? () => document.getElementById(props.boxId) : undefined
-  );
   return (
     <div
       css={css`
         background-color: ${props.backgroundColor ?? designTokens.colorSurface};
         margin-bottom: 20px;
-
-        ${isNewTheme &&
-        css`
-          font-family: 'Inter', system-ui;
-          // Updating 'font-size' here won't make difference since we use 'rem' units in components based on 'font-size' set in the <html> element
-        `}
       `}
-      {...(props.boxId ? { id: props.boxId } : {})}
     >
       <p
         css={css`
@@ -80,7 +69,11 @@ const Box = (props) => {
       >
         {`${props.themeName} theme`}
       </p>
-      {props.children}
+      {props.themeName === 'new' ? (
+        <LocalThemeProvider theme="test">{props.children}</LocalThemeProvider>
+      ) : (
+        props.children
+      )}
     </div>
   );
 };
@@ -88,7 +81,6 @@ Box.propTypes = {
   children: PropTypes.node.isRequired,
   backgroundColor: PropTypes.string,
   themeName: PropTypes.string.isRequired,
-  boxId: PropTypes.string,
 };
 
 const Pill = (props) => {
@@ -146,11 +138,7 @@ Props.propTypes = {
   propsToList: PropTypes.arrayOf(PropTypes.string),
 };
 
-const sequentialId = createSequentialId('local-');
-
 const Spec = (props) => {
-  const localId = useFieldId(undefined, sequentialId);
-
   return (
     <SpecContainer>
       <Label>{props.label}</Label>
@@ -168,15 +156,7 @@ const Spec = (props) => {
         </Box>
       ) : null}
       {props.testedThemes.includes('new') ? (
-        <Box
-          themeName="new"
-          boxId={localId}
-          backgroundColor={props.backgroundColor}
-        >
-          <ThemeProvider
-            theme="test"
-            parentSelector={() => document.getElementById(localId)}
-          />
+        <Box themeName="new" backgroundColor={props.backgroundColor}>
           {props.children}
         </Box>
       ) : null}

--- a/test/percy/spec.jsx
+++ b/test/percy/spec.jsx
@@ -64,7 +64,7 @@ const Box = (props) => {
         ${isNewTheme &&
         css`
           font-family: 'Inter', system-ui;
-          font-size: 16px; // This won't ever work since we use 'rem' units in components, so the font size will be calculated based on the font-size set in the <html> element
+          // Updating 'font-size' here won't make difference since we use 'rem' units in components based on 'font-size' set in the <html> element
         `}
       `}
       {...(props.boxId ? { id: props.boxId } : {})}
@@ -78,7 +78,7 @@ const Box = (props) => {
           }
         `}
       >
-        {props.themeName} theme:
+        {`${props.themeName} theme`}
       </p>
       {props.children}
     </div>
@@ -162,20 +162,24 @@ const Spec = (props) => {
           {props.children}
         </Props>
       )}
-      <Box themeName="old" backgroundColor={props.backgroundColor}>
-        {props.children}
-      </Box>
-      <Box
-        themeName="new"
-        boxId={localId}
-        backgroundColor={props.backgroundColor}
-      >
-        <ThemeProvider
-          theme="test"
-          parentSelector={() => document.getElementById(localId)}
-        />
-        {props.children}
-      </Box>
+      {props.testedTheme === 'both' || props.testedTheme === 'old' ? (
+        <Box themeName="old" backgroundColor={props.backgroundColor}>
+          {props.children}
+        </Box>
+      ) : null}
+      {props.testedTheme === 'both' || props.testedTheme === 'new' ? (
+        <Box
+          themeName="new"
+          boxId={localId}
+          backgroundColor={props.backgroundColor}
+        >
+          <ThemeProvider
+            theme="test"
+            parentSelector={() => document.getElementById(localId)}
+          />
+          {props.children}
+        </Box>
+      ) : null}
     </SpecContainer>
   );
 };
@@ -187,11 +191,13 @@ Spec.propTypes = {
   propsToList: PropTypes.arrayOf(PropTypes.string),
   omitPropsList: PropTypes.bool,
   backgroundColor: PropTypes.string,
+  testedTheme: PropTypes.oneOf(['new', 'old', 'both']),
 };
 
 Spec.defaultProps = {
   omitPropsList: false,
   listPropsOfNestedChild: false,
+  testedTheme: 'both',
 };
 
 Spec.displayName = 'Spec';

--- a/test/percy/spec.jsx
+++ b/test/percy/spec.jsx
@@ -1,8 +1,11 @@
 import { Children, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import { css } from '@emotion/react';
 import pick from 'lodash/pick';
-import { designTokens } from '../../design-system';
+import { createSequentialId } from '@commercetools-uikit/utils';
+import { useFieldId } from '@commercetools-uikit/hooks';
+import { designTokens, ThemeProvider } from '../../design-system';
 
 const SpecContainer = styled.div`
   display: flex;
@@ -48,11 +51,35 @@ const PropValue = styled.span`
   box-sizing: border-box;
 `;
 
-const Box = styled.div`
-  background-color: ${(props) =>
-    props.backgroundColor ?? designTokens.colorSurface};
-  }};
-`;
+const Box = (props) => (
+  <div
+    css={css`
+      background-color: ${(props) =>
+        props.backgroundColor ?? designTokens.colorSurface};
+      margin-bottom: 20px;
+    `}
+    {...(props.boxId ? { id: props.boxId } : {})}
+  >
+    <p
+      css={css`
+        text-decoration: underline;
+        font-weight: bold;
+        :first-letter {
+          text-transform: capitalize;
+        }
+      `}
+    >
+      {props.themeName} theme:
+    </p>
+    {props.children}
+  </div>
+);
+Box.propTypes = {
+  children: PropTypes.node.isRequired,
+  backgroundColor: PropTypes.string,
+  themeName: PropTypes.string.isRequired,
+  boxId: PropTypes.string.isRequired,
+};
 
 const Pill = (props) => {
   const value = (() => {
@@ -109,7 +136,11 @@ Props.propTypes = {
   propsToList: PropTypes.arrayOf(PropTypes.string),
 };
 
+const sequentialId = createSequentialId('local-');
+
 const Spec = (props) => {
+  const localId = useFieldId(undefined, sequentialId);
+
   return (
     <SpecContainer>
       <Label>{props.label}</Label>
@@ -121,7 +152,20 @@ const Spec = (props) => {
           {props.children}
         </Props>
       )}
-      <Box backgroundColor={props.backgroundColor}>{props.children}</Box>
+      <Box themeName="old" backgroundColor={props.backgroundColor}>
+        {props.children}
+      </Box>
+      <Box
+        themeName="new"
+        boxId={localId}
+        backgroundColor={props.backgroundColor}
+      >
+        <ThemeProvider
+          theme="test"
+          parentSelector={() => document.getElementById(localId)}
+        />
+        {props.children}
+      </Box>
     </SpecContainer>
   );
 };

--- a/test/percy/spec.jsx
+++ b/test/percy/spec.jsx
@@ -67,7 +67,7 @@ const Box = (props) => {
           }
         `}
       >
-        {`${props.themeName} theme`}
+        {props.themeName ? `${props.themeName} theme` : null}
       </p>
       {props.themeName === 'new' ? (
         <LocalThemeProvider theme="test">{props.children}</LocalThemeProvider>
@@ -160,6 +160,9 @@ const Spec = (props) => {
           {props.children}
         </Box>
       ) : null}
+      {props.testedThemes.length === 0 ? (
+        <Box backgroundColor={props.backgroundColor}>{props.children}</Box>
+      ) : null}
     </SpecContainer>
   );
 };
@@ -171,7 +174,7 @@ Spec.propTypes = {
   propsToList: PropTypes.arrayOf(PropTypes.string),
   omitPropsList: PropTypes.bool,
   backgroundColor: PropTypes.string,
-  testedThemes: PropTypes.arrayOf(['new', 'old']),
+  testedThemes: PropTypes.arrayOf(PropTypes.string),
 };
 
 Spec.defaultProps = {

--- a/test/percy/spec.jsx
+++ b/test/percy/spec.jsx
@@ -5,7 +5,7 @@ import { css } from '@emotion/react';
 import pick from 'lodash/pick';
 import { createSequentialId } from '@commercetools-uikit/utils';
 import { useFieldId } from '@commercetools-uikit/hooks';
-import { designTokens, ThemeProvider } from '../../design-system';
+import { designTokens, ThemeProvider, useTheme } from '../../design-system';
 
 const SpecContainer = styled.div`
   display: flex;
@@ -51,34 +51,44 @@ const PropValue = styled.span`
   box-sizing: border-box;
 `;
 
-const Box = (props) => (
-  <div
-    css={css`
-      background-color: ${(props) =>
-        props.backgroundColor ?? designTokens.colorSurface};
-      margin-bottom: 20px;
-    `}
-    {...(props.boxId ? { id: props.boxId } : {})}
-  >
-    <p
+const Box = (props) => {
+  const { isNewTheme } = useTheme(
+    props.boxId ? () => document.getElementById(props.boxId) : undefined
+  );
+  return (
+    <div
       css={css`
-        text-decoration: underline;
-        font-weight: bold;
-        :first-letter {
-          text-transform: capitalize;
-        }
+        background-color: ${props.backgroundColor ?? designTokens.colorSurface};
+        margin-bottom: 20px;
+
+        ${isNewTheme &&
+        css`
+          font-family: 'Inter', system-ui;
+          font-size: 16px; // This won't ever work since we use 'rem' units in components, so the font size will be calculated based on the font-size set in the <html> element
+        `}
       `}
+      {...(props.boxId ? { id: props.boxId } : {})}
     >
-      {props.themeName} theme:
-    </p>
-    {props.children}
-  </div>
-);
+      <p
+        css={css`
+          text-decoration: underline;
+          font-weight: bold;
+          :first-letter {
+            text-transform: capitalize;
+          }
+        `}
+      >
+        {props.themeName} theme:
+      </p>
+      {props.children}
+    </div>
+  );
+};
 Box.propTypes = {
   children: PropTypes.node.isRequired,
   backgroundColor: PropTypes.string,
   themeName: PropTypes.string.isRequired,
-  boxId: PropTypes.string.isRequired,
+  boxId: PropTypes.string,
 };
 
 const Pill = (props) => {

--- a/test/percy/spec.jsx
+++ b/test/percy/spec.jsx
@@ -162,12 +162,12 @@ const Spec = (props) => {
           {props.children}
         </Props>
       )}
-      {props.testedTheme === 'both' || props.testedTheme === 'old' ? (
+      {props.testedThemes.includes('old') ? (
         <Box themeName="old" backgroundColor={props.backgroundColor}>
           {props.children}
         </Box>
       ) : null}
-      {props.testedTheme === 'both' || props.testedTheme === 'new' ? (
+      {props.testedThemes.includes('new') ? (
         <Box
           themeName="new"
           boxId={localId}
@@ -191,13 +191,13 @@ Spec.propTypes = {
   propsToList: PropTypes.arrayOf(PropTypes.string),
   omitPropsList: PropTypes.bool,
   backgroundColor: PropTypes.string,
-  testedTheme: PropTypes.oneOf(['new', 'old', 'both']),
+  testedThemes: PropTypes.arrayOf(['new', 'old']),
 };
 
 Spec.defaultProps = {
   omitPropsList: false,
   listPropsOfNestedChild: false,
-  testedTheme: 'both',
+  testedThemes: ['new', 'old'],
 };
 
 Spec.displayName = 'Spec';

--- a/test/percy/spec.jsx
+++ b/test/percy/spec.jsx
@@ -80,7 +80,7 @@ const Box = (props) => {
 Box.propTypes = {
   children: PropTypes.node.isRequired,
   backgroundColor: PropTypes.string,
-  themeName: PropTypes.string.isRequired,
+  themeName: PropTypes.string,
 };
 
 const Pill = (props) => {
@@ -175,7 +175,7 @@ Spec.propTypes = {
   propsToList: PropTypes.arrayOf(PropTypes.string),
   omitPropsList: PropTypes.bool,
   backgroundColor: PropTypes.string,
-  testedThemes: PropTypes.arrayOf(PropTypes.string),
+  testedThemes: PropTypes.arrayOf('new', 'old'),
 };
 
 Spec.defaultProps = {

--- a/test/percy/spec.jsx
+++ b/test/percy/spec.jsx
@@ -160,6 +160,7 @@ const Spec = (props) => {
           {props.children}
         </Box>
       ) : null}
+      {/* For cases when the default theme is needed and the theme label is not necessary */}
       {props.testedThemes.length === 0 ? (
         <Box backgroundColor={props.backgroundColor}>{props.children}</Box>
       ) : null}


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

The aim of this PR is to showcase ui-kit components in both old- and the new theme in the ui-kit visual regression tests.
The idea is to leave the old theme vrts as they were, where css variables are read from the `:root` element of the visual testing app. On top of that, as part of each of the `<Spec>`s a local `<ThemeProvider>` context is created to showcase the component also in the new theme.

Remarks: 
- since we use `rem` font-size units, all font-size values (even the ones wrapped with local `<ThemeProvider>`) reference the value set in `:root`. This means that the screenshots do not 100% reflect how components look in the new theme. ([more on that in the thread](https://github.com/commercetools/ui-kit/pull/2462#discussion_r1145888671))
- I also considered going with the `new` theme first approach, but then we're experiencing the same issue as 👆. That means the components look a bit differently in the old theme scope and I thought this old theme will be our stable reference to how we are currently rendering components. I'm not sure about it thought 🤷‍♂️  
<img width="574" alt="Screenshot 2023-03-24 at 10 59 29" src="https://user-images.githubusercontent.com/49066275/227491681-9545b8e5-05cc-49f2-86ac-774b37360605.png">

- Last remark is about the use of `useTheme` hook within the components. Since we don't allow passing a `parentSelector` function to ui-kit components as a prop to use it like `useTheme(props.partentSelector)`, each use of `themedValue` or `isNewTheme` will not reflect the actual state for the nested theme context. Only `designTokens` values are reflected properly.
For instance: 
<img width="364" alt="Screenshot 2023-03-27 at 11 00 11" src="https://user-images.githubusercontent.com/49066275/227894584-de0cdf37-247a-422b-82e3-3cc6ee04b48b.png">
