### PR TITLE
`FieldLabel` style changes for the recolouring theme

### DIFF
--- a/.changeset/calm-emus-warn.md
+++ b/.changeset/calm-emus-warn.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/field-label': patch
+---
+
+Separate which `InfoButton` is shown in the `FieldLabel` component based on the theme.

--- a/packages/components/field-label/package.json
+++ b/packages/components/field-label/package.json
@@ -26,6 +26,7 @@
     "@commercetools-uikit/icon-button": "18.5.0",
     "@commercetools-uikit/icons": "18.5.0",
     "@commercetools-uikit/label": "18.5.0",
+    "@commercetools-uikit/secondary-icon-button": "18.5.0",
     "@commercetools-uikit/spacings-inline": "18.5.0",
     "@commercetools-uikit/spacings-stack": "18.5.0",
     "@commercetools-uikit/text": "18.5.0",

--- a/packages/components/field-label/src/field-label.tsx
+++ b/packages/components/field-label/src/field-label.tsx
@@ -9,12 +9,13 @@ import { warning } from '@commercetools-uikit/utils';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import IconButton from '@commercetools-uikit/icon-button';
-import { InformationIcon } from '@commercetools-uikit/icons';
+import SecondaryIconButton from '@commercetools-uikit/secondary-icon-button';
+import { InformationIcon, InfoIcon } from '@commercetools-uikit/icons';
 import Text from '@commercetools-uikit/text';
 import Constraints from '@commercetools-uikit/constraints';
 import Inline from '@commercetools-uikit/spacings-inline';
 import Label from '@commercetools-uikit/label';
-import { designTokens } from '@commercetools-uikit/design-system';
+import { designTokens, useTheme } from '@commercetools-uikit/design-system';
 
 export type TFieldLabelProps = {
   /**
@@ -104,6 +105,8 @@ const LabelRowWrapper = styled.div`
 `;
 
 const FieldLabel = (props: TFieldLabelProps) => {
+  const { themedValue } = useTheme();
+
   if (props.hintIcon) {
     warning(
       props.hintIcon.props.size === undefined,
@@ -129,14 +132,22 @@ const FieldLabel = (props: TFieldLabelProps) => {
             {props.title}
           </Label>
         </Text.Wrap>
-        {props.onInfoButtonClick && (
-          <IconButton
-            label="More Info"
-            icon={<InformationIcon />}
-            size="small"
-            onClick={props.onInfoButtonClick}
-          />
-        )}
+        {props.onInfoButtonClick &&
+          themedValue(
+            <IconButton
+              label="More Info"
+              icon={<InformationIcon />}
+              size="small"
+              onClick={props.onInfoButtonClick}
+            />,
+            <SecondaryIconButton
+              label="More Info"
+              icon={<InfoIcon />}
+              size="medium"
+              color="info"
+              onClick={props.onInfoButtonClick}
+            />
+          )}
       </Inline>
 
       {props.hint && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2854,6 +2854,7 @@ __metadata:
     "@commercetools-uikit/icon-button": 18.5.0
     "@commercetools-uikit/icons": 18.5.0
     "@commercetools-uikit/label": 18.5.0
+    "@commercetools-uikit/secondary-icon-button": 18.5.0
     "@commercetools-uikit/spacings-inline": 18.5.0
     "@commercetools-uikit/spacings-stack": 18.5.0
     "@commercetools-uikit/text": 18.5.0


### PR DESCRIPTION
Show a different info-button in the `FieldLabel` component based on the theme.

**Changes:**
<img width="399" alt="Screenshot 2024-03-21 at 14 21 02" src="https://github.com/commercetools/ui-kit/assets/52276952/78d55279-856a-440c-ad1c-9e16e0e16127">
<img width="368" alt="Screenshot 2024-03-21 at 14 21 07" src="https://github.com/commercetools/ui-kit/assets/52276952/079163fc-b26a-454e-b351-f728ad875d9a">


**Design requirements:**
<img width="595" alt="Screenshot 2024-03-21 at 12 36 05" src="https://github.com/commercetools/ui-kit/assets/52276952/cbff3614-cdd1-43c1-b4bb-c40ce9bd4390">
