### PR TITLE
Fix edge case with managing end transition in `Tooltip` component

### DIFF
--- a/.changeset/khaki-mirrors-refuse.md
+++ b/.changeset/khaki-mirrors-refuse.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/tooltip': patch
+---
+
+Fix an edge case when managing end transition side effects.

--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -256,7 +256,14 @@ const Tooltip = (props: TTooltipProps) => {
           const tooltipElement = popperInstance?.popper.querySelector(
             '[data-testid="tooltip-message-wrapper"]'
           ) as HTMLElement;
-          tooltipElement.addEventListener('animationend', () => handleClose());
+
+          if (tooltipElement) {
+            tooltipElement.addEventListener('animationend', () =>
+              handleClose()
+            );
+          } else {
+            handleClose();
+          }
 
           setState('exiting');
         }, closeAfter);


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Fix edge case with managing end transition in `Tooltip` component

## Description

We've seen some end-to-end test having random problems that involves the `Tooltip` component.

The error we see in the browser console in those cases is like this:
![image](https://github.com/commercetools/ui-kit/assets/97907068/8e187bda-02a5-431b-afd0-beaa15fdcb7e)

Code referenced in the stack trace:
![image](https://github.com/commercetools/ui-kit/assets/97907068/e2c22dbd-fda8-4c49-bcfb-fe5d31f5c81f)

It means, for some unknown reason, when we want to add a listener for the animation ending, the expected element does not exist anymore.
I don't understand this behaviour. Maybe it's due to the e2e test environment being slow (just a guess).

In this  PR I just check for that potential condition and, if there is no element to be animated, I assume is not in the DOM anymore and apply the side effect (calling the `onClose` props callback) right away.

I'm not adding any test because I don't know how to reproduce this error.

Any suggestion about how to handle this in any other way would be much appreciated.
