### PR TITLE
Fix select input components dropdown menu width

### DIFF
--- a/.changeset/rich-flies-behave.md
+++ b/.changeset/rich-flies-behave.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-uikit/select-input': patch
+'@commercetools-uikit/select-utils': patch
+---
+
+Fix styling issue with select input elements dropdown menu width.

--- a/packages/components/inputs/select-input/src/select-input.story.js
+++ b/packages/components/inputs/select-input/src/select-input.story.js
@@ -164,13 +164,13 @@ storiesOf('Components|Inputs/SelectInputs', module)
                   showOptionGroupDivider={showOptionGroupDivider}
                   iconLeft={iconLeft ? createElement(iconLeft) : undefined}
                   minMenuWidth={select(
-                    'minWidth',
-                    Constraints.getAcceptedMaxPropValues(),
-                    'scale'
+                    'minMenuWidth',
+                    Constraints.getAcceptedMaxPropValues(2),
+                    3
                   )}
                   maxMenuWidth={select(
-                    'maxWidth',
-                    Constraints.getAcceptedMaxPropValues(),
+                    'maxMenuWidth',
+                    Constraints.getAcceptedMaxPropValues(4),
                     'scale'
                   )}
                   {...addMenuPortalProps()}

--- a/packages/components/inputs/select-utils/src/create-select-styles.ts
+++ b/packages/components/inputs/select-utils/src/create-select-styles.ts
@@ -94,13 +94,17 @@ type TState = {
 
 type TDesignTokenName = keyof typeof designTokens;
 
+const upperFirst = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
+
 const getHorizontalConstraintValue = (
   value?: TProps['minMenuWidth'] | TProps['maxMenuWidth']
 ) => {
-  return (
-    designTokens[`constraint${value}` as TDesignTokenName] ||
-    designTokens.constraint3
-  );
+  const designTokenSuffix =
+    typeof value === 'string' ? upperFirst(value) : value;
+  const constraintValue =
+    designTokens[`constraint${designTokenSuffix}` as TDesignTokenName] ||
+    designTokens.constraint3;
+  return constraintValue;
 };
 
 const getInputBackgroundColor = (props: TProps) => {
@@ -243,8 +247,9 @@ const menuStyles = (props: TProps) => (base: TBase) => {
     minWidth: props.minMenuWidth
       ? getHorizontalConstraintValue(props.minMenuWidth)
       : designTokens.constraint3,
-    maxWidth:
-      props.maxMenuWidth ?? getHorizontalConstraintValue(props.maxMenuWidth),
+    maxWidth: props.maxMenuWidth
+      ? getHorizontalConstraintValue(props.maxMenuWidth)
+      : designTokens.constraintScale,
   };
 };
 

--- a/packages/components/inputs/select-utils/src/create-select-styles.ts
+++ b/packages/components/inputs/select-utils/src/create-select-styles.ts
@@ -94,17 +94,18 @@ type TState = {
 
 type TDesignTokenName = keyof typeof designTokens;
 
-const upperFirst = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
-
 const getHorizontalConstraintValue = (
   value?: TProps['minMenuWidth'] | TProps['maxMenuWidth']
 ) => {
-  const designTokenSuffix =
-    typeof value === 'string' ? upperFirst(value) : value;
-  const constraintValue =
-    designTokens[`constraint${designTokenSuffix}` as TDesignTokenName] ||
-    designTokens.constraint3;
-  return constraintValue;
+  switch (value) {
+    case 'auto':
+      return 'initial';
+    default:
+      return (
+        designTokens[`constraint${value}` as TDesignTokenName] ||
+        designTokens.constraintScale
+      );
+  }
 };
 
 const getInputBackgroundColor = (props: TProps) => {


### PR DESCRIPTION
#### Summary

Fix select input components dropdown menu width

## Description

We have an issue while calculating the width for the dropdown menu rendered when a select input component is clicked.
The problem is that we are using the minimum width configured also for the maximum width of that element:
![image](https://github.com/commercetools/ui-kit/assets/97907068/1c917b6f-2cbf-4c1c-8964-bb723d54d1e6)


