### PR TITLE
fix(ui-kit): override default anchor card wrapper display style

### DIFF
--- a/.changeset/tricky-humans-invite.md
+++ b/.changeset/tricky-humans-invite.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/card': patch
+---
+
+Fixes a display error when using clickable Card functionality

--- a/packages/components/card/src/card.tsx
+++ b/packages/components/card/src/card.tsx
@@ -80,6 +80,8 @@ const Card = (props: TCardProps) => {
           ? designTokens.colorNeutral98
           : undefined};
       }
+      // Overrides the default link styles
+      display: block;
       // Disables link text styling
       color: inherit;
       // Changes the opacity of the content, not the card itself


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

## Summary

This PR fixes a bug encountered in the Merchant Center, when using clickable `Card` functionality.

### To reproduce: 
Without `to` prop defined:
![image](https://github.com/commercetools/ui-kit/assets/15024562/83c2e3f9-0285-4840-9603-5676c95d08f5)

With `to` prop defined:
![image](https://github.com/commercetools/ui-kit/assets/15024562/fef54800-07d3-43d5-860a-f5df217d5f37)

## Description

TIL `<a>` tags are `display: inline;` by default. By overriding this style, we can match that of the `div` and ensure expected behavior when anchor tags are parent `Card` elements.
