### PR TITLE
fix: DateInput when providing invalid calendar date input

### DIFF
--- a/.changeset/calm-hairs-try.md
+++ b/.changeset/calm-hairs-try.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/calendar-utils': patch
+---
+
+Fix DateInput in Safari when providing invalid calendar date input

--- a/packages/calendar-utils/package.json
+++ b/packages/calendar-utils/package.json
@@ -33,6 +33,7 @@
     "@commercetools-uikit/utils": "16.7.3",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
+    "lodash": "4.17.21",
     "prop-types": "15.8.1",
     "react-select": "5.7.3"
   },

--- a/packages/calendar-utils/src/calendar.spec.js
+++ b/packages/calendar-utils/src/calendar.spec.js
@@ -1,5 +1,9 @@
 import moment from 'moment';
-import { getIsDateInRange, getExampleDateStrings } from './calendar';
+import {
+  getIsDateInRange,
+  getExampleDateStrings,
+  getPaddingDayCount,
+} from './calendar';
 
 describe('getIsDateInRange', () => {
   const min = '2019-01-01';
@@ -77,5 +81,11 @@ describe('getExampleDateStrings', () => {
         exampleDates.maxDate
       )
     ).toBeTruthy();
+  });
+});
+describe('getPaddingDayCount', () => {
+  it('should return a number for valid and NaN input', () => {
+    expect(getPaddingDayCount('2019-01-01')).toEqual(2);
+    expect(getPaddingDayCount(NaN)).toEqual(0);
   });
 });

--- a/packages/calendar-utils/src/calendar.ts
+++ b/packages/calendar-utils/src/calendar.ts
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import inRange from 'lodash/inRange';
 import type { MomentInput, DurationInputArg1 } from 'moment';
 
 export const getDaysInMonth = (day: MomentInput) => moment(day).daysInMonth();
@@ -17,9 +18,10 @@ export const getPreviousDay = (day: MomentInput) =>
 export const getPaddingDayCount = (day: MomentInput, locale: string) => {
   const firstDayOfWeek = moment.localeData(locale).firstDayOfWeek();
   const firstDayOfMonth = moment(day).startOf('month').day();
+  const paddingDayCount = (firstDayOfMonth - firstDayOfWeek + 7) % 7;
 
   // ensure number is always positive
-  return (firstDayOfMonth - firstDayOfWeek + 7) % 7;
+  return inRange(paddingDayCount, 0, 6) ? paddingDayCount : 0;
 };
 
 export const getWeekdayNames = (locale: string) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2481,6 +2481,7 @@ __metadata:
     "@commercetools-uikit/utils": 16.7.3
     "@emotion/react": ^11.10.5
     "@emotion/styled": ^11.10.5
+    lodash: 4.17.21
     moment: 2.29.4
     prop-types: 15.8.1
     react: 17.0.2


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Fixes [the reported issue](https://commercetools.atlassian.net/browse/SUPPORT-22938?atlOrigin=eyJpIjoiNDcwZTc0MWY5NzRjNDJlYjg5ZjQ1NDNmZjIyMGZkZTciLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

[Sentry error log](https://commercetools.sentry.io/issues/4477369881/events/3755b7e3471b478b88e632d15539ed52/?project=1549825&referrer=issue-list&statsPeriod=14d) 

The error:
<img width="572" alt="Screenshot 2023-09-18 at 12 20 43" src="https://github.com/commercetools/ui-kit/assets/49066275/630949a7-765b-4987-af8a-9acebb65cfb2">

Please mind all contexts in which `getPaddingDayCount` helper function is used ([1](https://github.com/commercetools/ui-kit/blob/73bc8841022ea3b46dc9e2b75d3f9fd3e1d4fff6/packages/components/inputs/date-input/src/date-input.tsx#L253-L254), [2](https://github.com/commercetools/ui-kit/blob/73bc8841022ea3b46dc9e2b75d3f9fd3e1d4fff6/packages/components/inputs/date-range-input/src/date-range-input.tsx#L430-L434), [3](https://github.com/commercetools/ui-kit/blob/73bc8841022ea3b46dc9e2b75d3f9fd3e1d4fff6/packages/components/inputs/date-time-input/src/date-time-input.tsx#L373-L378)) - it's always passed to the Array function (constructor) call

