### PR TITLE
refactor(storybook): migrate to v7 - part 1

### DIFF
--- a/.storybook/helpers/categorize.ts
+++ b/.storybook/helpers/categorize.ts
@@ -1,0 +1,5 @@
+const categorize = (subcategory: string, index: number) => ({
+  table: { subcategory: `${subcategory}${index ? ` ${index}` : ''}` },
+});
+
+export default categorize;

--- a/.storybook/helpers/hide-controls.ts
+++ b/.storybook/helpers/hide-controls.ts
@@ -1,0 +1,11 @@
+const hideControls = (controlsNames: string[] | string) => {
+  const namesArray = Array.isArray(controlsNames)
+    ? controlsNames
+    : [controlsNames];
+
+  return namesArray.reduce((argTypes, controlName) => {
+    return { ...argTypes, [controlName]: { control: false } };
+  }, {});
+};
+
+export default hideControls;

--- a/.storybook/helpers/horizontal-constraint-arg-type.ts
+++ b/.storybook/helpers/horizontal-constraint-arg-type.ts
@@ -9,7 +9,7 @@ type ExtractNumericValues<T> = T extends infer U
 type TMinMax = ExtractNumericValues<TMaxProp>;
 
 type THorizontalConstraintArgType = {
-  defaultValue: TMaxProp;
+  defaultValue?: TMaxProp;
   min?: TMinMax;
   max?: TMinMax;
 };

--- a/.storybook/helpers/horizontal-constraint-arg-type.ts
+++ b/.storybook/helpers/horizontal-constraint-arg-type.ts
@@ -9,17 +9,13 @@ type ExtractNumericValues<T> = T extends infer U
 type TMinMax = ExtractNumericValues<TMaxProp>;
 
 type THorizontalConstraintArgType = {
-  defaultValue?: TMaxProp;
   min?: TMinMax;
   max?: TMinMax;
 };
 
-const horizontalConstraintArgType = (
-  { defaultValue, min, max }: THorizontalConstraintArgType = { defaultValue: 7 }
-) => ({
+const horizontalConstraintArgType = (args?: THorizontalConstraintArgType) => ({
   control: 'select',
-  options: Constraints.getAcceptedMaxPropValues(min, max),
-  defaultValue: defaultValue,
+  options: Constraints.getAcceptedMaxPropValues(args?.min, args?.max),
 });
 
 export default horizontalConstraintArgType;

--- a/.storybook/helpers/horizontal-constraint-arg-type.ts
+++ b/.storybook/helpers/horizontal-constraint-arg-type.ts
@@ -1,0 +1,25 @@
+import Constraints, { type TMaxProp } from '@commercetools-uikit/constraints';
+
+type ExtractNumericValues<T> = T extends infer U
+  ? U extends number
+    ? U
+    : never
+  : never;
+
+type TMinMax = ExtractNumericValues<TMaxProp>;
+
+type THorizontalConstraintArgType = {
+  defaultValue: TMaxProp;
+  min?: TMinMax;
+  max?: TMinMax;
+};
+
+const horizontalConstraintArgType = (
+  { defaultValue, min, max }: THorizontalConstraintArgType = { defaultValue: 7 }
+) => ({
+  control: 'select',
+  options: Constraints.getAcceptedMaxPropValues(min, max),
+  defaultValue: defaultValue,
+});
+
+export default horizontalConstraintArgType;

--- a/.storybook/helpers/index.ts
+++ b/.storybook/helpers/index.ts
@@ -1,3 +1,5 @@
 export { default as withControlledValue } from './with-controlled-value';
 export { default as iconArgType } from './icon-arg-type';
 export { default as horizontalConstraintArgType } from './horizontal-constraint-arg-type';
+export { default as categorize } from './categorize';
+export { default as hideControls } from './hide-controls';

--- a/.storybook/helpers/index.ts
+++ b/.storybook/helpers/index.ts
@@ -1,2 +1,3 @@
 export { default as withControlledValue } from './with-controlled-value';
 export { default as iconArgType } from './icon-arg-type';
+export { default as horizontalConstraintArgType } from './horizontal-constraint-arg-type';

--- a/packages/components/messages/src/error-message/README.mdx
+++ b/packages/components/messages/src/error-message/README.mdx
@@ -1,0 +1,21 @@
+import { Canvas, Meta } from '@storybook/blocks';
+
+import * as ErrorMessageStories from './error-message.stories';
+
+<Meta of={ErrorMessageStories} />
+
+# Messages: ErrorMessage
+
+## Description
+
+Represents an error message.
+
+## Usage
+
+```js
+import { ErrorMessage } from '@commercetools-uikit/messages';
+
+<ErrorMessage>Something went wrong</ErrorMessage>;
+```
+
+<Canvas of={ErrorMessageStories.Default} />

--- a/packages/components/messages/src/error-message/error-message.stories.tsx
+++ b/packages/components/messages/src/error-message/error-message.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ErrorMessage from './error-message';
+
+const meta = {
+  title: 'Components/Messages/ErrorMessage',
+  component: ErrorMessage,
+  tags: ['autodocs'],
+} satisfies Meta<typeof ErrorMessage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: 'Required text missing',
+  },
+};

--- a/packages/components/messages/src/error-message/error-message.stories.tsx
+++ b/packages/components/messages/src/error-message/error-message.stories.tsx
@@ -4,7 +4,6 @@ import ErrorMessage from './error-message';
 const meta = {
   title: 'Components/Messages/ErrorMessage',
   component: ErrorMessage,
-  tags: ['autodocs'],
 } satisfies Meta<typeof ErrorMessage>;
 
 export default meta;

