### PR TITLE
Fix viewswitcher border radius

### DIFF
--- a/.changeset/twenty-paws-join.md
+++ b/.changeset/twenty-paws-join.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/view-switcher': minor
+---
+
+Fix viewswitcher border radius

--- a/packages/components/view-switcher/src/view-switcher.styles.ts
+++ b/packages/components/view-switcher/src/view-switcher.styles.ts
@@ -31,9 +31,10 @@ export const getButtonStyles = (
   isFirstButton?: TViewSwitcherButtonProps['isFirstButton'],
   isLastButton?: TViewSwitcherButtonProps['isLastButton']
 ) => {
-  const borderRadius = `${isFirstButton ? designTokens.borderRadius4 : '0'} ${
-    isLastButton ? `${designTokens.borderRadius4}` : '0 0'
-  } ${isFirstButton ? designTokens.borderRadius4 : '0'}`;
+  const borderRadius = `${isFirstButton ? designTokens.borderRadius4 : '0'}
+  ${isLastButton ? `${designTokens.borderRadius4}` : '0'}
+  ${isLastButton ? `${designTokens.borderRadius4}` : '0'}
+  ${isFirstButton ? designTokens.borderRadius4 : '0'}`;
 
   const fontColor = getFontColor(isDisabled, isActive);
 


### PR DESCRIPTION
#### Summary

Fix viewswitcher border radius

## Description

Screenshots:

Before: 
<img width="856" alt="image-20240319-103123" src="https://github.com/commercetools/ui-kit/assets/19975842/b8b112de-c7fd-401a-98c5-6e34809cec27">



After: 
<img width="472" alt="image" src="https://github.com/commercetools/ui-kit/assets/19975842/8c5c3bed-2879-4deb-b730-c21015f34f36">
