### PR TITLE
fix(create-select-styles): preserve default behavior for multi select

### DIFF
--- a/.changeset/forty-tips-deny.md
+++ b/.changeset/forty-tips-deny.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/select-utils': patch
+---
+
+Allow select inputs with multiple items to wrap.

--- a/packages/components/inputs/select-utils/src/create-select-styles.ts
+++ b/packages/components/inputs/select-utils/src/create-select-styles.ts
@@ -372,7 +372,7 @@ const placeholderStyles = (props: TProps) => (base: TBase) => {
 const valueContainerStyles = (props: TProps) => (base: TBase) => {
   return {
     ...base,
-    flexWrap: 'nowrap',
+    ...(!props.isMulti && { flexWrap: 'nowrap' }),
     padding: '0',
     backgroundColor: 'none',
     overflow: 'hidden',


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

<!-- provide a short summary of your changes -->
We should preserve default wrap behaviour for multi selection.
See reference for an example: https://github.com/commercetools/merchant-center-frontend/pull/16911#issuecomment-2144777982

nowrap should be added only when select input is not multi to keep the left icon wrapping fix.   

## Description

<!-- provide some context -->
