### PR TITLE
Fix for the heading issue of the `CollapsiblePanel'

### DIFF
--- a/.changeset/rare-jars-exercise.md
+++ b/.changeset/rare-jars-exercise.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/collapsible-panel': patch
+---
+
+Fix the error of headings wrapping another headings

--- a/packages/components/collapsible-panel/src/collapsible-panel-header.tsx
+++ b/packages/components/collapsible-panel/src/collapsible-panel-header.tsx
@@ -3,12 +3,16 @@ import Text from '@commercetools-uikit/text';
 
 type TCollapsiblePanelHeader = {
   children: ReactNode;
+  isCondensed?: boolean;
 };
-const CollapsiblePanelHeader = (props: TCollapsiblePanelHeader) => (
-  <Text.Headline as="h2" truncate={true}>
-    {props.children}
-  </Text.Headline>
-);
+const CollapsiblePanelHeader = (props: TCollapsiblePanelHeader) =>
+  props.isCondensed ? (
+    <>{props.children}</>
+  ) : (
+    <Text.Headline as="h2" truncate={true}>
+      {props.children}
+    </Text.Headline>
+  );
 
 CollapsiblePanelHeader.displayName = 'CollapsiblePanelHeader';
 

--- a/packages/components/collapsible-panel/src/collapsible-panel.spec.js
+++ b/packages/components/collapsible-panel/src/collapsible-panel.spec.js
@@ -124,7 +124,7 @@ describe('when onToggle is provided without isClosed', () => {
   });
 });
 
-describe('hen using CollapsiblePanelHeader component as header', () => {
+describe('condensed and when header prop has <CollapsiblePanelHeader>', () => {
   it('should render an H4 title when condensed', () => {
     render(
       <CollapsiblePanel

--- a/packages/components/collapsible-panel/src/collapsible-panel.spec.js
+++ b/packages/components/collapsible-panel/src/collapsible-panel.spec.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import { warning } from '@commercetools-uikit/utils';
 import { screen, render } from '../../../../test/test-utils';
 import CollapsiblePanel from './collapsible-panel';
+import CollapsiblePanelHeader from './collapsible-panel-header';
 
 const HeaderControls = (props) => (
   <div onClick={props.onClick}>Header Controls</div>
@@ -119,6 +120,38 @@ describe('when onToggle is provided without isClosed', () => {
     expect(warning).toHaveBeenCalledWith(
       expect.any(Boolean),
       expect.stringMatching(/Invalid prop `onToggle` supplied to (.*)/i)
+    );
+  });
+});
+
+describe('condensed and when header prop has <CollapsiblePanelHeader>', () => {
+  it('render a <h4>', () => {
+    render(
+      <CollapsiblePanel
+        header={<CollapsiblePanelHeader>Header</CollapsiblePanelHeader>}
+        onToggle={() => {}}
+        isClosed={false}
+        condensed={true}
+      >
+        Children
+      </CollapsiblePanel>
+    );
+    expect(screen.getByText('Header').tagName).toEqual('H4');
+  });
+
+  it('should not render a <h> as a child of a <h>', () => {
+    render(
+      <CollapsiblePanel
+        header={<CollapsiblePanelHeader>Header</CollapsiblePanelHeader>}
+        onToggle={() => {}}
+        isClosed={false}
+        condensed={true}
+      >
+        Children
+      </CollapsiblePanel>
+    );
+    expect(screen.getByText('Header').parentNode.tagName).not.toMatch(
+      /h[1-6]/i
     );
   });
 });

--- a/packages/components/collapsible-panel/src/collapsible-panel.spec.js
+++ b/packages/components/collapsible-panel/src/collapsible-panel.spec.js
@@ -124,8 +124,8 @@ describe('when onToggle is provided without isClosed', () => {
   });
 });
 
-describe('condensed and when header prop has <CollapsiblePanelHeader>', () => {
-  it('render a <h4>', () => {
+describe('hen using CollapsiblePanelHeader component as header', () => {
+  it('should render an H4 title when condensed', () => {
     render(
       <CollapsiblePanel
         header={<CollapsiblePanelHeader>Header</CollapsiblePanelHeader>}
@@ -139,20 +139,18 @@ describe('condensed and when header prop has <CollapsiblePanelHeader>', () => {
     expect(screen.getByText('Header').tagName).toEqual('H4');
   });
 
-  it('should not render a <h> as a child of a <h>', () => {
+  it('should render an H2 title when not condensed', () => {
     render(
       <CollapsiblePanel
         header={<CollapsiblePanelHeader>Header</CollapsiblePanelHeader>}
         onToggle={() => {}}
         isClosed={false}
-        condensed={true}
+        condensed={false}
       >
         Children
       </CollapsiblePanel>
     );
-    expect(screen.getByText('Header').parentNode.tagName).not.toMatch(
-      /h[1-6]/i
-    );
+    expect(screen.getByText('Header').tagName).toEqual('H2');
   });
 });
 

--- a/packages/components/collapsible-panel/src/collapsible-panel.tsx
+++ b/packages/components/collapsible-panel/src/collapsible-panel.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, cloneElement } from 'react';
 import isNil from 'lodash/isNil';
 import styled from '@emotion/styled';
 import {
@@ -154,7 +154,9 @@ const HeadLineText = (
 
   return (
     <Text.Subheadline as="h4" truncate>
-      {props.header}
+      {cloneElement(props.header as React.ReactElement, {
+        isCondensed: props.condensed,
+      })}
     </Text.Subheadline>
   );
 };

--- a/packages/components/collapsible-panel/src/collapsible-panel.tsx
+++ b/packages/components/collapsible-panel/src/collapsible-panel.tsx
@@ -154,9 +154,12 @@ const HeadLineText = (
 
   return (
     <Text.Subheadline as="h4" truncate>
-      {cloneElement(props.header as React.ReactElement, {
-        isCondensed: props.condensed,
-      })}
+      {/* TODO: this is a temporary fix, which will be refactored after we align with the desing team on how to proceed */}
+      {typeof props.header === 'string'
+        ? props.header
+        : cloneElement(props.header as React.ReactElement, {
+            isCondensed: props.condensed,
+          })}
     </Text.Subheadline>
   );
 };


### PR DESCRIPTION
We've found an inconsistency in out `CollapsiblePanel` component manages the `header` prop.

The issue is that we are rendering an invalid HTML structure when passing a `<CollapsiblePanelHeader>` component as a `header` prop and when `condensed` prop is set as true in `<CollapsiblePanel>`. 
In that case it would wrap `<h2>` tag in the `<h4>` which would cause the error - `<h2> cannot appear as a child of <h4>`.

![Screenshot 2023-07-03 at 14 11 14](https://github.com/commercetools/ui-kit/assets/52276952/3207e324-b117-4478-92d7-a495d46b9cb9)

This is a temporary fix, in order to unblock us and until we have a chance to discuss it with Filip on how to proceed further.
