### PR TITLE
Refactor `Inset` components vertical space usage

### DIFF
--- a/.changeset/proud-pugs-decide.md
+++ b/.changeset/proud-pugs-decide.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/card': minor
+---
+
+Make card content to always use all available vertical space.

--- a/.changeset/stale-radios-punch.md
+++ b/.changeset/stale-radios-punch.md
@@ -5,5 +5,4 @@
 
 Refactor vertical space usage so consumers can control it.
 
-There's a new property named `height` (available values: `min-content` and `max-content`; the former is the default) that will allow consumers to control the vertical space usage of the component.
-When using the `max-content` value, it will force the component main container to use `100%` of the available height.
+There's a new property named `height` (available values: `auto` and `100%`; the former is the default) that will allow consumers to control the vertical space usage of the component.

--- a/.changeset/stale-radios-punch.md
+++ b/.changeset/stale-radios-punch.md
@@ -1,0 +1,8 @@
+---
+'@commercetools-uikit/spacings-inset-squish': minor
+'@commercetools-uikit/spacings-inset': minor
+---
+
+Refactor vertical space usage so consumers can control it.
+
+There's a new property named `useAllAvailableHeight` that will force the component main container to use `100%` of the available height.

--- a/.changeset/stale-radios-punch.md
+++ b/.changeset/stale-radios-punch.md
@@ -5,5 +5,5 @@
 
 Refactor vertical space usage so consumers can control it.
 
-There's a new property named `height` (available values: `collapsed` and `expanded`) that will allow consumers to control the vertical space usage of the component.
-When using the `expanded` value, it will force the component main container to use `100%` of the available height.
+There's a new property named `height` (available values: `min-content` and `max-content`; the former is the default) that will allow consumers to control the vertical space usage of the component.
+When using the `max-content` value, it will force the component main container to use `100%` of the available height.

--- a/.changeset/stale-radios-punch.md
+++ b/.changeset/stale-radios-punch.md
@@ -5,4 +5,5 @@
 
 Refactor vertical space usage so consumers can control it.
 
-There's a new property named `useAllAvailableHeight` that will force the component main container to use `100%` of the available height.
+There's a new property named `height` (available values: `collapsed` and `expanded`) that will allow consumers to control the vertical space usage of the component.
+When using the `expanded` value, it will force the component main container to use `100%` of the available height.

--- a/packages/components/card/src/card.tsx
+++ b/packages/components/card/src/card.tsx
@@ -55,7 +55,7 @@ const Card = (props: TCardProps) => (
       // This is mostly useful in case custom styles are targeting this element.
       <div>{props.children}</div>
     ) : (
-      <Inset scale={props.insetScale} height="max-content">
+      <Inset scale={props.insetScale} height="100%">
         {props.children}
       </Inset>
     )}

--- a/packages/components/card/src/card.tsx
+++ b/packages/components/card/src/card.tsx
@@ -55,7 +55,7 @@ const Card = (props: TCardProps) => (
       // This is mostly useful in case custom styles are targeting this element.
       <div>{props.children}</div>
     ) : (
-      <Inset scale={props.insetScale} height="expanded">
+      <Inset scale={props.insetScale} height="max-content">
         {props.children}
       </Inset>
     )}

--- a/packages/components/card/src/card.tsx
+++ b/packages/components/card/src/card.tsx
@@ -55,7 +55,9 @@ const Card = (props: TCardProps) => (
       // This is mostly useful in case custom styles are targeting this element.
       <div>{props.children}</div>
     ) : (
-      <Inset scale={props.insetScale}>{props.children}</Inset>
+      <Inset scale={props.insetScale} useAllAvailableHeight>
+        {props.children}
+      </Inset>
     )}
   </div>
 );

--- a/packages/components/card/src/card.tsx
+++ b/packages/components/card/src/card.tsx
@@ -55,7 +55,7 @@ const Card = (props: TCardProps) => (
       // This is mostly useful in case custom styles are targeting this element.
       <div>{props.children}</div>
     ) : (
-      <Inset scale={props.insetScale} useAllAvailableHeight>
+      <Inset scale={props.insetScale} height="expanded">
         {props.children}
       </Inset>
     )}

