### PR TITLE
Fix invalid design token in `reset.css` file

### DIFF
--- a/.changeset/afraid-beans-grin.md
+++ b/.changeset/afraid-beans-grin.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/design-system': patch
+---
+
+Fix invalid CSS variable usage in reset.css exported file.

--- a/design-system/materials/resets.css
+++ b/design-system/materials/resets.css
@@ -6,7 +6,7 @@
 
 html,
 body {
-  color: var(--font-color-for-text);
+  color: var(--color-solid);
   font-family: var(--font-family);
   margin: 0;
   padding: 0;


### PR DESCRIPTION
#### Summary

Fix invalid design token in `reset.css` file.

## Description

This is a leftover of #2718

We were still using a legacy design tokens in the `reset.css` we export from the `@commercetools-uikit/design-system` package.
