### PR TITLE
Storybook v8 stories batch 5

### DIFF
--- a/packages/components/inputs/checkbox-input/src/checkbox-input.readme.mdx
+++ b/packages/components/inputs/checkbox-input/src/checkbox-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/CheckboxInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/checkbox-input/src/checkbox-input.stories.tsx
+++ b/packages/components/inputs/checkbox-input/src/checkbox-input.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import CheckboxInput from './checkbox-input';
+import styled from '@emotion/styled';
+
+const meta: Meta<typeof CheckboxInput> = {
+  title: 'Form/Inputs/CheckboxInput',
+  component: CheckboxInput,
+};
+export default meta;
+
+type Story = StoryObj<typeof CheckboxInput>;
+
+export const BasicExample: Story = {
+  args: {
+    isChecked: true,
+    children: 'I am a checkbox',
+  },
+};
+
+const DemoContainer = styled.div`
+  display: flex;
+  margin-bottom: 0.5em;
+  align-items: center;
+  gap: 1em;
+`;
+
+export const StatesAndVariants: Story = () => {
+  return (
+    <div>
+      {['', 'isDisabled', 'isReadOnly', 'hasError'].map((prop) => {
+        return (
+          <DemoContainer key={prop}>
+            <div style={{ width: '8em', fontWeight: 600 }}>
+              {prop || 'Default'}
+            </div>
+            <CheckboxInput
+              value="1"
+              isChecked={true}
+              onChange={() => {}}
+              {...{ [prop]: true }}
+            >
+              Checkbox Label
+            </CheckboxInput>
+            <CheckboxInput value="1" isChecked={false} onChange={() => {}}>
+              Checkbox Label
+            </CheckboxInput>
+            <CheckboxInput value="1" isIndeterminate={true} onChange={() => {}}>
+              Checkbox Label
+            </CheckboxInput>
+          </DemoContainer>
+        );
+      })}
+    </div>
+  );
+};
+
+StatesAndVariants.args = {
+  isChecked: true,
+};

--- a/packages/components/inputs/checkbox-input/src/checkbox-input.stories.tsx
+++ b/packages/components/inputs/checkbox-input/src/checkbox-input.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import CheckboxInput from './checkbox-input';
 import styled from '@emotion/styled';
