### PR TITLE
fix: proper border color when localized input in both disabled and read-only state

### DIFF
--- a/.changeset/eighty-items-kick.md
+++ b/.changeset/eighty-items-kick.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-uikit/localized-multiline-text-input': patch
+'@commercetools-uikit/localized-text-input': patch
+---
+
+Make border color in the `disabled` state take precedence over border color in the `read-only` state

--- a/packages/components/inputs/localized-multiline-text-input/src/translation-input.styles.ts
+++ b/packages/components/inputs/localized-multiline-text-input/src/translation-input.styles.ts
@@ -39,10 +39,14 @@ const getLanguageLabelBackgroundColor = (
   return designTokens.backgroundColorForLocalizedInputLabel;
 };
 
-const getLanguageLabelBorderColor = (props: TTranslationInputStylesProps) =>
-  props.isReadOnly
+const getLanguageLabelBorderColor = (props: TTranslationInputStylesProps) => {
+  if (props.isDisabled) {
+    return designTokens.borderColorForInputWhenDisabled;
+  }
+  return props.isReadOnly
     ? designTokens.borderColorForLocalizedInputLabelWhenReadonly
     : designTokens.borderColorForLocalizedInputLabel;
+};
 
 const getLanguageLabelStyles = (props: TTranslationInputStylesProps) => {
   return css`

--- a/packages/components/inputs/localized-text-input/src/localized-text-input.styles.ts
+++ b/packages/components/inputs/localized-text-input/src/localized-text-input.styles.ts
@@ -25,6 +25,15 @@ const getLanguageLabelBackgroundColor = (props: TLocalizedInputProps) => {
   return designTokens.backgroundColorForLocalizedInputLabel;
 };
 
+const getLanguageLabelBorderColor = (props: TLocalizedInputProps) => {
+  if (props.isDisabled) {
+    return designTokens.borderColorForInputWhenDisabled;
+  }
+  return props.isReadOnly
+    ? designTokens.borderColorForLocalizedInputLabelWhenReadonly
+    : designTokens.borderColorForLocalizedInputLabel;
+};
+
 const getLanguageLabelStyles = (
   props: TLocalizedInputProps & { isNewTheme: boolean }
 ) => {
@@ -42,10 +51,7 @@ const getLanguageLabelStyles = (
     background-color: ${getLanguageLabelBackgroundColor(props)};
     border-top-left-radius: ${designTokens.borderRadiusForInput};
     border-bottom-left-radius: ${designTokens.borderRadiusForInput};
-    border: 1px solid
-      ${props.isReadOnly && props.isNewTheme
-        ? designTokens.colorSurface
-        : designTokens.borderColorForInputWhenDisabled};
+    border: 1px solid ${getLanguageLabelBorderColor(props)};
     padding: ${designTokens.paddingForLocalizedInputLabel};
     transition: border-color ${designTokens.transitionStandard},
       background-color ${designTokens.transitionStandard},


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

closes #2483

Before:
|  LocalizedTextInput |  LocalizedMultilineTextInput |  
|---|---|
|  <img width="369" alt="Screenshot 2023-04-06 at 14 57 48" src="https://user-images.githubusercontent.com/49066275/230385387-740f6610-c868-4163-b2ad-8f00105e9bf5.png"> |   <img width="376" alt="Screenshot 2023-04-06 at 14 59 24" src="https://user-images.githubusercontent.com/49066275/230385790-89712d29-e1d9-4c02-b7e8-8ecd15a649f5.png"> |


After:
|  LocalizedTextInput | LocalizedMultilineTextInput  |  
|---|---|
|  <img width="394" alt="Screenshot 2023-04-06 at 14 58 44" src="https://user-images.githubusercontent.com/49066275/230385558-1306c07e-480e-4d7d-a58a-eb06718c60c1.png"> |  <img width="378" alt="Screenshot 2023-04-06 at 15 00 52" src="https://user-images.githubusercontent.com/49066275/230386123-ba93df22-cdcb-4849-ac2f-6ce68eb22d29.png"> |

