### PR TITLE
Pass down components prop to selectable search input

### DIFF
--- a/.changeset/selfish-hounds-beg.md
+++ b/.changeset/selfish-hounds-beg.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/selectable-search-input': major
+---
+
+pass down `components` props so that users can pass in custom select features

--- a/packages/components/inputs/selectable-search-input/src/selectable-search-input.tsx
+++ b/packages/components/inputs/selectable-search-input/src/selectable-search-input.tsx
@@ -221,6 +221,12 @@ export type TSelectableSearchInputProps = {
    * eg: inputDataProps={[{ 'prop-1': 'value-1' }, { 'prop-2': 'value-2' }]}
    */
   inputDataProps?: Record<string, string>;
+  /**
+   * Map of components to overwrite the default ones, see what components you can override
+   * <br/>
+   * [Props from React select was used](https://react-select.com/props)
+   */
+  components?: ReactSelectProps['components'];
 };
 
 const defaultProps: Pick<
@@ -447,6 +453,11 @@ const SelectableSearchInput = (props: TSelectableSearchInputProps) => {
             textInputRef={textInputRef}
             selectedOption={selectedOption}
             dataProps={transformedSelectDataProps}
+            components={
+              {
+                ...props.components,
+              } as ReactSelectProps['components']
+            }
           />
         </Constraints.Horizontal>
         <div

--- a/packages/components/inputs/selectable-search-input/src/selectable-select.tsx
+++ b/packages/components/inputs/selectable-search-input/src/selectable-select.tsx
@@ -69,6 +69,7 @@ const SelectableSelect = (props: TSelectableSelect) => {
           />
         ),
         DropdownIndicator,
+        ...props.components,
       }}
       options={props.options}
       menuIsOpen={props.isReadOnly ? false : undefined}


### PR DESCRIPTION
#### Summary

Make components prop from react-select available in the selectable-search-input components so users can customise the dropdown features to their taste.