### PR TITLE
Storybook v8 stories batch 2

### DIFF
--- a/packages/components/data-table-manager/src/data-table-manager.readme.mdx
+++ b/packages/components/data-table-manager/src/data-table-manager.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/DataTable/DataTableManager/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/data-table-manager/src/data-table-manager.stories.tsx
+++ b/packages/components/data-table-manager/src/data-table-manager.stories.tsx
@@ -1,0 +1,412 @@
+// @ts-expect-error
+import type { Meta, StoryFn } from '@storybook/react';
+import DataTable from './../../data-table';
+import DataTableManager from './index';
+import { useState } from 'react';
+import times from 'lodash/times';
+import PrimaryButton from '@commercetools-uikit/primary-button';
+import SecondaryButton from '@commercetools-uikit/secondary-button';
+import { useSorting } from '@commercetools-uikit/hooks';
+import { UPDATE_ACTIONS } from './constants';
+import { DataTableManagerProvider } from '@commercetools-uikit/data-table-manager/data-table-manager-provider';
+import Spacings from '@commercetools-uikit/spacings';
+import SearchTextInput from '@commercetools-uikit/search-text-input';
+
+const meta: Meta<typeof DataTableManager> = {
+  title: 'components/DataTable/DataTableManager',
+  component: DataTableManager,
+  argTypes: {
+    topBar: {
+      control: 'text',
+    },
+  },
+};
+export default meta;
+
+type Story = StoryFn<typeof DataTableManager>;
+
+const items = [
+  {
+    id: '5e188c29791747d9c54250e2',
+    name: 'Morgan Bean',
+    customRenderer: 'CYCLONICA',
+    phone: '+1 (895) 529-3300',
+    age: 23,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+  {
+    id: '5e188c295ae0bb19afbb115f',
+    name: 'Franklin Cochran',
+    customRenderer: 'TINGLES',
+    phone: '+1 (835) 571-3268',
+    age: 36,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+  {
+    id: '5e188c298f0ea901553c517f',
+    name: 'Salazar Craig',
+    customRenderer: 'ECRAZE',
+    phone: '+1 (944) 445-2594',
+    age: 21,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+  {
+    id: '5e188c29b09bb748df833ed0',
+    name: 'Pamela Noble',
+    customRenderer: 'FILODYNE',
+    phone: '+1 (875) 421-3328',
+    age: 34,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+  {
+    id: '5e188c29bc14e3b97ab2ad7d',
+    name: 'Terra Morrow',
+    customRenderer: 'DAISU',
+    phone: '+1 (807) 436-2026',
+    age: 30,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+  {
+    id: '5e188c296c9b7cf486a0479c',
+    name: 'Cline Hansen',
+    customRenderer: 'ULTRIMAX',
+    phone: '+1 (934) 402-3675',
+    age: 21,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+  {
+    id: '5e188c29b45c669d8e60303f',
+    name: 'Jefferson Rosario',
+    customRenderer: 'COMTOURS',
+    phone: '+1 (874) 437-2581',
+    age: 32,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+  {
+    id: '5e188c29ca865647af147b4a',
+    name: 'Tania Waller',
+    customRenderer: 'DOGSPA',
+    phone: '+1 (964) 585-3040',
+    age: 35,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+  {
+    id: '5e188c2910b83f907e9c66ab',
+    name: 'Butler Shepard',
+    customRenderer: 'HOUSEDOWN',
+    phone: '+1 (888) 434-2153',
+    age: 21,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+  {
+    id: '5e188c29a9ece9123d6a87a1',
+    name: 'Diana Wise',
+    customRenderer: 'SPEEDBOLT',
+    phone: '+1 (992) 535-2912',
+    age: 27,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+];
+
+const FooterPrimaryButton = () => (
+  <PrimaryButton
+    onClick={() => alert('This primary actions has been clicked!')}
+    label="Primary action"
+  />
+);
+
+const FooterSecondaryButton = () => (
+  <SecondaryButton
+    onClick={() => alert('This secondary actions has been clicked!')}
+    label="Secondary action"
+  />
+);
+
+const initialHiddenColumns = times(3, (num) => ({
+  key: `extra_${num + 1}`,
+  label: `Extra ${num + 1}`,
+  renderItem: () => `Extra content ${num + 1}`,
+}));
+
+const initialVisibleColumns = [
+  {
+    key: 'name',
+    label: 'Name',
+    isSortable: true,
+  },
+  {
+    key: 'customRenderer',
+    label: 'Custom Column',
+    // @ts-expect-error
+    renderItem: (row) => (
+      <a href="https://uikit.commercetools.com/">{row.customRenderer}</a>
+    ),
+  },
+  {
+    key: 'phone',
+    label: 'Phone',
+    shouldIgnoreRowClick: true,
+  },
+  {
+    key: 'age',
+    label: 'Age',
+    align: 'center',
+    isSortable: true,
+  },
+  {
+    key: 'about',
+    label: 'About',
+    width: 'minmax(150px, auto)',
+  },
+];
+
+const initialColumnsState = [...initialVisibleColumns, ...initialHiddenColumns];
+
+// @ts-expect-error
+export const BasicExample: Story = (args) => {
+  const [tableData, setTableData] = useState({
+    columns: initialColumnsState,
+    visibleColumnKeys: initialVisibleColumns.map(({ key }) => key),
+  });
+
+  const [isCondensed, setIsCondensed] = useState(true);
+  const [isWrappingText, setIsWrappingText] = useState(false);
+
+  const {
+    items: rows,
+    sortedBy,
+    sortDirection,
+    onSortChange,
+  } = useSorting(items);
+
+  const showDisplaySettingsConfirmationButtons = false;
+  const showColumnManagerConfirmationButtons = false;
+
+  const mappedColumns = tableData.columns.reduce(
+    (columns, column) => ({
+      ...columns,
+      [column.key]: column,
+    }),
+    {}
+  );
+  const visibleColumns = tableData.visibleColumnKeys.map(
+    // @ts-expect-error
+    (columnKey) => mappedColumns[columnKey]
+  );
+
+  const tableSettingsChangeHandler = {
+    // @ts-expect-error
+    [UPDATE_ACTIONS.COLUMNS_UPDATE]: (visibleColumnKeys) =>
+      setTableData({
+        ...tableData,
+        visibleColumnKeys,
+      }),
+    [UPDATE_ACTIONS.IS_TABLE_CONDENSED_UPDATE]: setIsCondensed,
+    [UPDATE_ACTIONS.IS_TABLE_WRAPPING_TEXT_UPDATE]: setIsWrappingText,
+  };
+
+  const displaySettingsButtons = showDisplaySettingsConfirmationButtons
+    ? {
+        primaryButton: <FooterPrimaryButton />,
+        secondaryButton: <FooterSecondaryButton />,
+      }
+    : {};
+
+  const columnManagerButtons = showColumnManagerConfirmationButtons
+    ? {
+        primaryButton: <FooterPrimaryButton />,
+        secondaryButton: <FooterSecondaryButton />,
+      }
+    : {};
+
+  const displaySettings = {
+    disableDisplaySettings: false,
+    isCondensed,
+    isWrappingText,
+    ...displaySettingsButtons,
+  };
+
+  const columnManager = {
+    areHiddenColumnsSearchable: true,
+    // @ts-expect-error
+    searchHiddenColumns: (searchTerm) => {
+      setTableData({
+        ...tableData,
+        columns: initialColumnsState.filter(
+          (column) =>
+            tableData.visibleColumnKeys.includes(column.key) ||
+            column.label
+              .toLocaleLowerCase()
+              .includes(searchTerm.toLocaleLowerCase())
+        ),
+      });
+    },
+    disableColumnManager: false,
+    visibleColumnKeys: tableData.visibleColumnKeys,
+    hideableColumns: tableData.columns,
+    ...columnManagerButtons,
+  };
+
+  return (
+    <>
+      <DataTableManager
+        {...args}
+        columns={visibleColumns}
+        onSettingsChange={(action, nextValue) => {
+          // @ts-expect-error
+          tableSettingsChangeHandler[action](nextValue);
+        }}
+        columnManager={columnManager}
+        displaySettings={displaySettings}
+      >
+        <DataTable
+          rows={rows}
+          sortedBy={sortedBy}
+          onSortChange={onSortChange}
+          sortDirection={sortDirection}
+        />
+      </DataTableManager>
+    </>
+  );
+};
+
+BasicExample.args = {
+  topBar: 'topBar can display arbitrary ReactNodes',
+  managerTheme: 'light',
+};
+
+/** Use the `DataTableManagerProvider` component if you need to customize the DOM-structure */
+// @ts-expect-error
+export const WithCustomLayout: Story = (args) => {
+  const [tableData, setTableData] = useState({
+    columns: initialColumnsState,
+    visibleColumnKeys: initialVisibleColumns.map(({ key }) => key),
+  });
+
+  const [isCondensed, setIsCondensed] = useState(true);
+  const [isWrappingText, setIsWrappingText] = useState(false);
+
+  const {
+    items: rows,
+    sortedBy,
+    sortDirection,
+    onSortChange,
+  } = useSorting(items);
+
+  const showDisplaySettingsConfirmationButtons = false;
+  const showColumnManagerConfirmationButtons = false;
+
+  const mappedColumns = tableData.columns.reduce(
+    (columns, column) => ({
+      ...columns,
+      [column.key]: column,
+    }),
+    {}
+  );
+  const visibleColumns = tableData.visibleColumnKeys.map(
+    // @ts-expect-error
+    (columnKey) => mappedColumns[columnKey]
+  );
+
+  const tableSettingsChangeHandler = {
+    // @ts-expect-error
+    [UPDATE_ACTIONS.COLUMNS_UPDATE]: (visibleColumnKeys) =>
+      setTableData({
+        ...tableData,
+        visibleColumnKeys,
+      }),
+    [UPDATE_ACTIONS.IS_TABLE_CONDENSED_UPDATE]: setIsCondensed,
+    [UPDATE_ACTIONS.IS_TABLE_WRAPPING_TEXT_UPDATE]: setIsWrappingText,
+  };
+
+  const displaySettingsButtons = showDisplaySettingsConfirmationButtons
+    ? {
+        primaryButton: <FooterPrimaryButton />,
+        secondaryButton: <FooterSecondaryButton />,
+      }
+    : {};
+
+  const columnManagerButtons = showColumnManagerConfirmationButtons
+    ? {
+        primaryButton: <FooterPrimaryButton />,
+        secondaryButton: <FooterSecondaryButton />,
+      }
+    : {};
+
+  const displaySettings = {
+    disableDisplaySettings: false,
+    isCondensed,
+    isWrappingText,
+    ...displaySettingsButtons,
+  };
+
+  const columnManager = {
+    areHiddenColumnsSearchable: true,
+    // @ts-expect-error
+    searchHiddenColumns: (searchTerm) => {
+      setTableData({
+        ...tableData,
+        columns: initialColumnsState.filter(
+          (column) =>
+            tableData.visibleColumnKeys.includes(column.key) ||
+            column.label
+              .toLocaleLowerCase()
+              .includes(searchTerm.toLocaleLowerCase())
+        ),
+      });
+    },
+    disableColumnManager: false,
+    visibleColumnKeys: tableData.visibleColumnKeys,
+    hideableColumns: tableData.columns,
+    ...columnManagerButtons,
+  };
+
+  return (
+    <DataTableManagerProvider
+      columns={visibleColumns}
+      displaySettings={displaySettings}
+      // @ts-expect-error
+      onSettingsChange={(action, nextValue) => {
+        tableSettingsChangeHandler[action](nextValue);
+      }}
+      columnManager={columnManager}
+    >
+      <Spacings.Stack>
+        <header>
+          <Spacings.Inline justifyContent="flex-end">
+            {/* @ts-expect-error */}
+            <DataTableManager />
+          </Spacings.Inline>
+          {/* @ts-expect-error */}
+          <SearchTextInput placeholder="'Dummy search component'" isReadOnly />
+        </header>
+        <main>
+          <DataTable
+            rows={rows}
+            sortedBy={sortedBy}
+            onSortChange={onSortChange}
+            sortDirection={sortDirection}
+          />
+        </main>
+
+        <br />
+        <hr />
+      </Spacings.Stack>
+    </DataTableManagerProvider>
+  );
+};
+
+WithCustomLayout.args = {
+  topBar: 'topBar can display arbitrary ReactNodes',
+  managerTheme: 'light',
+};

--- a/packages/components/data-table/src/data-table.readme.mdx
+++ b/packages/components/data-table/src/data-table.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/DataTable/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/data-table/src/data-table.stories.tsx
+++ b/packages/components/data-table/src/data-table.stories.tsx
@@ -1,0 +1,283 @@
+import { useMemo, useState } from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+import DataTable from './data-table';
+
+import CheckboxInput from '../../inputs/checkbox-input';
+
+import IconButton from '../../buttons/icon-button';
+import { InformationIcon } from '../../icons';
+import Spacings from '@commercetools-uikit/spacings';
+
+const meta: Meta<typeof DataTable> = {
+  title: 'components/DataTable',
+  component: DataTable,
+  argTypes: {
+    maxWidth: { control: 'text' },
+    maxHeight: { control: 'text' },
+  },
+};
+export default meta;
+
+type Story = StoryFn<typeof DataTable>;
+
+type FakeItem = {
+  id: string;
+  name: string;
+  phone: string;
+  age: number;
+  about: string;
+};
+
+const items: FakeItem[] = [
+  {
+    id: '5e188c29791747d9c54250e2',
+    name: 'Morgan Bean',
+    phone: '+1 (895) 529-3300',
+    age: 23,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+  {
+    id: '5e188c295ae0bb19afbb115f',
+    name: 'Franklin Cochran',
+    phone: '+1 (835) 571-3268',
+    age: 36,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+  {
+    id: '5e188c298f0ea901553c517f',
+    name: 'Salazar Craig',
+    phone: '+1 (944) 445-2594',
+    age: 21,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+  {
+    id: '5e188c29b09bb748df833ed0',
+    name: 'Pamela Noble',
+    phone: '+1 (875) 421-3328',
+    age: 34,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+  {
+    id: '5e188c29bc14e3b97ab2ad7d',
+    name: 'Terra Morrow',
+    phone: '+1 (807) 436-2026',
+    age: 30,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+  {
+    id: '5e188c296c9b7cf486a0479c',
+    name: 'Cline Hansen',
+    phone: '+1 (934) 402-3675',
+    age: 21,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+  {
+    id: '5e188c29b45c669d8e60303f',
+    name: 'Jefferson Rosario',
+    phone: '+1 (874) 437-2581',
+    age: 32,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+  {
+    id: '5e188c29ca865647af147b4a',
+    name: 'Tania Waller',
+    phone: '+1 (964) 585-3040',
+    age: 35,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+  {
+    id: '5e188c2910b83f907e9c66ab',
+    name: 'Butler Shepard',
+    phone: '+1 (888) 434-2153',
+    age: 21,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+  {
+    id: '5e188c29a9ece9123d6a87a1',
+    name: 'Diana Wise',
+    phone: '+1 (992) 535-2912',
+    age: 27,
+    about:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
+  },
+];
+
+type SortState = {
+  key: string;
+  dir: 'asc' | 'desc';
+};
+
+type ColumnSize = {
+  key: string;
+  width: number;
+};
+
+/**
+ * This example demonstrates a couple of use cases:
+ * - reacting to row clicks (and ignoring them if necessary)
+ * - allowing and disabling sorting
+ * - fixed width columns (name) & resizable columns (all others)
+ * - custom cell-renderer (linked, callable phone numbers)
+ * - custom footer
+ */
+export const BasicExample: Story = (args) => {
+  const { columns } = args;
+  const [sort, setSort] = useState<SortState>({
+    key: 'name',
+    dir: 'asc',
+  });
+
+  const [columnSizes, setColumnSizes] = useState<ColumnSize[]>([]);
+  const [checkedRowsState, setCheckedRowsState] = useState<
+    Record<string, boolean>
+  >({});
+
+  const rows = useMemo(() => {
+    if (!sort) {
+      return items;
+    }
+
+    const { key, dir } = sort;
+
+    return items.slice().sort((a, b) => {
+      // @ts-expect-error
+      if (a[key] < b[key]) {
+        return dir === 'asc' ? -1 : 1;
+      }
+
+      // @ts-expect-error
+      if (a[key] > b[key]) {
+        return dir === 'asc' ? 1 : -1;
+      }
+
+      return 0;
+    });
+  }, [sort]);
+
+  const tableColumns = useMemo(() => {
+    return [
+      {
+        key: 'checkbox',
+        label: '',
+        // @todo figure out why the following line does not work anymore
+        // label: <CheckboxInput onChange={() => {}} />,
+        shouldIgnoreRowClick: true,
+        align: 'center',
+        // @ts-expect-error
+        renderItem: (row) => (
+          <CheckboxInput
+            isChecked={checkedRowsState[row.id]}
+            onChange={() => {
+              setCheckedRowsState((obj) => ({
+                ...obj,
+                [row.id]: !obj[row.id],
+              }));
+            }}
+          />
+        ),
+        disableResizing: true,
+      },
+      ...columns,
+    ];
+  }, [columns, checkedRowsState]);
+
+  const onSortRequest = (key: SortState['key'], dir: SortState['dir']) => {
+    setSort({ key, dir });
+  };
+
+  return (
+    <>
+      <Spacings.Stack>
+        <DataTable
+          {...args}
+          rows={rows}
+          // @ts-expect-error
+          columns={tableColumns}
+          sortedBy={sort.key}
+          sortDirection={sort.dir}
+          onSortChange={onSortRequest}
+          // @ts-ignore
+          onColumnResized={(sizes) => setColumnSizes([...sizes])}
+        />
+
+        {Object.keys(checkedRowsState).length > 0 && (
+          <div>
+            <hr />
+            Beautiful! You checked some rows! Remember you have to keep track of
+            state yourself, here is a very basic state representation:
+            <pre>{JSON.stringify(checkedRowsState, null, 2)}</pre>
+          </div>
+        )}
+
+        {columnSizes.length > 0 && (
+          <div>
+            <hr />
+            Nice! You resized at least one column. You can use the{' '}
+            <pre style={{ display: 'inline-block' }}>onColumnResized</pre>{' '}
+            callback to react to column width changes (e.g store them in
+            localStorage and apply them to your columns on next visit).:
+            <pre>{JSON.stringify(columnSizes, null, 2)}</pre>
+          </div>
+        )}
+      </Spacings.Stack>
+    </>
+  );
+};
+
+BasicExample.args = {
+  onRowClick: (row) =>
+    alert('Congratulation! You clicked row with ID: ' + row.id),
+  columns: [
+    {
+      key: 'name',
+      label: 'Name',
+      isSortable: true,
+      width: '192px',
+      disableResizing: true,
+    },
+    {
+      key: 'phone',
+      label: 'Phone',
+      isSortable: true,
+      // @ts-ignore
+      renderItem: ({ phone }) => {
+        return <a href={`tel: ${phone}`}>{phone}</a>;
+      },
+      headerIcon: (
+        <IconButton
+          icon={<InformationIcon />}
+          label="Custom Column Information"
+          size="small"
+          onClick={() =>
+            alert(
+              'Check how the `headerIcon` property was used to display this info button and how the `renderItem` transforms the phone-number string into a click- & callable phone-number.'
+            )
+          }
+        />
+      ),
+      shouldIgnoreRowClick: true,
+    },
+    {
+      key: 'age',
+      label: 'Age',
+      isSortable: true,
+      align: 'center',
+    },
+    {
+      key: 'about',
+      label: 'About',
+      isSortable: false,
+      isTruncated: true,
+    },
+  ],
+  footer: <div>Display any React component as footer.</div>,
+};

--- a/packages/components/data-table/src/data-table.stories.tsx
+++ b/packages/components/data-table/src/data-table.stories.tsx
@@ -252,7 +252,7 @@ BasicExample.args = {
       renderItem: ({ phone }) => {
         return <a href={`tel: ${phone}`}>{phone}</a>;
       },
-      headerIcon: (
+      headerIcon: () => (
         <IconButton
           icon={<InformationIcon />}
           label="Custom Column Information"

--- a/packages/components/data-table/src/data-table.tsx
+++ b/packages/components/data-table/src/data-table.tsx
@@ -155,7 +155,26 @@ export type TDataTableProps<Row extends TRow = TRow> = {
    * the items of `rows` that you want to render under this column, and a `label`
    * which defines the name shown on the header.
    * The list of columns to be rendered.
-   * Each column can be customized (see properties below).
+   *
+   * Column item shape:
+   *
+   * ```
+   * {
+   *   key: string;
+   *   label: ReactNode;
+   *   width?: string;
+   *   align?: 'left' | 'center' | 'right';
+   *   onClick?: (event: MouseEventHandler) => void;
+   *   renderItem?: (row: Row, isRowCollapsed: boolean) => ReactNode;
+   *   headerIcon?: ReactNode;
+   *   isTruncated?: boolean;
+   *   isSortable?: boolean;
+   *   disableResizing?: boolean;
+   *   shouldIgnoreRowClick?: boolean;
+   * }
+   * ```
+   *
+   * [Colum signatures with description](/?path=/docs/components-datatable-readme--props#signatures)
    */
   columns: TColumn<Row>[];
   /**

--- a/packages/components/data-table/src/header-cell.tsx
+++ b/packages/components/data-table/src/header-cell.tsx
@@ -171,7 +171,11 @@ const HeaderCell = (props: THeaderCell) => {
           <HeaderLabelTextWrapper>{props.children}</HeaderLabelTextWrapper>
 
           {props.iconComponent && (
-            <HeaderIconWrapper>{props.iconComponent}</HeaderIconWrapper>
+            <HeaderIconWrapper>
+              {typeof props.iconComponent === 'function'
+                ? props.iconComponent()
+                : props.iconComponent}
+            </HeaderIconWrapper>
           )}
         </HeaderLabelWrapper>
         {props.isSortable && (


### PR DESCRIPTION
## Background
In an effort to switch from Storybook v5 to Storybook v8, the existing stories had to be migrated to a new storybook-format and converted to typescript. 

This pull-request is [part of a batch](https://github.com/commercetools/ui-kit/pull/2875). It contains the typescript-equivalents of existing storybook v5 stories and aims to replicate the same functionality / value. 

## Goal
Feature parity between v8 and v5 storybook. After merging all batches, a product developer who looked at the storybook v5 version yesterday, should be able to look at the v8 version tomorrow and be as productive (or more productive) as before. 

## Review instructions
A thorough **code review** is not required yet. The code was either copied from the existing js-equivalent or quickly written from scratch to replicate what was already there to fit the new story-format. It is expected that those stories contain typescript errors, introduced by the conversion or previously existing. (Another pull-request will take care of those issues at a later stage).

What is expect is a **story review**:

You will need to compare the v5 with the v8 storybook (ideally side-by-side) and make sure that every component in this pull-request has:

- [ ] a readme-file in the same or a parent-folder
- [ ] a props-table displaying available props (and appropriate inputs for them)
- [ ] one or more stories that showcase the same or more functionality as the v5 equivalent

You will find the links to the different storybooks below. 


> If something is missing or irritating, add a comment to the source file here in the pull-request to start a conversation.


