### PR TITLE
fix: memoize `useTheme.themedValue` helper

### DIFF
--- a/.changeset/old-pigs-check.md
+++ b/.changeset/old-pigs-check.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/design-system': patch
+---
+
+Memoized `useTheme.themedValue` helper

--- a/design-system/src/theme-provider.tsx
+++ b/design-system/src/theme-provider.tsx
@@ -128,10 +128,11 @@ const useTheme = (parentSelector = defaultParentSelector): TUseThemeResult => {
     attributeFilter: ['data-theme'],
   });
 
-  const themedValue: TUseThemeResult['themedValue'] = (
-    defaultThemeValue,
-    newThemeValue
-  ) => (theme === 'default' ? defaultThemeValue : newThemeValue);
+  const themedValue: TUseThemeResult['themedValue'] = useCallback(
+    (defaultThemeValue, newThemeValue) =>
+      theme === 'default' ? defaultThemeValue : newThemeValue,
+    [theme]
+  );
 
   // If we use 'useLayoutEffect' here, we would be trying to read the
   // data attribute before it gets set from the effect in the ThemeProvider


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary
`useTheme.themedValue` helper is causing re-renders in memoized code.

<!-- provide a short summary of your changes -->

## Description
While working on Discounts web app and trying to avoid re-renders on a form, I realized that `useTheme.themedValue` helper was causing them.
I know this helper is ephemeral, but is being used in production while the cleanup phase is not finished yet.

<!-- provide some context -->
