### PR TITLE
Fix <FieldLabel> title when is `ReactNode`

### DIFF
--- a/.changeset/lazy-icons-drive.md
+++ b/.changeset/lazy-icons-drive.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-uikit/field-label': patch
+'@commercetools-uikit/label': patch
+---
+
+Fix misplaced required indicator and `ReactNode` title in the `FieldLabel`

--- a/packages/components/field-label/src/field-label.visualroute.jsx
+++ b/packages/components/field-label/src/field-label.visualroute.jsx
@@ -33,6 +33,13 @@ export const component = () => (
         horizontalConstraint={7}
       />
     </Spec>
+    <Spec label="with required indicator and ReactNode as title">
+      <FieldLabel
+        title={<div>Hello</div>}
+        hasRequiredIndicator={true}
+        horizontalConstraint={7}
+      />
+    </Spec>
     <Spec label="with all options">
       <FieldLabel
         title="Hello"

--- a/packages/components/label/src/label.tsx
+++ b/packages/components/label/src/label.tsx
@@ -81,6 +81,7 @@ const Label = (props: TLabelProps) => {
       css={css`
         > div {
           font-weight: ${!props.isBold && designTokens.fontWeight500};
+          display: flex;
         }
       `}
       id={props.id}


### PR DESCRIPTION
This PR closes - [issue](https://github.com/commercetools/ui-kit/issues/2588).

There was an issue when displaying `FieldLabel` with `ReactNode` title and the required asterisk.

<img width="343" alt="Screenshot 2023-08-31 at 10 42 15" src="https://github.com/commercetools/ui-kit/assets/52276952/5289d04f-0d9b-4c6e-837b-c5a8394ae541">
<img width="355" alt="Screenshot 2023-08-31 at 10 43 19" src="https://github.com/commercetools/ui-kit/assets/52276952/e9040ed8-1aa3-4f3b-91de-5d32b009f45e">