### PR TITLE
feat(data table manager): fix data table manager scroll issue

### DIFF
--- a/.changeset/quiet-eagles-enjoy.md
+++ b/.changeset/quiet-eagles-enjoy.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-uikit/data-table': minor
+---
+
+When there is a horizontally long table that requires scrolling.
+The user should be able to horizontally scroll only the table container  without any other element of view scrolling along.

--- a/packages/components/data-table/src/data-table.styles.tsx
+++ b/packages/components/data-table/src/data-table.styles.tsx
@@ -55,7 +55,7 @@ const TableContainer = styled.div<TTableContainer>`
 
   ${(props) =>
     // this is needed in order to have a sticky header
-    props.maxHeight ? `overflow-x: auto;` : ''}
+    props.maxHeight ? `overflow-x: auto;` : 'overflow-x: scroll;'}
 
   ${(props) =>
     props.maxWidth && !props.disableSelfContainment


### PR DESCRIPTION
When there is a horizontally long table that requires scrolling,
The user should be able to horizontally scroll only the table container  without any other element of view scrolling along.

<img width="1105" alt="image" src="https://github.com/commercetools/ui-kit/assets/19975842/6fa224bc-7033-4396-8e2d-6198ac26a060">