### PR TITLE
Align siblings of radio input options

### DIFF
--- a/.changeset/funny-melons-design.md
+++ b/.changeset/funny-melons-design.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/radio-input': minor
+---
+
+align radio options siblings

--- a/.changeset/funny-melons-design.md
+++ b/.changeset/funny-melons-design.md
@@ -2,4 +2,4 @@
 '@commercetools-uikit/radio-input': minor
 ---
 
-align radio options siblings
+Align additional content.

--- a/packages/components/inputs/radio-input/src/radio-option.styles.ts
+++ b/packages/components/inputs/radio-input/src/radio-option.styles.ts
@@ -14,7 +14,6 @@ const LabelTextWrapper = styled.div<TStylesProps>`
 
 const AdditionalTextWrapper = styled.div<TStylesProps>`
   grid-area: content;
-  margin-left: ${designTokens.spacing10};
   font-size: 1rem;
   font-family: inherit;
 `;
@@ -159,6 +158,7 @@ const RadioOptionLabel = styled.label<TStylesProps>`
       ? `:focus-within ${LabelTextWrapper} {
       outline: auto 2px ${designTokens.borderColorForInputWhenFocused};
       outline-offset: 2px;
+      width: fit-content;
     }`
       : ''}
 


### PR DESCRIPTION
Enable proper alignment of <RadioInput.Option> sibling components

#### Summary

n the current implementation of the <RadioInput.Option> there is no possibility of proper aligning of sibling components out of the box. This leads to misalignments like in the picture below:

![image](https://github.com/commercetools/ui-kit/assets/19975842/ece0785f-1f04-4184-b653-f0719b374cee)
