### PR TITLE
Update `node-fetch` transitive dependency version

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -47,6 +47,7 @@
   "resolutions": {
     "@types/react": "17.0.75",
     "@types/react-dom": "17.0.25",
+    "node-fetch": "^2.6.7",
     "terser-webpack-plugin": "2.3.8",
     "webpack": "4.47.0"
   },

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -6435,7 +6435,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"encoding@npm:^0.1.11, encoding@npm:^0.1.13":
+"encoding@npm:^0.1.13":
   version: 0.1.13
   resolution: "encoding@npm:0.1.13"
   dependencies:
@@ -8650,13 +8650,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-stream@npm:^1.0.1":
-  version: 1.1.0
-  resolution: "is-stream@npm:1.1.0"
-  checksum: 063c6bec9d5647aa6d42108d4c59723d2bd4ae42135a2d4db6eadbd49b7ea05b750fd69d279e5c7c45cf9da753ad2c00d8978be354d65aa9f6bb434969c6a2ae
-  languageName: node
-  linkType: hard
-
 "is-string@npm:^1.0.5, is-string@npm:^1.0.7":
   version: 1.0.7
   resolution: "is-string@npm:1.0.7"
@@ -9934,19 +9927,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^1.0.1":
-  version: 1.7.3
-  resolution: "node-fetch@npm:1.7.3"
-  dependencies:
-    encoding: ^0.1.11
-    is-stream: ^1.0.1
-  checksum: 3bb0528c05d541316ebe52770d71ee25a6dce334df4231fd55df41a644143e07f068637488c18a5b0c43f05041dbd3346752f9e19b50df50569a802484544d5b
-  languageName: node
-  linkType: hard
-
-"node-fetch@npm:^2.6.0":
-  version: 2.6.9
-  resolution: "node-fetch@npm:2.6.9"
+"node-fetch@npm:^2.6.7":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
   dependencies:
     whatwg-url: ^5.0.0
   peerDependencies:
@@ -9954,7 +9937,7 @@ __metadata:
   peerDependenciesMeta:
     encoding:
       optional: true
-  checksum: acb04f9ce7224965b2b59e71b33c639794d8991efd73855b0b250921382b38331ffc9d61bce502571f6cc6e11a8905ca9b1b6d4aeb586ab093e2756a1fd190d0
+  checksum: d76d2f5edb451a3f05b15115ec89fc6be39de37c6089f1b6368df03b91e1633fd379a7e01b7ab05089a25034b2023d959b47e59759cb38d88341b2459e89d6e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Summary

Update `node-fetch` transitive dependency version

## Description

We have [this security alert](https://github.com/commercetools/ui-kit/security/dependabot/44) about the `node-fetch` dependency having a security issue.

This dependency is only used in Storybook.

Here is the dependency path:
```
@storybook/core@npm:5.3.21 -> isomorphic-fetch@npm:2.2.1 -> node-fetch@npm:1.7.3 (via npm:^1.0.1)
```