--- a/packages/components/messages/src/warning-message/README.mdx
+++ b/packages/components/messages/src/warning-message/README.mdx
@@ -1,0 +1,21 @@
+import { Canvas, Meta } from '@storybook/blocks';
+
+import * as WarningMessageStories from './warning-message.stories';
+
+<Meta of={WarningMessageStories} />
+
+# Messages: WarningMessage
+
+## Description
+
+Represents an warning message.
+
+## Usage
+
+```js
+import { WarningMessage } from '@commercetools-uikit/messages';
+
+<WarningMessage>This is a duplicate of {`${duplicate}`}</WarningMessage>;
+```
+
+<Canvas of={WarningMessageStories.Default} />

--- a/packages/components/messages/src/warning-message/warning-message.stories.tsx
+++ b/packages/components/messages/src/warning-message/warning-message.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import WarningMessage from './warning-message';
+
+const meta = {
+  title: 'Components/Messages/WarningMessage',
+  component: WarningMessage,
+  tags: ['autodocs'],
+} satisfies Meta<typeof WarningMessage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: 'This name is already being used by another variant',
+  },
+};

--- a/packages/components/messages/src/warning-message/warning-message.stories.tsx
+++ b/packages/components/messages/src/warning-message/warning-message.stories.tsx
@@ -4,7 +4,6 @@ import WarningMessage from './warning-message';
 const meta = {
   title: 'Components/Messages/WarningMessage',
   component: WarningMessage,
-  tags: ['autodocs'],
 } satisfies Meta<typeof WarningMessage>;
 
 export default meta;

--- a/packages/components/tooltip/README.mdx
+++ b/packages/components/tooltip/README.mdx
@@ -1,0 +1,184 @@
+import { Canvas, Meta } from '@storybook/blocks';
+
+import * as TooltipStories from './src/tooltip.stories';
+
+<Meta of={TooltipStories} />
+
+# Tooltip
+
+## Description
+
+Tooltips display informative text when users hover over or focus on an element.
+
+## Installation
+
+```
+yarn add @commercetools-uikit/tooltip
+```
+
+```
+npm --save install @commercetools-uikit/tooltip
+```
+
+Additionally install the peer dependencies (if not present)
+
+```
+yarn add react
+```
+
+```
+npm --save install react
+```
+
+## Usage
+
+```jsx
+import { forwardRef } from 'react';
+import PropTypes from 'prop-types';
+import ReactDOM from 'react-dom';
+import styled from '@emotion/styled';
+import Tooltip from '@commercetools-uikit/tooltip';
+
+/* 1. Standard example */
+const ExampleStandard = () => (
+  <Tooltip
+    placement="left"
+    title="If you buy a pizza, you will also get a free ice cream :)"
+  >
+    <button onClick={() => {}}>Submit</button>
+  </Tooltip>
+);
+
+/**
+ * 2. Working with disabled child elements
+ *
+ * When you use a tooltip with a disabled element, you should define the
+ * style `pointer-events: none` to the disabled element to stop it from capturing events.
+ * The Button components from UIKit already support this functionality.
+ */
+const ExampleWithDisabledElements = () => (
+  <Tooltip
+    placement="left"
+    title="You do not have permission to delete the database"
+  >
+    <button disabled onClick={() => {}} style={{ pointerEvents: 'none' }}>
+      Delete production database
+    </button>
+  </Tooltip>
+);
+
+/**
+ * 3. Customizing the wrapper
+ *
+ * The tooltip applies event listeners (`onMouseOver`, `onMouseLeave`, `onFocus`,
+ * and `onBlur`) to a wrapping `div` component around the children element.
+ * By default, this wrapper is displayed with style `inline-block`.
+ * If you want to customize this behaviour, then you can pass in a custom element.
+ * Be sure to use `React.forwardRef`, as we need the to pass the ref to the wrapper.
+ */
+const Wrapper = forwardRef((props, ref) => (
+  <div ref={ref} style={{ display: 'block' }} {...props}>
+    {props.children}
+  </div>
+));
+Wrapper.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+const FullWidthButton = styled.button`
+  display: block;
+  width: 100%;
+`;
+const ExampleWithCustomWrapper = () => (
+  <Tooltip title="Delete" components={{ WrapperComponent: Wrapper }}>
+    <FullWidthButton>Submit</FullWidthButton>
+  </Tooltip>
+);
+
+/**
+ * 4. Customizing the tooltip body
+ *
+ * You can customize the look and feel of the tooltip body by passing in a custom `BodyComponent`.
+ */
+const Body = styled.div`
+  color: red;
+`;
+const ExampleWithCustomBody = () => (
+  <Tooltip title="Delete" components={{ BodyComponent: Body }}>
+    <button>Submit</button>
+  </Tooltip>
+);
+
+/**
+ * 5. Customizing where the portal is rendered
+ *
+ * When you are dealing with virtualized components, it can be useful to render
+ * the tooltip into another part of the document.
+ * You can define a `TooltipWrapperComponent` to do this.
+ */
+const Portal = (props) => ReactDOM.createPortal(props.children, document.body);
+const ExampleWithCustomPortal = () => (
+  <Tooltip title="Delete" components={{ TooltipWrapperComponent: Portal }}>
+    <button>Submit</button>
+  </Tooltip>
+);
+
+/**
+ * 6. Conditionally displaying tooltips
+ *
+ * There may be cases when you only want to enable the display of a tooltip under
+ * a certain condition. In these cases, you may want to use the `off` prop.
+ * In the following example, the tooltip text only appears on hover when the button is disabled.
+ */
+const ExampleWithConditionals = (props) => (
+  <Tooltip
+    off={props.isDisabled}
+    title="You do not have permission to perform this action"
+  >
+    <button disabled={props.isDisabled}>Submit</button>
+  </Tooltip>
+);
+ExampleWithConditionals.propTypes = {
+  isDisabled: PropTypes.bool,
+};
+
+/**
+ * 7. Fine-tuning underlying Popper.js behavior
+ *
+ * This component uses [Popper.js](https://popper.js.org/) under the hood.
+ * Popper provides a way to adjust how tooltip element should behave, by providing
+ * a [set of `modifiers`](https://popper.js.org/popper-documentation.html#modifiers).
+ * For instance, forcing tooltip to stay in the original placement and not to try
+ * flipping when it's getting out of boundaries, can be implemented as following:
+ */
+const ExampleWithCustomPopperBehavior = (props) => (
+  <Tooltip
+    placement="left"
+    title="I will always be on the left side"
+    modifiers={{
+      preventOverflow: {
+        enabled: false,
+      },
+      flip: {
+        enabled: false,
+      },
+    }}
+  >
+    <button disabled={props.isDisabled}>Submit</button>
+  </Tooltip>
+);
+ExampleWithCustomPopperBehavior.propTypes = {
+  isDisabled: PropTypes.bool,
+};
+
+export {
+  ExampleStandard,
+  ExampleWithDisabledElements,
+  ExampleWithCustomWrapper,
+  ExampleWithCustomBody,
+  ExampleWithCustomPortal,
+  ExampleWithConditionals,
+  ExampleWithCustomPopperBehavior,
+};
+```
+
+<Canvas of={TooltipStories.Default} />

