### PR TITLE
Fix `DropdownMenu` positioning issue 

### DIFF
--- a/.changeset/kind-countries-yell.md
+++ b/.changeset/kind-countries-yell.md
@@ -1,0 +1,11 @@
+---
+'@commercetools-uikit/dropdown-menu': patch
+'@commercetools-uikit/data-table-manager': patch
+---
+
+We fixed an issue with the `DropdownMenu` component when using these values:
+
+* `menuPosition`: right
+* `menuHorizontalConstraint`: auto
+
+In that situation, the width and positioning of the floating menu was not correctly calculated.

--- a/packages/components/dropdowns/dropdown-menu/src/menu/dropdown-menu-menu.tsx
+++ b/packages/components/dropdowns/dropdown-menu/src/menu/dropdown-menu-menu.tsx
@@ -52,19 +52,19 @@ function DropdownBaseMenu(props: TDropdownBaseMenuProps) {
     if (props.isOpen && props.triggerElementRef.current && menuRef.current) {
       const triggerElementCoordinates =
         props.triggerElementRef.current.getBoundingClientRect();
-      const menuElementCoordinates = menuRef.current.getBoundingClientRect();
 
       menuRef.current.style.top = `${
         triggerElementCoordinates.top + triggerElementCoordinates.height
       }px`;
-      menuRef.current.style.left =
-        props.menuPosition === 'left'
-          ? `${triggerElementCoordinates.left}px`
-          : `${
-              triggerElementCoordinates.left +
-              triggerElementCoordinates.width -
-              menuElementCoordinates.width
-            }px`;
+      if (props.menuPosition === 'left') {
+        menuRef.current.style.left = `${triggerElementCoordinates.left}px`;
+        menuRef.current.style.removeProperty('right');
+      } else {
+        menuRef.current.style.right = `${
+          window.innerWidth - triggerElementCoordinates.right
+        }px`;
+        menuRef.current.style.removeProperty('left');
+      }
       menuRef.current.style.maxHeight = props.menuMaxHeight
         ? `${props.menuMaxHeight}px`
         : `calc(${


### PR DESCRIPTION
#### Summary

There's been found an issue with the width and positioning of the `DropdownMenu` floating panel element.

closes #2813

## Description

The issue can be reproduced when using this properties values combination:
* `menuPosition`: right
* `menuHorizontalConstraint`: auto

In this situation, the floating menu was not correctly aligned with the triggering element and also was narrower that expected.

The issue seems to be related with the rendering and painting synchronization: although we use the `useLayoutEffect` hook to perform the calculation about the width and positioning of the floating element, the actual read width of the menu (determined by its contents because of the _auto_ value for the `menuHorizontalConstraint` property) was not accurate.
We were using this width measurement in order to calculate the `left` positioning value of the floating menu so it didn't work well.

We've change the way we position the floating menu when receiving the **right** value for the `menuPosition` property to use the CSS `right` property (instead of always using `left`) so we don't actually need its width to correctly positioning it.


### BEFORE

https://github.com/commercetools/ui-kit/assets/97907068/aa960166-94a9-4f48-a39c-56e32156613d


### AFTER

https://github.com/commercetools/ui-kit/assets/97907068/070e9cbb-bddf-40cc-b312-2227413d9a9e


