### PR TITLE
Set `glob-parent` dependency minimum version

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "@typescript-eslint/eslint-plugin": "6.21.0",
     "@typescript-eslint/parser": "6.21.0",
     "core-js-compat": "^3.23.4",
+    "glob-parent": "^5.1.2",
     "minimatch": "^3.0.5",
     "json5": "^2.0.0",
     "react-from-dom": "0.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12288,30 +12288,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "glob-parent@npm:2.0.0"
-  dependencies:
-    is-glob: ^2.0.0
-  checksum: 734fc461d9d2753dd490dd072df6ce41fe4ebb60e9319b108bc538707b21780af3a61c3961ec2264131fad5d3d9a493e013a775aef11a69ac2f49fd7d8f46457
-  languageName: node
-  linkType: hard
-
-"glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
+"glob-parent@npm:^5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
     is-glob: ^4.0.1
   checksum: f4f2bfe2425296e8a47e36864e4f42be38a996db40420fe434565e4480e3322f18eb37589617a98640c5dc8fdec1a387007ee18dbb1f3f5553409c34d17f425e
-  languageName: node
-  linkType: hard
-
-"glob-parent@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "glob-parent@npm:6.0.2"
-  dependencies:
-    is-glob: ^4.0.3
-  checksum: c13ee97978bef4f55106b71e66428eb1512e71a7466ba49025fc2aec59a5bfb0954d5abd58fc5ee6c9b076eef4e1f6d3375c2e964b88466ca390da4419a786a8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Summary

Set `glob-parent` dependency minimum version

## Description

This is due to this security alert about that dependency having a [vulnerability](https://github.com/commercetools/ui-kit/security/dependabot/16).

This is a transitive dependency coming from the `@preconstruct/cli` which we already have in its latest version so that's why I added a new resolution to make sure it also uses the minimum version.
Building seems to work as well, so all good.
