### PR TITLE
fix(LocalizedRichTextInput): reset callback

### DIFF
--- a/.changeset/early-peas-return.md
+++ b/.changeset/early-peas-return.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/localized-rich-text-input': patch
+---
+
+Fix reset callback

--- a/packages/components/inputs/localized-rich-text-input/src/editor.styles.ts
+++ b/packages/components/inputs/localized-rich-text-input/src/editor.styles.ts
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { css } from '@emotion/react';
 import { designTokens } from '@commercetools-uikit/design-system';
 import type { TEditorProps } from './editor';
 
@@ -73,4 +74,32 @@ const ToggleButtonWrapper = styled.div`
   display: flex;
 `;
 
-export { EditorLanguageLabel, EditorWrapper, ToggleButtonWrapper };
+const RichTextInputVisibilityWrapper = styled.div<{ isVisible: boolean }>`
+  visibility: ${(props) => (props.isVisible ? 'visible' : 'hidden')} !important;
+
+  > div > div > div > div {
+    visibility: ${(props) =>
+      props.isVisible ? 'visible' : 'hidden'} !important;
+  }
+`;
+
+const LocalizedInputToggleContainer = styled.div<{
+  shouldUseAbsolutePosition: boolean;
+  top?: number;
+}>`
+  ${(props) =>
+    props.shouldUseAbsolutePosition &&
+    props.top &&
+    css`
+      position: absolute;
+      top: ${props.top}px;
+    `};
+`;
+
+export {
+  EditorLanguageLabel,
+  EditorWrapper,
+  ToggleButtonWrapper,
+  RichTextInputVisibilityWrapper,
+  LocalizedInputToggleContainer,
+};

--- a/packages/components/inputs/localized-rich-text-input/src/editor.styles.ts
+++ b/packages/components/inputs/localized-rich-text-input/src/editor.styles.ts
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { css } from '@emotion/react';
 import { designTokens } from '@commercetools-uikit/design-system';
 import type { TEditorProps } from './editor';
 
@@ -74,32 +73,4 @@ const ToggleButtonWrapper = styled.div`
   display: flex;
 `;
 
-const RichTextInputVisibilityWrapper = styled.div<{ isVisible: boolean }>`
-  visibility: ${(props) => (props.isVisible ? 'visible' : 'hidden')} !important;
-
-  > div > div > div > div {
-    visibility: ${(props) =>
-      props.isVisible ? 'visible' : 'hidden'} !important;
-  }
-`;
-
-const LocalizedInputToggleContainer = styled.div<{
-  shouldUseAbsolutePosition: boolean;
-  top?: number;
-}>`
-  ${(props) =>
-    props.shouldUseAbsolutePosition &&
-    props.top &&
-    css`
-      position: absolute;
-      top: ${props.top}px;
-    `};
-`;
-
-export {
-  EditorLanguageLabel,
-  EditorWrapper,
-  ToggleButtonWrapper,
-  RichTextInputVisibilityWrapper,
-  LocalizedInputToggleContainer,
-};
+export { EditorLanguageLabel, EditorWrapper, ToggleButtonWrapper };

