### PR TITLE
ci: include provenance info when publishing packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -51,6 +54,7 @@ jobs:
       - name: Creating .npmrc
         run: |
           cat << EOF > "$HOME/.npmrc"
+            provenance=true
             email=npmjs@commercetools.com
             //registry.npmjs.org/:_authToken=$NPM_TOKEN
           EOF


### PR DESCRIPTION
[NPM has support for provenance data](https://github.blog/2023-04-19-introducing-npm-package-provenance/) as a mean to increase supply-chain security for published packages.

See documentation on [how to enable it via GitHub Actions](https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions).