### PR TITLE
fix(RichTextInput): deserialization of `<sup>` and `<sub>`

### DIFF
--- a/.changeset/nervous-insects-dance.md
+++ b/.changeset/nervous-insects-dance.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-uikit/rich-text-input': patch
+'@commercetools-uikit/rich-text-utils': patch
+---
+
+Enable proper deserialization of `<sup>` and `<sub>` tags. 
+Prevent from unnecessary wrapping text nodes with a paragraph. 

--- a/.changeset/nervous-insects-dance.md
+++ b/.changeset/nervous-insects-dance.md
@@ -1,5 +1,4 @@
 ---
-'@commercetools-uikit/rich-text-input': patch
 '@commercetools-uikit/rich-text-utils': patch
 ---
 

--- a/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.story.js
+++ b/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.story.js
@@ -1,8 +1,7 @@
 /* eslint-disable react/prop-types, react/display-name */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useRef } from 'react';
 import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
 import {
   withKnobs,
   boolean,
@@ -11,13 +10,17 @@ import {
   object,
 } from '@storybook/addon-knobs/react';
 import Constraints from '@commercetools-uikit/constraints';
+import Spacings from '@commercetools-uikit/spacings';
+import PrimaryButton from '@commercetools-uikit/primary-button';
+import CollapsiblePanel from '@commercetools-uikit/collapsible-panel';
+import Text from '@commercetools-uikit/text';
 import { ErrorMessage, WarningMessage } from '@commercetools-uikit/messages';
 import Readme from '../README.md';
 import LocalizedRichTextInput from './localized-rich-text-input';
 
 // Create our initial value...
 
-const initialValue = '';
+const initialValue = '<h1>H1 <u>heading</u></h1>';
 
 const StoryWrapper = (props) => {
   const [value, setValue] = useState({
@@ -25,17 +28,32 @@ const StoryWrapper = (props) => {
     de: initialValue,
     'nan-Hant-TW': initialValue,
   });
+  const [resetValue, setResetValue] = useState({
+    en: initialValue,
+    de: initialValue,
+    'nan-Hant-TW': initialValue,
+  });
 
   const onChange = useCallback(
     (event) => {
-      setValue({
-        ...value,
+      setValue((currentValue) => ({
+        ...currentValue,
         [event.target.language]: event.target.value,
-      });
-      action('onChange')(event);
+      }));
     },
-    [value]
+    [setValue]
   );
+
+  const onResetValueChange = (lang) => (event) => {
+    setResetValue((currentValue) => ({
+      ...currentValue,
+      [lang]: event.target.value,
+    }));
+  };
+
+  const handleReset = () => {
+    ref.current?.resetValue(resetValue);
+  };
 
   const defaultExpandLanguages = boolean('defaultExpandLanguages', false);
   const defaultExpandMultilineText = boolean(
@@ -48,65 +66,103 @@ const StoryWrapper = (props) => {
   // is changed. Otherwise the knob would have no effect.
   // We do this by changing the key.
   const key = `${defaultExpandMultilineText}-${defaultExpandLanguages}`;
+  const ref = useRef(null);
 
   return (
-    <LocalizedRichTextInput
-      key={key}
-      id={text('id', 'test-id')}
-      name={text('name', 'productName')}
-      showExpandIcon={boolean('showExpandIcon', false)}
-      selectedLanguage={select(
-        'selectedLanguage',
-        ['en', 'de', 'nan-Hant-TW'],
-        'en'
-      )}
-      hideLanguageExpansionControls={boolean(
-        'hideLanguageExpansionControls',
-        false
-      )}
-      defaultExpandLanguages={
-        // we need to set undefined instead of false to avoid prop-type
-        // warnings in case hideLanguageExpansionControls is true
-        defaultExpandLanguages || undefined
-      }
-      defaultExpandMultilineText={defaultExpandMultilineText}
-      isAutofocussed={boolean('isAutofocussed', false)}
-      isDisabled={boolean('isDisabled', false)}
-      isReadOnly={boolean('isReadOnly', false)}
-      placeholder={object('placeholder', {
-        en: '',
-        de: '',
-        'nan-Hant-TW': '',
-      })}
-      horizontalConstraint={select(
-        'horizontalConstraint',
-        Constraints.getAcceptedMaxPropValues(7),
-        12
-      )}
-      hasError={boolean('hasError', false)}
-      hasWarning={boolean('hasWarning', false)}
-      errors={
-        Object.values(errors).some((error) => error.length > 0)
-          ? Object.entries(errors).reduce((acc, [language, error]) => {
-              if (error.length === 0) return acc;
-              acc[language] = <ErrorMessage>{error}</ErrorMessage>;
-              return acc;
-            }, {})
-          : undefined
-      }
-      warnings={
-        Object.values(warnings).some((warning) => warning.length > 0)
-          ? Object.entries(warnings).reduce((acc, [language, warning]) => {
-              if (warning.length === 0) return acc;
-              acc[language] = <WarningMessage>{warning}</WarningMessage>;
-              return acc;
-            }, {})
-          : undefined
-      }
-      value={value}
-      onChange={onChange}
-      data-test="foo"
-    />
+    <Spacings.Stack scale="l">
+      <CollapsiblePanel
+        header="Set initial value"
+        horizontalConstraint="scale"
+        isDefaultClosed
+      >
+        <Constraints.Horizontal max="scale">
+          <Spacings.Stack scale="m">
+            <textarea
+              defaultValue={resetValue.en}
+              onChange={onResetValueChange('en')}
+              rows={4}
+            />
+            <textarea
+              defaultValue={resetValue.de}
+              onChange={onResetValueChange('de')}
+              rows={4}
+            />
+            <textarea
+              defaultValue={resetValue['nan-Hant-TW']}
+              onChange={onResetValueChange('nan-Hant-TW')}
+              rows={4}
+            />
+            <Constraints.Horizontal max="auto">
+              <PrimaryButton
+                label="Reset"
+                onClick={handleReset}
+                size="medium"
+              />
+            </Constraints.Horizontal>
+          </Spacings.Stack>
+        </Constraints.Horizontal>
+      </CollapsiblePanel>
+      <LocalizedRichTextInput
+        key={key}
+        id={text('id', 'test-id')}
+        name={text('name', 'productName')}
+        showExpandIcon={boolean('showExpandIcon', false)}
+        selectedLanguage={select(
+          'selectedLanguage',
+          ['en', 'de', 'nan-Hant-TW'],
+          'en'
+        )}
+        hideLanguageExpansionControls={boolean(
+          'hideLanguageExpansionControls',
+          false
+        )}
+        defaultExpandLanguages={
+          // we need to set undefined instead of false to avoid prop-type
+          // warnings in case hideLanguageExpansionControls is true
+          defaultExpandLanguages || undefined
+        }
+        defaultExpandMultilineText={defaultExpandMultilineText}
+        isAutofocussed={boolean('isAutofocussed', false)}
+        isDisabled={boolean('isDisabled', false)}
+        isReadOnly={boolean('isReadOnly', false)}
+        placeholder={object('placeholder', {
+          en: '',
+          de: '',
+          'nan-Hant-TW': '',
+        })}
+        horizontalConstraint={select(
+          'horizontalConstraint',
+          Constraints.getAcceptedMaxPropValues(7),
+          12
+        )}
+        hasError={boolean('hasError', false)}
+        hasWarning={boolean('hasWarning', false)}
+        errors={
+          Object.values(errors).some((error) => error.length > 0)
+            ? Object.entries(errors).reduce((acc, [language, error]) => {
+                if (error.length === 0) return acc;
+                acc[language] = <ErrorMessage>{error}</ErrorMessage>;
+                return acc;
+              }, {})
+            : undefined
+        }
+        warnings={
+          Object.values(warnings).some((warning) => warning.length > 0)
+            ? Object.entries(warnings).reduce((acc, [language, warning]) => {
+                if (warning.length === 0) return acc;
+                acc[language] = <WarningMessage>{warning}</WarningMessage>;
+                return acc;
+              }, {})
+            : undefined
+        }
+        value={value}
+        onChange={onChange}
+        data-test="foo"
+        ref={ref}
+      />
+      <Text.Headline as="h3">Output</Text.Headline>
+      <pre>{JSON.stringify(value, null, 2)}</pre>
+    </Spacings.Stack>
   );
 };
 

--- a/packages/components/inputs/rich-text-input/src/rich-text-input.story.js
+++ b/packages/components/inputs/rich-text-input/src/rich-text-input.story.js
@@ -1,51 +1,22 @@
 /* eslint-disable react/prop-types, react/display-name */
 
-import { useState, useCallback } from 'react';
-import { Value } from 'react-value';
+import { useState, useCallback, useRef } from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, boolean, text } from '@storybook/addon-knobs/react';
 import { action } from '@storybook/addon-actions';
 import withReadme from 'storybook-readme/with-readme';
 import Spacings from '@commercetools-uikit/spacings';
+import PrimaryButton from '@commercetools-uikit/primary-button';
+import CollapsiblePanel from '@commercetools-uikit/collapsible-panel';
+import Constraints from '@commercetools-uikit/constraints';
+import Text from '@commercetools-uikit/text';
 import Section from '../../../../../docs/.storybook/decorators/section';
 import RichTextInput from './rich-text-input';
-import TextInput from '../../text-input';
 import Readme from '../README.md';
 
 // Create our initial value...
 
 const initialValue = '<h1>H1 <u>heading</u></h1>';
-
-const Input = (props) => {
-  const [value, setValue] = useState(initialValue);
-  const onChange = useCallback(
-    (event) => {
-      setValue(event.target.value);
-      action('onChange')(event);
-    },
-    [setValue]
-  );
-
-  return (
-    <RichTextInput
-      id={props.id}
-      name={props.name}
-      key={`rich-text-input-${props.defaultExpandMultilineText}`}
-      onChange={onChange}
-      value={value}
-      onBlur={props.onBlur}
-      onFocus={props.onFocus}
-      defaultExpandMultilineText={props.defaultExpandMultilineText}
-      placeholder={props.placeholder}
-      onClickExpand={props.onClickExpand}
-      showExpandIcon={props.showExpandIcon}
-      hasError={props.hasError}
-      hasWarning={props.hasWarning}
-      isDisabled={props.isDisabled}
-      isReadOnly={props.isReadOnly}
-    />
-  );
-};
 
 storiesOf('Components|Inputs', module)
   .addDecorator(withKnobs)
@@ -58,24 +29,51 @@ storiesOf('Components|Inputs', module)
 
     const onBlur = useCallback(action('onBlur'), []);
     const onFocus = useCallback(action('onFocus'), []);
-    const id = text('id', 'test-id');
+    const ref = useRef(null);
+    const [value, setValue] = useState(initialValue);
+    const [resetValue, setResetValue] = useState(initialValue);
+    const onChange = useCallback(
+      (event) => {
+        setValue(event.target.value);
+      },
+      [setValue]
+    );
+    const onResetValueChange = useCallback(
+      (event) => {
+        setResetValue(event.target.value);
+      },
+      [setResetValue]
+    );
+    const handleReset = () => {
+      ref.current?.resetValue(resetValue);
+    };
+
     return (
       <Section>
         <Spacings.Stack scale="l">
-          <Value
-            defaultValue={''}
-            render={(value, onChange) => (
-              <TextInput
-                id="text-input"
-                name="text-input"
-                value={value}
-                onChange={(event) => onChange(event.target.value)}
-              />
-            )}
-          />
-          <label htmlFor={id}>Rich Text</label>
-          <Input
-            id={text('id', 'test-id')}
+          <CollapsiblePanel
+            header="Set initial value"
+            horizontalConstraint="scale"
+            isDefaultClosed
+          >
+            <Constraints.Horizontal max="scale">
+              <Spacings.Stack scale="m">
+                <textarea
+                  defaultValue={resetValue}
+                  onChange={onResetValueChange}
+                  rows={4}
+                />
+                <Constraints.Horizontal max="auto">
+                  <PrimaryButton
+                    label="Reset"
+                    onClick={handleReset}
+                    size="medium"
+                  />
+                </Constraints.Horizontal>
+              </Spacings.Stack>
+            </Constraints.Horizontal>
+          </CollapsiblePanel>
+          <RichTextInput
             name={text('name', 'test-name')}
             onBlur={onBlur}
             onFocus={onFocus}
@@ -90,7 +88,12 @@ storiesOf('Components|Inputs', module)
             hasWarning={boolean('hasWarning', false)}
             isDisabled={boolean('isDisabled', false)}
             isReadOnly={boolean('isReadOnly', false)}
+            ref={ref}
+            onChange={onChange}
+            value={value}
           />
+          <Text.Headline as="h3">Output</Text.Headline>
+          <code>{value}</code>
         </Spacings.Stack>
       </Section>
     );

--- a/packages/components/inputs/rich-text-input/src/rich-text-input.story.js
+++ b/packages/components/inputs/rich-text-input/src/rich-text-input.story.js
@@ -93,7 +93,7 @@ storiesOf('Components|Inputs', module)
             value={value}
           />
           <Text.Headline as="h3">Output</Text.Headline>
-          <code>{value}</code>
+          <pre>{value}</pre>
         </Spacings.Stack>
       </Section>
     );

--- a/packages/components/inputs/rich-text-utils/src/html/html.spec.js
+++ b/packages/components/inputs/rich-text-utils/src/html/html.spec.js
@@ -106,9 +106,19 @@ describe('html', () => {
             '<ol><li><span style="font-weight: bold; font-family: &quot;Comic Sans MS&quot;;">Computermouse for <span style="text-decoration-line: underline;">controlling</span></span></li></ol><table class="table table-bordered"><tbody><tr><td>hello</td></tr><tr><td><p>world<img src="https://www.rollingstone.com/wp-content/uploads/2019/01/shutterstock_10010937aj.jpg" style="width: 100%; float: right;" class="pull-right img-circle"></p></td></tr></tbody></table><ol><li><span style="font-weight: bold; font-family: &quot;Comic Sans MS&quot;;"><span style="text-decoration-line: underline;"><br></span></span></li></ol>';
 
           expect(html.serialize(html.deserialize(htmlValue))).toEqual(
-            '<ol><li><strong>Computermouse for </strong><u><strong>controlling</strong></u></li></ol><p>hello</p><p>world</p><ol><li><u><strong></strong></u></li></ol>'
+            '<ol><li><strong>Computermouse for </strong><u><strong>controlling</strong></u></li></ol>hello<p>world</p><ol><li><u><strong></strong></u></li></ol>'
           );
         });
+      });
+    });
+    describe('multiple nested text nodes within parent text node', () => {
+      it('should properly serialize', () => {
+        const htmlValue =
+          '<p><del>first</del><del><sup>second</sup></del><del><sub><sup>third</sup></sub></del></p>';
+
+        expect(html.serialize(html.deserialize(htmlValue))).toEqual(
+          '<p><del>first</del><del><sup>second</sup></del><del><sub><sup>third</sup></sub></del></p>'
+        );
       });
     });
   });

