### PR TITLE
Update `puppeteer` config param

### DIFF
--- a/.changeset/nine-cooks-promise.md
+++ b/.changeset/nine-cooks-promise.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-uikit/localized-rich-text-input': minor
+'@commercetools-uikit/rich-text-input': minor
+---
+
+Update `puppeteer` configuration in the visual regression tests.

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -9,6 +9,7 @@ module.exports = {
   launch: {
     args: ['--no-sandbox', '--disable-setuid-sandbox'],
     executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
+    headless: 'new',
   },
   server: {
     command: 'yarn visual-testing-app:preview',

--- a/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.visualspec.js
+++ b/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.visualspec.js
@@ -8,6 +8,7 @@ jest.setTimeout(20000);
 
 beforeEach(async () => {
   browser = await puppeteer.launch({
+    headless: 'new',
     slowMo: 10, // Launching the browser in slow motion is necessary due to race conditions. Otherwise browser closes prematurely and tests fail.
   });
   page = await browser.newPage();

--- a/packages/components/inputs/rich-text-input/src/rich-text-input.visualspec.js
+++ b/packages/components/inputs/rich-text-input/src/rich-text-input.visualspec.js
@@ -8,6 +8,7 @@ jest.setTimeout(20000);
 
 beforeEach(async () => {
   browser = await puppeteer.launch({
+    headless: 'new',
     slowMo: 10, // Launching the browser in slow motion is necessary due to race conditions. Otherwise browser closes prematurely and tests fail.
   });
   page = await browser.newPage();


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Update `puppeteer` config param

## Description

We have some warning logs when running the visual regression tests related to some configuration update of the `puppeteer` package:
![image](https://github.com/commercetools/ui-kit/assets/97907068/469aa56b-4388-4a79-bba2-650c809a0bef)

That package will change the way the headless mode configuration works so I think it's better for use to update consciously.

[Here](https://developer.chrome.com/articles/new-headless/) are more details about this change.
