### PR TITLE
Storybook v8 stories batch 3

### DIFF
--- a/packages/components/field-errors/src/field-errors.readme.mdx
+++ b/packages/components/field-errors/src/field-errors.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Fields/Field___/FieldErrors/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/field-errors/src/field-errors.stories.tsx
+++ b/packages/components/field-errors/src/field-errors.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import FieldErrors from './field-errors';
+
+const meta: Meta<typeof FieldErrors> = {
+  title: 'Form/Fields/Field___/FieldErrors',
+  component: FieldErrors,
+};
+export default meta;
+
+type Story = StoryObj<typeof FieldErrors>;
+
+export const BasicExample: Story = {
+  args: {
+    id: 'error-id',
+    errors: {
+      missing: true,
+      duplicate: true,
+      minLength: true,
+    },
+    renderError: (key) => {
+      switch (key) {
+        case 'duplicate':
+          return 'This is already in use. It must be unique.';
+        default:
+          // When null is returned then the default error handling from
+          // renderDefaultError will kick in for that error.
+          return null;
+      }
+    },
+
+    renderDefaultError: (key) => {
+      switch (key) {
+        case 'minLength':
+          return 'This is too short.';
+        default:
+          // When null is returned then the error handling defined in
+          // FieldError itself will kick in
+          return null;
+      }
+    },
+    isVisible: true,
+  },
+};

