### PR TITLE
Decrease default font size for `Tooltip` component

### DIFF
--- a/.changeset/cool-countries-brake.md
+++ b/.changeset/cool-countries-brake.md
@@ -2,4 +2,4 @@
 '@commercetools-uikit/tooltip': minor
 ---
 
-Updated default font size (`0.8rem`) for the tooltip text.
+Updated default font size (`0.75rem`) for the tooltip text.

--- a/.changeset/cool-countries-brake.md
+++ b/.changeset/cool-countries-brake.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/tooltip': minor
+---
+
+Updated default font size (`0.8rem`) for the tooltip text.

--- a/packages/components/tooltip/src/tooltip.styles.ts
+++ b/packages/components/tooltip/src/tooltip.styles.ts
@@ -59,7 +59,7 @@ export const Body = styled.div`
   padding: ${designTokens.paddingForTooltip};
   border: none;
   box-shadow: ${designTokens.shadowForTooltip};
-  font-size: ${designTokens.fontSize12};
+  font-size: ${designTokens.fontSize10};
   opacity: 0.95;
   color: ${designTokens.colorSurface};
   background-color: ${designTokens.backgroundColorForTooltip};

--- a/packages/components/tooltip/src/tooltip.styles.ts
+++ b/packages/components/tooltip/src/tooltip.styles.ts
@@ -59,7 +59,7 @@ export const Body = styled.div`
   padding: ${designTokens.paddingForTooltip};
   border: none;
   box-shadow: ${designTokens.shadowForTooltip};
-  font-size: ${designTokens.fontSize20};
+  font-size: ${designTokens.fontSize12};
   opacity: 0.95;
   color: ${designTokens.colorSurface};
   background-color: ${designTokens.backgroundColorForTooltip};


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Decrease default font size for `Tooltip` component.

## Description

We're changing the default font size for the tooltip text from `0.875rem` to `0.75rem`. 

Bear in mind that consumers can customize Tooltip contents, so this change only applies when they don't customize them.
