### PR TITLE
Change queryselector to target outer table's header

### DIFF
--- a/.changeset/fuzzy-dogs-sip.md
+++ b/.changeset/fuzzy-dogs-sip.md
@@ -2,5 +2,5 @@
 '@commercetools-uikit/data-table': patch
 ---
 
-Change query selector to target only the `th` element of outer table  
+Updated table columns width calculation to take into account only main table header. This allows for having nested tables in its rows.
 

--- a/.changeset/fuzzy-dogs-sip.md
+++ b/.changeset/fuzzy-dogs-sip.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-uikit/data-table': patch
+---
+
+Change query selector to target only the `th` element of outer table  
+

--- a/packages/components/data-table/src/use-manual-column-resizing-reducer.ts
+++ b/packages/components/data-table/src/use-manual-column-resizing-reducer.ts
@@ -123,12 +123,14 @@ const useManualColumnResizing = (tableRef?: TTableRef) => {
   // if the table element has been rendered and we haven't yet measured the columns
   if (state.tableRef?.current && !state.sizes) {
     const renderedColumnMeasurements: TRenderedColumnMeasurements[] = [];
-    state.tableRef.current.querySelectorAll('th').forEach((header) => {
-      renderedColumnMeasurements.push({
-        key: header.getAttribute('data-id'),
-        width: header.getBoundingClientRect().width,
+    state.tableRef.current
+      .querySelectorAll(':scope > thead > tr > th')
+      .forEach((header) => {
+        renderedColumnMeasurements.push({
+          key: header.getAttribute('data-id'),
+          width: header.getBoundingClientRect().width,
+        });
       });
-    });
 
     dispatch({
       type: 'registerColumnMeasurements',


### PR DESCRIPTION
### Summary

This PR fixes the query selector in data table which calculates the individual column's width when user resizes any column.

Before the querySelector was targeting all `th` which was causing issue when a nested table is implemented and `th` of the inner table also considered for the computation. 

In this PR, only `th` of outertable is targeted leaving the inner table's th.

slack reference: https://commercetools.slack.com/archives/CCL83RA06/p1701436677019559