### PR TITLE
fix(Tag): make `TagBody` render as `span` rather than `p`

### DIFF
--- a/.changeset/curvy-boats-hunt.md
+++ b/.changeset/curvy-boats-hunt.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/tag': patch
+---
+
+Make `<TagBody>` render as `<span>` rather than `<p>`

--- a/packages/components/tag/src/tag-body.tsx
+++ b/packages/components/tag/src/tag-body.tsx
@@ -117,7 +117,9 @@ const TagBody = (props: TTagBodyProps) => {
         {props.isDraggable && !props.isDisabled ? (
           <DragIcon data-testid="drag-icon" size="medium" />
         ) : null}
-        <Text.Body tone={textTone}>{props.children}</Text.Body>
+        <Text.Body tone={textTone} as="span">
+          {props.children}
+        </Text.Body>
       </Spacings.Inline>
     </Body>
   );

--- a/packages/components/tag/src/tag.spec.js
+++ b/packages/components/tag/src/tag.spec.js
@@ -1,9 +1,21 @@
 import { screen, render } from '../../../../test/test-utils';
 import Tag from './tag';
 
-it('should render children', () => {
+it('should render text as children', () => {
   render(<Tag>Bread</Tag>);
   expect(screen.getByText('Bread')).toBeInTheDocument();
+});
+it('should render html markup as children', () => {
+  const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+  render(
+    <Tag>
+      <div>👋</div>
+    </Tag>
+  );
+
+  // ensure is renders correctly without validateDOMNesting warning
+  expect(screen.getByText('👋')).toBeInTheDocument();
+  expect(error).not.toHaveBeenCalled();
 });
 
 it('should call onClick when clicked', () => {


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

This PR fixes an issue with rendering `<div>`s as children of `<Tag>` component
