### PR TITLE
Padding Quiet select input

### DIFF
--- a/.changeset/lemon-keys-double.md
+++ b/.changeset/lemon-keys-double.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-uikit/select-utils': patch
+'@commercetools-uikit/design-system': patch
+---
+
+Use smaller padding for `selectInput` component when the appearance is `quiet`.

--- a/design-system/materials/custom-properties.css
+++ b/design-system/materials/custom-properties.css
@@ -585,6 +585,7 @@
   --padding-for-collapsible-panel-section-description-as-condensed: 0 0
     var(--spacing-40);
   --padding-for-input: 16px;
+  --padding-for-input-as-quiet: 8px;
   --padding-for-multiline-input: 8px;
   --padding-for-localized-rich-text-input-label: var(--spacing-20) 12px;
   --padding-for-localized-rich-text-dropdown-button: 5px var(--spacing-20);

--- a/design-system/materials/custom-properties.json
+++ b/design-system/materials/custom-properties.json
@@ -469,6 +469,7 @@
   "--padding-for-collapsible-panel-section-description": "0 0 var(--spacing-40)",
   "--padding-for-collapsible-panel-section-description-as-condensed": "0 0 var(--spacing-40)",
   "--padding-for-input": "16px",
+  "--padding-for-input-as-quiet": "8px",
   "--padding-for-multiline-input": "8px",
   "--padding-for-localized-rich-text-input-label": "var(--spacing-20) 12px",
   "--padding-for-localized-rich-text-dropdown-button": "5px var(--spacing-20)",

--- a/design-system/materials/internals/definition.yaml
+++ b/design-system/materials/internals/definition.yaml
@@ -1188,6 +1188,8 @@ decisionGroupsByTheme:
           choice: '0 0 var(--spacing-40)'
         padding-for-input:
           choice: spacing-30
+        padding-for-input-as-quiet:
+          choice: spacing-20
         padding-for-multiline-input:
           choice: spacing-20
         padding-for-localized-rich-text-input-label:

--- a/design-system/src/design-tokens.ts
+++ b/design-system/src/design-tokens.ts
@@ -503,6 +503,7 @@ export const themes = {
     paddingForCollapsiblePanelSectionDescriptionAsCondensed:
       '0 0 var(--spacing-40)',
     paddingForInput: '16px',
+    paddingForInputAsQuiet: '8px',
     paddingForMultilineInput: '8px',
     paddingForLocalizedRichTextInputLabel: 'var(--spacing-20) 12px',
     paddingForLocalizedRichTextDropdownButton: '5px var(--spacing-20)',
@@ -1281,6 +1282,7 @@ const designTokens = {
   paddingForCollapsiblePanelSectionDescriptionAsCondensed:
     'var(--padding-for-collapsible-panel-section-description-as-condensed, 0 0 var(--spacing-40))',
   paddingForInput: 'var(--padding-for-input, 16px)',
+  paddingForInputAsQuiet: 'var(--padding-for-input-as-quiet, 8px)',
   paddingForMultilineInput: 'var(--padding-for-multiline-input, 8px)',
   paddingForLocalizedRichTextInputLabel:
     'var(--padding-for-localized-rich-text-input-label, var(--spacing-20) 12px)',

--- a/packages/components/inputs/select-utils/src/create-select-styles.ts
+++ b/packages/components/inputs/select-utils/src/create-select-styles.ts
@@ -136,7 +136,10 @@ const controlStyles = (props: TProps) => (base: TBase, state: TState) => {
       if (props.isReadOnly) return 'default';
       return 'pointer';
     })(),
-    padding: `0 ${designTokens.paddingForInput}`,
+    padding:
+      props.appearance === 'quiet'
+        ? `0 ${designTokens.paddingForInputAsQuiet}`
+        : `0 ${designTokens.paddingForInput}`,
     transition: `border-color ${designTokens.transitionStandard},
     box-shadow ${designTokens.transitionStandard}`,
     outline: 0,


### PR DESCRIPTION
To more seamlessly integrate Quiet `selectInput` into sentences, which was a primary motivation for developing this component, we aim to modify the input paddings to `8px` instead of `16px`.

![Screenshot 2023-11-28 at 13 57 15](https://github.com/commercetools/ui-kit/assets/52276952/368644d5-f469-4322-8ab4-828fb4f5320a)

-----------------------------------------
**16px:**

![16px](https://github.com/commercetools/ui-kit/assets/52276952/e78d2e1f-3e7c-4678-b88b-9ae1a52e7ddf)

-----------------------------------------
**8px:**
![8px](https://github.com/commercetools/ui-kit/assets/52276952/e40b9474-e7ec-43ff-81ef-34c18bdf3eec)


