### PR TITLE
fix: enable passing `data-*` attributes to `TagList`

### DIFF
--- a/.changeset/cuddly-months-give.md
+++ b/.changeset/cuddly-months-give.md
@@ -2,4 +2,4 @@
 '@commercetools-uikit/tag': patch
 ---
 
-Enable passing a class name and `data-*` attributes to the `<TagList>` component
+Enable passing `data-*` attributes to the `<TagList>` component

--- a/.changeset/cuddly-months-give.md
+++ b/.changeset/cuddly-months-give.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/tag': patch
+---
+
+Enable passing a class name and `data-*` attributes to the `<TagList>` component

--- a/packages/components/tag/package.json
+++ b/packages/components/tag/package.json
@@ -27,6 +27,7 @@
     "@commercetools-uikit/icons": "15.14.3",
     "@commercetools-uikit/spacings": "15.14.3",
     "@commercetools-uikit/text": "15.14.3",
+    "@commercetools-uikit/utils": "15.14.3",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "prop-types": "15.8.1",

--- a/packages/components/tag/src/tag-list/tag-list.tsx
+++ b/packages/components/tag/src/tag-list/tag-list.tsx
@@ -6,6 +6,8 @@ import styled from '@emotion/styled';
 export type TTagListProps = {
   children: ReactNode;
   /**
+   * @deprecated
+   *
    * Allow to override the styles by passing a `className` prop.
    * <br/>
    * Custom styles can also be passed using the [`css` prop from emotion](https://emotion.sh/docs/css-prop#style-precedence).

--- a/packages/components/tag/src/tag-list/tag-list.tsx
+++ b/packages/components/tag/src/tag-list/tag-list.tsx
@@ -1,9 +1,16 @@
 import { type ReactNode, Children } from 'react';
 import { designTokens } from '@commercetools-uikit/design-system';
+import { filterDataAttributes } from '@commercetools-uikit/utils';
 import styled from '@emotion/styled';
 
 export type TTagListProps = {
   children: ReactNode;
+  /**
+   * Allow to override the styles by passing a `className` prop.
+   * <br/>
+   * Custom styles can also be passed using the [`css` prop from emotion](https://emotion.sh/docs/css-prop#style-precedence).
+   */
+  className?: string;
 };
 
 const TagListContainer = styled.div`
@@ -18,7 +25,10 @@ const TagListItem = styled.div`
 
 const TagList = (props: TTagListProps) => {
   return (
-    <TagListContainer>
+    <TagListContainer
+      className={props.className}
+      {...filterDataAttributes(props)}
+    >
       {Children.map(props.children, (tag) => (
         <TagListItem>{tag}</TagListItem>
       ))}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5104,6 +5104,7 @@ __metadata:
     "@commercetools-uikit/icons": 15.14.3
     "@commercetools-uikit/spacings": 15.14.3
     "@commercetools-uikit/text": 15.14.3
+    "@commercetools-uikit/utils": 15.14.3
     "@emotion/react": ^11.10.5
     "@emotion/styled": ^11.10.5
     prop-types: 15.8.1


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

I’ve been trying to integrate the new `<TagList>` component in the mc-fe and it turned out that:
- in almost every case we apply custom styles via a `className`. Some styles are quite sophisticated so I didn't want to change anything in the implementation and only pass the classname.
- most of the components are tested via `data-testid` attribute

We accept `className` as a prop in case of several ui-kit components, so I thought about doing it here as well instead of using a wrapper with custom styles in the client code. But I'm open to suggestions if you see it differently.

Another thing is the changeset. I've enclosed it but I'm not sure we need it if the component hasn’t been released yet 🤔, any ideas?
