### PR TITLE
Adding `nowrap` prop to the Text component

### DIFF
--- a/.changeset/serious-peas-run.md
+++ b/.changeset/serious-peas-run.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/text': minor
+---
+
+adding new prop `nowrap` to the Text components

--- a/packages/components/text/README.md
+++ b/packages/components/text/README.md
@@ -18,14 +18,15 @@ import Text from '@commercetools-uikit/text';
 
 ### Properties
 
-| Props         | Type             | Required | Values               | Default | Description                                                            |
-| ------------- | ---------------- | :------: | -------------------- | ------- | ---------------------------------------------------------------------- |
-| `as`          | `String`         |    ✅    | `['h1', 'h2', 'h3']` | -       | -                                                                      |
-| `children`    | `PropTypes.node` | ✅ (\*)  | -                    | -       | -                                                                      |
-| `intlMessage` | `intl message`   | ✅ (\*)  | -                    | -       | An `intl` message object that will be rendered with `FormattedMessage` |
-| `id`          | `String`         |    -     | -                    | -       | Used as HTML id property                                               |
-| `title`       | `String`         |    -     | -                    | -       | Text to show in a tooltip on hover over the element                    |
-| `truncate`    | `Bool`           |    -     | -                    | `false` | Option for truncate content in case the screen has small width         |
+| Props         | Type             | Required | Values               | Default | Description                                                                               |
+| ------------- | ---------------- | :------: | -------------------- | ------- | ----------------------------------------------------------------------------------------- |
+| `as`          | `String`         |    ✅    | `['h1', 'h2', 'h3']` | -       | -                                                                                         |
+| `children`    | `PropTypes.node` | ✅ (\*)  | -                    | -       | -                                                                                         |
+| `intlMessage` | `intl message`   | ✅ (\*)  | -                    | -       | An `intl` message object that will be rendered with `FormattedMessage`                    |
+| `id`          | `String`         |    -     | -                    | -       | Used as HTML id property                                                                  |
+| `title`       | `String`         |    -     | -                    | -       | Text to show in a tooltip on hover over the element                                       |
+| `truncate`    | `Bool`           |    -     | -                    | `false` | Option for truncate content in case the screen has small width                            |
+| `nowrap`      | `Bool`           |    -     | -                    | `false` | The content in the element will not be wrapped to a new line unless explicitly specified. |
 
 > `*`: `children` is required only if `intlMessage` is not provided
 
@@ -49,16 +50,17 @@ import Text from '@commercetools-uikit/text';
 
 ### Properties
 
-| Props         | Type             | Required | Values                                                            | Default |                                                                        |
-| ------------- | ---------------- | :------: | ----------------------------------------------------------------- | ------- | ---------------------------------------------------------------------- |
-| `as`          | `String`         |    ✅    | `['h4', 'h5']`                                                    | -       |                                                                        |
-| `id`          | `String`         |    -     | -                                                                 | -       | Used as HTML id property                                               |
-| `isBold`      | `Boolean`        |    -     | -                                                                 | `false` |                                                                        |
-| `tone`        | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative']` | -       |                                                                        |
-| `children`    | `PropTypes.node` | ✅ (\*)  | -                                                                 | -       |                                                                        |
-| `intlMessage` | `intl message`   | ✅ (\*)  | -                                                                 | -       | An `intl` message object that will be rendered with `FormattedMessage` |
-| `title`       | `String`         |    -     | -                                                                 | -       |                                                                        |
-| `truncate`    | `Bool`           |    -     | -                                                                 | `false` |                                                                        |
+| Props         | Type             | Required | Values                                                            | Default |                                                                                           |
+| ------------- | ---------------- | :------: | ----------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------- |
+| `as`          | `String`         |    ✅    | `['h4', 'h5']`                                                    | -       |                                                                                           |
+| `id`          | `String`         |    -     | -                                                                 | -       | Used as HTML id property                                                                  |
+| `isBold`      | `Boolean`        |    -     | -                                                                 | `false` |                                                                                           |
+| `tone`        | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative']` | -       |                                                                                           |
+| `children`    | `PropTypes.node` | ✅ (\*)  | -                                                                 | -       |                                                                                           |
+| `intlMessage` | `intl message`   | ✅ (\*)  | -                                                                 | -       | An `intl` message object that will be rendered with `FormattedMessage`                    |
+| `title`       | `String`         |    -     | -                                                                 | -       |                                                                                           |
+| `truncate`    | `Bool`           |    -     | -                                                                 | `false` |                                                                                           |
+| `nowrap`      | `Bool`           |    -     | -                                                                 | `false` | The content in the element will not be wrapped to a new line unless explicitly specified. |
 
 > `*`: `children` is required only if `intlMessage` is not provided
 
