### PR TITLE
fix(Text.Detail): forward `id` prop when `as` prop is not defined

### DIFF
--- a/.changeset/cool-gorillas-bow.md
+++ b/.changeset/cool-gorillas-bow.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/text': patch
+---
+
+`Detail` forwards `id` prop to its underlying element when `as` prop is not defined

--- a/packages/components/text/src/text.tsx
+++ b/packages/components/text/src/text.tsx
@@ -260,6 +260,7 @@ const Detail = (props: TDetailProps) => {
 
   return (
     <div
+      id={props.id}
       css={detailStyles(props)}
       title={props.title}
       aria-labelledby={props['aria-labelledby']}


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

Closes https://github.com/commercetools/ui-kit/issues/2867

#### Summary

<!-- provide a short summary of your changes -->
Forwards `Text.Detail` `id` prop in all circumstances.

## Description

<!-- provide some context -->
See full context in https://github.com/commercetools/ui-kit/issues/2867
