### PR TITLE
PANGOLIN- 3683 - <Tag/> styling updates

### DIFF
--- a/.changeset/smooth-baboons-beg.md
+++ b/.changeset/smooth-baboons-beg.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-uikit/tag': minor
+---
+
+Add additional border-radius and color styling to Tag components.  
+

--- a/.changeset/smooth-baboons-beg.md
+++ b/.changeset/smooth-baboons-beg.md
@@ -2,5 +2,5 @@
 '@commercetools-uikit/tag': minor
 ---
 
-Add additional border-radius and color styling to Tag components.  
+Component UI styling updates.  
 

--- a/packages/components/tag/src/tag-body.tsx
+++ b/packages/components/tag/src/tag-body.tsx
@@ -53,7 +53,7 @@ const getContentWrapperStyles = (props: TTagBodyProps) => {
     display: flex;
     box-sizing: border-box;
     align-items: center;
-    border-radius: ${designTokens.borderRadius2};
+    border-radius: ${designTokens.borderRadius20};
     padding: ${designTokens.spacing05} ${designTokens.spacing25};
     white-space: normal;
     text-align: left;
@@ -96,8 +96,8 @@ const TagBody = (props: TTagBodyProps) => {
         Boolean(props.onRemove) &&
           css`
             border-right: ${!props.isDisabled && '0'};
-            border-top-right-radius: 0;
-            border-bottom-right-radius: 0;
+            border-top-right-radius: ${designTokens.borderRadius20};
+            border-bottom-right-radius: ${designTokens.borderRadius20};
           `,
         !props.isDisabled &&
           Boolean(props.onClick) &&

--- a/packages/components/tag/src/tag-body.tsx
+++ b/packages/components/tag/src/tag-body.tsx
@@ -30,18 +30,6 @@ const defaultProps: Pick<TTagProps, 'type' | 'isDisabled' | 'isDraggable'> = {
 type TBody = Pick<TTagBodyProps, 'to' | 'as'>;
 const Body = styled.div<TBody>``;
 
-const getClickableContentWrapperStyles = (type: TTagBodyProps['type']) => {
-  return type === 'warning'
-    ? []
-    : [
-        css`
-          &:hover {
-            border-color: ${designTokens.colorPrimary90};
-          }
-        `,
-      ];
-};
-
 const getTextDetailColor = (isDisabled: TTagBodyProps['isDisabled']) => {
   if (isDisabled) return designTokens.colorNeutral60;
   return designTokens.colorSolid;
@@ -51,22 +39,13 @@ const getContentWrapperStyles = (props: TTagBodyProps) => {
   return css`
     position: relative;
     display: flex;
-    box-sizing: border-box;
     align-items: center;
-    border-radius: ${designTokens.borderRadius20};
     padding: ${designTokens.spacing05} ${designTokens.spacing25};
     white-space: normal;
     text-align: left;
     min-width: 0;
     overflow-wrap: break-word;
     hyphens: auto;
-    border-style: solid;
-    border-width: 1px;
-    border-color: ${props.type === 'warning'
-      ? designTokens.colorWarning85
-      : props.isDisabled
-      ? designTokens.colorNeutral
-      : designTokens.borderColorForTag};
     color: ${designTokens.colorSolid};
     fill: ${designTokens.colorNeutral40};
 
@@ -83,16 +62,6 @@ const getContentWrapperStyles = (props: TTagBodyProps) => {
         color: ${designTokens.colorNeutral60} !important;
       }
     `}
-
-    ${Boolean(props.onRemove) &&
-    css`
-      border-top-right-radius: ${props.isDisabled
-        ? `${designTokens.borderRadius20}`
-        : 'unset'} !important;
-      border-bottom-right-radius: ${props.isDisabled
-        ? `${designTokens.borderRadius20}`
-        : 'unset'} !important;
-    `}
   `;
 };
 
@@ -105,13 +74,6 @@ const TagBody = (props: TTagBodyProps) => {
       as={props.as}
       css={[
         getContentWrapperStyles(props),
-        Boolean(props.onRemove) &&
-          css`
-            border-right: ${!props.isDisabled && '0'};
-          `,
-        !props.isDisabled &&
-          Boolean(props.onClick) &&
-          getClickableContentWrapperStyles(props.type),
         !props.isDisabled &&
           Boolean(props.onClick) &&
           css`

--- a/packages/components/tag/src/tag-body.tsx
+++ b/packages/components/tag/src/tag-body.tsx
@@ -81,6 +81,16 @@ const getContentWrapperStyles = (props: TTagBodyProps) => {
         color: ${designTokens.colorNeutral60} !important;
       }
     `}
+
+    ${Boolean(props.onRemove) &&
+    css`
+      border-top-right-radius: ${props.isDisabled
+        ? `${designTokens.borderRadius20}`
+        : 'unset'} !important;
+      border-bottom-right-radius: ${props.isDisabled
+        ? `${designTokens.borderRadius20}`
+        : 'unset'} !important;
+    `}
   `;
 };
 
@@ -96,8 +106,6 @@ const TagBody = (props: TTagBodyProps) => {
         Boolean(props.onRemove) &&
           css`
             border-right: ${!props.isDisabled && '0'};
-            border-top-right-radius: ${designTokens.borderRadius20};
-            border-bottom-right-radius: ${designTokens.borderRadius20};
           `,
         !props.isDisabled &&
           Boolean(props.onClick) &&

--- a/packages/components/tag/src/tag-body.tsx
+++ b/packages/components/tag/src/tag-body.tsx
@@ -63,7 +63,7 @@ const getContentWrapperStyles = (props: TTagBodyProps) => {
     border-style: solid;
     border-width: 1px;
     border-color: ${props.type === 'warning'
-      ? designTokens.colorWarning
+      ? designTokens.colorWarning85
       : designTokens.borderColorForTag};
     color: ${designTokens.colorSolid};
     fill: ${designTokens.colorNeutral40};

--- a/packages/components/tag/src/tag-body.tsx
+++ b/packages/components/tag/src/tag-body.tsx
@@ -36,7 +36,7 @@ const getClickableContentWrapperStyles = (type: TTagBodyProps['type']) => {
     : [
         css`
           &:hover {
-            border-color: ${designTokens.colorNeutral};
+            border-color: ${designTokens.colorPrimary90};
           }
         `,
       ];

--- a/packages/components/tag/src/tag-body.tsx
+++ b/packages/components/tag/src/tag-body.tsx
@@ -64,6 +64,8 @@ const getContentWrapperStyles = (props: TTagBodyProps) => {
     border-width: 1px;
     border-color: ${props.type === 'warning'
       ? designTokens.colorWarning85
+      : props.isDisabled
+      ? designTokens.colorNeutral
       : designTokens.borderColorForTag};
     color: ${designTokens.colorSolid};
     fill: ${designTokens.colorNeutral40};

--- a/packages/components/tag/src/tag-body.tsx
+++ b/packages/components/tag/src/tag-body.tsx
@@ -117,9 +117,9 @@ const TagBody = (props: TTagBodyProps) => {
         {props.isDraggable && !props.isDisabled ? (
           <DragIcon data-testid="drag-icon" size="medium" />
         ) : null}
-        <Text.Body tone={textTone} as="span">
+        <Text.Detail tone={textTone} as="span">
           {props.children}
-        </Text.Body>
+        </Text.Detail>
       </Spacings.Inline>
     </Body>
   );

--- a/packages/components/tag/src/tag.spec.js
+++ b/packages/components/tag/src/tag.spec.js
@@ -5,6 +5,20 @@ it('should render text as children', () => {
   render(<Tag>Bread</Tag>);
   expect(screen.getByText('Bread')).toBeInTheDocument();
 });
+
+it('should render multiple text children', () => {
+  render(
+    <Tag>
+      <span>Bread</span>
+      <span>Peanut Butter</span>
+      <span>Honey</span>
+    </Tag>
+  );
+  expect(screen.getByText('Bread')).toBeInTheDocument();
+  expect(screen.getByText('Peanut Butter')).toBeInTheDocument();
+  expect(screen.getByText('Honey')).toBeInTheDocument();
+});
+
 it('should render html markup as children', () => {
   const error = jest.spyOn(console, 'error').mockImplementation(() => {});
   render(
@@ -108,8 +122,24 @@ describe('when `to` is set', () => {
     );
     screen.getByText('Bread').click();
     expect(onClick).toHaveBeenCalled();
-
     expect(history.location.pathname).toBe('/foo');
+  });
+
+  it('should redirect on link click if text children proceed it', () => {
+    const { history } = render(
+      <Tag>
+        <span>Bread</span>
+        <span>Peanut Butter</span>
+        <span onClick={() => history.push('/honey')}>Honey</span>
+      </Tag>
+    );
+
+    expect(screen.getByText('Bread')).toBeInTheDocument();
+    expect(screen.getByText('Peanut Butter')).toBeInTheDocument();
+    expect(screen.getByText('Honey')).toBeInTheDocument();
+
+    screen.getByText('Honey').click();
+    expect(history.location.pathname).toBe('/honey');
   });
 
   it('should not redirect when removed', () => {
@@ -126,7 +156,7 @@ describe('when `to` is set', () => {
     expect(onRemove).toHaveBeenCalled();
 
     // ensure the pathname is not "/foo", otherwise a redirect would have
-    // happend
+    // happened
     expect(history.location.pathname).toBe('/');
   });
 
@@ -140,7 +170,7 @@ describe('when `to` is set', () => {
     screen.getByText('Bread').click();
 
     // ensure the pathname is not "/foo", otherwise a redirect would have
-    // happend
+    // happened
     expect(history.location.pathname).toBe('/');
   });
 });

--- a/packages/components/tag/src/tag.tsx
+++ b/packages/components/tag/src/tag.tsx
@@ -88,22 +88,25 @@ const Tag = (props: TTagProps) => {
             cursor: pointer;
             text-decoration: none;
           }
-          cursor: default;
           min-width: 0;
           display: flex;
           border-radius: ${designTokens.borderRadius20};
-          background-color: ${props.type === 'warning'
+          background-color: ${props.isDisabled
+            ? designTokens.colorNeutral95
+            : props.type === 'warning'
             ? designTokens.colorWarning95
             : designTokens.backgroundColorForTag};
-
+          border-color: ${props.isDisabled
+            ? designTokens.colorNeutral
+            : designTokens.borderColorForTag};
           ${props.onClick &&
           `&:hover {
-            background-color: ${
-              props.type === 'warning'
-                ? designTokens.colorWarning95
-                : designTokens.backgroundColorForTagWhenHovered
-            };
-          }`}
+      background-color: ${
+        props.type === 'warning'
+          ? designTokens.colorWarning95
+          : designTokens.backgroundColorForTagWhenHovered
+      };
+    }`}
         `}
       >
         <TagBody

--- a/packages/components/tag/src/tag.tsx
+++ b/packages/components/tag/src/tag.tsx
@@ -126,7 +126,7 @@ const Tag = (props: TTagProps) => {
             css={[
               css`
                 border-color: ${props.type === 'warning'
-                  ? designTokens.colorWarning
+                  ? designTokens.colorWarning85
                   : designTokens.borderColorForTag};
                 padding: 0 ${designTokens.spacing25};
                 border-radius: 0 ${designTokens.borderRadius20}
@@ -139,7 +139,7 @@ const Tag = (props: TTagProps) => {
                 :not(:disabled)&:hover,
                 :not(:disabled)&:focus {
                   border-color: ${props.type === 'warning'
-                    ? designTokens.colorWarning
+                    ? designTokens.colorWarning85
                     : designTokens.borderColorForTag};
 
                   fill: ${designTokens.colorError};

--- a/packages/components/tag/src/tag.tsx
+++ b/packages/components/tag/src/tag.tsx
@@ -92,10 +92,10 @@ const Tag = (props: TTagProps) => {
           min-width: 0;
           display: flex;
           border-radius: ${designTokens.borderRadius20};
-          background-color: ${props.isDisabled && props.type === 'warning'
-            ? designTokens.colorWarning95
-            : props.isDisabled
-            ? designTokens.colorNeutral95
+          background-color: ${props.isDisabled
+            ? props.type === 'warning'
+              ? designTokens.colorWarning95
+              : designTokens.colorNeutral95
             : props.type === 'warning'
             ? designTokens.colorWarning95
             : designTokens.backgroundColorForTag};

--- a/packages/components/tag/src/tag.tsx
+++ b/packages/components/tag/src/tag.tsx
@@ -88,28 +88,31 @@ const Tag = (props: TTagProps) => {
             cursor: pointer;
             text-decoration: none;
           }
+          box-sizing: border-box;
           cursor: default;
           min-width: 0;
           display: flex;
           border-radius: ${designTokens.borderRadius20};
+          border-style: solid;
+          border-width: 1px;
           background-color: ${props.isDisabled
-            ? props.type === 'warning'
-              ? designTokens.colorWarning95
-              : designTokens.colorNeutral95
+            ? designTokens.colorNeutral95
             : props.type === 'warning'
             ? designTokens.colorWarning95
             : designTokens.backgroundColorForTag};
           border-color: ${props.isDisabled
             ? designTokens.colorNeutral
+            : props.type === 'warning'
+            ? designTokens.colorWarning85
             : designTokens.borderColorForTag};
           ${props.onClick &&
           `&:hover {
-      background-color: ${
-        props.type === 'warning'
-          ? designTokens.colorWarning95
-          : designTokens.backgroundColorForTagWhenHovered
-      };
-    }`}
+            background-color: ${
+              props.type === 'warning'
+                ? designTokens.colorWarning95
+                : designTokens.backgroundColorForTagWhenHovered
+            };
+          }`}
         `}
       >
         <TagBody
@@ -131,25 +134,9 @@ const Tag = (props: TTagProps) => {
             onClick={props.onRemove}
             css={[
               css`
-                border-color: ${props.type === 'warning'
-                  ? designTokens.colorWarning85
-                  : designTokens.borderColorForTag};
                 padding: 0 ${designTokens.spacing25};
-                border-radius: 0 ${designTokens.borderRadius20}
-                  ${designTokens.borderRadius20} 0;
                 display: flex;
                 align-items: center;
-                background: inherit;
-                border-style: solid;
-                border-width: 1px 1px 1px 0;
-                :not(:disabled)&:hover,
-                :not(:disabled)&:focus {
-                  border-color: ${props.type === 'warning'
-                    ? designTokens.colorWarning85
-                    : designTokens.borderColorForTag};
-
-                  fill: ${designTokens.colorError};
-                }
                 fill: ${designTokens.colorNeutral40};
                 &:disabled {
                   fill: ${designTokens.colorNeutral60};

--- a/packages/components/tag/src/tag.tsx
+++ b/packages/components/tag/src/tag.tsx
@@ -88,10 +88,13 @@ const Tag = (props: TTagProps) => {
             cursor: pointer;
             text-decoration: none;
           }
+          cursor: default;
           min-width: 0;
           display: flex;
           border-radius: ${designTokens.borderRadius20};
-          background-color: ${props.isDisabled
+          background-color: ${props.isDisabled && props.type === 'warning'
+            ? designTokens.colorWarning95
+            : props.isDisabled
             ? designTokens.colorNeutral95
             : props.type === 'warning'
             ? designTokens.colorWarning95

--- a/packages/components/tag/src/tag.tsx
+++ b/packages/components/tag/src/tag.tsx
@@ -109,7 +109,7 @@ const Tag = (props: TTagProps) => {
           `&:hover {
             background-color: ${
               props.type === 'warning'
-                ? designTokens.colorWarning95
+                ? designTokens.colorWarning85
                 : designTokens.backgroundColorForTagWhenHovered
             };
           }`}

--- a/packages/components/tag/src/tag.tsx
+++ b/packages/components/tag/src/tag.tsx
@@ -91,6 +91,7 @@ const Tag = (props: TTagProps) => {
           cursor: default;
           min-width: 0;
           display: flex;
+          border-radius: ${designTokens.borderRadius20};
           background-color: ${props.type === 'warning'
             ? designTokens.colorWarning95
             : designTokens.backgroundColorForTag};
@@ -128,8 +129,8 @@ const Tag = (props: TTagProps) => {
                   ? designTokens.colorWarning
                   : designTokens.borderColorForTag};
                 padding: 0 ${designTokens.spacing25};
-                border-radius: 0 ${designTokens.borderRadius2}
-                  ${designTokens.borderRadius2} 0;
+                border-radius: 0 ${designTokens.borderRadius20}
+                  ${designTokens.borderRadius20} 0;
                 display: flex;
                 align-items: center;
                 background: inherit;


### PR DESCRIPTION
Figma references [here](https://www.figma.com/file/PaImaWorWz1RbV85gqw4MH/Filter-%26-Table-controls?type=design&node-id=1133%3A127328&mode=dev)

This PR contains the following updates (screenshots below):
1.) **border-radius** from `2px` to `20px`    --> all tags, in any state
2.) **typography** - `Text.Body` to `Text.Detail` -->   in `TagBody` component
3.) **border-color** to `warning85` --> when type is warning
4.)  **border-color** to `colorPrimary90` --> when type is default w/ hover (onClick)
5.) **background-color** to `neutral95` && **border-color** to `neutral` --> when type is default & isDisabled

Updates 09/04/24:
6.) **background-color** to `neutral95` && **border-color** to `neutral` --> when type is warning && isDisabled (this now matches the color schema of type=default && isDisabled)
7.)  **background-color** to `colorWarning85` --> when type is default w/ hover (onClick)


1.) Before vs After
<img width="250" alt="Screenshot 2024-04-07 at 19 38 21" src="https://github.com/commercetools/ui-kit/assets/47182700/7be0a8bd-b825-4c44-8bf6-b7466f5aa3f9">
<img width="250" alt="Screenshot 2024-04-07 at 19 38 46" src="https://github.com/commercetools/ui-kit/assets/47182700/af551f05-aea5-4260-933c-128870ae8054">

2.) After
<img width="1095" alt="Screenshot 2024-04-07 at 19 52 29" src="https://github.com/commercetools/ui-kit/assets/47182700/aa115912-1f7b-4876-a0c6-2134e02a0bd1">

3.) Before vs After
<img width="250" alt="Screenshot 2024-04-07 at 19 41 38" src="https://github.com/commercetools/ui-kit/assets/47182700/806c247b-278d-4773-bb49-789fae8a1978">
<img width="250" alt="Screenshot 2024-04-07 at 19 42 09" src="https://github.com/commercetools/ui-kit/assets/47182700/602e5015-6a78-40cd-865b-cf283205a170">


4.) Before vs After
<img width="500" alt="Screenshot 2024-04-08 at 10 15 19" src="https://github.com/commercetools/ui-kit/assets/47182700/0ab9df66-ea0f-4cea-83f7-a3b4140b18e5">
<img width="500" alt="Screenshot 2024-04-08 at 10 19 08" src="https://github.com/commercetools/ui-kit/assets/47182700/52977a90-fb2a-4cd9-b60c-a74936f0ed3b">

5.) Before vs After
<img width="500" alt="Screenshot 2024-04-08 at 11 55 32" src="https://github.com/commercetools/ui-kit/assets/47182700/d0ccffe2-286e-4435-8114-c200d79b0432">

6.) screenshot in [comments](https://github.com/commercetools/ui-kit/pull/2767#discussion_r1558173559)

7.) Before vs After
<img width="250" alt="Screenshot 2024-04-09 at 14 40 59" src="https://github.com/commercetools/ui-kit/assets/47182700/cb73a60e-e86d-4c0d-80f7-cde0494f39a6">
<img width="250" alt="Screenshot 2024-04-09 at 14 42 36" src="https://github.com/commercetools/ui-kit/assets/47182700/18627c91-748b-42aa-b266-2eb89aa3ae7e">