@@ -98,18 +100,19 @@ import Text from '@commercetools-uikit/text';
 
 ### Properties
 
-| Props             | Type             | Required | Values                                                                        | Default |                                                                        |
-| ----------------- | ---------------- | :------: | ----------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------- |
-| `as`              | `String`         |    -     | `['p', 'span']`                                                               | -       |                                                                        |
-| `id`              | `String`         |    -     | -                                                                             | -       | Used as HTML id property                                               |
-| `isBold`          | `Boolean`        |    -     | -                                                                             | `false` |                                                                        |
-| `isItalic`        | `Boolean`        |    -     | -                                                                             | `false` |                                                                        |
-| `isStrikethrough` | `Boolean`        |    -     | -                                                                             | `false` |                                                                        |
-| `tone`            | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative', 'inverted']` | -       |                                                                        |
-| `children`        | `PropTypes.node` | ✅ (\*)  | -                                                                             | -       |                                                                        |
-| `intlMessage`     | `intl message`   | ✅ (\*)  | -                                                                             | -       | An `intl` message object that will be rendered with `FormattedMessage` |
-| `title`           | `String`         |    -     | -                                                                             | -       |                                                                        |
-| `truncate`        | `Bool`           |    -     | -                                                                             | `false` |                                                                        |
+| Props             | Type             | Required | Values                                                                        | Default |                                                                                           |
+| ----------------- | ---------------- | :------: | ----------------------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------- |
+| `as`              | `String`         |    -     | `['p', 'span']`                                                               | -       |                                                                                           |
+| `id`              | `String`         |    -     | -                                                                             | -       | Used as HTML id property                                                                  |
+| `isBold`          | `Boolean`        |    -     | -                                                                             | `false` |                                                                                           |
+| `isItalic`        | `Boolean`        |    -     | -                                                                             | `false` |                                                                                           |
+| `isStrikethrough` | `Boolean`        |    -     | -                                                                             | `false` |                                                                                           |
+| `tone`            | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative', 'inverted']` | -       |                                                                                           |
+| `children`        | `PropTypes.node` | ✅ (\*)  | -                                                                             | -       |                                                                                           |
+| `intlMessage`     | `intl message`   | ✅ (\*)  | -                                                                             | -       | An `intl` message object that will be rendered with `FormattedMessage`                    |
+| `title`           | `String`         |    -     | -                                                                             | -       |                                                                                           |
+| `truncate`        | `Bool`           |    -     | -                                                                             | `false` |                                                                                           |
+| `nowrap`          | `Bool`           |    -     | -                                                                             | `false` | The content in the element will not be wrapped to a new line unless explicitly specified. |
 
 > `*`: `children` is required only if `intlMessage` is not provided
 
@@ -135,19 +138,20 @@ import Text from '@commercetools-uikit/text';
 
 ### Properties
 