--- a/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.tsx
+++ b/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.tsx
@@ -1,6 +1,8 @@
 import {
   useReducer,
   useCallback,
+  useEffect,
+  useState,
   forwardRef,
   useRef,
   useImperativeHandle,
@@ -29,6 +31,10 @@ import { localized } from '@commercetools-uikit/rich-text-utils';
 import { warning, filterDataAttributes } from '@commercetools-uikit/utils';
 import RichTextInput from './rich-text-input';
 import RequiredValueErrorMessage from './required-value-error-message';
+import {
+  RichTextInputVisibilityWrapper,
+  LocalizedInputToggleContainer,
+} from './editor.styles';
 
 type TErrors = Record<string, string>;
 type TWarnings = Record<string, ReactNode>;
@@ -310,79 +316,103 @@ const LocalizedRichTextInput: ForwardRefExoticComponent<
     const shouldRenderLanguagesControl =
       languages.length > 1 && !props.hideLanguageExpansionControls;
 
+    const [firstEditorHeight, setFirstEditorHeight] = useState(0);
+    const updateFirstEditorHeight = useCallback(
+      () =>
+        setFirstEditorHeight(
+          document.querySelector(`label[for="rich-text.${languages[0]}"]`)
+            ?.clientHeight ?? 0
+        ),
+      []
+    );
+    useEffect(() => {
+      updateFirstEditorHeight();
+    });
+
     return (
       <Constraints.Horizontal max={props.horizontalConstraint}>
         <Stack scale="xs">
           <Stack>
             {languages.map((language, index) => {
               const isFirstLanguage = index === 0;
-              if (!isFirstLanguage && !areLanguagesOpened) return null;
               const isLastLanguage = index === languages.length - 1;
 
               const hasLanguagesControl =
                 (isFirstLanguage && !areLanguagesOpened) || isLastLanguage;
 
               return (
-                <RichTextInput
-                  {...filterDataAttributes(props)}
+                <RichTextInputVisibilityWrapper
+                  isVisible={!(!isFirstLanguage && !areLanguagesOpened)}
                   key={language}
-                  id={getId(props.id, language)}
-                  name={getName(props.name, language)}
-                  value={props.value[language]}
-                  onChange={createChangeHandler(language)}
-                  language={language}
-                  isOpen={expandedTranslationsState[language]}
-                  toggleLanguage={toggleLanguage}
-                  placeholder={
-                    props.placeholder ? props.placeholder[language] : undefined
-                  }
-                  onBlur={props.onBlur}
-                  onFocus={props.onFocus}
-                  isDisabled={props.isDisabled}
-                  isReadOnly={props.isReadOnly}
-                  hasError={Boolean(
-                    props.hasError || (props.errors && props.errors[language])
-                  )}
-                  hasWarning={Boolean(
-                    props.hasWarning ||
-                      (props.warnings && props.warnings[language])
-                  )}
-                  warning={props.warnings && props.warnings[language]}
-                  error={props.errors && props.errors[language]}
-                  showExpandIcon={props.showExpandIcon}
-                  onClickExpand={props.onClickExpand}
-                  hasLanguagesControl={hasLanguagesControl}
-                  defaultExpandMultilineText={Boolean(
-                    props.defaultExpandMultilineText
-                  )}
-                  ref={(el: RefWithImperativeResetHandler) =>
-                    langRefs.current.set(language, el)
-                  }
-                  {...createLocalizedDataAttributes(props, language)}
-                />
+                >
+                  <RichTextInput
+                    {...filterDataAttributes(props)}
+                    id={getId(props.id, language)}
+                    name={getName(props.name, language)}
+                    value={props.value[language]}
+                    onChange={createChangeHandler(language)}
+                    language={language}
+                    isOpen={expandedTranslationsState[language]}
+                    toggleLanguage={toggleLanguage}
+                    placeholder={
+                      props.placeholder
+                        ? props.placeholder[language]
+                        : undefined
+                    }
+                    onBlur={props.onBlur}
+                    onFocus={props.onFocus}
+                    isDisabled={props.isDisabled}
+                    isReadOnly={props.isReadOnly}
+                    hasError={Boolean(
+                      props.hasError || (props.errors && props.errors[language])
+                    )}
+                    hasWarning={Boolean(
+                      props.hasWarning ||
+                        (props.warnings && props.warnings[language])
+                    )}
+                    warning={props.warnings && props.warnings[language]}
+                    error={props.errors && props.errors[language]}
+                    showExpandIcon={props.showExpandIcon}
+                    onClickExpand={props.onClickExpand}
+                    hasLanguagesControl={hasLanguagesControl}
+                    defaultExpandMultilineText={Boolean(
+                      props.defaultExpandMultilineText
+                    )}
+                    ref={(el: RefWithImperativeResetHandler) =>
+                      langRefs.current.set(language, el)
+                    }
+                    {...createLocalizedDataAttributes(props, language)}
+                  />
+                </RichTextInputVisibilityWrapper>
               );
             })}
           </Stack>
-          {shouldRenderLanguagesControl && (
-            <LocalizedInputToggle
-              isOpen={areLanguagesOpened}
-              onClick={
-                toggleLanguages as (
-                  event:
-                    | MouseEvent<HTMLButtonElement>
-                    | KeyboardEvent<HTMLButtonElement>
-                    | boolean
-                ) => void
-              }
-              isDisabled={
-                areLanguagesOpened &&
-                Boolean(
-                  hasErrorInRemainingLanguages || hasWarningInRemainingLanguages
-                )
-              }
-              remainingLocalizations={languages.length - 1}
-            />
-          )}
+          <LocalizedInputToggleContainer
+            shouldUseAbsolutePosition={!areLanguagesOpened}
+            top={firstEditorHeight}
+          >
+            {shouldRenderLanguagesControl && (
+              <LocalizedInputToggle
+                isOpen={areLanguagesOpened}
+                onClick={
+                  toggleLanguages as (
+                    event:
+                      | MouseEvent<HTMLButtonElement>
+                      | KeyboardEvent<HTMLButtonElement>
+                      | boolean
+                  ) => void
+                }
+                isDisabled={
+                  areLanguagesOpened &&
+                  Boolean(
+                    hasErrorInRemainingLanguages ||
+                      hasWarningInRemainingLanguages
+                  )
+                }
+                remainingLocalizations={languages.length - 1}
+              />
+            )}
+          </LocalizedInputToggleContainer>
         </Stack>
       </Constraints.Horizontal>
     );

--- a/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.tsx
+++ b/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.tsx
@@ -1,8 +1,6 @@
 import {
   useReducer,
   useCallback,
-  useEffect,
-  useState,
   forwardRef,
   useRef,
   useImperativeHandle,
@@ -31,10 +29,6 @@ import { localized } from '@commercetools-uikit/rich-text-utils';
 import { warning, filterDataAttributes } from '@commercetools-uikit/utils';
 import RichTextInput from './rich-text-input';
 import RequiredValueErrorMessage from './required-value-error-message';
-import {
-  RichTextInputVisibilityWrapper,
-  LocalizedInputToggleContainer,
-} from './editor.styles';
 
 type TErrors = Record<string, string>;
 type TWarnings = Record<string, ReactNode>;
@@ -316,103 +310,79 @@ const LocalizedRichTextInput: ForwardRefExoticComponent<
     const shouldRenderLanguagesControl =
       languages.length > 1 && !props.hideLanguageExpansionControls;
 
-    const [firstEditorHeight, setFirstEditorHeight] = useState(0);
-    const updateFirstEditorHeight = useCallback(
-      () =>
-        setFirstEditorHeight(
-          document.querySelector(`label[for="rich-text.${languages[0]}"]`)
-            ?.clientHeight ?? 0
-        ),
-      []
-    );
-    useEffect(() => {
-      updateFirstEditorHeight();
-    });
-
     return (
       <Constraints.Horizontal max={props.horizontalConstraint}>
         <Stack scale="xs">
           <Stack>
             {languages.map((language, index) => {
               const isFirstLanguage = index === 0;
+              if (!isFirstLanguage && !areLanguagesOpened) return null;
               const isLastLanguage = index === languages.length - 1;
 
               const hasLanguagesControl =
                 (isFirstLanguage && !areLanguagesOpened) || isLastLanguage;
 
               return (
-                <RichTextInputVisibilityWrapper
-                  isVisible={!(!isFirstLanguage && !areLanguagesOpened)}
+                <RichTextInput
+                  {...filterDataAttributes(props)}
                   key={language}
-                >
-                  <RichTextInput
-                    {...filterDataAttributes(props)}
-                    id={getId(props.id, language)}
-                    name={getName(props.name, language)}
-                    value={props.value[language]}
-                    onChange={createChangeHandler(language)}
-                    language={language}
-                    isOpen={expandedTranslationsState[language]}
-                    toggleLanguage={toggleLanguage}
-                    placeholder={
-                      props.placeholder
-                        ? props.placeholder[language]
-                        : undefined
-                    }
-                    onBlur={props.onBlur}
-                    onFocus={props.onFocus}
-                    isDisabled={props.isDisabled}
-                    isReadOnly={props.isReadOnly}
-                    hasError={Boolean(
-                      props.hasError || (props.errors && props.errors[language])
-                    )}
-                    hasWarning={Boolean(
-                      props.hasWarning ||
-                        (props.warnings && props.warnings[language])
-                    )}
-                    warning={props.warnings && props.warnings[language]}
-                    error={props.errors && props.errors[language]}
-                    showExpandIcon={props.showExpandIcon}
-                    onClickExpand={props.onClickExpand}
-                    hasLanguagesControl={hasLanguagesControl}
-                    defaultExpandMultilineText={Boolean(
-                      props.defaultExpandMultilineText
-                    )}
-                    ref={(el: RefWithImperativeResetHandler) =>
-                      langRefs.current.set(language, el)
-                    }
-                    {...createLocalizedDataAttributes(props, language)}
-                  />
-                </RichTextInputVisibilityWrapper>
+                  id={getId(props.id, language)}
+                  name={getName(props.name, language)}
+                  value={props.value[language]}
+                  onChange={createChangeHandler(language)}
+                  language={language}
+                  isOpen={expandedTranslationsState[language]}
+                  toggleLanguage={toggleLanguage}
+                  placeholder={
+                    props.placeholder ? props.placeholder[language] : undefined
+                  }
+                  onBlur={props.onBlur}
+                  onFocus={props.onFocus}
+                  isDisabled={props.isDisabled}
+                  isReadOnly={props.isReadOnly}
+                  hasError={Boolean(
+                    props.hasError || (props.errors && props.errors[language])
+                  )}
+                  hasWarning={Boolean(
+                    props.hasWarning ||
+                      (props.warnings && props.warnings[language])
+                  )}
+                  warning={props.warnings && props.warnings[language]}
+                  error={props.errors && props.errors[language]}
+                  showExpandIcon={props.showExpandIcon}
+                  onClickExpand={props.onClickExpand}
+                  hasLanguagesControl={hasLanguagesControl}
+                  defaultExpandMultilineText={Boolean(
+                    props.defaultExpandMultilineText
+                  )}
+                  ref={(el: RefWithImperativeResetHandler) =>
+                    langRefs.current.set(language, el)
+                  }
+                  {...createLocalizedDataAttributes(props, language)}
+                />
               );
             })}
           </Stack>
-          <LocalizedInputToggleContainer
-            shouldUseAbsolutePosition={!areLanguagesOpened}
-            top={firstEditorHeight}
-          >
-            {shouldRenderLanguagesControl && (
-              <LocalizedInputToggle
-                isOpen={areLanguagesOpened}
-                onClick={
-                  toggleLanguages as (
-                    event:
-                      | MouseEvent<HTMLButtonElement>
-                      | KeyboardEvent<HTMLButtonElement>
-                      | boolean
-                  ) => void
-                }
-                isDisabled={
-                  areLanguagesOpened &&
-                  Boolean(
-                    hasErrorInRemainingLanguages ||
-                      hasWarningInRemainingLanguages
-                  )
-                }
-                remainingLocalizations={languages.length - 1}
-              />
-            )}
-          </LocalizedInputToggleContainer>
+          {shouldRenderLanguagesControl && (
+            <LocalizedInputToggle
+              isOpen={areLanguagesOpened}
+              onClick={
+                toggleLanguages as (
+                  event:
+                    | MouseEvent<HTMLButtonElement>
+                    | KeyboardEvent<HTMLButtonElement>
+                    | boolean
+                ) => void
+              }
+              isDisabled={
+                areLanguagesOpened &&
+                Boolean(
+                  hasErrorInRemainingLanguages || hasWarningInRemainingLanguages
+                )
+              }
+              remainingLocalizations={languages.length - 1}
+            />
+          )}
         </Stack>
       </Constraints.Horizontal>
     );

--- a/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.tsx
+++ b/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.tsx
@@ -295,7 +295,7 @@ const LocalizedRichTextInput: ForwardRefExoticComponent<
     const resetValue = useCallback(
       (newValue: string | Record<string, string>) => {
         langRefs.current.forEach((langRef) => {
-          langRef.resetValue(newValue);
+          langRef?.resetValue(newValue);
         });
       },
       []


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Fixes https://github.com/commercetools/ui-kit/issues/2626

##### More context about the issue:

In the `<LocalizedRichTextEditor>` component, when `<RichTextEditors>` for certain languages are first rendered, the refs are created. When the editors are hidden later on, the refs are null, so calling the reset callback for those hidden editors ends up with:
<img width="1399" alt="275848398-a6c7601a-3fe8-4090-a547-29b52d6f9b97-1" src="https://github.com/commercetools/ui-kit/assets/49066275/7eb4ff8e-3148-4fd4-9da2-17b8aeb99b04">