--- a/packages/components/tooltip/src/tooltip.stories.tsx
+++ b/packages/components/tooltip/src/tooltip.stories.tsx
@@ -53,6 +53,7 @@ export const Default: Story = {
     fullWidth: false,
     customBodyWrapper: false,
     horizontalConstraint: 'scale',
+    placement: 'top',
   },
   argTypes: {
     placement: {
@@ -71,7 +72,6 @@ export const Default: Story = {
         'left-start',
         'left-end',
       ],
-      defaultValue: 'top',
     },
     horizontalConstraint: horizontalConstraintArgType(),
   },

--- a/packages/components/tooltip/src/tooltip.stories.tsx
+++ b/packages/components/tooltip/src/tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import type { ComponentProps } from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
-import Constraints from '@commercetools-uikit/constraints';
+import { horizontalConstraintArgType } from '@/storybook-helpers';
 import { PrimaryButton } from '@commercetools-uikit/buttons';
 import type { Meta, StoryObj } from '@storybook/react';
 import Tooltip from './tooltip';
@@ -72,21 +72,9 @@ export const Default: Story = {
       ],
       defaultValue: 'top',
     },
-    horizontalConstraint: {
-      control: 'select',
-      options: Constraints.getAcceptedMaxPropValues(),
+    horizontalConstraint: horizontalConstraintArgType({
       defaultValue: 'scale',
-    },
-    components: {
-      table: {
-        disable: true,
-      },
-    },
-    children: {
-      table: {
-        disable: true,
-      },
-    },
+    }),
   },
   decorators: [
     (Story) => (
@@ -100,6 +88,7 @@ export const Default: Story = {
       </div>
     ),
   ],
+  parameters: { controls: { exclude: ['children', 'defaultSelected'] } },
   render: (args) => {
     const { fullWidth, customBodyWrapper } = args;
     return (

--- a/packages/components/tooltip/src/tooltip.stories.tsx
+++ b/packages/components/tooltip/src/tooltip.stories.tsx
@@ -69,19 +69,6 @@ export const Default: Story = {
     title: 'Tooltip text.',
     showAfter: 300,
     closeAfter: 200,
-    children: (
-      <div
-        css={css`
-          width: min-content;
-          cursor: not-allowed;
-          > :disabled {
-            pointer-events: none;
-          }
-        `}
-      >
-        <PrimaryButton onClick={() => {}} label="Submit" />
-      </div>
-    ),
     fullWidth: false,
     customBodyWrapper: false,
     horizontalConstraint: 'scale',
@@ -96,7 +83,19 @@ export const Default: Story = {
           WrapperComponent: fullWidth ? CustomWrapper : undefined,
           BodyComponent: customBodyWrapper ? CustomBody : undefined,
         }}
-      />
+      >
+        <div
+          css={css`
+            width: min-content;
+            cursor: not-allowed;
+            > :disabled {
+              pointer-events: none;
+            }
+          `}
+        >
+          <PrimaryButton onClick={() => {}} label="Submit" />
+        </div>
+      </Tooltip>
     );
   },
 };