-| Props             | Type             | Required | Values                                                                        | Default |                                                                                    |
-| ----------------- | ---------------- | :------: | ----------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------------------- |
-| `as`              | `string`         |    -     | `['small', 'span']` `[^]`                                                     | `false` |                                                                                    |
-| `id`              | `String`         |    -     | -                                                                             | -       | Used as HTML id property                                                           |
-| `isBold`          | `Boolean`        |    -     | -                                                                             | `false` |                                                                                    |
-| `isItalic`        | `Boolean`        |    -     | -                                                                             | `false` |                                                                                    |
-| `isStrikethrough` | `Boolean`        |    -     | -                                                                             | `false` |                                                                                    |
-| `tone`            | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative', 'warning'']` | -       |                                                                                    |
-| `children`        | `PropTypes.node` | ✅ (\*)  | -                                                                             | -       |                                                                                    |
-| `intlMessage`     | `intl message`   | ✅ (\*)  | -                                                                             | -       | An `intl` message object that will be rendered with `FormattedMessage`             |
-| `title`           | `String`         |    -     | -                                                                             | -       |                                                                                    |
-| `truncate`        | `Bool`           |    -     | -                                                                             | `false` |                                                                                    |
-| `aria-labelledby` | `String`         |    -     | -                                                                             | -       | HTML ID of an element containing the label for the text rendered in this component |
+| Props             | Type             | Required | Values                                                                        | Default |                                                                                           |
+| ----------------- | ---------------- | :------: | ----------------------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------- |
+| `as`              | `string`         |    -     | `['small', 'span']` `[^]`                                                     | `false` |                                                                                           |
+| `id`              | `String`         |    -     | -                                                                             | -       | Used as HTML id property                                                                  |
+| `isBold`          | `Boolean`        |    -     | -                                                                             | `false` |                                                                                           |
+| `isItalic`        | `Boolean`        |    -     | -                                                                             | `false` |                                                                                           |
+| `isStrikethrough` | `Boolean`        |    -     | -                                                                             | `false` |                                                                                           |
+| `tone`            | `String`         |    -     | `['primary', 'secondary', 'information', 'positive', 'negative', 'warning'']` | -       |                                                                                           |
+| `children`        | `PropTypes.node` | ✅ (\*)  | -                                                                             | -       |                                                                                           |
+| `intlMessage`     | `intl message`   | ✅ (\*)  | -                                                                             | -       | An `intl` message object that will be rendered with `FormattedMessage`                    |
+| `title`           | `String`         |    -     | -                                                                             | -       |                                                                                           |
+| `truncate`        | `Bool`           |    -     | -                                                                             | `false` |                                                                                           |
+| `aria-labelledby` | `String`         |    -     | -                                                                             | -       | HTML ID of an element containing the label for the text rendered in this component        |
+| `nowrap`          | `Bool`           |    -     | -                                                                             | `false` | The content in the element will not be wrapped to a new line unless explicitly specified. |
 
 > `*`: `children` is required only if `intlMessage` is not provided.
 > `[^]`: Use `as` prop to render an inline element.

--- a/packages/components/text/src/text.story.js
+++ b/packages/components/text/src/text.story.js
@@ -24,6 +24,7 @@ storiesOf('Basics|Typography/Text', module)
         as={select('as', ['h1', 'h2', 'h3'], 'h1')}
         title={text('title', 'Text to be shown as tooltip on hover')}
         truncate={boolean('truncate', false)}
+        nowrap={boolean('nowrap', false)}
       >
         {text('Text', 'Sample text Headline')}
       </Text.Headline>
@@ -44,6 +45,7 @@ storiesOf('Basics|Typography/Text', module)
         })}
         title={text('title', 'Text to be shown as tooltip on hover')}
         truncate={boolean('truncate', false)}
+        nowrap={boolean('nowrap', false)}
       >
         {text('Text', 'Sample text Subheadline')}
       </Text.Subheadline>
@@ -85,6 +87,7 @@ storiesOf('Basics|Typography/Text', module)
         })}
         title={text('title', 'Text to be shown as tooltip on hover')}
         truncate={boolean('truncate', false)}
+        nowrap={boolean('nowrap', false)}
       >
         {text('Text', 'Sample text Body')}
       </Text.Body>
@@ -112,6 +115,7 @@ storiesOf('Basics|Typography/Text', module)
         })}
         title={text('title', 'Text to be shown as tooltip on hover')}
         truncate={boolean('truncate', false)}
+        nowrap={boolean('nowrap', false)}
       >
         {text('Text', 'Sample text Detail')}
       </Text.Detail>

--- a/packages/components/text/src/text.styles.ts
+++ b/packages/components/text/src/text.styles.ts
@@ -20,6 +20,10 @@ const truncate = `
   text-overflow: ellipsis;
 `;
 
+const nowrap = `
+  white-space: nowrap;
+`;
+
 const bold = `
   font-weight: ${designTokens.fontWeightForTextAsBold};
 `;
@@ -119,6 +123,7 @@ export const bodyStyles = (props: TBodyProps) => css`
   ${props.isStrikethrough && strikethrough}
   ${props.tone && getTone(props.tone)}
   ${props.truncate && truncate}
+  ${props.nowrap && nowrap}
 `;
 
 export const headlineStyles = (props: THeadlineProps) => css`
@@ -128,6 +133,7 @@ export const headlineStyles = (props: THeadlineProps) => css`
   line-height: ${getElementLineHeight(props.as)};
   font-weight: ${getElementFontWeight(props.as)};
   ${props.truncate && truncate}
+  ${props.nowrap && nowrap}
 `;
 
 export const subheadlineStyles = (props: TSubheadlineProps) => css`
@@ -137,6 +143,7 @@ export const subheadlineStyles = (props: TSubheadlineProps) => css`
   line-height: ${getElementLineHeight(props.as)};
   font-weight: ${getElementFontWeight(props.as)};
   ${props.truncate && truncate}
+  ${props.nowrap && nowrap}
   ${props.isBold && bold}
   ${props.tone && getTone(props.tone)}
 `;