+import { useEffect, useState } from 'react';
 
 const meta: Meta<typeof CheckboxInput> = {
   title: 'Form/Inputs/CheckboxInput',
@@ -10,11 +11,26 @@ export default meta;
 
 type Story = StoryObj<typeof CheckboxInput>;
 
-export const BasicExample: Story = {
-  args: {
-    isChecked: true,
-    children: 'I am a checkbox',
-  },
+export const BasicExample: Story = (args) => {
+  const [checked, setChecked] = useState(args.isChecked);
+
+  useEffect(() => {
+    setChecked(args.isChecked);
+  }, [args.isChecked]);
+
+  return (
+    <CheckboxInput
+      {...args}
+      isChecked={checked}
+      onChange={() => setChecked(!checked)}
+    >
+      Checkbox Label
+    </CheckboxInput>
+  );
+};
+
+BasicExample.args = {
+  children: 'I am a checkbox',
 };
 
 const DemoContainer = styled.div`

--- a/packages/components/inputs/creatable-select-input/src/creatable-select-input.readme.mdx
+++ b/packages/components/inputs/creatable-select-input/src/creatable-select-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/CreatableSelectInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/creatable-select-input/src/creatable-select-input.stories.tsx
+++ b/packages/components/inputs/creatable-select-input/src/creatable-select-input.stories.tsx
@@ -1,0 +1,163 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import CreatableSelectInput from './creatable-select-input';
+import Spacings from '@commercetools-uikit/spacings';
+import { iconArgType } from '@/storybook-helpers';
+import { useEffect, useState } from 'react';
+
+const meta: Meta<typeof CreatableSelectInput> = {
+  title: 'Form/Inputs/CreatableSelectInput',
+  component: CreatableSelectInput,
+  argTypes: {
+    createOptionPosition: {
+      control: 'select',
+      options: ['first', 'last'],
+    },
+    iconLeft: iconArgType,
+    isMulti: { control: 'boolean' },
+    backspaceRemovesValue: { control: 'boolean' },
+    isClearable: { control: 'boolean' },
+    isSearchable: { control: 'boolean' },
+    closeMenuOnSelect: { control: 'boolean' },
+    allowCreateWhileLoading: { control: 'boolean' },
+    placeholder: { control: 'text' },
+    'aria-label': { control: 'text' },
+    'aria-labelledby': { control: 'text' },
+    'aria-invalid': { control: 'boolean' },
+    'aria-errormessage': { control: 'text' },
+    id: { control: 'text' },
+    containerId: { control: 'text' },
+    isDisabled: { control: 'boolean' },
+    isOptionDisabled: { control: 'boolean' },
+    maxMenuHeight: { control: 'number' },
+    menuShouldBlockScroll: { control: 'boolean' },
+    name: { control: 'text' },
+    tabIndex: { control: 'text' },
+    tabSelectsValue: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryFn<typeof CreatableSelectInput>;
+
+const options = [
+  {
+    options: [
+      { value: 'platypus', label: 'Platypus' },
+      { value: 'goat', label: 'Goat' },
+      { value: 'giraffe', label: 'Giraffe' },
+      { value: 'whale', label: 'Whale' },
+      { value: 'killer-whale', label: 'Killer Whale', isDisabled: true },
+      { value: 'otter', label: 'Otter' },
+      { value: 'elephant', label: 'Elephant' },
+      { value: 'rat', label: 'Rat' },
+      { value: 'anteater', label: 'Anteater' },
+      { value: 'alligator', label: 'Alligator' },
+      { value: 'dog', label: 'Dog' },
+      { value: 'pig', label: 'Pig' },
+      { value: 'hippopotamus', label: 'Hippopotamus' },
+      { value: 'lion', label: 'Lion' },
+      { value: 'monkey', label: 'Monkey' },
+      { value: 'kangaroo', label: 'Kangaroo' },
+    ],
+  },
+  {
+    options: [
+      { value: 'flamingo', label: 'Flamingo' },
+      { value: 'moose', label: 'Moose' },
+      { value: 'prairie-dog', label: 'Prairie Dog', isDisabled: true },
+      { value: 'snake', label: 'Snake' },
+      { value: 'porcupine', label: 'Porcupine' },
+      { value: 'stingray', label: 'Stingray' },
+      { value: 'panther', label: 'Panther' },
+      { value: 'lizard', label: 'Lizard' },
+      { value: 'parrot', label: 'Parrot' },
+      { value: 'dolphin', label: 'Dolphin' },
+      { value: 'chicken', label: 'Chicken' },
+      { value: 'sloth', label: 'Sloth' },
+      { value: 'shark', label: 'Shark' },
+      { value: 'ape', label: 'Ape' },
+      { value: 'bear', label: 'Bear' },
+      { value: 'cheetah', label: 'Cheetah' },
+      { value: 'camel', label: 'Camel' },
+      { value: 'beaver', label: 'Beaver' },
+      { value: 'armadillo', label: 'Armadillo' },
+    ],
+  },
+  {
+    options: [
+      { value: 'tiger', label: 'Tiger' },
+      { value: 'llama', label: 'Llama' },
+      { value: 'seal', label: 'Seal' },
+      { value: 'hawk', label: 'Hawk' },
+      { value: 'wolf', label: 'Wolf' },
+      { value: 'yak', label: 'Yak' },
+      { value: 'rhinoceros', label: 'Rhinoceros' },
+      { value: 'alpaca', label: 'Alpaca' },
+      { value: 'zebra', label: 'Zebra' },
+      { value: 'cat', label: 'Cat' },
+      { value: 'rabbit', label: 'Rabbit' },
+      { value: 'turtle', label: 'Turtle' },
+      { value: 'cow', label: 'Cow' },
+      { value: 'turkey', label: 'Turkey' },
+      { value: 'deer', label: 'Deer' },
+    ],
+  },
+];
+
+type SelectedOption = {
+  value: string;
+  label: string;
+  __isNew__?: boolean;
+};
+
+export const BasicExample: Story = (args) => {
+  const [value, setValue] = useState<
+    SelectedOption | SelectedOption[] | undefined
+  >([]);
+
+  useEffect(() => {
+    setValue(args.isMulti ? [] : undefined);
+  }, [args.isMulti]);
+
+  return (
+    <div style={{ minHeight: 350 }}>
+      <Spacings.Stack scale="l">
+        <CreatableSelectInput
+          value={value}
+          {...args}
+          onChange={(e) => {
+            setValue(e.target.value as SelectedOption | SelectedOption[]);
+          }}
+          /** needs to be set to undefined (cause storybook adds an empty function via args) */
+          onCreateOption={undefined}
+        />
+        <strong>state:</strong>
+        <pre>
+          {JSON.stringify(
+            {
+              value,
+            },
+            null,
+            2
+          )}
+        </pre>
+      </Spacings.Stack>
+    </div>
+  );
+};
+
+BasicExample.args = {
+  horizontalConstraint: 'scale',
+  options,
+  isMulti: true,
+  hasError: false,
+  hasWarning: false,
+  backspaceRemovesValue: true,
+  isClearable: false,
+  isSearchable: true,
+  closeMenuOnSelect: true,
+  placeholder: 'Select animals or create a new one...',
+  allowCreateWhileLoading: false,
+  createOptionPosition: 'last',
+  showOptionGroupDivider: false,
+};

--- a/packages/components/inputs/creatable-select-input/src/creatable-select-input.stories.tsx
+++ b/packages/components/inputs/creatable-select-input/src/creatable-select-input.stories.tsx
@@ -28,6 +28,7 @@ const meta: Meta<typeof CreatableSelectInput> = {
     containerId: { control: 'text' },
     isDisabled: { control: 'boolean' },
     isOptionDisabled: { control: 'boolean' },
+    isValidNewOption: { type: 'function' },
     maxMenuHeight: { control: 'number' },
     menuShouldBlockScroll: { control: 'boolean' },
     name: { control: 'text' },
@@ -149,7 +150,7 @@ export const BasicExample: Story = (args) => {
 BasicExample.args = {
   horizontalConstraint: 'scale',
   options,
-  isMulti: true,
+  isMulti: false,
   hasError: false,
   hasWarning: false,
   backspaceRemovesValue: true,

--- a/packages/components/inputs/date-input/src/date-input.readme.mdx
+++ b/packages/components/inputs/date-input/src/date-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/DateInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/date-input/src/date-input.stories.tsx
+++ b/packages/components/inputs/date-input/src/date-input.stories.tsx
@@ -4,6 +4,13 @@ import DateInput from './date-input';
 const meta: Meta<typeof DateInput> = {
   title: 'Form/Inputs/DateInput',
   component: DateInput,
+  decorators: [
+    (Story) => (
+      <div style={{ minHeight: 350 }}>
+        <Story />
+      </div>
+    ),
+  ],
 };
 export default meta;
 

--- a/packages/components/inputs/date-input/src/date-input.stories.tsx
+++ b/packages/components/inputs/date-input/src/date-input.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import DateInput from './date-input';
+
+const meta: Meta<typeof DateInput> = {
+  title: 'Form/Inputs/DateInput',
+  component: DateInput,
+};
+export default meta;
+
+type Story = StoryObj<typeof DateInput>;
+
+export const BasicExample: Story = {
+  args: {
+    horizontalConstraint: 7,
+  },
+};

--- a/packages/components/inputs/date-range-input/src/date-range-input-proxy.tsx
+++ b/packages/components/inputs/date-range-input/src/date-range-input-proxy.tsx
@@ -1,0 +1,7 @@
+import DateRangeInput, { TDateRangeInputProps } from './date-range-input';
+
+export const DateRangeInputProxy = (props: TDateRangeInputProps) => (
+  <DateRangeInput {...props} />
+);
+
+DateRangeInputProxy.displayName = 'DateRangeInput';

--- a/packages/components/inputs/date-range-input/src/date-range-input.readme.mdx
+++ b/packages/components/inputs/date-range-input/src/date-range-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/DateRangeInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/date-range-input/src/date-range-input.stories.tsx
+++ b/packages/components/inputs/date-range-input/src/date-range-input.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import DateRangeInput, { TDateRangeInputProps } from './date-range-input';
+import { DateRangeInputProxy } from './date-range-input-proxy';
+import { useState } from 'react';
+
+const meta: Meta<typeof DateRangeInputProxy> = {
+  title: 'Form/Inputs/DateRangeInput',
+  component: DateRangeInputProxy,
+};
+export default meta;
+
+type Story = StoryFn<typeof DateRangeInputProxy>;
+
+type DateRangeArray = [string, string];
+
+export const BasicExample: Story = (args: TDateRangeInputProps) => {
+  const [value, setValue] = useState<DateRangeArray>([
+    '2024-11-13',
+    '2024-11-16',
+  ]);
+  return (
+    <div style={{ height: 400 }}>
+      <DateRangeInput
+        {...args}
+        onChange={(e) => setValue(e.target.value as DateRangeArray)}
+        value={value}
+      />
+    </div>
+  );
+};
+
+BasicExample.args = {
+  horizontalConstraint: 10,
+  isClearable: true,
+};

--- a/packages/components/inputs/date-time-input/src/date-time-input-wrapper.tsx
+++ b/packages/components/inputs/date-time-input/src/date-time-input-wrapper.tsx
@@ -1,0 +1,6 @@
+import DateTimeInput, { TDateTimeInputProps } from './date-time-input';
+// @todo: refactor DateTimeInput, make it a functional component to get rid of this wrapper
+export const DateTimeInputWrapper = (props: TDateTimeInputProps) => (
+  <DateTimeInput {...props} />
+);
+DateTimeInputWrapper.displayName = 'DateTimeInput';

--- a/packages/components/inputs/date-time-input/src/date-time-input.readme.mdx
+++ b/packages/components/inputs/date-time-input/src/date-time-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/DateTimeInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/date-time-input/src/date-time-input.stories.tsx
+++ b/packages/components/inputs/date-time-input/src/date-time-input.stories.tsx
@@ -1,10 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import DateTimeInput, { TDateTimeInputProps } from './date-time-input';
+import { TDateTimeInputProps } from './date-time-input';
 import { useState } from 'react';
+import { DateTimeInputWrapper } from './date-time-input-wrapper';
 
-const meta: Meta<typeof DateTimeInput> = {
+const meta: Meta<typeof DateTimeInputWrapper> = {
   title: 'Form/Inputs/DateTimeInput',
-  component: DateTimeInput,
+  component: DateTimeInputWrapper,
   argTypes: {
     timeZone: {
       control: { type: 'select' },
@@ -20,14 +21,14 @@ const meta: Meta<typeof DateTimeInput> = {
 };
 export default meta;
 
-type Story = StoryObj<typeof DateTimeInput>;
+type Story = StoryObj<typeof DateTimeInputWrapper>;
 
 export const BasicExample: Story = (args: TDateTimeInputProps) => {
   const [value, setValue] = useState<string>('');
 
   return (
     <div style={{ height: 400 }}>
-      <DateTimeInput
+      <DateTimeInputWrapper
         {...args}
         onChange={(e) => setValue(e.target.value || '')}
         value={value}

--- a/packages/components/inputs/date-time-input/src/date-time-input.stories.tsx
+++ b/packages/components/inputs/date-time-input/src/date-time-input.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import DateTimeInput, { TDateTimeInputProps } from './date-time-input';
+import { useState } from 'react';
+
+const meta: Meta<typeof DateTimeInput> = {
+  title: 'Form/Inputs/DateTimeInput',
+  component: DateTimeInput,
+  argTypes: {
+    timeZone: {
+      control: { type: 'select' },
+      options: [
+        'UTC',
+        'America/Los_Angeles',
+        'America/New_York',
+        'Asia/Tokyo',
+        'Europe/Amsterdam',
+      ],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof DateTimeInput>;
+
+export const BasicExample: Story = (args: TDateTimeInputProps) => {
+  const [value, setValue] = useState<string>('');
+
+  return (
+    <div style={{ height: 400 }}>
+      <DateTimeInput
+        {...args}
+        onChange={(e) => setValue(e.target.value || '')}
+        value={value}
+      />
+    </div>
+  );
+};
+
+BasicExample.args = {
+  timeZone: 'UTC',
+  horizontalConstraint: 8,
+};

--- a/packages/components/inputs/localized-money-input/src/localized-money-input.readme.mdx
+++ b/packages/components/inputs/localized-money-input/src/localized-money-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/LocalizedMoneyInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/localized-money-input/src/localized-money-input.stories.tsx
+++ b/packages/components/inputs/localized-money-input/src/localized-money-input.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import LocalizedMoneyInput from './localized-money-input';
+import { useState } from 'react';
+
+const meta: Meta<typeof LocalizedMoneyInput> = {
+  title: 'Form/Inputs/LocalizedMoneyInput',
+  // @ts-ignore
+  component: LocalizedMoneyInput,
+  argTypes: {
+    selectedCurrency: {
+      control: 'select',
+      options: ['EUR', 'USD', 'EGP'],
+    },
+  },
+};
+export default meta;
+
+type Story = StoryFn<typeof LocalizedMoneyInput>;
+
+export const BasicExample: Story = ({
+  value: propsValue,
+  defaultExpandCurrencies,
+  ...args
+}) => {
+  const [value, setValue] = useState(
+    propsValue || {
+      EUR: { currencyCode: 'EUR', amount: '' },
+      USD: { currencyCode: 'USD', amount: '' },
+      EGP: { currencyCode: 'EGP', amount: '' },
+    }
+  );
+
+  return (
+    <LocalizedMoneyInput
+      defaultExpandCurrencies={
+        // we need to set undefined instead of false to avoid prop-type
+        // warnings in case hideCurrencyExpansionControls is true
+        defaultExpandCurrencies || undefined
+      }
+      data-test="foo"
+      {...args}
+      value={value}
+      onChange={(event) => {
+        setValue((currentValue) => ({
+          ...currentValue,
+          // @ts-ignore
+          [event.target.currency]: {
+            // @ts-ignore
+            currencyCode: event.target.currency,
+            amount: event.target.value,
+          },
+        }));
+      }}
+    />
+  );
+};
+
+BasicExample.args = {
+  id: 'moneyinput-id',
+  name: 'moneyinput-name',
+  defaultExpandCurrencies: false,
+  hasHighPrecisionBadge: false,
+  value: {
+    EUR: { currencyCode: 'EUR', amount: '' },
+    USD: { currencyCode: 'USD', amount: '' },
+    EGP: { currencyCode: 'EGP', amount: '' },
+  },
+  hideCurrencyExpansionControls: false,
+  isCondensed: false,
+  isDisabled: false,
+  isReadOnly: false,
+  placeholder: { EUR: '€', USD: '$', EGP: 'E£' },
+  horizontalConstraint: 7,
+  hasError: false,
+  selectedCurrency: 'EUR',
+};

--- a/packages/components/inputs/localized-multiline-text-input/README.md
+++ b/packages/components/inputs/localized-multiline-text-input/README.md
@@ -192,7 +192,7 @@ Returns `true` when at least one value is truthy.
 This field exports a default error message which can be used when the field is
 required, but the user provided no value. You can use it as
 
-```js
+```jsx
 render (
   return (
     <div>

--- a/packages/components/inputs/localized-multiline-text-input/docs/additional-info.md
+++ b/packages/components/inputs/localized-multiline-text-input/docs/additional-info.md
@@ -74,7 +74,7 @@ Returns `true` when at least one value is truthy.
 This field exports a default error message which can be used when the field is
 required, but the user provided no value. You can use it as
 
-```js
+```jsx
 render (
   return (
     <div>

--- a/packages/components/inputs/localized-multiline-text-input/src/localized-multiline-text-input.readme.mdx
+++ b/packages/components/inputs/localized-multiline-text-input/src/localized-multiline-text-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/LocalizedMultilineTextInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/localized-multiline-text-input/src/localized-multiline-text-input.stories.tsx
+++ b/packages/components/inputs/localized-multiline-text-input/src/localized-multiline-text-input.stories.tsx
@@ -21,7 +21,7 @@ export const BasicExample: Story = ({
   const [value, setValue] = useState({
     en: 'Horse\nCow\nDuck',
     de: 'Pferd\nKuh\nEnte',
-    'nan-Hant-TW': '马\n奶牛\n鸭子',
+    'nan-Hant-TW': '馬\n奶牛\n鴨子',
   });
 
   return (

--- a/packages/components/inputs/localized-multiline-text-input/src/localized-multiline-text-input.stories.tsx
+++ b/packages/components/inputs/localized-multiline-text-input/src/localized-multiline-text-input.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import LocalizedMultilineTextInput, {
+  TLocalizedMultilineTextInputProps,
+} from './localized-multiline-text-input';
+import { useState } from 'react';
+
+const meta: Meta<typeof LocalizedMultilineTextInput> = {
+  title: 'Form/Inputs/LocalizedMultilineTextInput',
+  // @ts-ignore
+  component: LocalizedMultilineTextInput,
+};
+export default meta;
+
+type Story = StoryFn<typeof LocalizedMultilineTextInput>;
+
+export const BasicExample: Story = ({
+  defaultExpandMultilineText,
+  defaultExpandLanguages,
+  ...args
+}: TLocalizedMultilineTextInputProps) => {
+  const [value, setValue] = useState({
+    en: 'Horse\nCow\nDuck',
+    de: 'Pferd\nKuh\nEnte',
+    'nan-Hant-TW': '马\n奶牛\n鸭子',
+  });
+
+  return (
+    <div>
+      <LocalizedMultilineTextInput
+        defaultExpandLanguages={
+          // we need to set undefined instead of false to avoid prop-type
+          // warnings in case hideLanguageExpansionControls is true
+          defaultExpandLanguages || undefined
+        }
+        defaultExpandMultilineText={defaultExpandMultilineText}
+        data-test="foo"
+        {...args}
+        value={value}
+        onChange={(event) => {
+          setValue((currentValue) => ({
+            ...currentValue,
+            [event.target.language]: event.target.value,
+          }));
+        }}
+      />
+      <br />
+      <strong>
+        <code>value:</code>
+      </strong>
+      <pre>{JSON.stringify(value, null, 2)}</pre>
+    </div>
+  );
+};
+
+BasicExample.args = {
+  id: 'product-id',
+  name: 'productName',
+  additionalInfo: {
+    en: '',
+    de: '',
+    'nan-Hant-TW': '',
+  },
+  hasError: false,
+  hasWarning: false,
+  horizontalConstraint: 7,
+  placeholder: {
+    en: 'placeholder text',
+    de: 'Platzhalter text',
+    'nan-Hant-TW': '',
+  },
+  isReadOnly: false,
+  isDisabled: false,
+  isCondensed: false,
+  cacheMeasurements: false,
+  isAutofocussed: false,
+  defaultExpandMultilineText: false,
+  defaultExpandLanguages: false,
+  selectedLanguage: 'en',
+  hideLanguageExpansionControls: false,
+};

--- a/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.readme.mdx
+++ b/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/LocalizedRichTextInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.stories.tsx
+++ b/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.stories.tsx
@@ -13,6 +13,12 @@ const meta: Meta<typeof LocalizedRichTextInput> = {
   title: 'Form/Inputs/LocalizedRichTextInput',
   // @ts-ignore
   component: LocalizedRichTextInput,
+  argTypes: {
+    selectedLanguage: {
+      control: 'select',
+      options: ['de', 'en', 'nan-Hant-TW'],
+    },
+  },
 };
 export default meta;
 

--- a/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.stories.tsx
+++ b/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.stories.tsx
@@ -1,0 +1,172 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import LocalizedRichTextInput, {
+  TLocalizedRichTextInputProps,
+} from './localized-rich-text-input';
+import { ChangeEvent, useCallback, useRef, useState } from 'react';
+import Spacings from '@commercetools-uikit/spacings';
+import CollapsiblePanel from '@commercetools-uikit/collapsible-panel';
+import Constraints from '@commercetools-uikit/constraints';
+import PrimaryButton from '@commercetools-uikit/primary-button';
+import Text from '@commercetools-uikit/text';
+
+const meta: Meta<typeof LocalizedRichTextInput> = {
+  title: 'Form/Inputs/LocalizedRichTextInput',
+  // @ts-ignore
+  component: LocalizedRichTextInput,
+};
+export default meta;
+
+type Story = StoryObj<typeof LocalizedRichTextInput>;
+
+const initialValue = '<h1>H1 <u>heading</u></h1>';
+
+export const BasicExample: Story = ({
+  defaultExpandLanguages,
+  defaultExpandMultilineText,
+  value: propsValue,
+  ...args
+}: TLocalizedRichTextInputProps) => {
+  const ref = useRef(null);
+
+  const [value, setValue] = useState(
+    propsValue || {
+      en: initialValue,
+      de: initialValue,
+      'nan-Hant-TW': initialValue,
+    }
+  );
+
+  const [resetValue, setResetValue] = useState({
+    en: initialValue,
+    de: initialValue,
+    'nan-Hant-TW': initialValue,
+  });
+
+  const onChange = useCallback(
+    (event) => {
+      setValue((currentValue) => ({
+        ...currentValue,
+        [event.target.language]: event.target.value,
+      }));
+    },
+    [setValue]
+  );
+
+  const onResetValueChange =
+    (lang: string) => (event: ChangeEvent<HTMLTextAreaElement>) => {
+      setResetValue((currentValue) => ({
+        ...currentValue,
+        [lang]: event.target.value,
+      }));
+    };
+
+  const handleReset = () => {
+    // @ts-ignore
+    ref.current?.resetValue(resetValue);
+  };
+
+  // We need to force the component to rerender in case a default value
+  // is changed. Otherwise the knob would have no effect.
+  // We do this by changing the key.
+  const key = `${defaultExpandMultilineText}-${defaultExpandLanguages}`;
+
+  return (
+    <Spacings.Stack scale="l">
+      <CollapsiblePanel
+        header="Set initial value"
+        horizontalConstraint="scale"
+        isDefaultClosed
+      >
+        <Constraints.Horizontal max="scale">
+          <Spacings.Stack scale="m">
+            <textarea
+              defaultValue={resetValue.en}
+              onChange={onResetValueChange('en')}
+              rows={4}
+            />
+            <textarea
+              defaultValue={resetValue.de}
+              onChange={onResetValueChange('de')}
+              rows={4}
+            />
+            <textarea
+              defaultValue={resetValue['nan-Hant-TW']}
+              onChange={onResetValueChange('nan-Hant-TW')}
+              rows={4}
+            />
+            <Constraints.Horizontal max="auto">
+              <PrimaryButton
+                label="Reset"
+                onClick={handleReset}
+                size="medium"
+              />
+            </Constraints.Horizontal>
+          </Spacings.Stack>
+        </Constraints.Horizontal>
+      </CollapsiblePanel>
+      <LocalizedRichTextInput
+        key={key}
+        defaultExpandLanguages={
+          // we need to set undefined instead of false to avoid prop-type
+          // warnings in case hideLanguageExpansionControls is true
+          defaultExpandLanguages || undefined
+        }
+        data-test="foo"
+        ref={ref}
+        value={value}
+        {...args}
+        onChange={onChange}
+      />
+      <Text.Headline as="h3">Output</Text.Headline>
+      <pre>{JSON.stringify(value, null, 2)}</pre>
+    </Spacings.Stack>
+  );
+};
+
+BasicExample.args = {
+  // @ts-ignore
+  id: 'test-id',
+  name: 'productName',
+  defaultExpandLanguages: false,
+  defaultExpandMultilineText: false,
+  showExpandIcon: false,
+  selectedLanguage: 'en',
+  hideLanguageExpansionControls: false,
+  isAutofocussed: false,
+  isDisabled: false,
+  isReadOnly: false,
+  placeholder: {
+    en: 'Placeholder',
+    de: 'Platzhalter',
+    'nan-Hant-TW': '占位符',
+  },
+  horizontalConstraint: 12,
+  hasError: false,
+  hasWarning: false,
+  value: {
+    en: initialValue,
+    de: initialValue,
+    'nan-Hant-TW': initialValue,
+  },
+  additionalInfo: {
+    de: 'Zusätzliche Informationen können hier dargestellt werden',
+    en: 'Additional information can be displayed here',
+    'nan-Hant-TW': '額外資訊可以在這裡顯示',
+  },
+};
+
+/**
+ * This story demonstrates how the component looks when it has errors.
+ */
+// @ts-ignore
+export const WithErrors = BasicExample.bind({});
+
+WithErrors.args = {
+  ...BasicExample.args,
+  additionalInfo: undefined,
+  errors: {
+    de: 'Fehlertexte sehen so aus',
+    en: 'Error messages look like this',
+    'nan-Hant-TW': '錯誤訊息看起來像這樣',
+  },
+};

--- a/packages/components/inputs/localized-text-input/src/localized-text-input.readme.mdx
+++ b/packages/components/inputs/localized-text-input/src/localized-text-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/LocalizedTextInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/localized-text-input/src/localized-text-input.stories.tsx
+++ b/packages/components/inputs/localized-text-input/src/localized-text-input.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import LocalizedTextInput from './localized-text-input';
+import { useState } from 'react';
+
+const meta: Meta<typeof LocalizedTextInput> = {
+  title: 'Form/Inputs/LocalizedTextInput',
+  // @ts-ignore
+  component: LocalizedTextInput,
+};
+export default meta;
+
+type Story = StoryFn<typeof LocalizedTextInput>;
+
+export const BasicExample: Story = ({
+  defaultExpandLanguages,
+  value: propsValue,
+  ...args
+}) => {
+  const [value, onChange] = useState(
+    propsValue || { en: '', de: '', 'nan-Hant-TW': '' }
+  );
+
+  // We need to force the component to rerender in case a default value
+  // is changed. Otherwise the knob would have no effect.
+  // We do this by changing the key.
+  const key = defaultExpandLanguages ? 'yes' : 'no';
+
+  return (
+    <LocalizedTextInput
+      key={key}
+      value={value}
+      defaultExpandLanguages={defaultExpandLanguages}
+      {...args}
+      onChange={(event) => {
+        onChange({
+          ...value,
+          [event.target.language]: event.target.value,
+        });
+      }}
+    />
+  );
+};
+
+BasicExample.args = {
+  defaultExpandLanguages: false,
+  selectedLanguage: 'en',
+  hideLanguageExpansionControls: false,
+  isAutofocussed: false,
+  isCondensed: false,
+  isDisabled: false,
+  isReadOnly: false,
+  placeholder: { en: 'Placeholder', de: 'Platzhalter' },
+  horizontalConstraint: 7,
+  hasError: false,
+  hasWarning: false,
+};

--- a/packages/components/inputs/localized-text-input/src/localized-text-input.stories.tsx
+++ b/packages/components/inputs/localized-text-input/src/localized-text-input.stories.tsx
@@ -6,6 +6,12 @@ const meta: Meta<typeof LocalizedTextInput> = {
   title: 'Form/Inputs/LocalizedTextInput',
   // @ts-ignore
   component: LocalizedTextInput,
+  argTypes: {
+    selectedLanguage: {
+      control: 'select',
+      options: ['de', 'en', 'nan-Hant-TW'],
+    },
+  },
 };
 export default meta;
 

--- a/packages/components/inputs/money-input/src/money-input.readme.mdx
+++ b/packages/components/inputs/money-input/src/money-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/MoneyInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/money-input/src/money-input.stories.tsx
+++ b/packages/components/inputs/money-input/src/money-input.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import MoneyInput, { TCurrencyCode } from './money-input';
+import { useState } from 'react';
+
+const meta: Meta<typeof MoneyInput> = {
+  title: 'Form/Inputs/MoneyInput',
+  component: MoneyInput,
+};
+export default meta;
+
+type Story = StoryFn<typeof MoneyInput>;
+
+export const BasicExample: Story = ({ value: propsValue, ...args }) => {
+  const [amount, setAmount] = useState((propsValue && propsValue.amount) || '');
+  const [currencyCode, setCurrencyCode] = useState<TCurrencyCode | ''>(
+    (propsValue && propsValue.currencyCode) || ''
+  );
+
+  const value = {
+    amount,
+    currencyCode,
+  };
+
+  return (
+    <div style={{ height: 250 }}>
+      <MoneyInput
+        {...args}
+        value={value}
+        onChange={(event) => {
+          if (!event.target.name) return;
+
+          if (event.target.name.endsWith('.amount')) {
+            setAmount(event.target.value as string);
+          }
+
+          if (event.target.name.endsWith('.currencyCode')) {
+            setCurrencyCode(event.target.value as TCurrencyCode);
+          }
+        }}
+      />
+      <pre>{JSON.stringify(value, null, 2)}</pre>
+    </div>
+  );
+};
+
+BasicExample.args = {
+  currencies: ['EUR', 'USD', 'AED', 'KWD', 'JPY'],
+  name: 'money-input',
+  placeholder: 'Placeholder',
+  isDisabled: false,
+  isReadOnly: false,
+  isAutofocussed: false,
+  isCurrencyInputDisabled: false,
+  hasError: false,
+  hasWarning: false,
+  horizontalConstraint: 7,
+  hasHighPrecisionBadge: false,
+};

--- a/packages/components/inputs/multiline-text-input/src/multiline-text-input.readme.mdx
+++ b/packages/components/inputs/multiline-text-input/src/multiline-text-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/MultilineTextInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/multiline-text-input/src/multiline-text-input.stories.tsx
+++ b/packages/components/inputs/multiline-text-input/src/multiline-text-input.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import MultilineTextInput from './multiline-text-input';
+import { iconArgType } from '@/storybook-helpers';
+
+const meta: Meta<typeof MultilineTextInput> = {
+  title: 'Form/Inputs/MultilineTextInput',
+  component: MultilineTextInput,
+  argTypes: {
+    rightActionIcon: iconArgType,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof MultilineTextInput>;
+
+export const BasicExample: Story = {
+  args: {
+    placeholder: 'Placeholder text',
+  },
+};

--- a/packages/components/inputs/multiline-text-input/src/multiline-text-input.tsx
+++ b/packages/components/inputs/multiline-text-input/src/multiline-text-input.tsx
@@ -111,6 +111,7 @@ export type TMultilineTextInputProps = {
 
   /**
    * Custom action icon to be displayed on the right side of the input.
+   * **Will only show**, if `rightActionProps` is provided.
    */
   rightActionIcon?: ReactElement;
   /**

--- a/packages/components/inputs/number-input/src/number-input.readme.mdx
+++ b/packages/components/inputs/number-input/src/number-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/NumberInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/number-input/src/number-input.stories.tsx
+++ b/packages/components/inputs/number-input/src/number-input.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import NumberInput from './number-input';
+
+const meta: Meta<typeof NumberInput> = {
+  title: 'Form/Inputs/NumberInput',
+  component: NumberInput,
+  argTypes: {
+    value: {
+      control: 'number',
+    },
+    step: {
+      control: 'number',
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof NumberInput>;
+
+export const BasicExample: Story = {
+  args: {
+    placeholder: 'Enter a number',
+    value: undefined,
+    horizontalConstraint: 7,
+  },
+};


### PR DESCRIPTION
## Background
In an effort to switch from Storybook v5 to Storybook v8, the existing stories had to be migrated to a new storybook-format and converted to typescript. 

This pull-request is [part of a batch](https://github.com/commercetools/ui-kit/pull/2875). It contains the typescript-equivalents of existing storybook v5 stories and aims to replicate the same functionality / value. 

## Goal
Feature parity between v8 and v5 storybook. After merging all batches, a product developer who looked at the storybook v5 version yesterday, should be able to look at the v8 version tomorrow and be as productive (or more productive) as before. 

## Review instructions
A thorough **code review** is not required yet. The code was either copied from the existing js-equivalent or quickly written from scratch to replicate what was already there to fit the new story-format. It is expected that those stories contain typescript errors, introduced by the conversion or previously existing. (Another pull-request will take care of those issues at a later stage).

What is expect is a **story review**:

You will need to compare the v5 with the v8 storybook (ideally side-by-side) and make sure that every component in this pull-request has:

- [ ] a readme-file in the same or a parent-folder
- [ ] a props-table displaying available props (and appropriate inputs for them)
- [ ] one or more stories that showcase the same or more functionality as the v5 equivalent

You will find the links to the different storybooks below. 


> If something is missing or irritating, add a comment to the source file here in the pull-request to start a conversation.


