### PR TITLE
Tooltip long title issue

### DIFF
--- a/.changeset/violet-mice-change.md
+++ b/.changeset/violet-mice-change.md
@@ -2,4 +2,4 @@
 '@commercetools-uikit/tooltip': patch
 ---
 
-Adding `break-space` prop to tooltip for long titles
+Fix tooltip content not completely visible when parent component has `white-space: nowrap` style.

--- a/.changeset/violet-mice-change.md
+++ b/.changeset/violet-mice-change.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/tooltip': patch
+---
+
+Adding `break-space` prop to tooltip for long titles

--- a/packages/components/tooltip/src/tooltip.styles.ts
+++ b/packages/components/tooltip/src/tooltip.styles.ts
@@ -63,6 +63,7 @@ export const Body = styled.div`
   opacity: 0.95;
   color: ${designTokens.colorSurface};
   background-color: ${designTokens.backgroundColorForTooltip};
+  white-space: break-spaces;
 `;
 
 // here we use object styles so we can spread these

--- a/packages/components/tooltip/src/tooltip.visualroute.jsx
+++ b/packages/components/tooltip/src/tooltip.visualroute.jsx
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled';
-import { PrimaryButton, Tooltip } from '@commercetools-frontend/ui-kit';
+import { PrimaryButton, Tooltip, Spacings, CollapsiblePanel } from '@commercetools-frontend/ui-kit';
 import { Suite, Spec } from '../../../../test/percy';
 
 const title = 'What kind of bear is best';
+const longTitle = 'What kind of bear is best? Everyones knows its a panda.';
 const noop = () => {};
 
 const Body = styled.div`
@@ -44,6 +45,31 @@ export const component = () => {
             <PrimaryButton onClick={noop} label="Hello" />
           </Tooltip>
         </ContainerWithPadding>
+      </Spec>
+      <Spec
+        label="CollapsiblePanel as a parent"
+        listPropsOfNestedChild={true}
+      >
+        <CollapsiblePanel
+          theme="dark"
+          header={
+            <Spacings.Inline scale="m" alignItems="center">
+              <CollapsiblePanel.Header>
+                Header
+              </CollapsiblePanel.Header>
+              <Tooltip 
+                title={longTitle} 
+                isOpen={true}
+                horizontalConstraint={6}
+                placement='bottom'
+              >
+                <PrimaryButton onClick={noop} label="Hello" />
+              </Tooltip>
+            </Spacings.Inline>
+          }
+        >
+          <div>Some content</div>
+        </CollapsiblePanel>
       </Spec>
     </Suite>
   );


### PR DESCRIPTION
Currently, when a tooltip is contained within a parent element with a `white-space` property set to `nowrap`, it will inherit the property and that will create an unwanted layout if the tooltip label is long.

<img width="1174" alt="Screenshot 2023-09-25 at 12 10 51" src="https://github.com/commercetools/ui-kit/assets/52276952/9ee78ea8-6f71-471b-ac6b-ee26b3d58a99">

We can address this issue by explicitly setting up the `white-space` to `break-spaces` and move to the next line when the text exceeds a certain length.

<img width="1085" alt="Screenshot 2023-09-25 at 12 11 19" src="https://github.com/commercetools/ui-kit/assets/52276952/24e9486e-dd92-4524-a3c9-2435ecdd88f1">
