### PR TITLE
Refactor `useMutationObserver` hook to manage subtree modifications

### DIFF
--- a/packages/hooks/src/use-mutation-observer/use-mutation-observer.spec.jsx
+++ b/packages/hooks/src/use-mutation-observer/use-mutation-observer.spec.jsx
@@ -1,0 +1,61 @@
+/* eslint-disable react/prop-types */
+import { useRef, useState } from "react";
+import { render, screen, waitFor } from '@testing-library/react';
+import useMutationObserver from "./use-mutation-observer";
+
+const TestComponent = (props) => {
+  const containerRef = useRef();
+  const [mutationCount, setMutationCount] = useState(0);
+  useMutationObserver(
+    containerRef,
+    (mutationsList) => {
+      setMutationCount(mutationCount + 1);
+      props.observerHandler(mutationsList);
+    },
+    {
+      childList: true,
+      ...(props.mutationObserverProps || {})
+    },
+  );
+  return (
+    <div ref={containerRef} data-testid="test-container" data-mutationscount={mutationCount}>
+      <main>__children placeholder__</main>
+    </div>
+  );
+};
+
+describe('useMutationObserver', () => {
+  it('should call the observerHandler when adding a child to the observed element', async () => {
+    const observerHandler = jest.fn();
+
+    render(<TestComponent observerHandler={observerHandler} />);
+
+    const containerElement = screen.getByTestId('test-container');
+    containerElement.innerHTML = '<div>test content</div>';
+
+    await screen.findByText('test content');
+    await waitFor(() => {
+      expect(containerElement.getAttribute('data-mutationscount')).toEqual('1');
+    });
+    expect(observerHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call the observerHandler when adding a garndchild to the observed element', async () => {
+    const observerHandler = jest.fn();
+    const mutationObserverProps = {
+      subtree: true,
+      parentTargetSelector: '[data-testid="test-container"]'
+    };
+
+    render(<TestComponent observerHandler={observerHandler} mutationObserverProps={mutationObserverProps} />);
+
+    const containerElement = screen.getByTestId('test-container');
+    containerElement.querySelector('main').innerHTML = '<div>test content</div>';
+
+    await screen.findByText('test content');
+    await waitFor(() => {
+      expect(containerElement.getAttribute('data-mutationscount')).toEqual('1');
+    });
+    expect(observerHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/hooks/src/use-mutation-observer/use-mutation-observer.spec.jsx
+++ b/packages/hooks/src/use-mutation-observer/use-mutation-observer.spec.jsx
@@ -44,7 +44,6 @@ describe('useMutationObserver', () => {
     const observerHandler = jest.fn();
     const mutationObserverProps = {
       subtree: true,
-      parentTargetSelector: '[data-testid="test-container"]'
     };
 
     render(<TestComponent observerHandler={observerHandler} mutationObserverProps={mutationObserverProps} />);


### PR DESCRIPTION
#### Summary

Refactor `useMutationObserver` hook to manage subtree modifications.

## Description

If we currently pass the subtree option to the `useMutationObserver` hook, we're not going to have our mutation callback called. This is because we can have a same `MutationObserver` observing different elements and, when we get the internal mutation callback in our hook, we check to see wether the mutated element is one of the ones we have previously registered.
In the case of adding a direct children to the observed element, that's not a problem; however, if we add a grandchildren to the observer element, consumers won't know about it because the mutated element will be an observer element child and we didn't registered those in our hook.

With this change, we introduce some changes for consumers to be allowed to be notified about nested elements mutated within the one registered in the hook.

In this first attempt, a selector is needed by the hook to check whether a mutated element is contained in the observed element.