### PR TITLE
Storybook v8 stories batch 6

### DIFF
--- a/packages/components/inputs/password-input/src/password-input.readme.mdx
+++ b/packages/components/inputs/password-input/src/password-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/PasswordInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/password-input/src/password-input.stories.tsx
+++ b/packages/components/inputs/password-input/src/password-input.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import PasswordInput from './password-input';
+
+const meta: Meta<typeof PasswordInput> = {
+  title: 'Form/Inputs/PasswordInput',
+  component: PasswordInput,
+};
+export default meta;
+
+type Story = StoryObj<typeof PasswordInput>;
+
+export const BasicExample: Story = {
+  args: {
+    name: 'password',
+    placeholder: 'Password',
+    horizontalConstraint: 7,
+  },
+};

--- a/packages/components/inputs/radio-input/src/radio-group.tsx
+++ b/packages/components/inputs/radio-input/src/radio-group.tsx
@@ -40,7 +40,10 @@ export type TGroupProps = {
     | 16
     | 'scale'
     | 'auto';
+  /** Pick the desired layout. Possible values are `stack` or `inline`, (= Radio.Option items will be
+   * wrapped with the `Spacing.Stack` or `Spacing.Inline` component)*/
   direction: 'stack' | 'inline';
+  /** Props uesed to configue the selected layout component that was picked via the `direction` property */
   directionProps: {
     scale?: TInlineProps['scale'];
     alignItems?: TInlineProps['alignItems'];

--- a/packages/components/inputs/radio-input/src/radio-input.readme.mdx
+++ b/packages/components/inputs/radio-input/src/radio-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/RadioInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/radio-input/src/radio-input.stories.tsx
+++ b/packages/components/inputs/radio-input/src/radio-input.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import RadioInput, { TGroupProps } from './index';
+import { useState } from 'react';
+
+const meta: Meta<typeof RadioInput.Group> = {
+  title: 'Form/Inputs/RadioInput',
+  component: RadioInput.Group,
+  subcomponents: {
+    // @ts-ignore
+    RadioOption: RadioInput.Option,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RadioInput.Group>;
+
+export const BasicExample: Story = (args: TGroupProps) => {
+  const [v, setV] = useState('1');
+
+  return (
+    <RadioInput.Group
+      {...args}
+      value={v}
+      onChange={(e) => setV(e.target.value)}
+    >
+      <RadioInput.Option value="1">🍎 Apple</RadioInput.Option>
+      <RadioInput.Option value="2">🍌 Banana</RadioInput.Option>
+      <RadioInput.Option value="3">🍍 Pineapple</RadioInput.Option>
+    </RadioInput.Group>
+  );
+};
+
+BasicExample.args = {
+  id: 'fruit-selector',
+  name: 'fruits',
+  direction: 'stack',
+  directionProps: {
+    scale: 'm',
+  },
+};

--- a/packages/components/inputs/rich-text-input/src/rich-text-input.readme.mdx
+++ b/packages/components/inputs/rich-text-input/src/rich-text-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/RichTextInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/rich-text-input/src/rich-text-input.stories.tsx
+++ b/packages/components/inputs/rich-text-input/src/rich-text-input.stories.tsx
@@ -16,7 +16,8 @@ export default meta;
 
 type Story = StoryFn<typeof RichTextInput>;
 
-const initialValue = '<h1>H1 <u>heading</u></h1>';
+const initialValue =
+  '<h1>Heading</h1><p>This is a paragraph.<br/><br/>New sentence, <strong>same</strong> paragraph, but with <u>soft</u>-linebreak (<em>Shift + Enter</em>).</p>';
 
 // @ts-ignore
 export const BasicExample: Story = (args: TRichTextInputProps) => {
@@ -30,7 +31,9 @@ export const BasicExample: Story = (args: TRichTextInputProps) => {
   );
 };
 
-BasicExample.args = {};
+BasicExample.args = {
+  defaultExpandMultilineText: true,
+};
 
 /** This demo allows to modify the intial input, do changes and verify if the html-output matches the expectations. */
 export const PlaygroundExample: Story = () => {

--- a/packages/components/inputs/rich-text-input/src/rich-text-input.stories.tsx
+++ b/packages/components/inputs/rich-text-input/src/rich-text-input.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import RichTextInput, { TRichTextInputProps } from './rich-text-input';
+import { useCallback, useRef, useState } from 'react';
+import CollapsiblePanel from '@commercetools-uikit/collapsible-panel';
+import Constraints from '@commercetools-uikit/constraints';
+import Spacings from '@commercetools-uikit/spacings';
+import PrimaryButton from '@commercetools-uikit/primary-button';
+import Text from '@commercetools-uikit/text';
+
+const meta: Meta<typeof RichTextInput> = {
+  title: 'Form/Inputs/RichTextInput',
+  // @ts-ignore
+  component: RichTextInput,
+};
+export default meta;
+
+type Story = StoryFn<typeof RichTextInput>;
+
+const initialValue = '<h1>H1 <u>heading</u></h1>';
+
+// @ts-ignore
+export const BasicExample: Story = (args: TRichTextInputProps) => {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <RichTextInput
+      {...args}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    />
+  );
+};
+
+BasicExample.args = {};
+
+/** This demo allows to modify the intial input, do changes and verify if the html-output matches the expectations. */
+export const PlaygroundExample: Story = () => {
+  const onClickExpand = useCallback(() => {
+    // eslint-disable-next-line no-alert
+    alert('Expand');
+  }, []);
+
+  const onBlur = useCallback(() => console.log('onBlur'), []);
+  const onFocus = useCallback(() => console.log('onFocus'), []);
+  const ref = useRef(null);
+  const [value, setValue] = useState(initialValue);
+  const [resetValue, setResetValue] = useState(initialValue);
+  const onChange = useCallback(
+    (event) => {
+      setValue(event.target.value);
+    },
+    [setValue]
+  );
+  const onResetValueChange = useCallback(
+    (event) => {
+      setResetValue(event.target.value);
+    },
+    [setResetValue]
+  );
+  const handleReset = () => {
+    //ref.current?.resetValue(resetValue);
+  };
+
+  return (
+    <Spacings.Stack scale="l">
+      <CollapsiblePanel
+        header="Set initial value"
+        horizontalConstraint="scale"
+        isDefaultClosed
+      >
+        <Constraints.Horizontal max="scale">
+          <Spacings.Stack scale="m">
+            <textarea
+              defaultValue={resetValue}
+              onChange={onResetValueChange}
+              rows={4}
+            />
+            <Constraints.Horizontal max="auto">
+              <PrimaryButton
+                label="Reset"
+                onClick={handleReset}
+                size="medium"
+              />
+            </Constraints.Horizontal>
+          </Spacings.Stack>
+        </Constraints.Horizontal>
+      </CollapsiblePanel>
+      <RichTextInput
+        name={'test-name'}
+        onBlur={onBlur}
+        onFocus={onFocus}
+        defaultExpandMultilineText={true}
+        placeholder={'Placeholder'}
+        showExpandIcon={false}
+        onClickExpand={() => {
+          onClickExpand();
+          return true;
+        }}
+        hasError={false}
+        hasWarning={false}
+        isDisabled={false}
+        isReadOnly={false}
+        ref={ref}
+        onChange={onChange}
+        value={value}
+      />
+      <Text.Headline as="h3">Output</Text.Headline>
+      <pre>{value}</pre>
+    </Spacings.Stack>
+  );
+};

--- a/packages/components/inputs/rich-text-input/src/rich-text-input.stories.tsx
+++ b/packages/components/inputs/rich-text-input/src/rich-text-input.stories.tsx
@@ -60,7 +60,7 @@ export const PlaygroundExample: Story = () => {
     [setResetValue]
   );
   const handleReset = () => {
-    //ref.current?.resetValue(resetValue);
+    ref.current?.resetValue(resetValue);
   };
 
   return (

--- a/packages/components/inputs/rich-text-input/src/rich-text-input.stories.tsx
+++ b/packages/components/inputs/rich-text-input/src/rich-text-input.stories.tsx
@@ -107,7 +107,7 @@ export const PlaygroundExample: Story = () => {
         value={value}
       />
       <Text.Headline as="h3">Output</Text.Headline>
-      <pre>{value}</pre>
+      <pre style={{ textWrap: 'auto' }}>{value}</pre>
     </Spacings.Stack>
   );
 };

--- a/packages/components/inputs/search-select-input/src/search-select-input.readme.mdx
+++ b/packages/components/inputs/search-select-input/src/search-select-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/SearchSelectInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/search-select-input/src/search-select-input.stories.tsx
+++ b/packages/components/inputs/search-select-input/src/search-select-input.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import SearchSelectInput from './search-select-input';
+import { iconArgType } from '@/storybook-helpers';
+import { useState } from 'react';
+import Spacings from '@commercetools-uikit/spacings';
+
+const meta: Meta<typeof SearchSelectInput> = {
+  title: 'Form/Inputs/SearchSelectInput',
+  component: SearchSelectInput,
+  argTypes: {
+    iconLeft: iconArgType,
+    isMulti: { control: { type: 'boolean' } },
+    backspaceRemovesValue: { control: { type: 'boolean' } },
+    controlShouldRenderValue: { control: { type: 'boolean' } },
+    closeMenuOnSelect: { control: { type: 'boolean' } },
+    tabSelectsValue: { control: { type: 'boolean' } },
+    cacheOptions: { control: { type: 'boolean' } },
+    'aria-label': { control: { type: 'text' } },
+    'aria-labelledby': { control: { type: 'text' } },
+    'aria-invalid': { control: { type: 'boolean' } },
+    'aria-errormessage': { control: { type: 'text' } },
+    id: { control: { type: 'text' } },
+    containerId: { control: { type: 'text' } },
+    tabIndex: { control: { type: 'number' } },
+    isOptionDisabled: { control: { type: 'boolean' } },
+    menuIsOpen: { control: { type: 'boolean' } },
+    menuShouldBlockScroll: { control: { type: 'boolean' } },
+    showOptionGroupDivider: { control: { type: 'boolean' } },
+  },
+};
+export default meta;
+
+type Story = StoryFn<typeof SearchSelectInput>;
+
+const colourOptions = [
+  {
+    label:
+      'This is label is very long and the reason that it is very long is to test how it is displayed in the dropdown or when it is select.',
+    value: 'ocean',
+    id: '1',
+  },
+  { label: 'Blue', value: 'blue', key: 'blue', id: '2' },
+  { label: 'Purple', value: 'purple', key: 'purple', id: '3' },
+  { label: 'Red', value: 'red', key: 'red', id: '4' },
+  { label: 'Orange', value: 'orange', key: 'orange', id: '5' },
+  { label: 'Yellow', value: 'yellow', key: 'yellow', id: '6' },
+  { label: 'Green', value: 'green', key: 'green', id: '7' },
+  { label: 'Forest', value: 'forest', key: 'forest', id: '8' },
+  { label: 'Slate', value: 'slate', key: 'slate', id: '9' },
+  { label: 'Silver', value: 'silver', key: 'silver', id: '10' },
+];
+
+const filterColors = (inputValue: string) =>
+  colourOptions.filter(
+    (colourOption) =>
+      colourOption.label === inputValue || colourOption.id === inputValue
+  );
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const loadOptions = (inputValue: string) =>
+  delay(500).then(() => filterColors(inputValue));
+
+export const BasicExample: Story = ({ isMulti, ...args }) => {
+  const [value, onChange] = useState<string | string[] | undefined>(
+    isMulti ? [] : undefined
+  );
+
+  return (
+    <div style={{ height: 400 }}>
+      <Spacings.Stack scale="m">
+        <SearchSelectInput
+          onChange={(event) => {
+            onChange(event.target.value as string | string[] | undefined);
+          }}
+          value={value}
+          {...args}
+          loadOptions={loadOptions}
+        />
+
+        <div>
+          <p>
+            In this example, the `loadOptions` function uses the data (given
+            below) to perform an exact match. It is case sensitive and it
+            performs a search based on{' '}
+            <b>
+              <i>id</i>
+            </b>{' '}
+            and{' '}
+            <b>
+              <i>label</i>
+            </b>{' '}
+            fields with a 500ms delay
+          </p>
+          <b>Data used:</b>
+          <pre style={{ textWrap: 'wrap' }}>
+            {JSON.stringify(colourOptions, undefined, 2)}
+          </pre>
+        </div>
+      </Spacings.Stack>
+    </div>
+  );
+};
+
+BasicExample.args = {
+  isMulti: false,
+  horizontalConstraint: 'scale',
+  noOptionsMessage: ({ inputValue }) =>
+    inputValue.length > 0
+      ? `No matches found for '${inputValue}'`
+      : 'No matches found',
+  loadingMessage: 'Loading exact matches',
+  hasError: false,
+  hasWarning: false,
+  isAutofocussed: false,
+  backspaceRemovesValue: true,
+  controlShouldRenderValue: true,
+  isClearable: true,
+  isCondensed: false,
+  isDisabled: false,
+  isReadOnly: false,
+  maxMenuHeight: 220,
+  closeMenuOnSelect: true,
+  name: 'form-field-name',
+  placeholder: 'Search by...',
+  tabSelectsValue: true,
+  cacheOptions: true,
+  optionType: 'single-property',
+};

--- a/packages/components/inputs/search-text-input/src/search-text-input.readme.mdx
+++ b/packages/components/inputs/search-text-input/src/search-text-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/SearchTextInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/search-text-input/src/search-text-input.stories.tsx
+++ b/packages/components/inputs/search-text-input/src/search-text-input.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SearchTextInput from './search-text-input';
+
+const meta: Meta<typeof SearchTextInput> = {
+  title: 'Form/Inputs/SearchTextInput',
+  // @ts-ignore, sb seems unable to deal with this complex type (forwardedRef & partial)
+  component: SearchTextInput,
+};
+export default meta;
+
+type Story = StoryObj<typeof SearchTextInput>;
+
+export const BasicExample: Story = {
+  args: {
+    // @ts-ignore
+    placeholder: 'Placeholder text',
+  },
+};

--- a/packages/components/inputs/select-input/src/select-input.readme.mdx
+++ b/packages/components/inputs/select-input/src/select-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/SelectInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/select-input/src/select-input.stories.tsx
+++ b/packages/components/inputs/select-input/src/select-input.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SelectInput from './select-input';
+
+const meta: Meta<typeof SelectInput> = {
+  title: 'Form/Inputs/SelectInput',
+  component: SelectInput,
+};
+export default meta;
+
+type Story = StoryObj<typeof SelectInput>;
+
+const options = [
+  {
+    label: 'Animals 1',
+    options: [
+      { value: 'platypus', label: 'Platypus' },
+      { value: 'goat', label: 'Goat' },
+      { value: 'giraffe', label: 'Giraffe' },
+      { value: 'whale', label: 'Whale' },
+      { value: 'killer-whale', label: 'Killer Whale', isDisabled: true },
+      { value: 'otter', label: 'Otter' },
+      { value: 'elephant', label: 'Elephant' },
+      { value: 'rat', label: 'Rat' },
+      { value: 'anteater', label: 'Anteater' },
+      { value: 'alligator', label: 'Alligator' },
+      { value: 'dog', label: 'Dog' },
+      { value: 'pig', label: 'Pig' },
+      { value: 'hippopotamus', label: 'Hippopotamus' },
+      { value: 'lion', label: 'Lion' },
+      { value: 'monkey', label: 'Monkey' },
+      { value: 'kangaroo', label: 'Kangaroo' },
+      { value: 'flamingo', label: 'Flamingo' },
+      { value: 'moose', label: 'Moose' },
+    ],
+  },
+  {
+    label: 'Animals 2',
+    options: [
+      { value: 'prairie-dog', label: 'Prairie Dog', isDisabled: true },
+      { value: 'snake', label: 'Snake' },
+      { value: 'porcupine', label: 'Porcupine' },
+      { value: 'stingray', label: 'Stingray' },
+      { value: 'panther', label: 'Panther' },
+      { value: 'lizard', label: 'Lizard' },
+      { value: 'parrot', label: 'Parrot' },
+      { value: 'dolphin', label: 'Dolphin' },
+      { value: 'chicken', label: 'Chicken' },
+      { value: 'sloth', label: 'Sloth' },
+      { value: 'shark', label: 'Shark' },
+      { value: 'ape', label: 'Ape' },
+      { value: 'bear', label: 'Bear' },
+      { value: 'cheetah', label: 'Cheetah' },
+      { value: 'camel', label: 'Camel' },
+      { value: 'beaver', label: 'Beaver' },
+      { value: 'armadillo', label: 'Armadillo' },
+      { value: 'tiger', label: 'Tiger' },
+    ],
+  },
+  {
+    label: 'Animals 3',
+    options: [
+      { value: 'llama', label: 'Llama' },
+      { value: 'seal', label: 'Seal' },
+      { value: 'hawk', label: 'Hawk' },
+      { value: 'wolf', label: 'Wolf' },
+      { value: 'yak', label: 'Yak' },
+      { value: 'rhinoceros', label: 'Rhinoceros' },
+      { value: 'alpaca', label: 'Alpaca' },
+      { value: 'zebra', label: 'Zebra' },
+      { value: 'cat', label: 'Cat' },
+      { value: 'rabbit', label: 'Rabbit' },
+      { value: 'turtle', label: 'Turtle' },
+      { value: 'cow', label: 'Cow' },
+      { value: 'turkey', label: 'Turkey' },
+      { value: 'deer', label: 'Deer' },
+    ],
+  },
+];
+
+export const BasicExample: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ height: 350 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    options,
+    horizontalConstraint: 7,
+  },
+};

--- a/packages/components/inputs/select-input/src/select-input.stories.tsx
+++ b/packages/components/inputs/select-input/src/select-input.stories.tsx
@@ -1,9 +1,39 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import SelectInput from './select-input';
+import { iconArgType } from '@/storybook-helpers';
 
 const meta: Meta<typeof SelectInput> = {
   title: 'Form/Inputs/SelectInput',
   component: SelectInput,
+  argTypes: {
+    iconLeft: iconArgType,
+    'aria-label': { control: { type: 'text' } },
+    'aria-labelledby': { control: { type: 'text' } },
+    'aria-invalid': { control: { type: 'boolean' } },
+    'aria-errormessage': { control: { type: 'text' } },
+    backspaceRemovesValue: { control: { type: 'boolean' } },
+    controlShouldRenderValue: { control: { type: 'boolean' } },
+    filterOption: { type: 'function' },
+    id: { control: { type: 'text' } },
+    inputValue: { control: { type: 'text' } },
+    containerId: { control: { type: 'text' } },
+    isClearable: { control: { type: 'boolean' } },
+    isDisabled: { control: { type: 'boolean' } },
+    isOptionDisabled: { type: 'function' },
+    isMulti: { control: { type: 'boolean' } },
+    isSearchable: { control: { type: 'boolean' } },
+    menuIsOpen: { control: { type: 'boolean' } },
+    maxMenuHeight: { control: { type: 'number' } },
+    menuPortalTarget: { control: false },
+    menuShouldBlockScroll: { control: { type: 'boolean' } },
+    closeMenuOnSelect: { control: { type: 'boolean' } },
+    name: { control: { type: 'text' } },
+    noOptionsMessage: { type: 'function' },
+    placeholder: { control: { type: 'text' } },
+    tabIndex: { control: { type: 'number' } },
+    tabSelectsValue: { control: { type: 'boolean' } },
+    value: { control: false },
+  },
 };
 export default meta;
 

--- a/packages/components/inputs/select-input/src/select-input.stories.tsx
+++ b/packages/components/inputs/select-input/src/select-input.stories.tsx
@@ -1,6 +1,7 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import SelectInput from './select-input';
 import { iconArgType } from '@/storybook-helpers';
+import { useEffect, useState } from 'react';
 
 const meta: Meta<typeof SelectInput> = {
   title: 'Form/Inputs/SelectInput',
@@ -34,10 +35,17 @@ const meta: Meta<typeof SelectInput> = {
     tabSelectsValue: { control: { type: 'boolean' } },
     value: { control: false },
   },
+  decorators: [
+    (Story) => (
+      <div style={{ height: 350 }}>
+        <Story />
+      </div>
+    ),
+  ],
 };
 export default meta;
 
-type Story = StoryObj<typeof SelectInput>;
+type Story = StoryFn<typeof SelectInput>;
 
 const options = [
   {
@@ -107,16 +115,27 @@ const options = [
   },
 ];
 
-export const BasicExample: Story = {
-  decorators: [
-    (Story) => (
-      <div style={{ height: 350 }}>
-        <Story />
-      </div>
-    ),
-  ],
-  args: {
-    options,
-    horizontalConstraint: 7,
-  },
+export const BasicExample: Story = (args) => {
+  const [value, setValue] = useState<string | string[] | null | undefined>(
+    null
+  );
+
+  useEffect(() => {
+    setValue(null);
+  }, [args.isMulti]);
+
+  return (
+    <SelectInput
+      {...args}
+      value={value}
+      onChange={(e) => {
+        setValue(e.target.value);
+      }}
+    />
+  );
+};
+
+BasicExample.args = {
+  options,
+  horizontalConstraint: 7,
 };

--- a/packages/components/inputs/selectable-search-input/src/selectable-search-input.readme.mdx
+++ b/packages/components/inputs/selectable-search-input/src/selectable-search-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/SelectableSearchInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/selectable-search-input/src/selectable-search-input.stories.tsx
+++ b/packages/components/inputs/selectable-search-input/src/selectable-search-input.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SelectableSearchInput from './selectable-search-input';
+import { iconArgType } from '@/storybook-helpers';
+
+const meta: Meta<typeof SelectableSearchInput> = {
+  title: 'Form/Inputs/SelectableSearchInput',
+  component: SelectableSearchInput,
+  argTypes: {
+    rightActionIcon: iconArgType,
+    menuShouldBlockScroll: {
+      control: 'boolean',
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SelectableSearchInput>;
+
+const options = [
+  {
+    label: 'Animals 1',
+    options: [
+      { value: 'platypus', label: 'Platypus' },
+      { value: 'goat', label: 'Goat' },
+      { value: 'giraffe', label: 'Giraffe' },
+      { value: 'whale', label: 'Whale' },
+      { value: 'killer-whale', label: 'Killer Whale', isDisabled: true },
+      { value: 'otter', label: 'Otter' },
+      { value: 'elephant', label: 'Elephant' },
+      { value: 'rat', label: 'Rat' },
+      { value: 'anteater', label: 'Anteater' },
+      { value: 'alligator', label: 'Alligator' },
+      { value: 'dog', label: 'Dog' },
+      { value: 'pig', label: 'Pig' },
+      { value: 'hippopotamus', label: 'Hippopotamus' },
+      { value: 'lion', label: 'Lion' },
+      { value: 'monkey', label: 'Monkey' },
+      { value: 'kangaroo', label: 'Kangaroo' },
+      { value: 'flamingo', label: 'Flamingo' },
+      { value: 'moose', label: 'Moose' },
+    ],
+  },
+  {
+    label: 'Animals 2',
+    options: [
+      { value: 'prairie-dog', label: 'Prairie Dog', isDisabled: true },
+      { value: 'snake', label: 'Snake' },
+      { value: 'porcupine', label: 'Porcupine' },
+      { value: 'stingray', label: 'Stingray' },
+      { value: 'panther', label: 'Panther' },
+      { value: 'lizard', label: 'Lizard' },
+      { value: 'parrot', label: 'Parrot' },
+      { value: 'dolphin', label: 'Dolphin' },
+      { value: 'chicken', label: 'Chicken' },
+      { value: 'sloth', label: 'Sloth' },
+      { value: 'shark', label: 'Shark' },
+      { value: 'ape', label: 'Ape' },
+      { value: 'bear', label: 'Bear' },
+      { value: 'cheetah', label: 'Cheetah' },
+      { value: 'camel', label: 'Camel' },
+      { value: 'beaver', label: 'Beaver' },
+      { value: 'armadillo', label: 'Armadillo' },
+      { value: 'tiger', label: 'Tiger' },
+    ],
+  },
+  {
+    label: 'Animals 3',
+    options: [
+      { value: 'llama', label: 'Llama' },
+      { value: 'seal', label: 'Seal' },
+      { value: 'hawk', label: 'Hawk' },
+      { value: 'wolf', label: 'Wolf' },
+      { value: 'yak', label: 'Yak' },
+      { value: 'rhinoceros', label: 'Rhinoceros' },
+      { value: 'alpaca', label: 'Alpaca' },
+      { value: 'zebra', label: 'Zebra' },
+      { value: 'cat', label: 'Cat' },
+      { value: 'rabbit', label: 'Rabbit' },
+      { value: 'turtle', label: 'Turtle' },
+      { value: 'cow', label: 'Cow' },
+      { value: 'turkey', label: 'Turkey' },
+      { value: 'deer', label: 'Deer' },
+    ],
+  },
+];
+
+export const BasicExample: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ height: 400 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    id: 'ssi-test-id',
+    name: 'ssi-test-name',
+    placeholder: 'Placeholder text...',
+    value: {
+      text: 'Dachshund',
+      option: 'dog',
+    },
+    rightActionProps: {
+      label: 'Right action',
+      onClick: () => {},
+    },
+    options,
+  },
+};

--- a/packages/components/inputs/text-input/src/text-input.readme.mdx
+++ b/packages/components/inputs/text-input/src/text-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/TextInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/text-input/src/text-input.stories.tsx
+++ b/packages/components/inputs/text-input/src/text-input.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import TextInput from './text-input';
+
+const meta: Meta<typeof TextInput> = {
+  title: 'Form/Inputs/TextInput',
+  component: TextInput,
+};
+export default meta;
+
+type Story = StoryObj<typeof TextInput>;
+
+export const BasicExample: Story = {
+  args: {
+    placeholder: 'Placeholder text',
+  },
+};

--- a/packages/components/inputs/time-input/src/time-input.readme.mdx
+++ b/packages/components/inputs/time-input/src/time-input.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/TimeInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/time-input/src/time-input.stories.tsx
+++ b/packages/components/inputs/time-input/src/time-input.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import TimeInput from './time-input';
+
+const meta: Meta<typeof TimeInput> = {
+  title: 'Form/Inputs/TimeInput',
+  component: TimeInput,
+};
+export default meta;
+
+type Story = StoryObj<typeof TimeInput>;
+
+export const BasicExample: Story = {
+  args: {
+    value: '17:12',
+    placeholder: 'Enter time...',
+    horizontalConstraint: 7,
+  },
+};

--- a/packages/components/inputs/time-input/src/time-input.stories.tsx
+++ b/packages/components/inputs/time-input/src/time-input.stories.tsx
@@ -1,5 +1,6 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import TimeInput from './time-input';
+import { useState } from 'react';
 
 const meta: Meta<typeof TimeInput> = {
   title: 'Form/Inputs/TimeInput',
@@ -7,12 +8,20 @@ const meta: Meta<typeof TimeInput> = {
 };
 export default meta;
 
-type Story = StoryObj<typeof TimeInput>;
+type Story = StoryFn<typeof TimeInput>;
 
-export const BasicExample: Story = {
-  args: {
-    value: '17:12',
-    placeholder: 'Enter time...',
-    horizontalConstraint: 7,
-  },
+export const BasicExample: Story = (args) => {
+  const [value, setValue] = useState('17:12');
+  return (
+    <TimeInput
+      {...args}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    />
+  );
+};
+
+BasicExample.args = {
+  placeholder: 'Enter time...',
+  horizontalConstraint: 7,
 };

--- a/packages/components/inputs/time-input/src/time-input.tsx
+++ b/packages/components/inputs/time-input/src/time-input.tsx
@@ -232,7 +232,7 @@ TimeInput.to24h = (time: string) => {
 
 TimeInput.defaultProps = {
   horizontalConstraint: 'scale',
-};
+} as Pick<TTimeInputProps, 'horizontalConstraint'>;
 
 // Converts any value to either a formatted value or an empty string
 // The resulting format might use 12h or 24h, unless the time contains

--- a/packages/components/inputs/toggle-input/src/toggle.readme.mdx
+++ b/packages/components/inputs/toggle-input/src/toggle.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/ToggleInput/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/inputs/toggle-input/src/toggle.stories.tsx
+++ b/packages/components/inputs/toggle-input/src/toggle.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Toggle, { TToggleInputProps } from './toggle-input';
+import { useState } from 'react';
+
+const meta: Meta<typeof Toggle> = {
+  title: 'Form/Inputs/ToggleInput',
+  component: Toggle,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Toggle>;
+
+export const BasicExample: Story = ({
+  isChecked,
+  ...args
+}: TToggleInputProps) => {
+  const [isActive, setIsActive] = useState(false);
+
+  return (
+    <Toggle
+      isChecked={isChecked === undefined ? isActive : isChecked}
+      {...args}
+      onChange={() => setIsActive(!isActive)}
+    />
+  );
+};
+
+BasicExample.args = {};

--- a/packages/components/label/src/label.readme.mdx
+++ b/packages/components/label/src/label.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Form/Inputs/Label/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/label/src/label.stories.tsx
+++ b/packages/components/label/src/label.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Label from './label';
+
+const meta: Meta<typeof Label> = {
+  title: 'Form/Inputs/Label',
+  component: Label,
+};
+export default meta;
+
+type Story = StoryObj<typeof Label>;
+
+export const BasicExample: Story = {
+  args: {
+    children: 'Label value',
+  },
+};

--- a/packages/components/link/src/link.readme.mdx
+++ b/packages/components/link/src/link.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/Link/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/link/src/link.stories.tsx
+++ b/packages/components/link/src/link.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import Link from './link';
+
+const meta: Meta<typeof Link> = {
+  title: 'components/Link',
+  component: Link,
+};
+export default meta;
+
+type Story = StoryObj<typeof Link>;
+
+export const BasicExample: Story = {
+  decorators: [
+    (Story) => (
+      <Router>
+        <Story />
+      </Router>
+    ),
+  ],
+  args: {
+    children: 'Sample Link',
+    to: '/path/to/link/to',
+  },
+};
+
+export const ExternalLink: Story = {
+  args: {
+    children: 'External Text',
+    to: '/path/to/link/to',
+    isExternal: true,
+  },
+
+  decorators: [
+    (Story) => (
+      <Router>
+        <Story />
+      </Router>
+    ),
+  ],
+};

--- a/storybook/.storybook/preview.tsx
+++ b/storybook/.storybook/preview.tsx
@@ -12,6 +12,7 @@ const preview: Preview = {
   },
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' },
+    controls: { expanded: true },
     options: {
       storySort: {
         method: 'alphabetical',


### PR DESCRIPTION
## Background
In an effort to switch from Storybook v5 to Storybook v8, the existing stories had to be migrated to a new storybook-format and converted to typescript. 

This pull-request is [part of a batch](https://github.com/commercetools/ui-kit/pull/2875). It contains the typescript-equivalents of existing storybook v5 stories and aims to replicate the same functionality / value. 

## Goal
Feature parity between v8 and v5 storybook. After merging all batches, a product developer who looked at the storybook v5 version yesterday, should be able to look at the v8 version tomorrow and be as productive (or more productive) as before. 

## Review instructions
A thorough **code review** is not required yet. The code was either copied from the existing js-equivalent or quickly written from scratch to replicate what was already there to fit the new story-format. It is expected that those stories contain typescript errors, introduced by the conversion or previously existing. (Another pull-request will take care of those issues at a later stage).

What is expect is a **story review**:

You will need to compare the v5 with the v8 storybook (ideally side-by-side) and make sure that every component in this pull-request has:

- [ ] a readme-file in the same or a parent-folder
- [ ] a props-table displaying available props (and appropriate inputs for them)
- [ ] one or more stories that showcase the same or more functionality as the v5 equivalent

You will find the links to the different storybooks below. 


> If something is missing or irritating, add a comment to the source file here in the pull-request to start a conversation.