--- a/packages/components/tooltip/src/tooltip.stories.tsx
+++ b/packages/components/tooltip/src/tooltip.stories.tsx
@@ -1,0 +1,115 @@
+import type { ComponentProps } from 'react';
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+import Constraints from '@commercetools-uikit/constraints';
+import { PrimaryButton } from '@commercetools-uikit/buttons';
+import type { Meta, StoryObj } from '@storybook/react';
+import Tooltip from './tooltip';
+
+const CustomWrapper = styled.div`
+  display: block;
+  background-color: pink;
+`;
+
+const CustomBody = styled.div`
+  font-size: 0.875rem;
+  color: red;
+`;
+
+type TooltipPropsAndCustomArgs = ComponentProps<typeof Tooltip> & {
+  fullWidth?: boolean;
+  customBodyWrapper?: boolean;
+};
+
+const meta = {
+  title: 'Components/Tooltip',
+  component: Tooltip,
+  tags: ['autodocs'],
+} satisfies Meta<TooltipPropsAndCustomArgs>;
+
+export default meta;
+
+type Story = StoryObj<TooltipPropsAndCustomArgs>;
+
+export const Default: Story = {
+  args: {
+    off: false,
+    title: 'Tooltip text.',
+    showAfter: 300,
+    closeAfter: 200,
+    placement: 'top',
+    horizontalConstraint: 'scale',
+    children: (
+      <div
+        css={css`
+          width: min-content;
+          cursor: not-allowed;
+          > :disabled {
+            pointer-events: none;
+          }
+        `}
+      >
+        <PrimaryButton onClick={() => {}} label="Submit" />
+      </div>
+    ),
+    fullWidth: false,
+    customBodyWrapper: false,
+  },
+  argTypes: {
+    placement: {
+      control: 'select',
+      options: [
+        'top',
+        'top-start',
+        'top-end',
+        'right',
+        'right-start',
+        'right-end',
+        'bottom',
+        'bottom-start',
+        'bottom-end',
+        'left',
+        'left-start',
+        'left-end',
+      ],
+    },
+    horizontalConstraint: {
+      control: 'select',
+      options: Constraints.getAcceptedMaxPropValues(),
+    },
+    components: {
+      table: {
+        disable: true,
+      },
+    },
+    children: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        css={css`
+          padding: 80px 0 80px 80px;
+        `}
+      >
+        <p>With ui kit button</p>
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args) => {
+    const { fullWidth, customBodyWrapper } = args;
+    return (
+      <Tooltip
+        {...args}
+        components={{
+          WrapperComponent: fullWidth ? CustomWrapper : undefined,
+          BodyComponent: customBodyWrapper ? CustomBody : undefined,
+        }}
+      />
+    );
+  },
+};

--- a/packages/components/tooltip/src/tooltip.stories.tsx
+++ b/packages/components/tooltip/src/tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import type { ComponentProps } from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
-import { horizontalConstraintArgType } from '@/storybook-helpers';
+import { horizontalConstraintArgType, hideControls } from '@/storybook-helpers';
 import { PrimaryButton } from '@commercetools-uikit/buttons';
 import type { Meta, StoryObj } from '@storybook/react';
 import Tooltip from './tooltip';
