### PR TITLE
fix(hooks): export polyfills as a separate entry point

### DIFF
--- a/.changeset/hot-ways-care.md
+++ b/.changeset/hot-ways-care.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/hooks': patch
+---
+
+Export polyfill as separate entry point. Consumers should import this explicitly in their application when using SSR.

--- a/packages/hooks/index.ts
+++ b/packages/hooks/index.ts
@@ -1,1 +1,0 @@
-export * from './src';

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -17,7 +17,7 @@
   "sideEffects": false,
   "main": "dist/commercetools-uikit-hooks.cjs.js",
   "module": "dist/commercetools-uikit-hooks.esm.js",
-  "files": ["dist"],
+  "files": ["dist", "polyfills.js"],
   "dependencies": {
     "@babel/runtime": "^7.20.13",
     "@babel/runtime-corejs3": "^7.20.13",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -17,7 +17,10 @@
   "sideEffects": false,
   "main": "dist/commercetools-uikit-hooks.cjs.js",
   "module": "dist/commercetools-uikit-hooks.esm.js",
-  "files": ["dist", "polyfills.js"],
+  "preconstruct": {
+    "entrypoints": ["./index.ts", "./polyfills.ts"]
+  },
+  "files": ["dist", "polyfills"],
   "dependencies": {
     "@babel/runtime": "^7.20.13",
     "@babel/runtime-corejs3": "^7.20.13",

--- a/packages/hooks/polyfills.js
+++ b/packages/hooks/polyfills.js
@@ -1,5 +1,5 @@
 // Polyfill for `MutationObserver` when used with SSR.
-global.MutationObserver =
+(window || global).MutationObserver =
   typeof window !== 'undefined' && 'MutationObserver' in window
     ? window.MutationObserver
     : class MutationObserver {

--- a/packages/hooks/polyfills.js
+++ b/packages/hooks/polyfills.js
@@ -1,5 +1,6 @@
 // Polyfill for `MutationObserver` when used with SSR.
-(window || global).MutationObserver =
+// eslint-disable-next-line no-undef
+globalThis.MutationObserver =
   typeof window !== 'undefined' && 'MutationObserver' in window
     ? window.MutationObserver
     : class MutationObserver {
@@ -9,6 +10,3 @@
           return [];
         }
       };
-
-// Empty export statement to identify this as a module.
-export {};

--- a/packages/hooks/polyfills/package.json
+++ b/packages/hooks/polyfills/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/commercetools-uikit-hooks-polyfills.cjs.js",
+  "module": "dist/commercetools-uikit-hooks-polyfills.esm.js"
+}

--- a/packages/hooks/src/polyfills.ts
+++ b/packages/hooks/src/polyfills.ts
@@ -10,3 +10,6 @@ globalThis.MutationObserver =
           return [];
         }
       };
+
+// Empty export statement to identify this as a module.
+export {};

--- a/packages/hooks/src/use-mutation-observer/use-mutation-observer.ts
+++ b/packages/hooks/src/use-mutation-observer/use-mutation-observer.ts
@@ -2,7 +2,6 @@
 // except for the usage of `MutationObserver` instead of `IntersectionObserver`.
 import { useEffect, useLayoutEffect, useRef } from 'react';
 import rafSchd from 'raf-schd';
-import './polyfill';
 
 export type TUseMutationObserverCallback = (
   mutationsList: MutationRecord[],


### PR DESCRIPTION
Follow up of #2485 

Including the polyfill into the normal bundle will result in the polyfill code to be removed because the bundle itself has already evaluated it.

However, what we want is to provide the polyfill to consumers of the package as it needs to be evaluated when building the end application.

Therefore, we should export the polyfill as a separate entry point.