### PR TITLE
fix: ui regression with `controlShouldRenderValue`

### DIFF
--- a/.changeset/olive-readers-return.md
+++ b/.changeset/olive-readers-return.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-uikit/select-input': patch
+'@commercetools-uikit/select-utils': patch
+---
+
+Fix ui regression in select inputs and fields with `controlShouldRenderValue` prop value

--- a/packages/components/inputs/select-input/src/select-input.tsx
+++ b/packages/components/inputs/select-input/src/select-input.tsx
@@ -324,11 +324,10 @@ export type TSelectInputProps = {
 
 const defaultProps: Pick<
   TSelectInputProps,
-  'maxMenuHeight' | 'menuPortalZIndex' | 'controlShouldRenderValue' | 'options'
+  'maxMenuHeight' | 'menuPortalZIndex' | 'options'
 > = {
   maxMenuHeight: 220,
   menuPortalZIndex: 1,
-  controlShouldRenderValue: true,
   options: [],
 };
 

--- a/packages/components/inputs/select-utils/src/create-select-styles.ts
+++ b/packages/components/inputs/select-utils/src/create-select-styles.ts
@@ -254,7 +254,9 @@ const valueContainerStyles = (props: TProps) => (base: TBase) => {
     // See PR from react select for more insight https://github.com/JedWatson/react-select/pull/4833
     display:
       (props.iconLeft && !props.isMulti) ||
-      (props.isMulti && props.hasValue && props.controlShouldRenderValue)
+      (props.isMulti &&
+        props.hasValue &&
+        (props.controlShouldRenderValue ?? true))
         ? 'flex'
         : 'grid',
     fill:


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Closes #2503
Regression resulting from https://github.com/commercetools/ui-kit/pull/2490/

Appearing in all select fields and inputs (apart from `SelectField` and `SelectInput` where the default `controlShouldRenderValue` prop value was added).
