### PR TITLE
Update `trim` transitive dependency version

### DIFF
--- a/.changeset/great-carpets-share.md
+++ b/.changeset/great-carpets-share.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-local/generator-readme': patch
+---
+
+Update `trim` dependency

--- a/package.json
+++ b/package.json
@@ -165,7 +165,8 @@
     "@types/unist": "3.0.2",
     "@typescript-eslint/eslint-plugin": "6.19.0",
     "@typescript-eslint/parser": "6.19.0",
-    "core-js-compat": "^3.23.4"
+    "core-js-compat": "^3.23.4",
+    "trim": "^0.0.3"
   },
   "engines": {
     "node": ">=18 <19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19119,10 +19119,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"trim@npm:0.0.1":
-  version: 0.0.1
-  resolution: "trim@npm:0.0.1"
-  checksum: 2b4646dff99a222e8e1526edd4e3a43bbd925af0b8e837c340455d250157e7deefaa4da49bb891ab841e5c27b1afc5e9e32d4b57afb875d2dfcabf4e319b8f7f
+"trim@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "trim@npm:0.0.3"
+  checksum: 9a059ba56d5e22c9e571798a7c63640cb25478c495d8a9d001f6352927207c6bd224018751a0c5145fbedc943ee2ebab1d7cc2e8ccba3121a51a7d3428dd879c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Summary

Update `trim` transitive dependency version.

## Description

We have [this security alert](https://github.com/commercetools/ui-kit/security/dependabot/14) about the `trim` dependency having a security issue.

Here is the dependency path:
```
@commercetools-local/generator-readme -> remark-parse@npm:8.0.3 ->  trim@npm:0.0.1 (via npm:0.0.1)
```
