### PR TITLE
docs: `<Label>` component's readme

### DIFF
--- a/packages/components/label/README.md
+++ b/packages/components/label/README.md
@@ -12,26 +12,27 @@ In order to improve readability, using `inverted` tone is recommended on dark ba
 
 ```js
 import Label from '@commercetools-uikit/label';
+import { FormattedMessage } from 'react-intl';
 
-<Label
-  isRequiredIndicatorVisible={true}
-  isBold={false}
-  tone="inverted"
-/>
-  <FormattedMessage {...messages.title} />
-</Label>
+const Example = () => (
+  <Label isRequiredIndicatorVisible={true} isBold={false} tone="inverted">
+    <FormattedMessage {...messages.title} />
+  </Label>
+);
+
+export default Example;
 ```
 
 ## Properties
 
-| Props                        | Type           | Required | Values                    | Default | Description                                                                                                     |
-| ---------------------------- | -------------- | :------: | ------------------------- | ------- | --------------------------------------------------------------------------------------------------------------- | --- |
-| `tone`                       | `string`       |    -     | `['primary', 'inverted']` | \_      | Indicates the tone to be applied to the label                                                                   |
-| `children`                   | `node`         | ✅ (\*)  | -                         | -       | Value of the label                                                                                              |
-| `intlMessage`                | `intl message` | ✅ (\*)  | -                         | -       | An intl message object that will be rendered with `FormattedMessage`                                            |
-| `isBold`                     | `bool`         |    -     | -                         | `false` | Indicates if the label title should be in bold text                                                             |
-| `isRequiredIndicatorVisible` | `bool`         |    -     | -                         | `false` | Indicates if the labeled field is required in a form                                                            |     |
-| `htmlFor`                    | `string`       |    -     | -                         | -       | The `for` HTML attribute, used to reference form elements with the related attribute `id` or `aria-labelledby`. |
-| `id`                         | `string`       |    -     | -                         | -       | The `id` HTML attribute, used to reference non-form elements with the related attribute `aria-labelledby`.      |
+| Props                        | Type                                                      | Required | Values | Default | Description                                                                                                     |
+| ---------------------------- | --------------------------------------------------------- | :------: | ------ | ------- | --------------------------------------------------------------------------------------------------------------- |
+| `tone`                       | `union`<br/>Possible values:<br/>`'primary' , 'inverted'` |    -     | -      | -       | Indicates the tone to be applied to the label                                                                   |
+| `children`                   | `ReactNode`                                               | ✅ (\*)  | -      | -       | Value of the label                                                                                              |
+| `intlMessage`                | `MessageDescriptor`                                       | ✅ (\*)  | -      | -       | An intl message object that will be rendered with `FormattedMessage`                                            |
+| `isBold`                     | `boolean`                                                 |    -     | -      | `false` | Indicates if the label title should be in bold text                                                             |
+| `isRequiredIndicatorVisible` | `boolean`                                                 |    -     | -      | `false` | Indicates if the labeled field is required in a form                                                            |
+| `htmlFor`                    | `string`                                                  |    -     | -      | -       | The `for` HTML attribute, used to reference form elements with the related attribute `id` or `aria-labelledby`. |
+| `id`                         | `string`                                                  |    -     | -      | -       | The `id` HTML attribute, used to reference non-form elements with the related attribute `aria-labelledby`.      |
 
 > `*`: `children` is required only if `intlMessage` is not provided, and vice-versa


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

closes #2472

Label is one of the components where the Readme file is not autogenerated due to issues with [jsx](https://github.com/commercetools/ui-kit/blob/ee7bf3220169b8eb34926d86e1d4dd909d76dc05/packages/components/label/src/label.tsx#L21-L37) within markdown parsing. The aim of this PR is just to format the table properly. 