--- a/packages/components/field-label/src/field-label.readme.mdx
+++ b/packages/components/field-label/src/field-label.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Fields/Field__/FieldLabel/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/field-label/src/field-label.stories.tsx
+++ b/packages/components/field-label/src/field-label.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { iconArgType } from '@/storybook-helpers';
+import FieldLabel from './field-label';
+import FlatButton from '@commercetools-uikit/flat-button';
+import { BoxIcon } from '@commercetools-uikit/icons';
+
+const meta: Meta<typeof FieldLabel> = {
+  title: 'Form/Fields/Field__/FieldLabel',
+  // @ts-ignore
+  component: FieldLabel,
+  argTypes: {
+    hintIcon: iconArgType,
+    title: { control: { type: 'text' } },
+    hint: { control: { type: 'text' } },
+    description: { control: { type: 'text' } },
+    badge: {
+      control: { disable: true },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof FieldLabel>;
+
+export const BasicExample: Story = {
+  args: {
+    horizontalConstraint: 'scale',
+    title: 'Sort Order',
+    hasRequiredIndicator: false,
+    hint: 'Enter a number between 0 and 1',
+    /** @ts-ignore */
+    hintIcon: 'SortingIcon',
+    description: 'This order will be used to sort the categories.',
+    badge: (
+      <FlatButton
+        tone="primary"
+        icon={<BoxIcon />}
+        label="I'm used as badge"
+        onClick={() => {}}
+      />
+    ),
+  },
+};

--- a/packages/components/field-warnings/src/field-warning.readme.mdx
+++ b/packages/components/field-warnings/src/field-warning.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Fields/Field__/FieldWarnings/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/field-warnings/src/field-warning.stories.tsx
+++ b/packages/components/field-warnings/src/field-warning.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import FieldWarnings from './field-warnings';
+
+const meta: Meta<typeof FieldWarnings> = {
+  title: 'Form/Fields/Field__/FieldWarnings',
+  component: FieldWarnings,
+};
+export default meta;
+
+type Story = StoryObj<typeof FieldWarnings>;
+
+export const BasicExample: Story = {
+  args: {
+    id: 'warning-id',
+    warnings: {
+      customWarning: true,
+      defaultWarning: true,
+    },
+    renderWarning: (key) => {
+      return key === 'customWarning'
+        ? 'The current password is weak, You may want to use a stronger password'
+        : null;
+    },
+    renderDefaultWarning: (key /*, warning*/) => {
+      return key === 'defaultWarning' ? 'Always use a strong password' : null;
+    },
+    isVisible: true,
+  },
+};

--- a/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.readme.mdx
+++ b/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Fields/AsyncCreatableSelectField/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.stories.tsx
+++ b/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.stories.tsx
@@ -1,0 +1,193 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import AsyncCreatableSelectField from './async-creatable-select-field';
+import { useEffect, useState } from 'react';
+import { iconArgType } from '@/storybook-helpers';
+
+const meta: Meta<typeof AsyncCreatableSelectField> = {
+  title: 'Form/Fields/AsyncCreatableSelectField',
+  // @ts-expect-error, @todo: fix typings of field component
+  component: AsyncCreatableSelectField,
+  argTypes: {
+    // @ts-expect-error, @todo: fix typings of field component
+    hintIcon: iconArgType,
+    iconLeft: iconArgType,
+    id: { control: { type: 'text' } },
+    isMulti: { control: { type: 'boolean' } },
+    hint: { control: { type: 'text' } },
+    description: { control: { type: 'text' } },
+    badge: { control: { type: 'text' } },
+    name: { control: { type: 'text' } },
+    touched: { control: { type: 'boolean' } },
+    'aria-label': { control: { type: 'text' } },
+    'aria-labelledby': { control: { type: 'text' } },
+    backspaceRemovesValue: { control: { type: 'boolean' } },
+    containerId: { control: { type: 'text' } },
+    isDisabled: { control: { type: 'boolean' } },
+    placeholder: { control: { type: 'text' } },
+    title: { control: { type: 'text' } },
+    isSearchable: { control: { type: 'boolean' } },
+    isClearable: { control: { type: 'boolean' } },
+    tabIndex: { control: { type: 'text' } },
+    tabSelectsValue: { control: { type: 'boolean' } },
+    cacheOptions: { control: { type: 'boolean' } },
+    allowCreateWhileLoading: { control: { type: 'boolean' } },
+    createOptionPosition: { control: 'select', options: ['first', 'last'] },
+    menuShouldBlockScroll: { control: { type: 'boolean' } },
+  },
+};
+export default meta;
+
+const animalOptions = [
+  { value: 'platypus', label: 'Platypus' },
+  { value: 'goat', label: 'Goat' },
+  { value: 'giraffe', label: 'Giraffe' },
+  { value: 'whale', label: 'Whale' },
+  { value: 'killer-whale', label: 'Killer Whale', isDisabled: true },
+  { value: 'otter', label: 'Otter' },
+  { value: 'elephant', label: 'Elephant' },
+  { value: 'rat', label: 'Rat' },
+  { value: 'anteater', label: 'Anteater' },
+  { value: 'alligator', label: 'Alligator' },
+  { value: 'dog', label: 'Dog' },
+  { value: 'pig', label: 'Pig' },
+  { value: 'hippopotamus', label: 'Hippopotamus' },
+  { value: 'lion', label: 'Lion' },
+  { value: 'monkey', label: 'Monkey' },
+  { value: 'kangaroo', label: 'Kangaroo' },
+  { value: 'flamingo', label: 'Flamingo' },
+  { value: 'moose', label: 'Moose' },
+  { value: 'prairie-dog', label: 'Prairie Dog', isDisabled: true },
+  { value: 'snake', label: 'Snake' },
+  { value: 'porcupine', label: 'Porcupine' },
+  { value: 'stingray', label: 'Stingray' },
+  { value: 'panther', label: 'Panther' },
+  { value: 'lizard', label: 'Lizard' },
+  { value: 'parrot', label: 'Parrot' },
+  { value: 'dolphin', label: 'Dolphin' },
+  { value: 'chicken', label: 'Chicken' },
+  { value: 'sloth', label: 'Sloth' },
+  { value: 'shark', label: 'Shark' },
+  { value: 'ape', label: 'Ape' },
+  { value: 'bear', label: 'Bear' },
+  { value: 'cheetah', label: 'Cheetah' },
+  { value: 'camel', label: 'Camel' },
+  { value: 'beaver', label: 'Beaver' },
+  { value: 'armadillo', label: 'Armadillo' },
+  { value: 'tiger', label: 'Tiger' },
+  { value: 'llama', label: 'Llama' },
+  { value: 'seal', label: 'Seal' },
+  { value: 'hawk', label: 'Hawk' },
+  { value: 'wolf', label: 'Wolf' },
+  { value: 'yak', label: 'Yak' },
+  { value: 'rhinoceros', label: 'Rhinoceros' },
+  { value: 'alpaca', label: 'Alpaca' },
+  { value: 'zebra', label: 'Zebra' },
+  { value: 'cat', label: 'Cat' },
+  { value: 'rabbit', label: 'Rabbit' },
+  { value: 'turtle', label: 'Turtle' },
+  { value: 'cow', label: 'Cow' },
+  { value: 'turkey', label: 'Turkey' },
+  { value: 'deer', label: 'Deer' },
+];
+
+const filterAnimals = (inputValue: string) =>
+  animalOptions.filter((animalOption) =>
+    animalOption.label.toLowerCase().includes(inputValue.toLowerCase())
+  );
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const loadOptions = (inputValue: string) =>
+  delay(500).then(() => filterAnimals(inputValue));
+
+type Story = StoryFn<typeof AsyncCreatableSelectField>;
+
+export const BasicExample: Story = (args) => {
+  const [value, onChange] = useState<string | string[] | undefined | unknown>(
+    undefined
+  );
+
+  useEffect(() => {
+    // @ts-expect-error, @todo: fix typings of field component
+    onChange(args.isMulti ? [] : undefined);
+    // @ts-expect-error, @todo: fix typings of field component
+  }, [args.isMulti]);
+
+  // hintIcon will only render when hint exists
+
+  return (
+    <div style={{ height: 300 }}>
+      {/* @ts-expect-error, @todo: fix typings of field component */}
+      <AsyncCreatableSelectField
+        value={value}
+        {...args}
+        onChange={(event) => {
+          onChange(event.target.value);
+        }}
+        /** needs to be set to undefined (cause storybook adds an empty function via args) */
+        onCreateOption={undefined}
+      />
+      <hr />
+      <strong>State:</strong>
+      <pre>{JSON.stringify({ value }, null, 2)}</pre>
+    </div>
+  );
+};
+
+BasicExample.args = {
+  // @ts-expect-error, @todo: fix typings of field component
+  id: 'favAnimal-id',
+  isMulti: true,
+  hint: 'Bonus points if it is a mammal',
+  defaultOptions: animalOptions,
+  description: '',
+  badge: '',
+  name: 'favAnimal',
+  horizontalConstraint: 7,
+  errors: {
+    missing: true,
+    customError: true,
+  },
+  renderError: (key: string) => {
+    switch (key) {
+      case 'customError':
+        return 'A custom error.';
+      default:
+        return null;
+    }
+  },
+  warnings: {
+    customWarning: true,
+  },
+  renderWarning: (key: string) => {
+    switch (key) {
+      case 'customWarning':
+        return 'A custom warning.';
+      default:
+        return null;
+    }
+  },
+  isRequired: false,
+  touched: false,
+  'aria-label': 'Accessible label',
+  'aria-labelledby': '',
+  backspaceRemovesValue: true,
+  containerId: '',
+  isAutofocussed: false,
+  isDisabled: false,
+  isReadOnly: false,
+  hasWarning: false,
+  placeholder: 'Select animal...',
+  title: 'Favourite animal',
+  maxMenuHeight: 220,
+  isSearchable: true,
+  isClearable: false,
+  tabIndex: '0',
+  tabSelectsValue: true,
+  loadOptions: loadOptions,
+  cacheOptions: false,
+  allowCreateWhileLoading: false,
+  createOptionPosition: 'last',
+  isCondensed: false,
+  noOptionsMessage: (str: string) => `There are no animals matching "${str}"`,
+};

--- a/packages/components/fields/async-select-field/src/async-select-field.readme.mdx
+++ b/packages/components/fields/async-select-field/src/async-select-field.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Fields/AsyncSelectField/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/fields/async-select-field/src/async-select-field.stories.tsx
+++ b/packages/components/fields/async-select-field/src/async-select-field.stories.tsx
@@ -1,0 +1,184 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import AsyncSelectField from './async-select-field';
+import { useEffect, useState } from 'react';
+import { iconArgType } from '@/storybook-helpers';
+
+const meta: Meta<typeof AsyncSelectField> = {
+  title: 'Form/Fields/AsyncSelectField',
+  //@ts-expect-error refactor component for propert typings
+  component: AsyncSelectField,
+  argTypes: {
+    //@ts-expect-error refactor component for propert typings
+    iconLeft: iconArgType,
+    hintIcon: iconArgType,
+    name: { control: { type: 'text' } },
+    id: { control: { type: 'text' } },
+    hint: { control: { type: 'text' } },
+    loadingMessage: { control: { type: 'text' } },
+    touched: { control: { type: 'boolean' } },
+    'aria-label': { control: { type: 'text' } },
+    'aria-labelledby': { control: { type: 'text' } },
+    backspaceRemovesValue: { control: { type: 'boolean' } },
+    containerId: { control: { type: 'text' } },
+    controlShouldRenderValue: { control: { type: 'boolean' } },
+    isDisabled: { control: { type: 'boolean' } },
+    isMulti: { control: { type: 'boolean' } },
+    placeholder: { control: { type: 'text' } },
+    title: { control: { type: 'text' } },
+    isSearchable: { control: { type: 'boolean' } },
+    isClearable: { control: { type: 'boolean' } },
+    tabIndex: { control: { type: 'text' } },
+    tabSelectsValue: { control: { type: 'boolean' } },
+    cacheOptions: { control: { type: 'boolean' } },
+    description: { control: { type: 'text' } },
+    badge: { control: { type: 'text' } },
+    menuShouldBlockScroll: { control: { type: 'boolean' } },
+  },
+};
+export default meta;
+
+type Story = StoryFn<typeof AsyncSelectField>;
+
+const animalOptions = [
+  { value: 'platypus', label: 'Platypus' },
+  { value: 'goat', label: 'Goat' },
+  { value: 'giraffe', label: 'Giraffe' },
+  { value: 'whale', label: 'Whale' },
+  { value: 'killer-whale', label: 'Killer Whale', isDisabled: true },
+  { value: 'otter', label: 'Otter' },
+  { value: 'elephant', label: 'Elephant' },
+  { value: 'rat', label: 'Rat' },
+  { value: 'anteater', label: 'Anteater' },
+  { value: 'alligator', label: 'Alligator' },
+  { value: 'dog', label: 'Dog' },
+  { value: 'pig', label: 'Pig' },
+  { value: 'hippopotamus', label: 'Hippopotamus' },
+  { value: 'lion', label: 'Lion' },
+  { value: 'monkey', label: 'Monkey' },
+  { value: 'kangaroo', label: 'Kangaroo' },
+  { value: 'flamingo', label: 'Flamingo' },
+  { value: 'moose', label: 'Moose' },
+  { value: 'prairie-dog', label: 'Prairie Dog', isDisabled: true },
+  { value: 'snake', label: 'Snake' },
+  { value: 'porcupine', label: 'Porcupine' },
+  { value: 'stingray', label: 'Stingray' },
+  { value: 'panther', label: 'Panther' },
+  { value: 'lizard', label: 'Lizard' },
+  { value: 'parrot', label: 'Parrot' },
+  { value: 'dolphin', label: 'Dolphin' },
+  { value: 'chicken', label: 'Chicken' },
+  { value: 'sloth', label: 'Sloth' },
+  { value: 'shark', label: 'Shark' },
+  { value: 'ape', label: 'Ape' },
+  { value: 'bear', label: 'Bear' },
+  { value: 'cheetah', label: 'Cheetah' },
+  { value: 'camel', label: 'Camel' },
+  { value: 'beaver', label: 'Beaver' },
+  { value: 'armadillo', label: 'Armadillo' },
+  { value: 'tiger', label: 'Tiger' },
+  { value: 'llama', label: 'Llama' },
+  { value: 'seal', label: 'Seal' },
+  { value: 'hawk', label: 'Hawk' },
+  { value: 'wolf', label: 'Wolf' },
+  { value: 'yak', label: 'Yak' },
+  { value: 'rhinoceros', label: 'Rhinoceros' },
+  { value: 'alpaca', label: 'Alpaca' },
+  { value: 'zebra', label: 'Zebra' },
+  { value: 'cat', label: 'Cat' },
+  { value: 'rabbit', label: 'Rabbit' },
+  { value: 'turtle', label: 'Turtle' },
+  { value: 'cow', label: 'Cow' },
+  { value: 'turkey', label: 'Turkey' },
+  { value: 'deer', label: 'Deer' },
+];
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const filterAnimals = (inputValue: string) =>
+  animalOptions.filter((animalOption) =>
+    animalOption.label.toLowerCase().includes(inputValue.toLowerCase())
+  );
+
+const loadOptions = (inputValue: string) =>
+  delay(500).then(() => filterAnimals(inputValue));
+
+export const BasicExample: Story = (args) => {
+  const [value, onChange] = useState<unknown>(undefined);
+
+  useEffect(() => {
+    //@ts-expect-error refactor component for propert typings
+    onChange(args.isMulti ? [] : undefined);
+    //@ts-expect-error refactor component for propert typings
+  }, [args.isMulti]);
+
+  // hintIcon will only render when hint exists
+
+  return (
+    <div style={{ height: 300 }}>
+      {/** @ts-expect-error refactor component for propert typings */}
+      <AsyncSelectField
+        {...args}
+        value={value}
+        onChange={(event) => {
+          onChange(event.target.value);
+        }}
+      />
+    </div>
+  );
+};
+
+BasicExample.args = {
+  // @ts-expect-error refactor component for propert typings
+  name: 'favAnimal-name',
+  id: 'favAnimal-id',
+  hint: 'Bonus points if it is a mammal',
+  loadingMessage: 'Loading results',
+  horizontalConstraint: 7,
+  errors: { missing: true, customError: true },
+  renderError: (key: string) => {
+    switch (key) {
+      case 'customError':
+        return 'A custom error.';
+      default:
+        return null;
+    }
+  },
+  warnings: {
+    customWarning: true,
+  },
+  renderWarning: (key: string) => {
+    switch (key) {
+      case 'customWarning':
+        return 'A custom warning.';
+      default:
+        return null;
+    }
+  },
+  isRequired: false,
+  touched: false,
+  'aria-label': '',
+  'aria-labelledby': '',
+  backspaceRemovesValue: true,
+  containerId: '',
+  controlShouldRenderValue: true,
+  isAutofocussed: false,
+  isCondensed: false,
+  isDisabled: false,
+  isReadOnly: false,
+  isMulti: false,
+  hasWarning: false,
+  placeholder: 'Select animal...',
+  title: 'Favourite animal',
+  maxMenuHeight: 220,
+  isSearchable: true,
+  isClearable: true,
+  tabIndex: '0',
+  tabSelectsValue: true,
+  loadOptions,
+  cacheOptions: false,
+  description: '',
+  badge: '',
+  defaultOptions: animalOptions,
+  noOptionsMessage: ({ inputValue }: { inputValue: string }) =>
+    `Nothing found for "${inputValue}"`,
+};

--- a/packages/components/fields/creatable-select-field/src/creatable-select-field.readme.mdx
+++ b/packages/components/fields/creatable-select-field/src/creatable-select-field.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Fields/CreatableSelectField/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/fields/creatable-select-field/src/creatable-select-field.stories.tsx
+++ b/packages/components/fields/creatable-select-field/src/creatable-select-field.stories.tsx
@@ -1,0 +1,173 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import { iconArgType } from '@/storybook-helpers';
+import CreatableSelectField from './creatable-select-field';
+import { useEffect, useState } from 'react';
+
+const meta: Meta<typeof CreatableSelectField> = {
+  title: 'Form/Fields/CreatableSelectField',
+  // @ts-expect-error, @todo component needs refactoring
+  component: CreatableSelectField,
+  argTypes: {
+    // @ts-expect-error, @todo component needs refactoring
+    isMulti: { control: 'boolean' },
+    hint: { control: 'text' },
+    name: { control: 'text' },
+    id: { control: 'text' },
+    touched: { control: 'boolean' },
+    'aria-label': { control: 'text' },
+    'aria-labelledby': { control: 'text' },
+    backspaceRemovesValue: { control: 'boolean' },
+    containerId: { control: 'text' },
+    isDisabled: { control: 'boolean' },
+    isReadOnly: { control: 'boolean' },
+    placeholder: { control: 'text' },
+    title: { control: 'text' },
+    isSearchable: { control: 'boolean' },
+    isClearable: { control: 'boolean' },
+    tabIndex: { control: 'text' },
+    tabSelectsValue: { control: 'boolean' },
+    allowCreateWhileLoading: { control: 'boolean' },
+    createOptionPosition: {
+      control: 'select',
+      options: ['first', 'last'],
+    },
+    description: { control: 'text' },
+    badge: { control: 'text' },
+    menuShouldBlockScroll: { control: 'boolean' },
+    hintIcon: iconArgType,
+    iconLeft: iconArgType,
+  },
+};
+export default meta;
+
+type Story = StoryFn<typeof CreatableSelectField>;
+
+const options = [
+  { value: 'platypus', label: 'Platypus' },
+  { value: 'goat', label: 'Goat' },
+  { value: 'giraffe', label: 'Giraffe' },
+  { value: 'whale', label: 'Whale' },
+  { value: 'killer-whale', label: 'Killer Whale', isDisabled: true },
+  { value: 'otter', label: 'Otter' },
+  { value: 'elephant', label: 'Elephant' },
+  { value: 'rat', label: 'Rat' },
+  { value: 'anteater', label: 'Anteater' },
+  { value: 'alligator', label: 'Alligator' },
+  { value: 'dog', label: 'Dog' },
+  { value: 'pig', label: 'Pig' },
+  { value: 'hippopotamus', label: 'Hippopotamus' },
+  { value: 'lion', label: 'Lion' },
+  { value: 'monkey', label: 'Monkey' },
+  { value: 'kangaroo', label: 'Kangaroo' },
+  { value: 'flamingo', label: 'Flamingo' },
+  { value: 'moose', label: 'Moose' },
+  { value: 'prairie-dog', label: 'Prairie Dog', isDisabled: true },
+  { value: 'snake', label: 'Snake' },
+  { value: 'porcupine', label: 'Porcupine' },
+  { value: 'stingray', label: 'Stingray' },
+  { value: 'panther', label: 'Panther' },
+  { value: 'lizard', label: 'Lizard' },
+  { value: 'parrot', label: 'Parrot' },
+  { value: 'dolphin', label: 'Dolphin' },
+  { value: 'chicken', label: 'Chicken' },
+  { value: 'sloth', label: 'Sloth' },
+  { value: 'shark', label: 'Shark' },
+  { value: 'ape', label: 'Ape' },
+  { value: 'bear', label: 'Bear' },
+  { value: 'cheetah', label: 'Cheetah' },
+  { value: 'camel', label: 'Camel' },
+  { value: 'beaver', label: 'Beaver' },
+  { value: 'armadillo', label: 'Armadillo' },
+  { value: 'tiger', label: 'Tiger' },
+  { value: 'llama', label: 'Llama' },
+  { value: 'seal', label: 'Seal' },
+  { value: 'hawk', label: 'Hawk' },
+  { value: 'wolf', label: 'Wolf' },
+  { value: 'yak', label: 'Yak' },
+  { value: 'rhinoceros', label: 'Rhinoceros' },
+  { value: 'alpaca', label: 'Alpaca' },
+  { value: 'zebra', label: 'Zebra' },
+  { value: 'cat', label: 'Cat' },
+  { value: 'rabbit', label: 'Rabbit' },
+  { value: 'turtle', label: 'Turtle' },
+  { value: 'cow', label: 'Cow' },
+  { value: 'turkey', label: 'Turkey' },
+  { value: 'deer', label: 'Deer' },
+];
+
+export const BasicExample: Story = (args) => {
+  const [value, onChange] = useState<unknown>(undefined);
+
+  useEffect(() => {
+    // @ts-expect-error, @todo component needs refactoring
+    onChange(args.isMulti ? [] : undefined);
+    // @ts-expect-error, @todo component needs refactoring
+  }, [args.isMulti]);
+
+  return (
+    <div style={{ height: 350 }}>
+      {/* @ts-expect-error, @todo component needs refactoring */}
+      <CreatableSelectField
+        {...args}
+        value={value}
+        onChange={(event) => {
+          onChange(event.target.value);
+        }}
+        /** needs to be set to undefined (cause storybook adds an empty function via args) */
+        onCreateOption={undefined}
+      />
+    </div>
+  );
+};
+
+BasicExample.args = {
+  // @ts-expect-error, @todo component needs refactoring
+  isMulti: false,
+  hint: 'Bonus points if it is a mammal',
+  name: 'favAnimal-name',
+  id: 'favAnimal-id',
+  horizontalConstraint: 7,
+  errors: { missing: true, customError: true },
+  renderError: (key: string) => {
+    switch (key) {
+      case 'customError':
+        return 'A custom error.';
+      default:
+        return null;
+    }
+  },
+  warnings: {
+    customWarning: true,
+  },
+  renderWarning: (key: string) => {
+    switch (key) {
+      case 'customWarning':
+        return 'A custom warning.';
+      default:
+        return null;
+    }
+  },
+  isRequired: false,
+  touched: false,
+  'aria-label': '',
+  'aria-labelledby': '',
+  backspaceRemovesValue: true,
+  containerId: '',
+  isAutofocussed: false,
+  isCondensed: false,
+  isDisabled: false,
+  isReadOnly: false,
+  hasWarning: false,
+  placeholder: 'Select...',
+  title: 'Favourite animal',
+  maxMenuHeight: 220,
+  isSearchable: true,
+  isClearable: true,
+  options,
+  tabIndex: '0',
+  tabSelectsValue: true,
+  allowCreateWhileLoading: false,
+  createOptionPosition: 'last',
+  description: '',
+  badge: '',
+};

--- a/packages/components/fields/date-field/README.md
+++ b/packages/components/fields/date-field/README.md
@@ -102,7 +102,9 @@ export default Example;
 ### Signature `onInfoButtonClick`
 
 ```ts
-() => void
+(
+  event: MouseEvent<HTMLButtonElement> | KeyboardEvent<HTMLButtonElement>
+) => void
 ```
 
 ## `data-*` props

--- a/packages/components/fields/date-field/src/date-field.readme.mdx
+++ b/packages/components/fields/date-field/src/date-field.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Fields/DateField/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/fields/date-field/src/date-field.stories.tsx
+++ b/packages/components/fields/date-field/src/date-field.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import DateField from './date-field';
+import { getExampleDateStrings } from '@commercetools-uikit/calendar-utils';
+import { useState } from 'react';
+
+const meta: Meta<typeof DateField> = {
+  title: 'Form/Fields/DateField',
+  // @ts-expect-error, @todo refactory component and/or component-types
+  component: DateField,
+};
+export default meta;
+
+type Story = StoryFn<typeof DateField>;
+
+const exampleDates = getExampleDateStrings();
+
+export const BasicExample: Story = (args) => {
+  const [value, onChange] = useState<string | undefined>('');
+
+  return (
+    <div style={{ height: 400 }}>
+      {/* @ts-expect-error, @todo refactory component and/or component-types */}
+      <DateField
+        {...args}
+        value={value || ''}
+        onChange={(event) => {
+          onChange(event.target.value);
+        }}
+      />
+    </div>
+  );
+};
+
+BasicExample.args = {
+  // @ts-expect-error, @todo refactory component and/or component-types
+  name: 'dateField-name',
+  id: 'dateField-id',
+  horizontalConstraint: 7,
+  errors: { missing: true, customError: true },
+  renderError: (key: string) => {
+    switch (key) {
+      case 'customError':
+        return 'A custom error.';
+      default:
+        return null;
+    }
+  },
+  warnings: {
+    customWarning: true,
+  },
+  renderWarning: (key: string) => {
+    switch (key) {
+      case 'customWarning':
+        return 'A custom warning.';
+      default:
+        return null;
+    }
+  },
+  isRequired: false,
+  touched: false,
+  minValue: exampleDates.minDate,
+  maxValue: exampleDates.maxDate,
+  isCondensed: false,
+  isDisabled: false,
+  isReadOnly: false,
+  placeholder: 'Set a date...',
+  title: 'Release Date',
+  hint: 'Select the date of publication',
+  description: '',
+  badge: '',
+};

--- a/packages/components/fields/date-field/src/date-field.stories.tsx
+++ b/packages/components/fields/date-field/src/date-field.stories.tsx
@@ -2,11 +2,15 @@ import type { Meta, StoryFn } from '@storybook/react';
 import DateField from './date-field';
 import { getExampleDateStrings } from '@commercetools-uikit/calendar-utils';
 import { useState } from 'react';
+import { iconArgType } from '@/storybook-helpers';
 
 const meta: Meta<typeof DateField> = {
   title: 'Form/Fields/DateField',
   // @ts-expect-error, @todo refactory component and/or component-types
   component: DateField,
+  argTypes: {
+    hintIcon: iconArgType,
+  },
 };
 export default meta;
 

--- a/packages/components/fields/date-field/src/date-field.tsx
+++ b/packages/components/fields/date-field/src/date-field.tsx
@@ -153,15 +153,15 @@ export type TDateFieldProps = {
   /**
    * Title of the label
    */
-  title: string | ReactNode;
+  title: ReactNode;
   /**
    * Hint for the label. Provides a supplementary but important information regarding the behaviour of the input (e.g warn about uniqueness of a field, when it can only be set once), whereas `description` can describe it in more depth. Can also receive a `hintIcon`.
    */
-  hint?: string | ReactNode;
+  hint?: ReactNode;
   /**
    * Provides a description for the title.
    */
-  description?: string | ReactNode;
+  description?: ReactNode;
   /**
    * Function called when info button is pressed.
    * <br />

--- a/packages/components/fields/date-field/src/date-field.tsx
+++ b/packages/components/fields/date-field/src/date-field.tsx
@@ -1,10 +1,13 @@
 import {
   Component,
   isValidElement,
+  type MouseEvent,
+  type KeyboardEvent,
   type FocusEventHandler,
   type ReactElement,
   type ReactNode,
 } from 'react';
+
 import {
   filterDataAttributes,
   createSequentialId,
@@ -164,7 +167,9 @@ export type TDateFieldProps = {
    * <br />
    * Info button will only be visible when this prop is passed.
    */
-  onInfoButtonClick?: () => void;
+  onInfoButtonClick?: (
+    event: MouseEvent<HTMLButtonElement> | KeyboardEvent<HTMLButtonElement>
+  ) => void;
   /**
    * Icon to be displayed beside the hint text.
    * <br />

--- a/packages/components/fields/date-range-field/src/date-range-field.readme.mdx
+++ b/packages/components/fields/date-range-field/src/date-range-field.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Fields/DateRangeField/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/fields/date-range-field/src/date-range-field.stories.tsx
+++ b/packages/components/fields/date-range-field/src/date-range-field.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import DateRangeField from './date-range-field';
+import { useState } from 'react';
+import { type MomentInput } from 'moment';
+
+const meta: Meta<typeof DateRangeField> = {
+  title: 'Form/Fields/DateRangeField',
+  /** @ts-expect-error @todo refactor component/component-types*/
+  component: DateRangeField,
+};
+export default meta;
+
+type Story = StoryFn<typeof DateRangeField>;
+
+export const BasicExample: Story = (args) => {
+  const [value, onChange] = useState<MomentInput[] | undefined>(undefined);
+
+  return (
+    <div style={{ height: 350 }}>
+      {/** @ts-expect-error  */}
+      <DateRangeField
+        {...args}
+        value={(value || []).map(String)}
+        onChange={(event) => {
+          onChange(event.target.value);
+        }}
+      />
+    </div>
+  );
+};
+
+BasicExample.args = {
+  // @ts-expect-error
+  id: 'date-range-field-id',
+  name: 'date-range-field-name',
+  horizontalConstraint: 7,
+  errors: { missing: true, customError: true },
+  renderError: (key: string) => {
+    switch (key) {
+      case 'customError':
+        return 'A custom error.';
+      default:
+        return null;
+    }
+  },
+  warnings: {
+    customWarning: true,
+  },
+  renderWarning: (key: string) => {
+    switch (key) {
+      case 'customWarning':
+        return 'A custom warning.';
+      default:
+        return null;
+    }
+  },
+  isRequired: false,
+  touched: false,
+  isCondensed: false,
+  isDisabled: false,
+  isReadOnly: false,
+  placeholder: 'Set a start- & end-date...',
+  title: 'Free vacations',
+  hint: 'Select when you want to have free vacations',
+  description: '',
+  badge: '',
+  onInfoButtonClick: () =>
+    alert(`You won't actually get any free vacations :(`),
+};

--- a/packages/components/fields/date-time-field/src/date-time-field.readme.mdx
+++ b/packages/components/fields/date-time-field/src/date-time-field.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Fields/DateTimeField/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/fields/date-time-field/src/date-time-field.stories.tsx
+++ b/packages/components/fields/date-time-field/src/date-time-field.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import DateTimeField from './date-time-field';
+import { useState } from 'react';
+
+const meta: Meta<typeof DateTimeField> = {
+  title: 'Form/Fields/DateTimeField',
+  // @ts-expect-error @todo fix component and/or component-types
+  component: DateTimeField,
+  argTypes: {
+    // @ts-expect-error
+    timeZone: {
+      control: 'select',
+      options: [
+        'UTC',
+        'America/Los_Angeles',
+        'America/New_York',
+        'Asia/Tokyo',
+        'Europe/Amsterdam',
+      ],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryFn<typeof DateTimeField>;
+
+export const BasicExample: Story = (args) => {
+  const [value, onChange] = useState<string | undefined>('');
+
+  return (
+    <div style={{ height: 400 }}>
+      {/** @ts-expect-error */}
+      <DateTimeField
+        {...args}
+        value={value || ''}
+        onChange={(event) => {
+          onChange(event.target.value);
+        }}
+      />
+    </div>
+  );
+};
+
+BasicExample.args = {
+  // @ts-expect-error
+  id: 'date-time-field-id',
+  name: 'date-time-field-name',
+  horizontalConstraint: 7,
+  errors: { missing: true, customError: true },
+  renderError: (key: string) => {
+    switch (key) {
+      case 'customError':
+        return 'A custom error.';
+      default:
+        return null;
+    }
+  },
+  warnings: {
+    customWarning: true,
+  },
+  renderWarning: (key: string) => {
+    switch (key) {
+      case 'customWarning':
+        return 'A custom warning.';
+      default:
+        return null;
+    }
+  },
+  isRequired: false,
+  touched: false,
+  timeZone: 'UTC',
+  isCondensed: false,
+  isDisabled: false,
+  isReadOnly: false,
+  placeholder: 'Select a date and time',
+  title: 'Release Date',
+  hint: 'Select the date of publication',
+  description: '',
+  badge: '',
+};

--- a/packages/components/fields/localized-multiline-text-field/src/localized-multiline-text-field.readme.mdx
+++ b/packages/components/fields/localized-multiline-text-field/src/localized-multiline-text-field.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Fields/LocalizedMultilineTextField/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/fields/localized-multiline-text-field/src/localized-multiline-text-field.stories.tsx
+++ b/packages/components/fields/localized-multiline-text-field/src/localized-multiline-text-field.stories.tsx
@@ -1,0 +1,117 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import { iconArgType } from '@/storybook-helpers';
+import LocalizedMultilineTextField, {
+  TLocalizedMultilineTextFieldProps,
+} from './localized-multiline-text-field';
+import { useState } from 'react';
+
+const meta: Meta<typeof LocalizedMultilineTextField> = {
+  title: 'Form/Fields/LocalizedMultilineTextField',
+  // @ts-expect-error, @todo fix component/types
+  component: LocalizedMultilineTextField,
+  argTypes: {
+    // @ts-expect-error
+    selectedLanguage: {
+      control: 'select',
+      options: ['en', 'de'],
+    },
+    placeholder: { control: 'text' },
+    title: { control: 'text' },
+    hint: { control: 'text' },
+    description: { control: 'text' },
+    badge: { control: 'text' },
+    hintIcon: iconArgType,
+  },
+};
+
+export default meta;
+
+type Story = StoryFn<typeof LocalizedMultilineTextField>;
+
+// @ts-expect-error
+export const BasicExample: Story = (
+  args: TLocalizedMultilineTextFieldProps
+) => {
+  const [value, onChange] = useState({
+    en: 'Parrot that knows how to party',
+    de: 'Papagei der ordentlich abfeiert',
+  });
+
+  const { defaultExpandMultilineText, defaultExpandLanguages } = args;
+
+  const key = `${defaultExpandMultilineText}-${defaultExpandLanguages}`;
+
+  return (
+    <LocalizedMultilineTextField
+      {...args}
+      key={key}
+      value={value}
+      onChange={(event) => {
+        onChange({
+          ...value,
+          [event.target.language]: event.target.value,
+        });
+      }}
+    />
+  );
+};
+
+BasicExample.args = {
+  // @ts-expect-error
+  id: 'lmtf-id',
+  name: 'lmtf-name',
+  horizontalConstraint: 7,
+  errors: null,
+  renderError: (errorKey: string) => {
+    switch (errorKey) {
+      case 'customError':
+        return 'A custom error.';
+      default:
+        return null;
+    }
+  },
+  warnings: {
+    customWarning: true,
+  },
+  renderWarning: (key: string) => {
+    switch (key) {
+      case 'customWarning':
+        return 'A custom warning.';
+      default:
+        return null;
+    }
+  },
+  isRequired: false,
+  touched: false,
+  selectedLanguage: 'en',
+  hideLanguageExpansionControls: false,
+  defaultExpandLanguages: false,
+  defaultExpandMultilineText: false,
+  isAutofocussed: false,
+  cacheMeasurements: false,
+  isCondensed: false,
+  isDisabled: false,
+  isReadOnly: false,
+  placeholder: 'Placeholder...',
+  /* , */
+  additionalInfo: {
+    en: 'Additional information',
+    de: 'Zusätzliche Informationen',
+  },
+  title: 'Description',
+  hint: 'More information about the product',
+  description: '',
+  onInfoButtonClick: () => alert('You clicked the info-button!'),
+  badge: '',
+};
+
+export const WithError = BasicExample.bind({});
+
+WithError.args = {
+  ...BasicExample.args,
+  // @ts-expect-error
+  errorsByLanguage: {
+    en: 'A sample error',
+    de: 'Ein Beispiel-Fehler',
+  },
+};

--- a/packages/components/fields/localized-text-field/src/localized-text-field.readme.mdx
+++ b/packages/components/fields/localized-text-field/src/localized-text-field.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Fields/LocalizedTextField/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/fields/localized-text-field/src/localized-text-field.stories.tsx
+++ b/packages/components/fields/localized-text-field/src/localized-text-field.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import LocalizedTextField, {
+  TLocalizedTextFieldProps,
+} from './localized-text-field';
+import { useState } from 'react';
+
+const meta: Meta<typeof LocalizedTextField> = {
+  title: 'Form/Fields/LocalizedTextField',
+  // @ts-expect-error, fix component and/or component types
+  component: LocalizedTextField,
+  argTypes: {
+    // @ts-expect-error
+    selectedLanguage: {
+      control: 'select',
+      options: ['en', 'de'],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryFn<typeof LocalizedTextField>;
+
+// @ts-expect-error
+export const BasicExample: Story = (args: TLocalizedTextFieldProps) => {
+  const { defaultExpandLanguages } = args;
+  const [value, onChange] = useState({
+    en: 'Parrot that knows how to party',
+    de: 'Papagei der ordentlich abfeiert',
+  });
+
+  return (
+    <LocalizedTextField
+      {...args}
+      value={value}
+      onChange={(event) => {
+        onChange({
+          ...value,
+          [event.target.language]: event.target.value,
+        });
+      }}
+      defaultExpandLanguages={
+        // we need to set undefined instead of false to avoid prop-type
+        // warnings in case hideLanguageExpansionControls is true
+        defaultExpandLanguages || undefined
+      }
+    />
+  );
+};
+
+BasicExample.args = {
+  // @ts-expect-error
+  id: 'ltf-id',
+  name: 'ltf-name',
+  horizontalConstraint: 7,
+  errors: null,
+  warnings: {
+    customWarning: true,
+  },
+  renderWarning: (key: string) => {
+    switch (key) {
+      case 'customWarning':
+        return 'A custom warning.';
+      default:
+        return null;
+    }
+  },
+  isRequired: false,
+  touched: false,
+  selectedLanguage: 'en',
+  hideLanguageExpansionControls: false,
+  defaultExpandLanguages: false,
+  isAutofocussed: false,
+  isCondensed: false,
+  isDisabled: false,
+  isReadOnly: false,
+  placeholder: {
+    en: 'Placeholder',
+    de: 'Platzhalter',
+  },
+  additionalInfo: {
+    en: 'additional info for language en',
+    de: 'zusätzliche Informationen für die Sprache de',
+  },
+  title: 'Description',
+  hint: 'More information about the product',
+  description: '',
+  onInfoButtonClick: () => alert('Info button clicked'),
+  badge: '',
+};
+
+export const WithError = BasicExample.bind({});
+
+WithError.args = {
+  ...BasicExample.args,
+  // @ts-expect-error
+  errorsByLanguage: {
+    en: 'An error for language en',
+    de: 'Ein Fehler für die Sprache de',
+  },
+};

--- a/packages/components/fields/localized-text-field/src/localized-text-field.stories.tsx
+++ b/packages/components/fields/localized-text-field/src/localized-text-field.stories.tsx
@@ -3,6 +3,7 @@ import LocalizedTextField, {
   TLocalizedTextFieldProps,
 } from './localized-text-field';
 import { useState } from 'react';
+import { iconArgType } from '@/storybook-helpers';
 
 const meta: Meta<typeof LocalizedTextField> = {
   title: 'Form/Fields/LocalizedTextField',
@@ -14,6 +15,7 @@ const meta: Meta<typeof LocalizedTextField> = {
       control: 'select',
       options: ['en', 'de'],
     },
+    hintIcon: iconArgType,
   },
 };
 export default meta;

--- a/packages/components/fields/money-field/src/money-field.readme.mdx
+++ b/packages/components/fields/money-field/src/money-field.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Fields/MoneyField/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/fields/money-field/src/money-field.stories.tsx
+++ b/packages/components/fields/money-field/src/money-field.stories.tsx
@@ -9,20 +9,27 @@ const meta: Meta<typeof MoneyField> = {
   component: MoneyField,
   argTypes: {
     // @ts-expect-error,
-    currencies: {
-      control: 'select',
-      options: ['EUR', 'USD', 'AED', 'KWD', 'JPY'],
-    },
     title: { control: 'text' },
     hint: { control: 'text' },
     description: { control: 'text' },
     menuShouldBlockScroll: { control: 'boolean' },
     hintIcon: iconArgType,
   },
+  decorators: [
+    (Story) => (
+      // @ts-expect-error,
+      <div style={{ height: '320px' }}>
+        {/** @ts-expect-error */}
+        <Story />
+      </div>
+    ),
+  ],
 };
 export default meta;
 
 type Story = StoryFn<typeof MoneyField>;
+
+const currencies = ['EUR', 'USD', 'AED', 'KWD', 'JPY'];
 
 export const BasicExample: Story = (args) => {
   const [value, onChange] = useState({
@@ -64,6 +71,7 @@ BasicExample.args = {
   // @ts-expect-error
   id: 'money-field-id',
   name: 'money-field-name',
+  currencies,
   horizontalConstraint: 7,
   isRequired: false,
   touched: { amount: true, currencyCode: true },

--- a/packages/components/fields/money-field/src/money-field.stories.tsx
+++ b/packages/components/fields/money-field/src/money-field.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import MoneyField from './money-field';
+import { useState } from 'react';
+import { iconArgType } from '@/storybook-helpers';
+
+const meta: Meta<typeof MoneyField> = {
+  title: 'Form/Fields/MoneyField',
+  // @ts-expect-error, refactor component/types
+  component: MoneyField,
+  argTypes: {
+    // @ts-expect-error,
+    currencies: {
+      control: 'select',
+      options: ['EUR', 'USD', 'AED', 'KWD', 'JPY'],
+    },
+    title: { control: 'text' },
+    hint: { control: 'text' },
+    description: { control: 'text' },
+    menuShouldBlockScroll: { control: 'boolean' },
+    hintIcon: iconArgType,
+  },
+};
+export default meta;
+
+type Story = StoryFn<typeof MoneyField>;
+
+export const BasicExample: Story = (args) => {
+  const [value, onChange] = useState({
+    amount: '123.45',
+    currencyCode: 'EUR',
+  });
+
+  console.log('vlaue is', value);
+
+  return (
+    <MoneyField
+      {...args}
+      // @ts-expect-error
+      value={value}
+      onChange={(event) => {
+        if (event.target.name?.endsWith('.amount')) {
+          onChange((currentVal) => {
+            return {
+              ...currentVal,
+              amount: event.target.value as string,
+            };
+          });
+        }
+
+        if (event.target.name?.endsWith('.currencyCode')) {
+          onChange((currentVal) => {
+            return {
+              ...currentVal,
+              currencyCode: event.target.value as string,
+            };
+          });
+        }
+      }}
+    />
+  );
+};
+
+BasicExample.args = {
+  // @ts-expect-error
+  id: 'money-field-id',
+  name: 'money-field-name',
+  horizontalConstraint: 7,
+  isRequired: false,
+  touched: { amount: true, currencyCode: true },
+  placeholder: 'Placeholder text',
+  isDisabled: false,
+  isReadOnly: false,
+  isAutofocussed: false,
+  isCurrencyInputDisabled: false,
+  title: 'Price',
+  hint: 'How much is the fish?',
+  description: '',
+  onInfoButtonClick: () => alert('info button clicked'),
+  hasHighPrecisionBadge: false,
+};
+
+/** Example with error & warnings */
+export const WithError = BasicExample.bind({});
+
+WithError.args = {
+  ...BasicExample.args,
+  // @ts-expect-error
+  warnings: {
+    customWarning: true,
+  },
+  errors: { missing: true, customError: true },
+  renderError: (key: string) => {
+    switch (key) {
+      case 'customError':
+        return 'A custom error.';
+      default:
+        return null;
+    }
+  },
+  renderWarning: (key: string) => {
+    switch (key) {
+      case 'customWarning':
+        return 'A custom warning.';
+      default:
+        return null;
+    }
+  },
+};


### PR DESCRIPTION
## Background
In an effort to switch from Storybook v5 to Storybook v8, the existing stories had to be migrated to a new storybook-format and converted to typescript. 

This pull-request is [part of a batch](https://github.com/commercetools/ui-kit/pull/2875). It contains the typescript-equivalents of existing storybook v5 stories and aims to replicate the same functionality / value. 

## Goal
Feature parity between v8 and v5 storybook. After merging all batches, a product developer who looked at the storybook v5 version yesterday, should be able to look at the v8 version tomorrow and be as productive (or more productive) as before. 

## Review instructions
A thorough **code review** is not required yet. The code was either copied from the existing js-equivalent or quickly written from scratch to replicate what was already there to fit the new story-format. It is expected that those stories contain typescript errors, introduced by the conversion or previously existing. (Another pull-request will take care of those issues at a later stage).

What is expect is a **story review**:

You will need to compare the v5 with the v8 storybook (ideally side-by-side) and make sure that every component in this pull-request has:

- [ ] a readme-file in the same or a parent-folder
- [ ] a props-table displaying available props (and appropriate inputs for them)
- [ ] one or more stories that showcase the same or more functionality as the v5 equivalent

You will find the links to the different storybooks below. 


> If something is missing or irritating, add a comment to the source file here in the pull-request to start a conversation.


