### PR TITLE
Fix `useTheme` hook helper

### DIFF
--- a/.changeset/fresh-suns-count.md
+++ b/.changeset/fresh-suns-count.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/design-system': patch
+---
+
+Fixes the `themedValue` helper exported from the `useTheme` hook so it always return the right-hand side parameter as we now want to always use the "new" themed values.

--- a/design-system/src/theme-provider.tsx
+++ b/design-system/src/theme-provider.tsx
@@ -133,7 +133,7 @@ const useTheme = (parentSelector = defaultParentSelector): TUseThemeResult => {
   // TODO - make sure old and new theme return same value as new defaultThemeValue
   // At least for the remaining places that we still use this function
   const themedValue: TUseThemeResult['themedValue'] = useCallback(
-    (defaultThemeValue, _newThemeValue) => defaultThemeValue,
+    (_defaultThemeValue, newThemeValue) => newThemeValue,
     []
   );
 


### PR DESCRIPTION
#### Summary

Fix `useTheme` hook helper.

## Description

The `themedValue` helper is now always returning the left-side provided parameter (meaning "old" value) where it should be always returning the right-side one ("new" value) as we already migrated to the new theme.
