### PR TITLE
fix: extend TDataTableProps type

### DIFF
--- a/.changeset/afraid-brooms-punch.md
+++ b/.changeset/afraid-brooms-punch.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table': patch
+---
+
+Extend `TDataTableProps` type by using the generic row type in its `columns` property

--- a/packages/components/data-table/src/data-table.tsx
+++ b/packages/components/data-table/src/data-table.tsx
@@ -25,7 +25,9 @@ export interface TRow {
   id: string;
 }
 
-const getColumnsLayoutInfo = (columns: TColumn[]) =>
+const getColumnsLayoutInfo = <Row extends TRow = TRow>(
+  columns: TColumn<Row>[]
+) =>
   columns.reduce<Pick<TColumn, 'key' | 'width'>[]>(
     (acc, currentValue) => [
       ...acc,
@@ -154,7 +156,7 @@ export type TDataTableProps<Row extends TRow = TRow> = {
    * The list of columns to be rendered.
    * Each column can be customized (see properties below).
    */
-  columns: TColumn[];
+  columns: TColumn<Row>[];
   /**
    * Element to render within the `tfoot` (footer) element of the table.
    */
@@ -279,7 +281,7 @@ const DataTable = <Row extends TRow = TRow>(props: TDataTableProps<Row>) => {
       <TableGrid
         ref={tableRef as LegacyRef<HTMLTableElement>}
         {...filterDataAttributes(props)}
-        columns={props.columns}
+        columns={props.columns as TColumn<TRow>[]}
         maxHeight={props.maxHeight}
         disableSelfContainment={!!props.disableSelfContainment}
         resizedTotalWidth={resizedTotalWidth}


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary
This PR extends `TDataTableProps` type by using the generic row type in its `columns` property

## Description
While typing column definitions in one of Discounts web app features, the following error appeared. The type of the `columns` prop of the `DataTable` component can be improved.
![Screenshot 2023-04-28 at 12 59 47](https://user-images.githubusercontent.com/13467563/235130871-858acd7a-1e9b-4350-b73d-42abe19178a2.png)