@@ -24,38 +24,8 @@ type TooltipPropsAndCustomArgs = ComponentProps<typeof Tooltip> & {
 const meta = {
   title: 'Components/Tooltip',
   component: Tooltip,
-  tags: ['autodocs'],
-} satisfies Meta<TooltipPropsAndCustomArgs>;
-
-export default meta;
-
-type Story = StoryObj<TooltipPropsAndCustomArgs>;
-
-export const Default: Story = {
-  args: {
-    off: false,
-    title: 'Tooltip text.',
-    showAfter: 300,
-    closeAfter: 200,
-    children: (
-      <div
-        css={css`
-          width: min-content;
-          cursor: not-allowed;
-          > :disabled {
-            pointer-events: none;
-          }
-        `}
-      >
-        <PrimaryButton onClick={() => {}} label="Submit" />
-      </div>
-    ),
-    fullWidth: false,
-    customBodyWrapper: false,
-    horizontalConstraint: 'scale',
-    placement: 'top',
-  },
   argTypes: {
+    ...hideControls(['children']),
     placement: {
       control: 'select',
       options: [
@@ -87,7 +57,36 @@ export const Default: Story = {
       </div>
     ),
   ],
-  parameters: { controls: { exclude: ['children', 'defaultSelected'] } },
+} satisfies Meta<TooltipPropsAndCustomArgs>;
+
+export default meta;
+
+type Story = StoryObj<TooltipPropsAndCustomArgs>;
+
+export const Default: Story = {
+  args: {
+    off: false,
+    title: 'Tooltip text.',
+    showAfter: 300,
+    closeAfter: 200,
+    children: (
+      <div
+        css={css`
+          width: min-content;
+          cursor: not-allowed;
+          > :disabled {
+            pointer-events: none;
+          }
+        `}
+      >
+        <PrimaryButton onClick={() => {}} label="Submit" />
+      </div>
+    ),
+    fullWidth: false,
+    customBodyWrapper: false,
+    horizontalConstraint: 'scale',
+    placement: 'top',
+  },
   render: (args) => {
     const { fullWidth, customBodyWrapper } = args;
     return (

--- a/packages/components/tooltip/src/tooltip.stories.tsx
+++ b/packages/components/tooltip/src/tooltip.stories.tsx
@@ -52,6 +52,7 @@ export const Default: Story = {
     ),
     fullWidth: false,
     customBodyWrapper: false,
+    horizontalConstraint: 'scale',
   },
   argTypes: {
     placement: {
@@ -72,9 +73,7 @@ export const Default: Story = {
       ],
       defaultValue: 'top',
     },
-    horizontalConstraint: horizontalConstraintArgType({
-      defaultValue: 'scale',
-    }),
+    horizontalConstraint: horizontalConstraintArgType(),
   },
   decorators: [
     (Story) => (

--- a/packages/components/tooltip/src/tooltip.stories.tsx
+++ b/packages/components/tooltip/src/tooltip.stories.tsx
@@ -37,8 +37,6 @@ export const Default: Story = {
     title: 'Tooltip text.',
     showAfter: 300,
     closeAfter: 200,
-    placement: 'top',
-    horizontalConstraint: 'scale',
     children: (
       <div
         css={css`
@@ -72,10 +70,12 @@ export const Default: Story = {
         'left-start',
         'left-end',
       ],
+      defaultValue: 'top',
     },
     horizontalConstraint: {
       control: 'select',
       options: Constraints.getAcceptedMaxPropValues(),
+      defaultValue: 'scale',
     },
     components: {
       table: {

--- a/packages/components/view-switcher/README.mdx
+++ b/packages/components/view-switcher/README.mdx
@@ -100,16 +100,4 @@ const ControlledExample = () => {
 export { UncontrolledExample, ControlledExample };
 ```
 
-## Signatures
-
-### Signature `onChange`
-
-```ts
-(value: string) => void
-```
-
-## Invariants
-
-1. The `ViewSwitcher.Group` must have at least one `ViewSwitcher.Button` element as `children`
-
 <Canvas of={ViewSwitcherStories.Default} />

--- a/packages/components/view-switcher/README.mdx
+++ b/packages/components/view-switcher/README.mdx
@@ -1,0 +1,115 @@
+import { Canvas, Meta } from '@storybook/blocks';
+
+import * as ViewSwitcherStories from './src/view-switcher.stories';
+
+<Meta of={ViewSwitcherStories} />
+
+# ViewSwitcher
+
+## Description
+
+The `<ViewSwitcher>` component allow users to toggle between two or more different views of the same, similar or related content items within the same space on screen.
+
+## When to use
+
+Let users toggle between different formatting's, like with a grid view and a table view.
+
+## When not to use
+
+**Do not use the `<ViewSwitcher>` as tabs.**
+Tabs should be used when the content on the page is divided into related sections but without any overlap.
+
+**Do not use the `<ViewSwitcher>` as toggle.**
+Toggles are used for "yes/no" or "on/off" binary decisions.
+
+## Do's and Don'ts
+
+- If you use an icon within the `<ViewSwitcher>`, each switch needs to have an icon.
+- No colored icons are allowed. Only `--color-solid` (black).
+- Do not use two lines of text in one switch field.
+
+## Installation
+
+```
+yarn add @commercetools-uikit/view-switcher
+```
+
+```
+npm --save install @commercetools-uikit/view-switcher
+```
+
+Additionally install the peer dependencies (if not present)
+
+```
+yarn add react
+```
+
+```
+npm --save install react
+```
+
+## Usage
+
+```jsx
+import { useState } from 'react';
+import ViewSwitcher from '@commercetools-uikit/view-switcher';
+
+/**
+ * 1. Uncontrolled mode
+ *
+ * The component controls its own internal state and switching between options.
+ * The `defaultSelected` value is only used on the initial render. Changes to that value
+ * are not reflected in the component state.
+ */
+const UncontrolledExample = () => (
+  <ViewSwitcher.Group
+    defaultSelected="button 2"
+    onChange={(value) => console.log(value)}
+  >
+    <ViewSwitcher.Button isDisabled value="button 1">
+      View 1
+    </ViewSwitcher.Button>
+    <ViewSwitcher.Button value="button 2">View 2</ViewSwitcher.Button>
+    <ViewSwitcher.Button value="button 3">View 3</ViewSwitcher.Button>
+  </ViewSwitcher.Group>
+);
+
+/**
+ * 2. Controlled mode
+ *
+ * The component is controlled from a parent component, using the prop `selectedValue`.
+ * The component does not use an internal state and the parent must implement the `onChange` callback.
+ */
+const ControlledExample = () => {
+  const [seletedValue, setSelectedValue] = useState('button 1');
+
+  return (
+    <ViewSwitcher.Group
+      selectedValue={seletedValue}
+      onChange={setSelectedValue}
+    >
+      <ViewSwitcher.Button isDisabled value="button 1">
+        View 1
+      </ViewSwitcher.Button>
+      <ViewSwitcher.Button value="button 2">View 2</ViewSwitcher.Button>
+      <ViewSwitcher.Button value="button 3">View 3</ViewSwitcher.Button>
+    </ViewSwitcher.Group>
+  );
+};
+
+export { UncontrolledExample, ControlledExample };
+```
+
+## Signatures
+
+### Signature `onChange`
+
+```ts
+(value: string) => void
+```
+
+## Invariants
+
+1. The `ViewSwitcher.Group` must have at least one `ViewSwitcher.Button` element as `children`
+
+<Canvas of={ViewSwitcherStories.Default} />

--- a/packages/components/view-switcher/src/view-switcher.stories.tsx
+++ b/packages/components/view-switcher/src/view-switcher.stories.tsx
@@ -1,56 +1,37 @@
-import type { ComponentProps } from 'react';
+import type { ReactElement } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import ViewSwitcher from '.';
-import type { TViewSwitcherButtonProps } from './view-switcher-button';
 import { iconArgType, categorize, hideControls } from '@/storybook-helpers';
+import ViewSwitcher, { type TViewSwitcherProps } from '.';
 
 const BASE_CATEGORY = 'View Switcher Button';
 const BUTTONS_COUNT = 4;
 const DEFAULT_BUTTON_ICON = 'WorldIcon';
 
-type ViewSwitcherPropsAndCustomArgs = ComponentProps<
-  typeof ViewSwitcher.Group
-> & {
-  iconViewSwitcherButton1: string;
-  iconViewSwitcherButton2: string;
-  iconViewSwitcherButton3: string;
-  iconViewSwitcherButton4: string;
-  iconOnlyButton1: boolean;
-  iconOnlyButton2: boolean;
-  iconOnlyButton3: boolean;
-  iconOnlyButton4: boolean;
-  isDisabledButton1: boolean;
-  isDisabledButton2: boolean;
-  isDisabledButton3: boolean;
-  isDisabledButton4: boolean;
+type StoryAttributeName =
+  | `iconViewSwitcherButton${number}`
+  | `iconOnlyButton${number}`
+  | `isDisabledButton${number}`;
+type StoryAttributes = {
+  [K in StoryAttributeName]: K extends `iconViewSwitcherButton${number}`
+    ? string
+    : boolean;
 };
+type ViewSwitcherPropsAndCustomArgs = TViewSwitcherProps & StoryAttributes;
 
 const meta = {
   title: 'Components/ViewSwitcher',
   component: ViewSwitcher.Group,
-  tags: ['autodocs'],
-} satisfies Meta<ViewSwitcherPropsAndCustomArgs>;
-
-export default meta;
-
-type Story = StoryObj<ViewSwitcherPropsAndCustomArgs>;
-
-export const Default: Story = {
   args: {
     isCondensed: false,
-    defaultSelected: 'Button 3',
-    iconViewSwitcherButton1: DEFAULT_BUTTON_ICON,
+    defaultSelected: 'Button 2',
     iconOnlyButton1: false,
     isDisabledButton1: false,
-    iconViewSwitcherButton2: DEFAULT_BUTTON_ICON,
     iconOnlyButton2: false,
     isDisabledButton2: false,
-    iconViewSwitcherButton3: DEFAULT_BUTTON_ICON,
     iconOnlyButton3: false,
     isDisabledButton3: false,
-    iconViewSwitcherButton4: DEFAULT_BUTTON_ICON,
     iconOnlyButton4: false,
-    isDisabledButton4: false,
+    isDisabledButton4: true,
   },
   argTypes: {
     ...hideControls('defaultSelected'),
@@ -79,67 +60,59 @@ export const Default: Story = {
     iconOnlyButton4: categorize(BASE_CATEGORY, 4),
     isDisabledButton4: categorize(BASE_CATEGORY, 4),
   },
-  render: (args) => (
-    <ViewSwitcher.Group {...args}>
-      {[...Array(BUTTONS_COUNT).keys()].map((index) => {
-        const i = index + 1;
+} satisfies Meta<ViewSwitcherPropsAndCustomArgs>;
 
-        return (
-          <ViewSwitcher.Button
-            key={i}
-            label={`View ${i}`}
-            isDisabled={
-              args[
-                `isDisabledButton${i}` as keyof typeof args
-              ] as TViewSwitcherButtonProps['isDisabled']
-            }
-            value={`Button ${i}`}
-            icon={
-              args[
-                `iconViewSwitcherButton${i}` as keyof typeof args
-              ] as TViewSwitcherButtonProps['icon']
-            }
-          >
-            {!args[`iconOnlyButton${i}` as keyof typeof args]
-              ? `View ${i}`
-              : undefined}
-          </ViewSwitcher.Button>
-        );
-      })}
-    </ViewSwitcher.Group>
-  ),
+export default meta;
+
+type Story = StoryObj<ViewSwitcherPropsAndCustomArgs>;
+
+const ViewSwitcherStoryWrapper = (props: ViewSwitcherPropsAndCustomArgs) => (
+  <ViewSwitcher.Group {...props}>
+    {[...Array(BUTTONS_COUNT).keys()].map((index) => {
+      const i = index + 1;
+      return (
+        <ViewSwitcher.Button
+          key={i}
+          label={`View ${i}`}
+          isDisabled={props[`isDisabledButton${i}`]}
+          value={`Button ${i}`}
+          icon={props[`iconViewSwitcherButton${i}`] as unknown as ReactElement}
+        >
+          {!props[`iconOnlyButton${i}`] ? `View ${index + 1}` : undefined}
+        </ViewSwitcher.Button>
+      );
+    })}
+  </ViewSwitcher.Group>
+);
+
+export const Default: Story = {
+  args: {
+    iconViewSwitcherButton1: DEFAULT_BUTTON_ICON,
+    iconOnlyButton1: false,
+    iconViewSwitcherButton2: DEFAULT_BUTTON_ICON,
+    iconOnlyButton2: false,
+    iconViewSwitcherButton3: DEFAULT_BUTTON_ICON,
+    iconOnlyButton3: false,
+    iconViewSwitcherButton4: DEFAULT_BUTTON_ICON,
+    iconOnlyButton4: false,
+  },
+  render: ViewSwitcherStoryWrapper,
 };
 
 export const WithoutIcons: Story = {
-  args: {
-    isCondensed: false,
-    defaultSelected: 'Button 3',
-    isDisabledButton1: false,
-    isDisabledButton2: false,
-    isDisabledButton3: false,
-    isDisabledButton4: false,
-  },
-  argTypes: hideControls('defaultSelected'),
-  render: (args) => (
-    <ViewSwitcher.Group {...args}>
-      {[...Array(BUTTONS_COUNT).keys()].map((index) => {
-        const i = index + 1;
+  render: ViewSwitcherStoryWrapper,
+};
 
-        return (
-          <ViewSwitcher.Button
-            key={i}
-            label={`View ${i}`}
-            isDisabled={
-              args[
-                `isDisabledButton${i}` as keyof typeof args
-              ] as TViewSwitcherButtonProps['isDisabled']
-            }
-            value={`Button ${i}`}
-          >
-            {`View ${i}`}
-          </ViewSwitcher.Button>
-        );
-      })}
-    </ViewSwitcher.Group>
-  ),
+export const OnlyIcons: Story = {
+  args: {
+    iconViewSwitcherButton1: DEFAULT_BUTTON_ICON,
+    iconOnlyButton1: true,
+    iconViewSwitcherButton2: DEFAULT_BUTTON_ICON,
+    iconOnlyButton2: true,
+    iconViewSwitcherButton3: DEFAULT_BUTTON_ICON,
+    iconOnlyButton3: true,
+    iconViewSwitcherButton4: DEFAULT_BUTTON_ICON,
+    iconOnlyButton4: true,
+  },
+  render: ViewSwitcherStoryWrapper,
 };

--- a/packages/components/view-switcher/src/view-switcher.stories.tsx
+++ b/packages/components/view-switcher/src/view-switcher.stories.tsx
@@ -2,8 +2,9 @@ import type { ComponentProps } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import ViewSwitcher from '.';
 import type { TViewSwitcherButtonProps } from './view-switcher-button';
-import { iconArgType } from '@/storybook-helpers';
+import { iconArgType, categorize, hideControls } from '@/storybook-helpers';
 
+const BASE_CATEGORY = 'View Switcher Button';
 const BUTTONS_COUNT = 4;
 const DEFAULT_BUTTON_ICON = 'WorldIcon';
 
@@ -52,41 +53,31 @@ export const Default: Story = {
     isDisabledButton4: false,
   },
   argTypes: {
-    children: {
-      table: {
-        disable: true,
-      },
+    ...hideControls('defaultSelected'),
+    iconViewSwitcherButton1: {
+      ...iconArgType,
+      ...categorize(BASE_CATEGORY, 1),
     },
-    defaultSelected: {
-      table: {
-        disable: true,
-      },
+    iconOnlyButton1: categorize(BASE_CATEGORY, 1),
+    isDisabledButton1: categorize(BASE_CATEGORY, 1),
+    iconViewSwitcherButton2: {
+      ...iconArgType,
+      ...categorize(BASE_CATEGORY, 2),
     },
-    ...[...Array(BUTTONS_COUNT).keys()].reduce((acc, index) => {
-      const i = index + 1;
-      const temp = {
-        ...acc,
-        ...{
-          [`iconViewSwitcherButton${i}`]: {
-            ...iconArgType,
-            table: {
-              subcategory: `View Switcher Button ${i}`,
-            },
-          },
-          [`iconOnlyButton${i}`]: {
-            table: {
-              subcategory: `View Switcher Button ${i}`,
-            },
-          },
-          [`isDisabledButton${i}`]: {
-            table: {
-              subcategory: `View Switcher Button ${i}`,
-            },
-          },
-        },
-      };
-      return temp;
-    }, {}),
+    iconOnlyButton2: categorize(BASE_CATEGORY, 2),
+    isDisabledButton2: categorize(BASE_CATEGORY, 2),
+    iconViewSwitcherButton3: {
+      ...iconArgType,
+      ...categorize(BASE_CATEGORY, 3),
+    },
+    iconOnlyButton3: categorize(BASE_CATEGORY, 3),
+    isDisabledButton3: categorize(BASE_CATEGORY, 3),
+    iconViewSwitcherButton4: {
+      ...iconArgType,
+      ...categorize(BASE_CATEGORY, 4),
+    },
+    iconOnlyButton4: categorize(BASE_CATEGORY, 4),
+    isDisabledButton4: categorize(BASE_CATEGORY, 4),
   },
   render: (args) => (
     <ViewSwitcher.Group {...args}>
@@ -128,18 +119,7 @@ export const WithoutIcons: Story = {
     isDisabledButton3: false,
     isDisabledButton4: false,
   },
-  argTypes: {
-    children: {
-      table: {
-        disable: true,
-      },
-    },
-    defaultSelected: {
-      table: {
-        disable: true,
-      },
-    },
-  },
+  argTypes: hideControls('defaultSelected'),
   render: (args) => (
     <ViewSwitcher.Group {...args}>
       {[...Array(BUTTONS_COUNT).keys()].map((index) => {

--- a/packages/components/view-switcher/src/view-switcher.stories.tsx
+++ b/packages/components/view-switcher/src/view-switcher.stories.tsx
@@ -1,14 +1,11 @@
 import type { ComponentProps } from 'react';
-import { createElement } from 'react';
-import * as icons from '@commercetools-uikit/icons';
 import type { Meta, StoryObj } from '@storybook/react';
 import ViewSwitcher from '.';
 import type { TViewSwitcherButtonProps } from './view-switcher-button';
+import { iconArgType } from '@/storybook-helpers';
 
 const BUTTONS_COUNT = 4;
 const DEFAULT_BUTTON_ICON = 'WorldIcon';
-
-const iconNames = Object.keys(icons);
 
 type ViewSwitcherPropsAndCustomArgs = ComponentProps<
   typeof ViewSwitcher.Group
@@ -65,22 +62,10 @@ export const Default: Story = {
         disable: true,
       },
     },
-    iconViewSwitcherButton1: {
-      control: 'select',
-      options: iconNames,
-    },
-    iconViewSwitcherButton2: {
-      control: 'select',
-      options: iconNames,
-    },
-    iconViewSwitcherButton3: {
-      control: 'select',
-      options: iconNames,
-    },
-    iconViewSwitcherButton4: {
-      control: 'select',
-      options: iconNames,
-    },
+    iconViewSwitcherButton1: iconArgType,
+    iconViewSwitcherButton2: iconArgType,
+    iconViewSwitcherButton3: iconArgType,
+    iconViewSwitcherButton4: iconArgType,
   },
   render: (args) => (
     <ViewSwitcher.Group {...args}>
@@ -97,13 +82,11 @@ export const Default: Story = {
               ] as TViewSwitcherButtonProps['isDisabled']
             }
             value={`Button ${i}`}
-            icon={createElement(
-              icons[
-                args[
-                  `iconViewSwitcherButton${i}` as keyof typeof args
-                ] as keyof typeof icons
-              ]
-            )}
+            icon={
+              args[
+                `iconViewSwitcherButton${i}` as keyof typeof args
+              ] as TViewSwitcherButtonProps['icon']
+            }
           >
             {!args[`iconOnlyButton${i}` as keyof typeof args]
               ? `View ${i}`

--- a/packages/components/view-switcher/src/view-switcher.stories.tsx
+++ b/packages/components/view-switcher/src/view-switcher.stories.tsx
@@ -1,0 +1,161 @@
+import type { ComponentProps } from 'react';
+import { createElement } from 'react';
+import * as icons from '@commercetools-uikit/icons';
+import type { Meta, StoryObj } from '@storybook/react';
+import ViewSwitcher from '.';
+import type { TViewSwitcherButtonProps } from './view-switcher-button';
+
+const BUTTONS_COUNT = 4;
+const DEFAULT_BUTTON_ICON = 'WorldIcon';
+
+const iconNames = Object.keys(icons);
+
+type ViewSwitcherPropsAndCustomArgs = ComponentProps<
+  typeof ViewSwitcher.Group
+> & {
+  iconViewSwitcherButton1: string;
+  iconViewSwitcherButton2: string;
+  iconViewSwitcherButton3: string;
+  iconViewSwitcherButton4: string;
+  iconOnlyButton1: boolean;
+  iconOnlyButton2: boolean;
+  iconOnlyButton3: boolean;
+  iconOnlyButton4: boolean;
+  isDisabledButton1: boolean;
+  isDisabledButton2: boolean;
+  isDisabledButton3: boolean;
+  isDisabledButton4: boolean;
+};
+
+const meta = {
+  title: 'Components/ViewSwitcher',
+  component: ViewSwitcher.Group,
+  tags: ['autodocs'],
+} satisfies Meta<ViewSwitcherPropsAndCustomArgs>;
+
+export default meta;
+
+type Story = StoryObj<ViewSwitcherPropsAndCustomArgs>;
+
+export const Default: Story = {
+  args: {
+    isCondensed: false,
+    defaultSelected: 'Button 3',
+    iconViewSwitcherButton1: DEFAULT_BUTTON_ICON,
+    iconOnlyButton1: false,
+    isDisabledButton1: false,
+    iconViewSwitcherButton2: DEFAULT_BUTTON_ICON,
+    iconOnlyButton2: false,
+    isDisabledButton2: false,
+    iconViewSwitcherButton3: DEFAULT_BUTTON_ICON,
+    iconOnlyButton3: false,
+    isDisabledButton3: false,
+    iconViewSwitcherButton4: DEFAULT_BUTTON_ICON,
+    iconOnlyButton4: false,
+    isDisabledButton4: false,
+  },
+  argTypes: {
+    children: {
+      table: {
+        disable: true,
+      },
+    },
+    defaultSelected: {
+      table: {
+        disable: true,
+      },
+    },
+    iconViewSwitcherButton1: {
+      control: 'select',
+      options: iconNames,
+    },
+    iconViewSwitcherButton2: {
+      control: 'select',
+      options: iconNames,
+    },
+    iconViewSwitcherButton3: {
+      control: 'select',
+      options: iconNames,
+    },
+    iconViewSwitcherButton4: {
+      control: 'select',
+      options: iconNames,
+    },
+  },
+  render: (args) => (
+    <ViewSwitcher.Group {...args}>
+      {[...Array(BUTTONS_COUNT).keys()].map((index) => {
+        const i = index + 1;
+
+        return (
+          <ViewSwitcher.Button
+            key={i}
+            label={`View ${i}`}
+            isDisabled={
+              args[
+                `isDisabledButton${i}` as keyof typeof args
+              ] as TViewSwitcherButtonProps['isDisabled']
+            }
+            value={`Button ${i}`}
+            icon={createElement(
+              icons[
+                args[
+                  `iconViewSwitcherButton${i}` as keyof typeof args
+                ] as keyof typeof icons
+              ]
+            )}
+          >
+            {!args[`iconOnlyButton${i}` as keyof typeof args]
+              ? `View ${i}`
+              : undefined}
+          </ViewSwitcher.Button>
+        );
+      })}
+    </ViewSwitcher.Group>
+  ),
+};
+
+export const WithoutIcons: Story = {
+  args: {
+    isCondensed: false,
+    defaultSelected: 'Button 3',
+    isDisabledButton1: false,
+    isDisabledButton2: false,
+    isDisabledButton3: false,
+    isDisabledButton4: false,
+  },
+  argTypes: {
+    children: {
+      table: {
+        disable: true,
+      },
+    },
+    defaultSelected: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  render: (args) => (
+    <ViewSwitcher.Group {...args}>
+      {[...Array(BUTTONS_COUNT).keys()].map((index) => {
+        const i = index + 1;
+
+        return (
+          <ViewSwitcher.Button
+            key={i}
+            label={`View ${i}`}
+            isDisabled={
+              args[
+                `isDisabledButton${i}` as keyof typeof args
+              ] as TViewSwitcherButtonProps['isDisabled']
+            }
+            value={`Button ${i}`}
+          >
+            {`View ${i}`}
+          </ViewSwitcher.Button>
+        );
+      })}
+    </ViewSwitcher.Group>
+  ),
+};

--- a/packages/components/view-switcher/src/view-switcher.stories.tsx
+++ b/packages/components/view-switcher/src/view-switcher.stories.tsx
@@ -62,10 +62,31 @@ export const Default: Story = {
         disable: true,
       },
     },
-    iconViewSwitcherButton1: iconArgType,
-    iconViewSwitcherButton2: iconArgType,
-    iconViewSwitcherButton3: iconArgType,
-    iconViewSwitcherButton4: iconArgType,
+    ...[...Array(BUTTONS_COUNT).keys()].reduce((acc, index) => {
+      const i = index + 1;
+      const temp = {
+        ...acc,
+        ...{
+          [`iconViewSwitcherButton${i}`]: {
+            ...iconArgType,
+            table: {
+              subcategory: `View Switcher Button ${i}`,
+            },
+          },
+          [`iconOnlyButton${i}`]: {
+            table: {
+              subcategory: `View Switcher Button ${i}`,
+            },
+          },
+          [`isDisabledButton${i}`]: {
+            table: {
+              subcategory: `View Switcher Button ${i}`,
+            },
+          },
+        },
+      };
+      return temp;
+    }, {}),
   },
   render: (args) => (
     <ViewSwitcher.Group {...args}>


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

This pull request migrates the initial set of Storybook stories for the `Tooltip`, `ViewSwitcher`, `ErrorMessage`, and `WarningMessage` components
