### PR TITLE
Prevent CheckboxInput icon shrinking when label text wraps

### DIFF
--- a/.changeset/hip-ducks-jog.md
+++ b/.changeset/hip-ducks-jog.md
@@ -1,0 +1,5 @@
+---
+"@commercetools-uikit/checkbox-input": patch
+---
+
+Prevent CheckboxInput icon shrinking when label text wraps

--- a/packages/components/inputs/checkbox-input/src/checkbox-input.tsx
+++ b/packages/components/inputs/checkbox-input/src/checkbox-input.tsx
@@ -142,6 +142,7 @@ const CheckboxIconWrapper = styled.div<TCheckboxIconWrapperProps>`
   width: ${(props) => props.width};
   height: ${(props) => props.height};
   display: flex;
+  flex-shrink: 0;
   align-items: center;
   justify-content: center;
   border-radius: ${designTokens.borderRadius6};


### PR DESCRIPTION
#### Summary

Make the CheckboxIcon not be compressed when wrapping the text.

## Description

`CheckboxIcon` is in a flexbox with `LabelTextWrapper` and if they don't fit the flexbox shrinks them both equally, which compresses the icon. It should only shrink the label.
