### PR TITLE
Alternative proposal for multiline inputs height management

### DIFF
--- a/packages/components/inputs/input-utils/src/multiline-input/multiline-input.tsx
+++ b/packages/components/inputs/input-utils/src/multiline-input/multiline-input.tsx
@@ -34,6 +34,20 @@ export type TMultiLineInputProps = {
   'aria-errormessage'?: string;
 };
 
+// We cache the vertical padding of the element becuase
+// it does not change over time so we don't need to
+// recalculate it on every height change event.
+let _elementVerticalPadding: number | null = null;
+const getElementVerticalPadding = (element: Element) => {
+  if (_elementVerticalPadding === null) {
+    const computedStyle = getComputedStyle(element);
+    const paddingTop = parseInt(computedStyle.paddingTop, 10);
+    const paddingBottom = parseInt(computedStyle.paddingBottom, 10);
+    _elementVerticalPadding = paddingTop + paddingBottom;
+  }
+  return _elementVerticalPadding;
+};
+
 const MultilineInput = (props: TMultiLineInputProps) => {
   const { onHeightChange } = props;
   const ref = useRef<HTMLTextAreaElement | null>(null);
@@ -42,20 +56,10 @@ const MultilineInput = (props: TMultiLineInputProps) => {
     (height: number, meta: TextareaHeightChangeMeta) => void
   >(
     (_, meta: TextareaHeightChangeMeta) => {
-      const containerHeight = Math.floor(
-        ref.current?.scrollHeight || 0 / meta.rowHeight
-      );
-
-      const lineHeight = parseInt(
-        getComputedStyle(ref.current as Element).getPropertyValue(
-          'line-height'
-        ),
-        10
-      );
-
-      const rowCount = Math.floor(
-        (ref.current?.scrollHeight || 0) / lineHeight
-      );
+      const containerHeight = ref.current!.scrollHeight;
+      const textHeight =
+        containerHeight - getElementVerticalPadding(ref.current!);
+      const rowCount = Math.floor(textHeight / meta.rowHeight);
 
       if (onHeightChange) {
         onHeightChange(containerHeight, rowCount);

--- a/packages/components/inputs/input-utils/src/multiline-input/multiline-input.tsx
+++ b/packages/components/inputs/input-utils/src/multiline-input/multiline-input.tsx
@@ -23,11 +23,7 @@ export type TMultiLineInputProps = {
   placeholder?: string;
   value: string;
   isOpen: boolean;
-  onHeightChange?: (
-    height: number,
-    containerHeight: number,
-    hasSeveralRows: boolean
-  ) => void;
+  onHeightChange?: (height: number, rowCount: number) => void;
   /**
    * Indicate if the value entered in the input is invalid.
    */
@@ -45,7 +41,7 @@ const MultilineInput = (props: TMultiLineInputProps) => {
   const handleHeightChange = useCallback<
     (height: number, meta: TextareaHeightChangeMeta) => void
   >(
-    (height: number, meta: TextareaHeightChangeMeta) => {
+    (_, meta: TextareaHeightChangeMeta) => {
       const containerHeight = Math.floor(
         ref.current?.scrollHeight || 0 / meta.rowHeight
       );
@@ -62,7 +58,7 @@ const MultilineInput = (props: TMultiLineInputProps) => {
       );
 
       if (onHeightChange) {
-        onHeightChange(height, containerHeight, rowCount > 1);
+        onHeightChange(containerHeight, rowCount);
       }
     },
     [ref, onHeightChange]

--- a/packages/components/inputs/localized-multiline-text-input/src/translation-input.tsx
+++ b/packages/components/inputs/localized-multiline-text-input/src/translation-input.tsx
@@ -82,7 +82,7 @@ const Row = styled.div`
 `;
 
 const TranslationInput = (props: TranslationInputProps) => {
-  const [inputHasSeveralRows, setInputHasSeveralRows] = useState(true);
+  const [inputHasSeveralRows, setInputHasSeveralRows] = useState(false);
 
   const handleHeightChange = useCallback(
     (_, rowCount) => {

--- a/packages/components/inputs/localized-multiline-text-input/src/translation-input.tsx
+++ b/packages/components/inputs/localized-multiline-text-input/src/translation-input.tsx
@@ -85,10 +85,10 @@ const TranslationInput = (props: TranslationInputProps) => {
   const [inputHasSeveralRows, setInputHasSeveralRows] = useState(true);
 
   const handleHeightChange = useCallback(
-    (_, __, hasSeveralRows) => {
+    (_, rowCount) => {
       // This checks if the content in the textarea is greater than one row. If it is, then the toggle button will be shown.
       // This is to prevent the toggle button from showing when there is not enough content to expand/collapse.
-      setInputHasSeveralRows(hasSeveralRows);
+      setInputHasSeveralRows(rowCount > 1);
     },
     [setInputHasSeveralRows]
   );

--- a/packages/components/inputs/localized-multiline-text-input/src/translation-input.tsx
+++ b/packages/components/inputs/localized-multiline-text-input/src/translation-input.tsx
@@ -82,21 +82,15 @@ const Row = styled.div`
 `;
 
 const TranslationInput = (props: TranslationInputProps) => {
-  const [contentRowCount, setContentRowCount] = useState(0);
-  const [firstRowHeight, setFirstRowHeight] = useState(0);
+  const [inputHasSeveralRows, setInputHasSeveralRows] = useState(true);
 
   const handleHeightChange = useCallback(
-    (_, rowCount) => {
-      setContentRowCount(rowCount);
+    (_, __, hasSeveralRows) => {
+      // This checks if the content in the textarea is greater than one row. If it is, then the toggle button will be shown.
+      // This is to prevent the toggle button from showing when there is not enough content to expand/collapse.
+      setInputHasSeveralRows(hasSeveralRows);
     },
-    [setContentRowCount]
-  );
-
-  const calculateFirstRowHeight = useCallback(
-    (rowHeight) => {
-      setFirstRowHeight(rowHeight);
-    },
-    [setFirstRowHeight]
+    [setInputHasSeveralRows]
   );
 
   const { onChange } = props;
@@ -130,7 +124,7 @@ const TranslationInput = (props: TranslationInputProps) => {
 
   // This checks if the content in the textarea is greater than 38 (one row). If it is, then the toggle button will be shown.
   // This is to prevent the toggle button from showing when there is not enough content to expand/collapse.
-  const contentExceedsShownRows = contentRowCount > firstRowHeight;
+  // const contentExceedsShownRows = contentRowCount > firstRowHeight;
 
   const shouldToggleButtonTakeSpace =
     /*
@@ -141,9 +135,7 @@ const TranslationInput = (props: TranslationInputProps) => {
       then it can be placed statically because it will then be a sibling to the error/warning message
       and LocalizedInputToggle is placed below the errors/warnings.
     */
-    (!props.isCollapsed &&
-      contentExceedsShownRows &&
-      !props.hasLanguagesControl) ||
+    (!props.isCollapsed && inputHasSeveralRows && !props.hasLanguagesControl) ||
     props.error ||
     props.warning;
 
@@ -174,7 +166,6 @@ const TranslationInput = (props: TranslationInputProps) => {
           value={props.value}
           onChange={handleChange}
           onHeightChange={handleHeightChange}
-          calculateFirstRowHeight={calculateFirstRowHeight}
           onBlur={props.onBlur}
           onFocus={handleFocus}
           isDisabled={props.isDisabled}
@@ -220,7 +211,7 @@ const TranslationInput = (props: TranslationInputProps) => {
             );
           return null;
         })()}
-        {!props.isCollapsed && contentExceedsShownRows && (
+        {!props.isCollapsed && inputHasSeveralRows && (
           <>
             <LeftColumn />
             <RightColumn>

--- a/packages/components/inputs/multiline-text-input/src/multiline-text-input.tsx
+++ b/packages/components/inputs/multiline-text-input/src/multiline-text-input.tsx
@@ -111,7 +111,7 @@ const defaultProps: Pick<
 const MultilineTextInput = (props: TMultilineTextInputProps) => {
   const intl = useIntl();
   const [shouldRenderToggleButton, setShouldRenderToggleButton] =
-    useState(true);
+    useState(false);
 
   const [isOpen, toggle] = useToggleState(props.defaultExpandMultilineText);
 

--- a/packages/components/inputs/multiline-text-input/src/multiline-text-input.tsx
+++ b/packages/components/inputs/multiline-text-input/src/multiline-text-input.tsx
@@ -125,12 +125,12 @@ const MultilineTextInput = (props: TMultilineTextInputProps) => {
   );
 
   const handleHeightChange = useCallback<
-    (height: number, containerHeight: number, hasSeveralRows: boolean) => void
+    (height: number, rowCount: number) => void
   >(
-    (_, __, hasSeveralRows) => {
+    (_, rowCount) => {
       // This checks if the content in the textarea is greater than one row. If it is, then the toggle button will be shown.
       // This is to prevent the toggle button from showing when there is not enough content to expand/collapse.
-      setShouldRenderToggleButton(hasSeveralRows);
+      setShouldRenderToggleButton(rowCount > 1);
     },
     [setShouldRenderToggleButton]
   );

--- a/packages/components/inputs/multiline-text-input/src/multiline-text-input.tsx
+++ b/packages/components/inputs/multiline-text-input/src/multiline-text-input.tsx
@@ -110,9 +110,8 @@ const defaultProps: Pick<
 
 const MultilineTextInput = (props: TMultilineTextInputProps) => {
   const intl = useIntl();
-
-  const [contentRowCount, setContentRowCount] = useState<number>(0);
-  const [firstRowHeight, setFirstRowHeight] = useState(0);
+  const [shouldRenderToggleButton, setShouldRenderToggleButton] =
+    useState(true);
 
   const [isOpen, toggle] = useToggleState(props.defaultExpandMultilineText);
 
@@ -126,24 +125,15 @@ const MultilineTextInput = (props: TMultilineTextInputProps) => {
   );
 
   const handleHeightChange = useCallback<
-    (height: number, rowCount: number) => void
+    (height: number, rowCount: number, hasSeveralRows: boolean) => void
   >(
-    (_, rowCount) => {
-      setContentRowCount(rowCount);
+    (_, __, hasSeveralRows) => {
+      // This checks if the content in the textarea is greater than one row. If it is, then the toggle button will be shown.
+      // This is to prevent the toggle button from showing when there is not enough content to expand/collapse.
+      setShouldRenderToggleButton(hasSeveralRows);
     },
-    [setContentRowCount]
+    [setShouldRenderToggleButton]
   );
-
-  const calculateFirstRowHeight = useCallback(
-    (rowHeight) => {
-      setFirstRowHeight(rowHeight);
-    },
-    [setFirstRowHeight]
-  );
-
-  // This checks if the content in the textarea is greater than 38 (one row). If it is, then the toggle button will be shown.
-  // This is to prevent the toggle button from showing when there is not enough content to expand/collapse.
-  const shouldRenderToggleButton = contentRowCount > firstRowHeight;
 
   return (
     <Constraints.Horizontal max={props.horizontalConstraint}>
@@ -154,7 +144,6 @@ const MultilineTextInput = (props: TMultilineTextInputProps) => {
           value={props.value}
           onChange={props.onChange}
           onHeightChange={handleHeightChange}
-          calculateFirstRowHeight={calculateFirstRowHeight}
           id={props.id}
           onBlur={props.onBlur}
           onFocus={handleFocus}

--- a/packages/components/inputs/multiline-text-input/src/multiline-text-input.tsx
+++ b/packages/components/inputs/multiline-text-input/src/multiline-text-input.tsx
@@ -125,7 +125,7 @@ const MultilineTextInput = (props: TMultilineTextInputProps) => {
   );
 
   const handleHeightChange = useCallback<
-    (height: number, rowCount: number, hasSeveralRows: boolean) => void
+    (height: number, containerHeight: number, hasSeveralRows: boolean) => void
   >(
     (_, __, hasSeveralRows) => {
       // This checks if the content in the textarea is greater than one row. If it is, then the toggle button will be shown.


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Alternative proposal (#2511 ) for multiline inputs height management.

## Description

The idea is to abstract if the component has more than one row in the util `MultilineInput` component so it's easier for its consumers to deal with it since the former is the one which has all the info to calculate the values.
