### PR TITLE
refactor(icons): update ts type exporting for custom icon components

### DIFF
--- a/packages/components/icons/src/export-types.ts
+++ b/packages/components/icons/src/export-types.ts
@@ -1,2 +1,1 @@
 export type { Props, SVGProps } from './templates/icon.styles';
-export type { TLeadingIconProps } from './leading-icon';

--- a/packages/components/icons/src/inline-svg/export-types.ts
+++ b/packages/components/icons/src/inline-svg/export-types.ts
@@ -1,0 +1,1 @@
+export type { InlineSvgProps } from './inline-svg';

--- a/packages/components/icons/src/inline-svg/index.ts
+++ b/packages/components/icons/src/inline-svg/index.ts
@@ -1,1 +1,2 @@
 export { default } from './inline-svg';
+export * from './export-types';

--- a/packages/components/icons/src/inline-svg/inline-svg.tsx
+++ b/packages/components/icons/src/inline-svg/inline-svg.tsx
@@ -12,7 +12,7 @@ import { ClassNames } from '@emotion/react';
 import { canUseDOM } from '@commercetools-uikit/utils';
 import { getIconStyles } from '../templates/icon.styles';
 
-type InlineSvgProps = Props & {
+export type InlineSvgProps = Props & {
   data: string;
 };
 

--- a/packages/components/icons/src/leading-icon/export-types.ts
+++ b/packages/components/icons/src/leading-icon/export-types.ts
@@ -1,0 +1,1 @@
+export type { TLeadingIconProps } from './leading-icon';

--- a/packages/components/icons/src/leading-icon/index.ts
+++ b/packages/components/icons/src/leading-icon/index.ts
@@ -1,1 +1,2 @@
-export { default, type TLeadingIconProps } from './leading-icon';
+export { default } from './leading-icon';
+export * from './export-types';


### PR DESCRIPTION
#### Summary

This is al alternative proposal for #2752.

#### Description

Here I'm proposing a change in the way we want to expose custom icon components types so they can be consumed from their own entry point.

With the implementation proposed in the original PR, a user wanting to use the `LeadingIcon` component and also access its type would need two different _imports_:
```
import LeadingIcon from '@commercetools-uikit/icons/leading-icon';
import { type TLeadingIconProps } from '@commercetools-uikit/icons';
```

With the approach I'm proposing here, only one import is required:
```
import LeadingIcon, { type TLeadingIconProps } from '@commercetools-uikit/icons/leading-icon';
```

I'm also doing the same for the ` InlineSvg` component.