--- a/packages/components/card/src/card.visualroute.jsx
+++ b/packages/components/card/src/card.visualroute.jsx
@@ -17,10 +17,11 @@ const WrappedCard = (props) => (
     css={css`
       margin: 16px;
       width: 300px;
+      height: ${props.height || 'auto'};
     `}
     {...props}
   >
-    <Text.Body>{props.children}</Text.Body>
+    {props.children}
   </Card>
 );
 
@@ -28,74 +29,94 @@ export const component = () => (
   <Suite>
     <Spec label="Type - Raised, Theme - Light, InsetScale - None">
       <WrappedCard type="raised" theme="light" insetScale="none">
-        {text}
+        <Text.Body>{text}</Text.Body>
       </WrappedCard>
     </Spec>
     <Spec label="Type - Raised, Theme - Dark, InsetScale - None">
       <WrappedCard type="raised" theme="dark" insetScale="none">
-        {text}
+        <Text.Body>{text}</Text.Body>
       </WrappedCard>
     </Spec>
     <Spec label="Type - Flat, Theme - Light, InsetScale - None">
       <WrappedCard type="flat" theme="light" insetScale="none">
-        {text}
+        <Text.Body>{text}</Text.Body>
       </WrappedCard>
     </Spec>
     <Spec label="Type - Flat, Theme - Dark, InsetScale - None">
       <WrappedCard type="flat" theme="dark" insetScale="none">
-        {text}
+        <Text.Body>{text}</Text.Body>
       </WrappedCard>
     </Spec>
 
     <Spec label="Type - Raised, Theme - Light, InsetScale - S">
       <WrappedCard type="raised" theme="light" insetScale="s">
-        {text}
+        <Text.Body>{text}</Text.Body>
       </WrappedCard>
     </Spec>
     <Spec label="Type - Raised, Theme - Dark, InsetScale - S">
       <WrappedCard type="raised" theme="dark" insetScale="s">
-        {text}
+        <Text.Body>{text}</Text.Body>
       </WrappedCard>
     </Spec>
     <Spec label="Type - Flat, Theme - Light, InsetScale - S">
       <WrappedCard type="flat" theme="light" insetScale="s">
-        {text}
+        <Text.Body>{text}</Text.Body>
       </WrappedCard>
     </Spec>
     <Spec label="Type - Flat, Theme - Dark, InsetScale - S">
       <WrappedCard type="flat" theme="dark" insetScale="s">
-        {text}
+        <Text.Body>{text}</Text.Body>
       </WrappedCard>
     </Spec>
 
     <Spec label="Type - Raised, Theme - Light, InsetScale - M">
       <WrappedCard type="raised" theme="light" insetScale="m">
-        {text}
+        <Text.Body>{text}</Text.Body>
       </WrappedCard>
     </Spec>
     <Spec label="Type - Raised, Theme - Dark, InsetScale - M">
       <WrappedCard type="raised" theme="dark" insetScale="m">
-        {text}
+        <Text.Body>{text}</Text.Body>
       </WrappedCard>
     </Spec>
     <Spec label="Type - Flat, Theme - Light, InsetScale - M">
       <WrappedCard type="flat" theme="light" insetScale="m">
-        {text}
+        <Text.Body>{text}</Text.Body>
       </WrappedCard>
     </Spec>
     <Spec label="Type - Flat, Theme - Dark, InsetScale - M">
       <WrappedCard type="flat" theme="dark" insetScale="m">
-        {text}
+        <Text.Body>{text}</Text.Body>
       </WrappedCard>
     </Spec>
     <Spec label="Type - Raised, Theme - Light, InsetScale - L">
       <WrappedCard type="raised" theme="light" insetScale="l">
-        {text}
+        <Text.Body>{text}</Text.Body>
       </WrappedCard>
     </Spec>
     <Spec label="Type - Raised, Theme - Light, InsetScale - XL">
       <WrappedCard type="raised" theme="light" insetScale="xl">
-        {text}
+        <Text.Body>{text}</Text.Body>
+      </WrappedCard>
+    </Spec>
+
+    <Spec label="Content using all vertical space from the parent">
+      <WrappedCard type="raised" theme="light" insetScale="m" height="400px">
+        <div
+          css={css`
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            height: 100%;
+          `}
+        >
+          <div>
+            {text}
+          </div>
+          <div>
+            {text}
+          </div>
+        </div>
       </WrappedCard>
     </Spec>
   </Suite>

--- a/packages/components/spacings/spacings-inset-squish/README.md
+++ b/packages/components/spacings/spacings-inset-squish/README.md
@@ -36,11 +36,11 @@ import Spacings from '@commercetools-uikit/spacings';
 
 ## Properties
 
-| Props      | Type             | Required | Values                       | Default       |
-| ---------- | ---------------- | :------: | ---------------------------- | ------------- |
-| `scale`    | `String`         |    -     | `['s', 'm', 'l']`            | `m`           |
-| `height`   | `String`         |    -     | `min-content`, `max-content` | `min-content` |
-| `children` | `PropTypes.node` |    -     | -                            | -             |
+| Props      | Type             | Required | Values            | Default |
+| ---------- | ---------------- | :------: | ----------------- | ------- |
+| `scale`    | `String`         |    -     | `['s', 'm', 'l']` | `m`     |
+| `height`   | `String`         |    -     | `auto`, `100%`    | `auto`  |
+| `children` | `PropTypes.node` |    -     | -                 | -       |
 
 ## Scales
 

--- a/packages/components/spacings/spacings-inset-squish/README.md
+++ b/packages/components/spacings/spacings-inset-squish/README.md
@@ -36,10 +36,11 @@ import Spacings from '@commercetools-uikit/spacings';
 
 ## Properties
 
-| Props      | Type             | Required | Values            | Default |
-| ---------- | ---------------- | :------: | ----------------- | ------- |
-| `scale`    | `String`         |    -     | `['s', 'm', 'l']` | `m`     |
-| `children` | `PropTypes.node` |    -     | -                 | -       |
+| Props                   | Type             | Required | Values            | Default |
+| ----------------------- | ---------------- | :------: | ----------------- | ------- |
+| `scale`                 | `String`         |    -     | `['s', 'm', 'l']` | `m`     |
+| `useAllAvailableHeight` | `boolean`        |    -     | `true`            | `false` |
+| `children`              | `PropTypes.node` |    -     | -                 | -       |
 
 ## Scales
 

--- a/packages/components/spacings/spacings-inset-squish/README.md
+++ b/packages/components/spacings/spacings-inset-squish/README.md
@@ -36,11 +36,11 @@ import Spacings from '@commercetools-uikit/spacings';
 
 ## Properties
 
-| Props                   | Type             | Required | Values            | Default |
-| ----------------------- | ---------------- | :------: | ----------------- | ------- |
-| `scale`                 | `String`         |    -     | `['s', 'm', 'l']` | `m`     |
-| `useAllAvailableHeight` | `boolean`        |    -     | `true`, `false`   | `false` |
-| `children`              | `PropTypes.node` |    -     | -                 | -       |
+| Props      | Type             | Required | Values                  | Default     |
+| ---------- | ---------------- | :------: | ----------------------- | ----------- |
+| `scale`    | `String`         |    -     | `['s', 'm', 'l']`       | `m`         |
+| `height`   | `String`         |    -     | `collapsed`, `expanded` | `collapsed` |
+| `children` | `PropTypes.node` |    -     | -                       | -           |
 
 ## Scales
 

--- a/packages/components/spacings/spacings-inset-squish/README.md
+++ b/packages/components/spacings/spacings-inset-squish/README.md
@@ -39,7 +39,7 @@ import Spacings from '@commercetools-uikit/spacings';
 | Props                   | Type             | Required | Values            | Default |
 | ----------------------- | ---------------- | :------: | ----------------- | ------- |
 | `scale`                 | `String`         |    -     | `['s', 'm', 'l']` | `m`     |
-| `useAllAvailableHeight` | `boolean`        |    -     | `true`            | `false` |
+| `useAllAvailableHeight` | `boolean`        |    -     | `true`, `false`   | `false` |
 | `children`              | `PropTypes.node` |    -     | -                 | -       |
 
 ## Scales

--- a/packages/components/spacings/spacings-inset-squish/README.md
+++ b/packages/components/spacings/spacings-inset-squish/README.md
@@ -36,11 +36,11 @@ import Spacings from '@commercetools-uikit/spacings';
 
 ## Properties
 
-| Props      | Type             | Required | Values                  | Default     |
-| ---------- | ---------------- | :------: | ----------------------- | ----------- |
-| `scale`    | `String`         |    -     | `['s', 'm', 'l']`       | `m`         |
-| `height`   | `String`         |    -     | `collapsed`, `expanded` | `collapsed` |
-| `children` | `PropTypes.node` |    -     | -                       | -           |
+| Props      | Type             | Required | Values                       | Default       |
+| ---------- | ---------------- | :------: | ---------------------------- | ------------- |
+| `scale`    | `String`         |    -     | `['s', 'm', 'l']`            | `m`           |
+| `height`   | `String`         |    -     | `min-content`, `max-content` | `min-content` |
+| `children` | `PropTypes.node` |    -     | -                            | -             |
 
 ## Scales
 

--- a/packages/components/spacings/spacings-inset-squish/src/inset-squish.tsx
+++ b/packages/components/spacings/spacings-inset-squish/src/inset-squish.tsx
@@ -6,7 +6,7 @@ import { filterDataAttributes } from '@commercetools-uikit/utils';
 export type TScale = 's' | 'm' | 'l';
 export type TInsetSquishProps = {
   scale: TScale;
-  height: 'collapsed' | 'expanded';
+  height: 'min-content' | 'max-content';
   children: ReactNode;
 };
 
@@ -27,7 +27,7 @@ const InsetSquish = (props: TInsetSquishProps) => (
   <div
     css={css`
       padding: ${getPadding(props.scale)};
-      height: ${props.height === 'expanded' ? '100%' : 'auto'};
+      height: ${props.height === 'max-content' ? '100%' : 'auto'};
     `}
     {...filterDataAttributes(props)}
   >
@@ -36,7 +36,7 @@ const InsetSquish = (props: TInsetSquishProps) => (
 );
 const defaultProps: Pick<TInsetSquishProps, 'scale' | 'height'> = {
   scale: 'm',
-  height: 'collapsed',
+  height: 'min-content',
 };
 InsetSquish.displayName = 'InsetSquish';
 InsetSquish.defaultProps = defaultProps;

--- a/packages/components/spacings/spacings-inset-squish/src/inset-squish.tsx
+++ b/packages/components/spacings/spacings-inset-squish/src/inset-squish.tsx
@@ -6,6 +6,7 @@ import { filterDataAttributes } from '@commercetools-uikit/utils';
 export type TScale = 's' | 'm' | 'l';
 export type TInsetSquishProps = {
   scale: TScale;
+  useAllAvailableHeight: boolean;
   children: ReactNode;
 };
 
@@ -26,16 +27,18 @@ const InsetSquish = (props: TInsetSquishProps) => (
   <div
     css={css`
       padding: ${getPadding(props.scale)};
-      height: 100%;
+      height: ${props.useAllAvailableHeight ? '100%' : 'auto'};
     `}
     {...filterDataAttributes(props)}
   >
     {props.children}
   </div>
 );
-const defaultProps: Pick<TInsetSquishProps, 'scale'> = {
-  scale: 'm',
-};
+const defaultProps: Pick<TInsetSquishProps, 'scale' | 'useAllAvailableHeight'> =
+  {
+    scale: 'm',
+    useAllAvailableHeight: false,
+  };
 InsetSquish.displayName = 'InsetSquish';
 InsetSquish.defaultProps = defaultProps;
 

--- a/packages/components/spacings/spacings-inset-squish/src/inset-squish.tsx
+++ b/packages/components/spacings/spacings-inset-squish/src/inset-squish.tsx
@@ -6,7 +6,7 @@ import { filterDataAttributes } from '@commercetools-uikit/utils';
 export type TScale = 's' | 'm' | 'l';
 export type TInsetSquishProps = {
   scale: TScale;
-  useAllAvailableHeight: boolean;
+  height: 'collapsed' | 'expanded';
   children: ReactNode;
 };
 
@@ -27,18 +27,17 @@ const InsetSquish = (props: TInsetSquishProps) => (
   <div
     css={css`
       padding: ${getPadding(props.scale)};
-      height: ${props.useAllAvailableHeight ? '100%' : 'auto'};
+      height: ${props.height === 'expanded' ? '100%' : 'auto'};
     `}
     {...filterDataAttributes(props)}
   >
     {props.children}
   </div>
 );
-const defaultProps: Pick<TInsetSquishProps, 'scale' | 'useAllAvailableHeight'> =
-  {
-    scale: 'm',
-    useAllAvailableHeight: false,
-  };
+const defaultProps: Pick<TInsetSquishProps, 'scale' | 'height'> = {
+  scale: 'm',
+  height: 'collapsed',
+};
 InsetSquish.displayName = 'InsetSquish';
 InsetSquish.defaultProps = defaultProps;
 

--- a/packages/components/spacings/spacings-inset-squish/src/inset-squish.tsx
+++ b/packages/components/spacings/spacings-inset-squish/src/inset-squish.tsx
@@ -6,7 +6,7 @@ import { filterDataAttributes } from '@commercetools-uikit/utils';
 export type TScale = 's' | 'm' | 'l';
 export type TInsetSquishProps = {
   scale: TScale;
-  height: 'min-content' | 'max-content';
+  height: 'auto' | '100%';
   children: ReactNode;
 };
 
@@ -27,7 +27,7 @@ const InsetSquish = (props: TInsetSquishProps) => (
   <div
     css={css`
       padding: ${getPadding(props.scale)};
-      height: ${props.height === 'max-content' ? '100%' : 'auto'};
+      height: ${props.height};
     `}
     {...filterDataAttributes(props)}
   >
@@ -36,7 +36,7 @@ const InsetSquish = (props: TInsetSquishProps) => (
 );
 const defaultProps: Pick<TInsetSquishProps, 'scale' | 'height'> = {
   scale: 'm',
-  height: 'min-content',
+  height: 'auto',
 };
 InsetSquish.displayName = 'InsetSquish';
 InsetSquish.defaultProps = defaultProps;

--- a/packages/components/spacings/spacings-inset/README.md
+++ b/packages/components/spacings/spacings-inset/README.md
@@ -26,11 +26,11 @@ import Spacings from '@commercetools-uikit/spacings';
 
 ## Properties
 
-| Props                   | Type             | Required | Values                        | Default |
-| ----------------------- | ---------------- | :------: | ----------------------------- | ------- |
-| `scale`                 | `String`         |    -     | `['xs', 's', 'm', 'l', 'xl']` | `x`     |
-| `useAllAvailableHeight` | `boolean`        |    -     | `true`, `false`               | `false` |
-| `children`              | `PropTypes.node` |    -     | -                             | -       |
+| Props      | Type             | Required | Values                        | Default     |
+| ---------- | ---------------- | :------: | ----------------------------- | ----------- |
+| `scale`    | `String`         |    -     | `['xs', 's', 'm', 'l', 'xl']` | `x`         |
+| `height`   | `String`         |    -     | `collapsed`, `expanded`       | `collapsed` |
+| `children` | `PropTypes.node` |    -     | -                             | -           |
 
 ## Scales
 

--- a/packages/components/spacings/spacings-inset/README.md
+++ b/packages/components/spacings/spacings-inset/README.md
@@ -29,7 +29,7 @@ import Spacings from '@commercetools-uikit/spacings';
 | Props                   | Type             | Required | Values                        | Default |
 | ----------------------- | ---------------- | :------: | ----------------------------- | ------- |
 | `scale`                 | `String`         |    -     | `['xs', 's', 'm', 'l', 'xl']` | `x`     |
-| `useAllAvailableHeight` | `boolean`        |    -     | `true`                        | `false` |
+| `useAllAvailableHeight` | `boolean`        |    -     | `true`, `false`               | `false` |
 | `children`              | `PropTypes.node` |    -     | -                             | -       |
 
 ## Scales

--- a/packages/components/spacings/spacings-inset/README.md
+++ b/packages/components/spacings/spacings-inset/README.md
@@ -26,11 +26,11 @@ import Spacings from '@commercetools-uikit/spacings';
 
 ## Properties
 
-| Props      | Type             | Required | Values                        | Default     |
-| ---------- | ---------------- | :------: | ----------------------------- | ----------- |
-| `scale`    | `String`         |    -     | `['xs', 's', 'm', 'l', 'xl']` | `x`         |
-| `height`   | `String`         |    -     | `collapsed`, `expanded`       | `collapsed` |
-| `children` | `PropTypes.node` |    -     | -                             | -           |
+| Props      | Type             | Required | Values                        | Default       |
+| ---------- | ---------------- | :------: | ----------------------------- | ------------- |
+| `scale`    | `String`         |    -     | `['xs', 's', 'm', 'l', 'xl']` | `x`           |
+| `height`   | `String`         |    -     | `min-content`, `max-content`  | `min-content` |
+| `children` | `PropTypes.node` |    -     | -                             | -             |
 
 ## Scales
 

--- a/packages/components/spacings/spacings-inset/README.md
+++ b/packages/components/spacings/spacings-inset/README.md
@@ -26,10 +26,11 @@ import Spacings from '@commercetools-uikit/spacings';
 
 ## Properties
 
-| Props      | Type             | Required | Values                        | Default |
-| ---------- | ---------------- | :------: | ----------------------------- | ------- |
-| `scale`    | `String`         |    -     | `['xs', 's', 'm', 'l', 'xl']` | `x`     |
-| `children` | `PropTypes.node` |    -     | -                             | -       |
+| Props                   | Type             | Required | Values                        | Default |
+| ----------------------- | ---------------- | :------: | ----------------------------- | ------- |
+| `scale`                 | `String`         |    -     | `['xs', 's', 'm', 'l', 'xl']` | `x`     |
+| `useAllAvailableHeight` | `boolean`        |    -     | `true`                        | `false` |
+| `children`              | `PropTypes.node` |    -     | -                             | -       |
 
 ## Scales
 

--- a/packages/components/spacings/spacings-inset/README.md
+++ b/packages/components/spacings/spacings-inset/README.md
@@ -26,11 +26,11 @@ import Spacings from '@commercetools-uikit/spacings';
 
 ## Properties
 
-| Props      | Type             | Required | Values                        | Default       |
-| ---------- | ---------------- | :------: | ----------------------------- | ------------- |
-| `scale`    | `String`         |    -     | `['xs', 's', 'm', 'l', 'xl']` | `x`           |
-| `height`   | `String`         |    -     | `min-content`, `max-content`  | `min-content` |
-| `children` | `PropTypes.node` |    -     | -                             | -             |
+| Props      | Type             | Required | Values                        | Default |
+| ---------- | ---------------- | :------: | ----------------------------- | ------- |
+| `scale`    | `String`         |    -     | `['xs', 's', 'm', 'l', 'xl']` | `x`     |
+| `height`   | `String`         |    -     | `auto`, `100%`                | `auto`  |
+| `children` | `PropTypes.node` |    -     | -                             | -       |
 
 ## Scales
 

--- a/packages/components/spacings/spacings-inset/src/inset.tsx
+++ b/packages/components/spacings/spacings-inset/src/inset.tsx
@@ -24,7 +24,7 @@ const getPadding = (scale?: TScale) => {
 
 export type TInsetProps = {
   scale: TScale;
-  height: 'min-content' | 'max-content';
+  height: 'auto' | '100%';
   children?: ReactNode;
 };
 
@@ -32,7 +32,7 @@ const Inset = (props: TInsetProps) => (
   <div
     css={css`
       padding: ${getPadding(props.scale)};
-      height: ${props.height === 'max-content' ? '100%' : 'auto'};
+      height: ${props.height};
     `}
     {...filterDataAttributes(props)}
   >
@@ -41,7 +41,7 @@ const Inset = (props: TInsetProps) => (
 );
 const defaultProps: Pick<TInsetProps, 'scale' | 'height'> = {
   scale: 'm',
-  height: 'min-content',
+  height: 'auto',
 };
 Inset.displayName = 'Inset';
 Inset.defaultProps = defaultProps;

--- a/packages/components/spacings/spacings-inset/src/inset.tsx
+++ b/packages/components/spacings/spacings-inset/src/inset.tsx
@@ -24,6 +24,7 @@ const getPadding = (scale?: TScale) => {
 
 export type TInsetProps = {
   scale: TScale;
+  useAllAvailableHeight: boolean;
   children?: ReactNode;
 };
 
@@ -31,15 +32,16 @@ const Inset = (props: TInsetProps) => (
   <div
     css={css`
       padding: ${getPadding(props.scale)};
-      height: 100%;
+      height: ${props.useAllAvailableHeight ? '100%' : 'auto'};
     `}
     {...filterDataAttributes(props)}
   >
     {props.children}
   </div>
 );
-const defaultProps: Pick<TInsetProps, 'scale'> = {
+const defaultProps: Pick<TInsetProps, 'scale' | 'useAllAvailableHeight'> = {
   scale: 'm',
+  useAllAvailableHeight: false,
 };
 Inset.displayName = 'Inset';
 Inset.defaultProps = defaultProps;

--- a/packages/components/spacings/spacings-inset/src/inset.tsx
+++ b/packages/components/spacings/spacings-inset/src/inset.tsx
@@ -24,7 +24,7 @@ const getPadding = (scale?: TScale) => {
 
 export type TInsetProps = {
   scale: TScale;
-  height: 'collapsed' | 'expanded';
+  height: 'min-content' | 'max-content';
   children?: ReactNode;
 };
 
@@ -32,7 +32,7 @@ const Inset = (props: TInsetProps) => (
   <div
     css={css`
       padding: ${getPadding(props.scale)};
-      height: ${props.height === 'expanded' ? '100%' : 'auto'};
+      height: ${props.height === 'max-content' ? '100%' : 'auto'};
     `}
     {...filterDataAttributes(props)}
   >
@@ -41,7 +41,7 @@ const Inset = (props: TInsetProps) => (
 );
 const defaultProps: Pick<TInsetProps, 'scale' | 'height'> = {
   scale: 'm',
-  height: 'collapsed',
+  height: 'min-content',
 };
 Inset.displayName = 'Inset';
 Inset.defaultProps = defaultProps;

--- a/packages/components/spacings/spacings-inset/src/inset.tsx
+++ b/packages/components/spacings/spacings-inset/src/inset.tsx
@@ -24,7 +24,7 @@ const getPadding = (scale?: TScale) => {
 
 export type TInsetProps = {
   scale: TScale;
-  useAllAvailableHeight: boolean;
+  height: 'collapsed' | 'expanded';
   children?: ReactNode;
 };
 
@@ -32,16 +32,16 @@ const Inset = (props: TInsetProps) => (
   <div
     css={css`
       padding: ${getPadding(props.scale)};
-      height: ${props.useAllAvailableHeight ? '100%' : 'auto'};
+      height: ${props.height === 'expanded' ? '100%' : 'auto'};
     `}
     {...filterDataAttributes(props)}
   >
     {props.children}
   </div>
 );
-const defaultProps: Pick<TInsetProps, 'scale' | 'useAllAvailableHeight'> = {
+const defaultProps: Pick<TInsetProps, 'scale' | 'height'> = {
   scale: 'm',
-  useAllAvailableHeight: false,
+  height: 'collapsed',
 };
 Inset.displayName = 'Inset';
 Inset.defaultProps = defaultProps;


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Refactor `Inset` components vertical space usage

## Description

We found a problem with the vertical space of the `Card` component contents which we tried to address in [this PR](https://github.com/commercetools/ui-kit/pull/2624).

In that one, we thought it made sense to address the `Inset` and `InsetSquish` components (as the `Card` is using the former`) since, as container components, they should always use its parent available vertical space but we were wrong.
We noticed several use cases where this is not true so we're now proposing another approach.

The idea is that the vertical space used by `Inset` and `InsetSquish` components can be controlled with a new prop (`useAllAvailableHeight`) defaulting to the previous behaviour and only changing it for the `Card` component use case.

We suggest to use a boolean property instead of an open height so we can still control what we allow those component to render, but I'm happy to hear another suggestions.
