### PR TITLE
Storybook v8 stories batch 1

### DIFF
--- a/packages/components/avatar/src/avatar.readme.mdx
+++ b/packages/components/avatar/src/avatar.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/Avatar/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/avatar/src/avatar.stories.tsx
+++ b/packages/components/avatar/src/avatar.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Avatar from './avatar';
+import { iconArgType } from '@/storybook-helpers';
+
+const meta: Meta<typeof Avatar> = {
+  title: 'components/Avatar',
+  component: Avatar,
+  argTypes: {
+    icon: iconArgType,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Avatar>;
+
+export const BasicExample: Story = {
+  args: {
+    firstName: 'John',
+    lastName: 'Doe',
+    size: 'm',
+  },
+};

--- a/packages/components/buttons/flat-button/src/flat-button.readme.mdx
+++ b/packages/components/buttons/flat-button/src/flat-button.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/Buttons/FlatButton/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/buttons/flat-button/src/flat-button.stories.tsx
+++ b/packages/components/buttons/flat-button/src/flat-button.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import FlatButton from './flat-button';
+import { iconArgType } from '@/storybook-helpers';
+
+const meta: Meta<typeof FlatButton> = {
+  title: 'components/Buttons/FlatButton',
+  component: FlatButton,
+  argTypes: {
+    icon: iconArgType,
+    as: {
+      control: 'text',
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof FlatButton>;
+
+export const BasicExample: Story = {
+  args: {
+    tone: 'primary',
+    label: 'A label text',
+    onClick: () => alert('Button clicked'),
+    isDisabled: false,
+  },
+};

--- a/packages/components/buttons/icon-button/src/icon-button.readme.mdx
+++ b/packages/components/buttons/icon-button/src/icon-button.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/Buttons/IconButton/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/buttons/icon-button/src/icon-button.stories.tsx
+++ b/packages/components/buttons/icon-button/src/icon-button.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import IconButton from './icon-button';
+import { iconArgType } from '@/storybook-helpers';
+import { InformationIcon } from '@commercetools-uikit/icons';
+
+const meta: Meta<typeof IconButton> = {
+  title: 'components/Buttons/IconButton',
+  component: IconButton,
+  argTypes: {
+    as: {
+      control: 'text',
+    },
+    icon: iconArgType,
+    size: {
+      control: 'select',
+      options: ['10', '20', '30', '40'],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof IconButton>;
+
+export const BasicExample: Story = {
+  args: {
+    icon: <InformationIcon />,
+    label: 'A mandatory label for screenreaders',
+    onClick: () => alert('Button clicked'),
+  },
+};

--- a/packages/components/buttons/link-button/src/link-button.readme.mdx
+++ b/packages/components/buttons/link-button/src/link-button.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/Buttons/LinkButton/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/buttons/primary-button/src/primary-button.readme.mdx
+++ b/packages/components/buttons/primary-button/src/primary-button.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/Buttons/PrimaryButton/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/buttons/primary-button/src/primary-button.stories.tsx
+++ b/packages/components/buttons/primary-button/src/primary-button.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import PrimaryButton from './primary-button';
+import { iconArgType } from '@/storybook-helpers';
+
+const meta: Meta<typeof PrimaryButton> = {
+  title: 'components/Buttons/PrimaryButton',
+  component: PrimaryButton,
+  argTypes: {
+    as: {
+      control: 'text',
+    },
+    iconLeft: iconArgType,
+    size: {
+      control: 'select',
+      options: ['10', '20'],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof PrimaryButton>;
+
+export const BasicExample: Story = {
+  args: {
+    label: 'Button Label Text',
+    iconLeft: 'AngleDownIcon',
+  },
+};

--- a/packages/components/buttons/secondary-button/src/secondary-button.readme.mdx
+++ b/packages/components/buttons/secondary-button/src/secondary-button.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/Buttons/SecondaryButton/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/buttons/secondary-button/src/secondary-button.stories.tsx
+++ b/packages/components/buttons/secondary-button/src/secondary-button.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SecondaryButton from './secondary-button';
+import { iconArgType } from '@/storybook-helpers';
+
+const meta: Meta<typeof SecondaryButton> = {
+  title: 'components/Buttons/SecondaryButton',
+  component: SecondaryButton,
+  argTypes: {
+    iconLeft: iconArgType,
+    as: {
+      control: 'text',
+    },
+    size: {
+      control: 'select',
+      options: ['10', '20'],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SecondaryButton>;
+
+export const BasicExample: Story = {
+  args: {
+    label: 'Button Label Text',
+    iconLeft: 'AngleDownIcon',
+  },
+};

--- a/packages/components/buttons/secondary-icon-button/src/secondary-icon-button.readme.mdx
+++ b/packages/components/buttons/secondary-icon-button/src/secondary-icon-button.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/Buttons/SecondaryIconButton/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/buttons/secondary-icon-button/src/secondary-icon-button.stories.tsx
+++ b/packages/components/buttons/secondary-icon-button/src/secondary-icon-button.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SecondaryIconButton from './secondary-icon-button';
+import { iconArgType } from '@/storybook-helpers';
+
+const meta: Meta<typeof SecondaryIconButton> = {
+  title: 'components/Buttons/SecondaryIconButton',
+  component: SecondaryIconButton,
+  argTypes: {
+    as: {
+      control: 'text',
+    },
+    icon: iconArgType,
+    size: {
+      control: 'select',
+      options: ['10', '20', '30', '40'],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SecondaryIconButton>;
+
+export const BasicExample: Story = {
+  args: {
+    icon: 'AngleDownIcon',
+    label: 'Descriptive mandatory label',
+  },
+};

--- a/packages/components/card/src/card.readme.mdx
+++ b/packages/components/card/src/card.readme.mdx
@@ -1,0 +1,7 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+import Changelog from './../CHANGELOG.md?raw';
+
+<Meta title="components/Card/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/card/src/card.stories.tsx
+++ b/packages/components/card/src/card.stories.tsx
@@ -1,0 +1,33 @@
+import type { ComponentProps } from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+
+import Card from './card';
+import { BrowserRouter as Router } from 'react-router-dom';
+
+type CardProps = ComponentProps<typeof Card>;
+
+const meta: Meta<CardProps> = {
+  title: 'components/Card',
+  component: Card,
+  argTypes: {
+    to: {
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+
+export const BasicExample: StoryFn<CardProps> = (args) => {
+  return (
+    <Router>
+      <Card {...args} />
+    </Router>
+  );
+};
+
+BasicExample.args = {
+  children:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  onClick: undefined,
+};

--- a/packages/components/collapsible-motion/src/collapsible-motion.readme.mdx
+++ b/packages/components/collapsible-motion/src/collapsible-motion.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/Panels/CollapsibleMotion/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/collapsible-motion/src/collapsible-motion.stories.tsx
+++ b/packages/components/collapsible-motion/src/collapsible-motion.stories.tsx
@@ -1,0 +1,115 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+import CollapsibleMotion from './collapsible-motion';
+import PrimaryButton from '@commercetools-uikit/primary-button';
+
+type CollapsibleMotionProps = ComponentProps<typeof CollapsibleMotion>;
+
+const meta: Meta<CollapsibleMotionProps> = {
+  title: 'components/Panels/CollapsibleMotion',
+  component: CollapsibleMotion,
+};
+export default meta;
+
+export const BasicExample: StoryFn<CollapsibleMotionProps> = (args) => {
+  const [open, setOpen] = useState<boolean>(true);
+
+  return (
+    <div style={{ height: 640 }}>
+      <div style={{ display: 'flex', marginBottom: '4em' }}>
+        <div style={{ width: 200, marginRight: '2em', flexShrink: 0 }}>
+          <h1>Uncontrolled Example</h1>
+          <br />
+          <p>
+            <code>{`<CollapsibleMotion/>`}</code> is taking care of its
+            open/closed-state.
+          </p>
+        </div>
+        <div>
+          <CollapsibleMotion {...args}>
+            {({ isOpen, toggle, containerStyles, registerContentNode }) => (
+              <div>
+                <PrimaryButton
+                  data-testid="button"
+                  onClick={toggle}
+                  label={isOpen ? 'Close' : 'Open'}
+                />
+
+                <hr />
+                <div data-testid="container-node" style={containerStyles}>
+                  <div data-testid="content-node" ref={registerContentNode}>
+                    <h2>CollapsibleMotion</h2>
+                    <p>
+                      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                      Sed ac purus eget justo aliquam suscipit. Nullam nec metus
+                      vestibulum, vehicula mi nec, ultricies sapien. Donec
+                      sollicitudin, metus et lacinia tincidunt, ante neque
+                      cursus lorem, nec varius nunc nunc id turpis. Sed auctor,
+                      eros at lacinia lacinia, erat felis ultricies magna, nec
+                      suscipit libero purus vel purus. Nullam in nunc nec nunc
+                      ultricies dictum. Sed nec lacinia mi. Nullam ac nunc nec
+                      nunc sollicitudin.
+                    </p>
+                  </div>
+                </div>
+                <hr />
+                <div>
+                  I am content that is displayed below the collapsible stuff.
+                </div>
+              </div>
+            )}
+          </CollapsibleMotion>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex' }}>
+        <div style={{ width: 200, marginRight: '2em', flexShrink: 0 }}>
+          <h1>Controlled Example</h1>
+          <br />
+          <p>
+            <code>{`<CollapsibleMotion/>`}</code>
+            {`'s`} closed state is controlled via the <code>isClosed</code>{' '}
+            property.
+          </p>
+          <br />
+          <p>
+            <PrimaryButton
+              data-testid="button"
+              onClick={() => setOpen(!open)}
+              label={open ? 'Close' : 'Open'}
+            />
+          </p>
+        </div>
+        <div>
+          <CollapsibleMotion isClosed={!open}>
+            {({ containerStyles, registerContentNode }) => (
+              <div>
+                <div data-testid="container-node" style={containerStyles}>
+                  <div data-testid="content-node" ref={registerContentNode}>
+                    <h2>CollapsibleMotion</h2>
+                    <p>
+                      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                      Sed ac purus eget justo aliquam suscipit. Nullam nec metus
+                      vestibulum, vehicula mi nec, ultricies sapien. Donec
+                      sollicitudin, metus et lacinia tincidunt, ante neque
+                      cursus lorem, nec varius nunc nunc id turpis. Sed auctor,
+                      eros at lacinia lacinia, erat felis ultricies magna, nec
+                      suscipit libero purus vel purus. Nullam in nunc nec nunc
+                      ultricies dictum. Sed nec lacinia mi. Nullam ac nunc nec
+                      nunc sollicitudin.
+                    </p>
+                  </div>
+                </div>
+                <hr />
+                <div>
+                  I am content that is displayed below the collapsible stuff.
+                </div>
+              </div>
+            )}
+          </CollapsibleMotion>
+        </div>
+      </div>
+      <hr />
+    </div>
+  );
+};

--- a/packages/components/collapsible-panel/src/collapsible-panel.readme.mdx
+++ b/packages/components/collapsible-panel/src/collapsible-panel.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/Panels/CollapsiblePanel/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/collapsible-panel/src/collapsible-panel.stories.tsx
+++ b/packages/components/collapsible-panel/src/collapsible-panel.stories.tsx
@@ -1,0 +1,59 @@
+import { type ComponentProps } from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+import CollapsiblePanel from './collapsible-panel';
+import CollapsiblePanelHeader from './collapsible-panel-header';
+
+type CollapsiblePanelProps = ComponentProps<typeof CollapsiblePanel>;
+
+const meta: Meta<CollapsiblePanelProps> = {
+  title: 'components/Panels/CollapsiblePanel',
+  component: CollapsiblePanel,
+  argTypes: {
+    header: {
+      control: 'text',
+    },
+    secondaryHeader: {
+      control: 'text',
+    },
+    headerControls: {
+      control: 'text',
+    },
+  },
+};
+export default meta;
+
+export const BasicExample: StoryFn<CollapsiblePanelProps> = ({
+  condensed,
+  header,
+  ...args
+}) => {
+  return (
+    <CollapsiblePanel
+      condensed={condensed}
+      header={
+        condensed ? (
+          header
+        ) : (
+          <CollapsiblePanelHeader>{header}</CollapsiblePanelHeader>
+        )
+      }
+      {...args}
+    />
+  );
+};
+
+BasicExample.args = {
+  id: '12345',
+  description: 'Description',
+  header: 'Header',
+  secondaryHeader: 'Subtitle',
+  isSticky: false,
+  isDisabled: false,
+  tone: 'primary',
+  condensed: false,
+  hideExpansionControls: false,
+  isClosed: undefined,
+  headerControls: 'Here you can place controls',
+  theme: 'light',
+  children: 'Content',
+};

--- a/packages/components/constraints/src/helpers.ts
+++ b/packages/components/constraints/src/helpers.ts
@@ -1,4 +1,5 @@
 import { designTokens } from '@commercetools-uikit/design-system';
+import { TMaxProp } from './horizontal';
 
 type TDesignTokenName = keyof typeof designTokens;
 
@@ -18,7 +19,7 @@ const getAcceptedMaxPropValues = (min = 1, max = 16) => {
     ...Array.from({ length: max - min + 1 }).map((_, index) => index + min),
     'scale',
     'auto',
-  ];
+  ] as TMaxProp[];
 };
 
 export { getMaxPropTokenValue, getAcceptedMaxPropValues };

--- a/packages/components/constraints/src/horizontal/horizontal.readme.mdx
+++ b/packages/components/constraints/src/horizontal/horizontal.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../../README.md?raw';
+
+<Meta title="layout/Constraints/Horizontal/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/constraints/src/horizontal/horizontal.stories.tsx
+++ b/packages/components/constraints/src/horizontal/horizontal.stories.tsx
@@ -1,0 +1,102 @@
+import type { ComponentProps } from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+import Constraints from './../index';
+import styled from '@emotion/styled';
+import { designTokens } from '@commercetools-uikit/design-system';
+import { getAcceptedMaxPropValues, getMaxPropTokenValue } from '../helpers';
+
+type ConstraintsHorizontalProps = ComponentProps<typeof Constraints.Horizontal>;
+
+const meta: Meta<ConstraintsHorizontalProps> = {
+  title: 'layout/Constraints/Horizontal',
+  component: Constraints.Horizontal,
+};
+export default meta;
+
+const ColouredRow = styled.div`
+  display: flex;
+  padding: 2px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border-radius: ${designTokens.borderRadius6};
+  color: ${designTokens.colorSurface};
+  background-color: ${designTokens.colorPrimary};
+`;
+
+const Stack = styled.div`
+  > * + * {
+    margin: 8px 0 0;
+  }
+`;
+
+const Wrapper = styled.div`
+  position: relative;
+  padding-top: ${designTokens.spacing50};
+`;
+
+const ColumnsContainer = styled.div`
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  white-space: nowrap;
+`;
+const Column = styled.div`
+  display: inline-block;
+  width: ${designTokens.constraint2};
+  margin-right: ${designTokens.spacing30};
+  height: 100%;
+  text-align: center;
+  background-color: rgba(241, 109, 14, 0.3);
+`;
+
+const Outlined = styled.div`
+  outline: 1px solid tomato;
+`;
+
+/**
+ * At it's most basic usage, this component accepts a `max` prop which limits the width that is available to its children
+ */
+export const BasicExample: StoryFn<ConstraintsHorizontalProps> = (args) => {
+  return (
+    <Constraints.Horizontal {...args}>
+      <Outlined>
+        The {`<Constraints.Horizontal/>`} component limits my width
+      </Outlined>
+    </Constraints.Horizontal>
+  );
+};
+
+BasicExample.args = {
+  max: 6,
+};
+
+/**
+ * This story demos the different values that can be passed to the `max` prop
+ */
+export const VisualizeConstraints: StoryFn<ConstraintsHorizontalProps> = () => {
+  const values = getAcceptedMaxPropValues();
+
+  return (
+    <Wrapper>
+      <ColumnsContainer>
+        {Array.from({ length: 8 }).map((_, index) => (
+          <Column key={index}>{`Column ${index + 1}`}</Column>
+        ))}
+      </ColumnsContainer>
+      <Stack>
+        {values.map((max) => (
+          <Constraints.Horizontal key={max} max={max}>
+            <ColouredRow>
+              <b>{max.toString()}</b>
+              {typeof max === 'number' ? (
+                <small>{`${getMaxPropTokenValue(max)}`}</small>
+              ) : null}
+            </ColouredRow>
+          </Constraints.Horizontal>
+        ))}
+      </Stack>
+    </Wrapper>
+  );
+};

--- a/packages/components/dropdowns/dropdown-menu/src/dropdown-menu.readme.mdx
+++ b/packages/components/dropdowns/dropdown-menu/src/dropdown-menu.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/Dropdowns/DropdownMenu/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/dropdowns/dropdown-menu/src/dropdown-menu.stories.tsx
+++ b/packages/components/dropdowns/dropdown-menu/src/dropdown-menu.stories.tsx
@@ -1,0 +1,217 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import DropdownMenu from './dropdown-menu';
+import { SecondaryButton, IconButton } from '@commercetools-uikit/buttons';
+import { ColumnsIcon, FilterIcon } from '@commercetools-uikit/icons';
+import Constraints from '@commercetools-uikit/constraints/src';
+import SpacingsStack from '@commercetools-uikit/spacings-stack';
+import SpacingsInline from '@commercetools-uikit/spacings-inline';
+import SelectInput from '@commercetools-uikit/select-input';
+import Text from '@commercetools-uikit/text';
+import { useState } from 'react';
+import CheckboxInput from '@commercetools-uikit//checkbox-input';
+
+const meta: Meta<typeof DropdownMenu> = {
+  title: 'components/Dropdowns/DropdownMenu',
+  component: DropdownMenu,
+  subcomponents: {
+    /**
+     * todo: remove once sb fixed the following issue
+     * @link https://github.com/storybookjs/storybook/issues/23170
+     */
+    // @ts-ignore
+    'DropdownMenu.ListMenuItem': DropdownMenu.ListMenuItem,
+  } as const,
+  argTypes: {
+    menuHorizontalConstraint: {
+      control: {
+        type: 'select',
+      },
+      options: Constraints.getAcceptedMaxPropValues(),
+    },
+    triggerElement: {
+      control: 'text',
+    },
+  },
+};
+export default meta;
+
+type Story = StoryFn<typeof DropdownMenu>;
+
+export const BasicExample: Story = ({ triggerElement, ...args }) => {
+  return (
+    <div
+      style={{
+        height: 256,
+        position: 'relative',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <DropdownMenu
+        triggerElement={
+          triggerElement || <IconButton icon={<ColumnsIcon />} label="list" />
+        }
+        menuPosition="left"
+        menuType="list"
+        {...args}
+      >
+        <DropdownMenu.ListMenuItem onClick={() => {}}>
+          Option 1
+        </DropdownMenu.ListMenuItem>
+        <DropdownMenu.ListMenuItem onClick={() => {}} isDisabled>
+          Option 2
+        </DropdownMenu.ListMenuItem>
+        <DropdownMenu.ListMenuItem onClick={() => {}}>
+          Option 3
+        </DropdownMenu.ListMenuItem>
+      </DropdownMenu>
+    </div>
+  );
+};
+
+type SelectValueType = string | string[] | null | undefined;
+
+/**
+ * The `DrodwnMenu` component can display complex content, such as form elements.
+ */
+export const ComplexMenuContent: Story = ({ triggerElement, ...args }) => {
+  const selectValueOptions = [
+    { value: 'is', label: 'is' },
+    { value: 'is not', label: 'is not' },
+  ];
+  const [selectValue, setSelectValue] = useState<SelectValueType>(
+    selectValueOptions[0].value
+  );
+
+  const select2ValueOptions = [
+    { value: 'laval', label: 'Laval Montreal' },
+    { value: 'forest', label: 'Forest Ottawa' },
+    { value: 'squirrel', label: 'Squirrel Whistler' },
+  ];
+
+  const [select2Value, setSelect2Value] = useState<SelectValueType>(
+    selectValueOptions[0].value
+  );
+
+  const [isChecked, setIsChecked] = useState<boolean>(true);
+
+  return (
+    <div
+      style={{
+        height: 256,
+        position: 'relative',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <DropdownMenu
+        triggerElement={
+          triggerElement || (
+            <SecondaryButton label="Filters" iconLeft={<FilterIcon />} />
+          )
+        }
+        {...args}
+      >
+        <SpacingsStack scale="m">
+          <SpacingsInline scale="s" alignItems="center">
+            <Text.Body>Store</Text.Body>
+            <SelectInput
+              appearance="quiet"
+              value={selectValue}
+              menuPortalTarget={document.body}
+              menuPortalZIndex={5}
+              onChange={(event) => setSelectValue(event.target.value)}
+              options={selectValueOptions}
+            />
+          </SpacingsInline>
+          <SelectInput
+            value={select2Value}
+            onChange={(event) => setSelect2Value(event.target.value)}
+            menuPortalTarget={document.body}
+            menuPortalZIndex={5}
+            options={select2ValueOptions}
+            placeholder="Select or type store key"
+          />
+          <CheckboxInput
+            isChecked={isChecked}
+            value="store"
+            onChange={(event) => setIsChecked(event.target.checked)}
+          >
+            Canada (FR)
+          </CheckboxInput>
+        </SpacingsStack>
+      </DropdownMenu>
+    </div>
+  );
+};
+
+ComplexMenuContent.args = {
+  menuType: 'default',
+};
+
+/**
+ * If there is not enough space to show the `DrodwnMenu` in the desired position,
+ * it will automatically adjust its position to fit in the available space.
+ */
+export const AutoAdjustPositions: Story = ({ triggerElement, ...args }) => {
+  return (
+    <div style={{ position: 'relative', height: 256, zIndex: 2 }}>
+      {[
+        {
+          id: 1,
+          position: 'absolute' as const,
+          top: 24,
+          left: 24,
+        },
+        {
+          id: 2,
+          position: 'absolute' as const,
+          top: 24,
+          right: 24,
+        },
+        {
+          id: 3,
+          position: 'absolute' as const,
+          bottom: 24,
+          right: 24,
+        },
+        {
+          id: 4,
+          position: 'absolute' as const,
+          bottom: 24,
+          left: 24,
+        },
+        {
+          id: 5,
+          position: 'absolute' as const,
+          top: '50%',
+          left: '50%',
+        },
+      ].map(({ id, ...css }) => (
+        <div key={id} style={{ ...css }}>
+          <DropdownMenu
+            triggerElement={
+              triggerElement || (
+                <IconButton icon={<ColumnsIcon />} label="list" />
+              )
+            }
+            {...args}
+          >
+            {new Array(5).fill('').map((_, index) => (
+              <DropdownMenu.ListMenuItem key={index}>{`Pick this option ${
+                index + 1
+              }`}</DropdownMenu.ListMenuItem>
+            ))}
+          </DropdownMenu>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+AutoAdjustPositions.args = {
+  menuType: 'list',
+  menuHorizontalConstraint: 10,
+};

--- a/storybook/.storybook/preview-head.html
+++ b/storybook/.storybook/preview-head.html
@@ -19,4 +19,10 @@
   .sbdocs-content table[class*="TableGrid"] {
     margin: 0;
   }
+
+  /** add a good old-fashioned underline to links in markdown-content, even when they are inside code elements */
+  .sbdocs-content .sbdocs-a,
+  .sbdocs-content .sbdocs-a code {
+    text-decoration: underline;
+  }
 </style>


### PR DESCRIPTION
## Background
In an effort to switch from Storybook v5 to Storybook v8, the existing stories had to be migrated to a new storybook-format and converted to typescript. 

This pull-request is [part of a batch](https://github.com/commercetools/ui-kit/pull/2875). It contains the typescript-equivalents of existing storybook v5 stories and aims to replicate the same functionality / value. 

## Goal
Feature parity between v8 and v5 storybook. After merging all batches, a product developer who looked at the storybook v5 version yesterday, should be able to look at the v8 version tomorrow and be as productive (or more productive) as before. 

## Review instructions
A thorough **code review** is not required yet. The code was either copied from the existing js-equivalent or quickly written from scratch to replicate what was already there to fit the new story-format. It is expected that those stories contain typescript errors, introduced by the conversion or previously existing. (Another pull-request will take care of those issues at a later stage).

What is expect is a **story review**:

You will need to compare the v5 with the v8 storybook (ideally side-by-side) and make sure that every component in this pull-request has:

- [ ] a readme-file in the same or a parent-folder
- [ ] a props-table displaying available props (and appropriate inputs for them)
- [ ] one or more stories that showcase the same or more functionality as the v5 equivalent

You will find the links to the different storybooks below. 


> If something is missing or irritating, add a comment to the source file here in the pull-request to start a conversation.