@@ -157,4 +164,5 @@ export const detailStyles = (props: TDetailProps) => css`
   ${props.isStrikethrough && strikethrough}
   ${props.tone && getTone(props.tone)}
   ${props.truncate && truncate}
+  ${props.nowrap && nowrap}
 `;

--- a/packages/components/text/src/text.tsx
+++ b/packages/components/text/src/text.tsx
@@ -83,6 +83,7 @@ Text.displayName = 'Text';
 export type THeadlineProps = {
   as?: 'h1' | 'h2' | 'h3';
   truncate?: boolean;
+  nowrap?: boolean;
 } & TBasicTextProps &
   TBasicHeadlineProps;
 
@@ -119,6 +120,7 @@ Headline.displayName = 'TextHeadline';
 export type TSubheadlineProps = {
   as?: 'h4' | 'h5';
   truncate?: boolean;
+  nowrap?: boolean;
   isBold?: boolean;
   tone?: TTone;
 } & TBasicTextProps &
@@ -179,6 +181,7 @@ export type TBodyProps = {
   isStrikethrough?: boolean;
   tone?: TTone | 'inverted';
   truncate?: boolean;
+  nowrap?: boolean;
 } & TBasicTextProps &
   TBasicHeadlineProps;
 
@@ -220,6 +223,7 @@ export type TDetailProps = {
   as?: 'span' | 'small';
   tone?: TTone | 'warning' | 'inverted';
   truncate?: boolean;
+  nowrap?: boolean;
   'aria-labelledby'?: string;
 } & TBasicTextProps &
   TBasicHeadlineProps;

--- a/packages/components/text/src/text.visualroute.jsx
+++ b/packages/components/text/src/text.visualroute.jsx
@@ -22,6 +22,13 @@ export const component = () => (
         </Text.Headline>
       </Spec>
     </NarrowBox>
+    <NarrowBox>
+      <Spec label="Headline - h1 - nowrap">
+        <Text.Headline as="h1" nowrap={true}>
+          {'A longer title that should not be new line'}
+        </Text.Headline>
+      </Spec>
+    </NarrowBox>
 
     <Spec label="Headline - h2">
       <Text.Headline as="h2">{'Title H2'}</Text.Headline>
@@ -36,6 +43,13 @@ export const component = () => (
       <Spec label="Subheadline - h4 - truncated">
         <Text.Subheadline as="h4" truncate={true}>
           {'A longer subheadline that should be truncated'}
+        </Text.Subheadline>
+      </Spec>
+    </NarrowBox>
+    <NarrowBox>
+      <Spec label="Subheadline - h4 - nowrap">
+        <Text.Subheadline as="h4" nowrap={true}>
+          {'A longer title that should not be new line'}
         </Text.Subheadline>
       </Spec>
     </NarrowBox>
@@ -116,6 +130,13 @@ export const component = () => (
         </Text.Body>
       </Spec>
     </NarrowBox>
+    <NarrowBox>
+      <Spec label="Body - nowrap">
+        <Text.Body nowrap={true}>
+          A longer title that should not be new line
+        </Text.Body>
+      </Spec>
+    </NarrowBox>
     <Spec label="Body - inline" omitPropsList>
       <Text.Body as="span">One inline body text{'. '}</Text.Body>
       <Text.Body as="span">A second inline text.</Text.Body>
@@ -151,6 +172,13 @@ export const component = () => (
       <Spec label="Detail - truncate">
         <Text.Detail truncate={true}>
           A longer detail text that needs to be truncated.
+        </Text.Detail>
+      </Spec>
+    </NarrowBox>
+    <NarrowBox>
+      <Spec label="Detail - nowrap">
+        <Text.Detail nowrap={true}>
+          A longer title that should not be new line
         </Text.Detail>
       </Spec>
     </NarrowBox>


### PR DESCRIPTION
When using `Spacings.Inline` to lay out two elements side-by-side, if one of the elements is a text element and the other is large enough, the text may wrap, which is undesirable in some cases.

That's why we've introduced the `nowrap` prop for the Text components. 
It renders the `white-space` CSS prop and then the element will not be wrapped to a new line.

Closes [this issue](https://github.com/commercetools/ui-kit/issues/2474).

**Before the change:**
<img width="274" alt="before_nowrap" src="https://user-images.githubusercontent.com/52276952/231801354-a35b0e8e-0438-40bc-95fd-ef62178de719.png">

**After the change:** 
<img width="345" alt="after_nowrap" src="https://user-images.githubusercontent.com/52276952/231801399-3905cb23-2cdf-41a7-b86b-0f6aba1df680.png">
