### PR TITLE
chore: get rid of excess ';' character

### DIFF
--- a/docs/.storybook/manager-head.html
+++ b/docs/.storybook/manager-head.html
@@ -1,4 +1,4 @@
-<script>document.title = "UI Kit";</script>;
+<script>document.title = "UI Kit";</script>
 <script>
   function injectScript(url, attributes = {}, onLoad) {
     var tag = document.createElement('script');


### PR DESCRIPTION
![Screenshot 2024-07-22 at 14 18 44](https://github.com/user-attachments/assets/a135b0d8-7de1-46be-8666-770b80854c16)

Somehow an excess `;` character was overseen by all of us and is (was) messing with the layout.