### PR TITLE
Remove unwanted cursor css property

### DIFF
--- a/.changeset/tricky-deers-sparkle.md
+++ b/.changeset/tricky-deers-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/tooltip': patch
+---
+
+Remove unnecessary cursor css property from tooltip wrapper

--- a/packages/components/tooltip/src/tooltip.story.js
+++ b/packages/components/tooltip/src/tooltip.story.js
@@ -21,7 +21,6 @@ const CustomWrapper = styled.div`
 
 const CustomButtonWrapper = styled.div`
   width: min-content;
-  cursor: not-allowed;
   > :disabled {
     pointer-events: none;
   }

--- a/packages/components/tooltip/src/tooltip.styles.ts
+++ b/packages/components/tooltip/src/tooltip.styles.ts
@@ -99,7 +99,6 @@ export const getTooltipStyles = (tooltipState: TTooltipState) =>
 
 export const Wrapper = styled.div`
   display: inline-block;
-  cursor: not-allowed;
   > :disabled {
     pointer-events: none;
   }


### PR DESCRIPTION

#### Summary
Remove unnecessary cursor: not-allowed property from tooltip container on the <Tooltip> component.

Closes #2663