### PR TITLE
Fix `LoadingSpinner` early rendering

### DIFF
--- a/.changeset/wild-ways-hunt.md
+++ b/.changeset/wild-ways-hunt.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/loading-spinner': patch
+---
+
+Fix early rendering when providing `0` as the value for `maxDelayDuration` prop.

--- a/packages/components/loading-spinner/src/loading-spinner.spec.js
+++ b/packages/components/loading-spinner/src/loading-spinner.spec.js
@@ -4,10 +4,10 @@ import LoadingSpinner from './loading-spinner';
 
 const delay = (byMs) => new Promise((resolve) => setTimeout(resolve, byMs));
 
-const renderSpinner = () => {
+const renderSpinner = (customProps = { maxDelayDuration: 100 }) => {
   const props = {
     scale: 'l',
-    maxDelayDuration: 100,
+    ...customProps,
   };
   const rendered = render(
     <LoadingSpinner
@@ -31,6 +31,11 @@ it('should show loading spinner and render children when the maximum delay durat
   expect(rendered.getByTestId('loading-spinner-child')).toBeInTheDocument();
 });
 
+it('should show loading spinner right away when using 0 delay', () => {
+  const rendered = renderSpinner({ maxDelayDuration: 0 });
+  expect(rendered.getByTestId('loading-spinner-child')).toBeInTheDocument();
+});
+
 it('should not show loading spinner before maximum delay duration has passed', async () => {
   const rendered = renderSpinner();
 
@@ -39,4 +44,6 @@ it('should not show loading spinner before maximum delay duration has passed', a
   ).not.toBeInTheDocument();
 
   await rendered.waitUntilMaxDuration();
+
+  expect(rendered.getByTestId('loading-spinner-child')).toBeInTheDocument();
 });

--- a/packages/components/loading-spinner/src/loading-spinner.tsx
+++ b/packages/components/loading-spinner/src/loading-spinner.tsx
@@ -59,7 +59,7 @@ const LoadingSpinner = (props: TLoadingSpinnerProps) => {
     return () => clearTimeout(delaySpinnerTimeout);
   }, [props.maxDelayDuration]);
 
-  if (!showSpinner) return null;
+  if (!showSpinner && (props.maxDelayDuration ?? 0) > 0) return null;
 
   return (
     <Inline alignItems="center">


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Fix `LoadingSpinner` early rendering.

closes #2425

## Description

When providing a `0` value to `maxDelayDuration` a consumer would expect this component to render right away but that's not technically the case since the component will only start actually render its contents after its first initial render kicks a `useEffect` in, which in turn fires a `setTimeout` which (again) technically can last more that 0 milliseconds as it will add a task to the JS engine event loop and it will depend on how many tasks are already in the loop.

Also, when using the component in a SSR environment, the component would never render since `useEffect` does not run in that environment.
