### PR TITLE
Export more Typescript types from Select components

### DIFF
--- a/.changeset/modern-books-tie.md
+++ b/.changeset/modern-books-tie.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/select-input': patch
+---
+
+Export new Typescript types: TSelectInputProps, `TOption`, `TOptionObject`, `TOptions` and `TCustomEvent`.

--- a/.changeset/tidy-shoes-play.md
+++ b/.changeset/tidy-shoes-play.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/select-field': patch
+---
+
+Export new Typescript types: `TSelectFieldProps`, `TOption`, `TOptionObject`, `TOptions` and `TCustomEvent`.

--- a/packages/components/fields/select-field/src/export-types.ts
+++ b/packages/components/fields/select-field/src/export-types.ts
@@ -1,1 +1,7 @@
-export type { TSelectFieldProps } from './select-field';
+export type {
+  TSelectFieldProps,
+  TOption,
+  TOptionObject,
+  TOptions,
+  TCustomEvent,
+} from './select-field';

--- a/packages/components/fields/select-field/src/select-field.tsx
+++ b/packages/components/fields/select-field/src/select-field.tsx
@@ -20,15 +20,15 @@ import FieldErrors from '@commercetools-uikit/field-errors';
 import type { Props as ReactSelectProps } from 'react-select';
 
 type TErrorRenderer = (key: string, error?: boolean) => ReactNode;
-type TOption = {
+export type TOption = {
   value: string;
   label?: ReactNode;
 };
-type TOptionObject = {
+export type TOptionObject = {
   options: TOption[];
 };
-type TOptions = TOption[] | TOptionObject[];
-type TCustomEvent = {
+export type TOptions = TOption[] | TOptionObject[];
+export type TCustomEvent = {
   target: {
     id?: ReactSelectProps['inputId'];
     name?: ReactSelectProps['name'];
@@ -196,7 +196,7 @@ export type TSelectFieldProps = {
    * <br/>
    * The value will be the selected option, or an array of options in case isMulti is true.
    */
-  onChange?: (event?: TCustomEvent) => void;
+  onChange?: (event: TCustomEvent) => void;
   /**
    * Handle focus events on the control
    * <br/>

--- a/packages/components/inputs/select-input/src/export-types.ts
+++ b/packages/components/inputs/select-input/src/export-types.ts
@@ -1,1 +1,7 @@
-export type { TSelectInputProps, TOption } from './select-input';
+export type {
+  TSelectInputProps,
+  TOption,
+  TOptionObject,
+  TOptions,
+  TCustomEvent,
+} from './select-input';

--- a/packages/components/inputs/select-input/src/select-input.tsx
+++ b/packages/components/inputs/select-input/src/select-input.tsx
@@ -32,13 +32,13 @@ export type TOption = {
   label?: ReactNode;
 };
 
-type TOptionObject = {
+export type TOptionObject = {
   options: TOption[];
 };
 
-type TOptions = TOption[] | TOptionObject[];
+export type TOptions = TOption[] | TOptionObject[];
 
-type TCustomEvent = {
+export type TCustomEvent = {
   target: {
     id?: ReactSelectProps['inputId'];
     name?: ReactSelectProps['name'];


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Export more Typescript types from Select components

## Description

In order to help consumers using `SelectInput` and `SelectField` components, I propose to expose more TS types from them.

