### PR TITLE
`Select-input` small UI improvements

### DIFF
--- a/.changeset/polite-glasses-move.md
+++ b/.changeset/polite-glasses-move.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/select-utils': patch
+---
+
+Small UI improvements.

--- a/packages/components/inputs/select-utils/src/create-select-styles.ts
+++ b/packages/components/inputs/select-utils/src/create-select-styles.ts
@@ -304,6 +304,7 @@ const optionStyles = () => (base: TBase, state: TState) => {
       color ${designTokens.transitionStandard}`,
     padding: `${designTokens.spacing20} ${designTokens.spacing30}`,
     lineHeight: designTokens.lineHeight40,
+    cursor: state.isDisabled ? 'not-allowed' : 'pointer',
     color: (() => {
       if (!state.isDisabled) return designTokens.fontColorForInput;
       if (state.isSelected) return designTokens.fontColorForInput;
@@ -411,7 +412,7 @@ const groupHeadingStyles = () => (base: TBase) => {
   return {
     ...base,
     color: designTokens.fontColorForInputWhenReadonly,
-    fontSize: designTokens.fontSize30,
+    fontSize: designTokens.fontSize20,
     borderBottom: `1px solid ${designTokens.colorNeutral90}`,
     textTransform: 'none',
     fontWeight: designTokens.fontWeight500,


### PR DESCRIPTION
1. Changing the `font-size` of the `GroupHeading` to '14px'.
<img width="396" alt="Screenshot 2024-02-28 at 13 21 46" src="https://github.com/commercetools/ui-kit/assets/52276952/fa563541-7ad7-4386-b018-c242b4dcf664">
___________________________________________________________

2. Setting up 'not-allowed' cursor when `MenuItem` is disabled.
<img width="297" alt="Screenshot 2024-02-28 at 13 21 29" src="https://github.com/commercetools/ui-kit/assets/52276952/31eb3459-21bc-4254-9611-38bff2456577">