--- a/packages/components/inputs/rich-text-utils/src/html/html.tsx
+++ b/packages/components/inputs/rich-text-utils/src/html/html.tsx
@@ -149,6 +149,8 @@ const TEXT_TAGS = {
   EM: () => ({ italic: true }),
   I: () => ({ italic: true }),
   S: () => ({ strikethrough: true }),
+  SUP: () => ({ superscript: true }),
+  SUB: () => ({ subscript: true }),
   STRONG: () => ({ bold: true }),
   U: () => ({ underline: true }),
 };
@@ -279,10 +281,7 @@ const deserializeElement = (
     return children.map((child) => jsx('text', attrs, child));
   }
 
-  // each non-empty text node must be wrapped with a paragraph
-  return children.map((child) =>
-    Text.isText(child) && child.text ? wrapWithParagraph(child) : child
-  );
+  return children;
 };
 const deserialize = (html: Html) => {
   const document = new DOMParser().parseFromString(

--- a/packages/components/inputs/rich-text-utils/src/slate-helpers.tsx
+++ b/packages/components/inputs/rich-text-utils/src/slate-helpers.tsx
@@ -190,14 +190,24 @@ const toggleBlock = (editor: TEditor, format: Format) => {
   }
 };
 
+function nonNullable<T>(value: T): value is NonNullable<T> {
+  return value !== null && value !== undefined;
+}
+
 const validSlateStateAdapter = (
   value: Deserialized | Deserialized[]
 ): Descendant[] => {
   if (SlateElement.isElement(value) || Text.isText(value)) {
     return [value];
   }
-  if (SlateElement.isElementList(value) || Text.isTextList(value)) {
-    return value;
+  if (
+    SlateElement.isElementList(value) ||
+    Text.isTextList(value) ||
+    // in case of an array of mixed text and element nodes
+    (Array.isArray(value) &&
+      value.every((node) => SlateElement.isElement(node) || Text.isText(node)))
+  ) {
+    return value.filter(nonNullable);
   }
   return defaultSlateState;
 };

--- a/packages/components/inputs/rich-text-utils/src/slate-helpers.tsx
+++ b/packages/components/inputs/rich-text-utils/src/slate-helpers.tsx
@@ -197,9 +197,7 @@ function nonNullable<T>(value: T): value is NonNullable<T> {
 const validSlateStateAdapter = (
   value: Deserialized | Deserialized[]
 ): Descendant[] => {
-  if (SlateElement.isElement(value) || Text.isText(value)) {
-    return [value];
-  }
+  const valueAsArray: Deserialized[] = Array.isArray(value) ? value : [value];
   if (
     SlateElement.isElementList(value) ||
     Text.isTextList(value) ||
@@ -207,7 +205,11 @@ const validSlateStateAdapter = (
     (Array.isArray(value) &&
       value.every((node) => SlateElement.isElement(node) || Text.isText(node)))
   ) {
-    return value.filter(nonNullable);
+    return valueAsArray
+      .map((node) =>
+        Text.isText(node) ? { type: 'text', children: [node] } : node
+      )
+      .filter(nonNullable);
   }
   return defaultSlateState;
 };
@@ -226,9 +228,7 @@ const resetEditor = (editor: Editor, resetValue?: string) => {
   });
 
   const newState = resetValue
-    ? validSlateStateAdapter(html.deserialize(resetValue)).map((node) =>
-        Text.isText(node) ? { type: 'text', children: [node] } : node
-      )
+    ? validSlateStateAdapter(html.deserialize(resetValue))
     : defaultSlateState;
 
   // insert all new nodes

--- a/packages/components/inputs/rich-text-utils/src/slate-helpers.tsx
+++ b/packages/components/inputs/rich-text-utils/src/slate-helpers.tsx
@@ -213,18 +213,26 @@ const validSlateStateAdapter = (
 };
 
 const resetEditor = (editor: Editor, resetValue?: string) => {
-  const children = [...editor.children];
-  children.forEach((node) =>
-    editor.apply({ type: 'remove_node', path: [0], node })
-  );
-  const newState = resetValue
-    ? validSlateStateAdapter(html.deserialize(resetValue))
-    : defaultSlateState;
-  editor.apply({
-    type: 'insert_node',
-    path: [0],
-    node: newState[0],
+  Transforms.delete(editor, {
+    at: {
+      anchor: Editor.start(editor, []),
+      focus: Editor.end(editor, []),
+    },
   });
+
+  // Removes empty node
+  Transforms.removeNodes(editor, {
+    at: [0],
+  });
+
+  const newState = resetValue
+    ? validSlateStateAdapter(html.deserialize(resetValue)).map((node) =>
+        Text.isText(node) ? { type: 'text', children: [node] } : node
+      )
+    : defaultSlateState;
+
+  // insert all new nodes
+  Transforms.insertNodes(editor, newState);
 };
 
 const focusEditor = (editor: Editor) => {

--- a/packages/components/inputs/rich-text-utils/src/slate-helpers.tsx
+++ b/packages/components/inputs/rich-text-utils/src/slate-helpers.tsx
@@ -220,7 +220,7 @@ const resetEditor = (editor: Editor, resetValue?: string) => {
     },
   });
 
-  // Removes empty node
+  // remove empty node
   Transforms.removeNodes(editor, {
     at: [0],
   });


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

This PR is meant to fix:
- `<sup>` and `<sub>` deserialization
![2023-06-01 11 00 15](https://github.com/commercetools/ui-kit/assets/49066275/f2386958-1f0b-47d7-9763-2186560a9b65)
- issue with rich text state resetting
- removes unnecessary wrapping every text node with paragraph in the deserialization function
- adds a more complex story to enable manual tests of `<RichTextInput>` and `LocalizedRichTextInput>` 

⚠️ ⚠️ ⚠️ it does not cover #2522 ⚠️ ⚠️ ⚠️


