### PR TITLE
Storybook v8 stories batch 7

### DIFF
--- a/packages/components/loading-spinner/src/loading-spinner.readme.mdx
+++ b/packages/components/loading-spinner/src/loading-spinner.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/LoadingSpinner/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/loading-spinner/src/loading-spinner.stories.tsx
+++ b/packages/components/loading-spinner/src/loading-spinner.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import LoadingSpinner from './loading-spinner';
+
+const meta: Meta<typeof LoadingSpinner> = {
+  title: 'components/LoadingSpinner',
+  component: LoadingSpinner,
+  argTypes: {
+    children: {
+      control: 'text',
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof LoadingSpinner>;
+
+export const BasicExample: Story = {
+  args: {
+    scale: 'l',
+    children: 'Loading text...',
+  },
+};

--- a/packages/components/messages/src/additional-info-message/additional-info-message.stories.tsx
+++ b/packages/components/messages/src/additional-info-message/additional-info-message.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import AdditionalInfoMessage from './additional-info-message';
+
+const meta: Meta<typeof AdditionalInfoMessage> = {
+  title: 'components/Messages/AdditionalInfoMessage',
+  component: AdditionalInfoMessage,
+};
+export default meta;
+
+type Story = StoryObj<typeof AdditionalInfoMessage>;
+
+export const BasicExample: Story = {
+  args: {
+    message: 'This is an information message',
+  },
+};

--- a/packages/components/messages/src/error-message/error-message.stories.tsx
+++ b/packages/components/messages/src/error-message/error-message.stories.tsx
@@ -4,6 +4,9 @@ import ErrorMessage from './error-message';
 const meta: Meta<typeof ErrorMessage> = {
   title: 'components/Messages/ErrorMessage',
   component: ErrorMessage,
+    argTypes: {
+    intlMessage: { control: { disable: true } },
+  },
 };
 export default meta;
 

--- a/packages/components/messages/src/error-message/error-message.stories.tsx
+++ b/packages/components/messages/src/error-message/error-message.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ErrorMessage from './error-message';
+
+const meta: Meta<typeof ErrorMessage> = {
+  title: 'components/Messages/ErrorMessage',
+  component: ErrorMessage,
+};
+export default meta;
+
+type Story = StoryObj<typeof ErrorMessage>;
+
+export const BasicExample: Story = {
+  args: {
+    children: 'Required text missing',
+  },
+};

--- a/packages/components/messages/src/error-message/error-message.stories.tsx
+++ b/packages/components/messages/src/error-message/error-message.stories.tsx
@@ -4,7 +4,7 @@ import ErrorMessage from './error-message';
 const meta: Meta<typeof ErrorMessage> = {
   title: 'components/Messages/ErrorMessage',
   component: ErrorMessage,
-    argTypes: {
+  argTypes: {
     intlMessage: { control: { disable: true } },
   },
 };

--- a/packages/components/messages/src/messages.readme.mdx
+++ b/packages/components/messages/src/messages.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/Messages/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/messages/src/warning-message/warning-message.stories.tsx
+++ b/packages/components/messages/src/warning-message/warning-message.stories.tsx
@@ -4,6 +4,9 @@ import WarningMessage from './warning-message';
 const meta: Meta<typeof WarningMessage> = {
   title: 'components/Messages/WarningMessage',
   component: WarningMessage,
+  argTypes: {
+    intlMessage: { control: { disable: true } },
+  },
 };
 export default meta;
 

--- a/packages/components/messages/src/warning-message/warning-message.stories.tsx
+++ b/packages/components/messages/src/warning-message/warning-message.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import WarningMessage from './warning-message';
+
+const meta: Meta<typeof WarningMessage> = {
+  title: 'components/Messages/WarningMessage',
+  component: WarningMessage,
+};
+export default meta;
+
+type Story = StoryObj<typeof WarningMessage>;
+
+export const BasicExample: Story = {
+  args: {
+    children: 'This name is already being used by another variant',
+  },
+};

--- a/packages/components/notifications/src/notification.readme.mdx
+++ b/packages/components/notifications/src/notification.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/Notification/ContentNotification/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/notifications/src/notification.stories.tsx
+++ b/packages/components/notifications/src/notification.stories.tsx
@@ -4,6 +4,9 @@ import ContentNotification from './content-notification';
 const meta: Meta<typeof ContentNotification> = {
   title: 'components/Notification/ContentNotification',
   component: ContentNotification,
+  argTypes: {
+    intlMessage: { control: false },
+  },
 };
 export default meta;
 

--- a/packages/components/notifications/src/notification.stories.tsx
+++ b/packages/components/notifications/src/notification.stories.tsx
@@ -11,7 +11,8 @@ type Story = StoryObj<typeof ContentNotification>;
 
 export const BasicExample: Story = {
   args: {
-    children: 'I am displaying all kinds of notifications!',
+    children: 'I can display different kinds of notifications!',
+    type: 'warning',
     onRemove: undefined,
   },
 };

--- a/packages/components/notifications/src/notification.stories.tsx
+++ b/packages/components/notifications/src/notification.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ContentNotification from './content-notification';
+
+const meta: Meta<typeof ContentNotification> = {
+  title: 'components/Notification/ContentNotification',
+  component: ContentNotification,
+};
+export default meta;
+
+type Story = StoryObj<typeof ContentNotification>;
+
+export const BasicExample: Story = {
+  args: {
+    children: 'I am displaying all kinds of notifications!',
+    onRemove: undefined,
+  },
+};
+
+/** Provide an `onRemove` function to display a Close-Button: */
+export const DismissableNotification: Story = {
+  args: {
+    children: 'Fabulous, everything went as expected!',
+    type: 'success',
+    onRemove: () => alert('Notification close clicked!'),
+  },
+};

--- a/packages/components/pagination/src/page-navigator/page-navigator.stories.tsx
+++ b/packages/components/pagination/src/page-navigator/page-navigator.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import styled from '@emotion/styled';
+import PageNavigator from './page-navigator';
+
+const meta: Meta<typeof PageNavigator> = {
+  title: 'components/Pagination/PageNavigator',
+  component: PageNavigator,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PageNavigator>;
+
+const Container = styled.div`
+  display: block;
+  height: 256px;
+  margin-top: 96px;
+  align-items: center;
+`;
+
+export const BasicExample: Story = {
+  args: {
+    totalPages: 10,
+    page: 2,
+    onPageChange: () => {},
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <Container>
+          <Story />
+        </Container>
+      );
+    },
+  ],
+};

--- a/packages/components/pagination/src/page-size-selector/page-size-selector.stories.tsx
+++ b/packages/components/pagination/src/page-size-selector/page-size-selector.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import styled from '@emotion/styled';
+import PageSizeSelector from './page-size-selector';
+
+const meta: Meta<typeof PageSizeSelector> = {
+  title: 'components/Pagination/PageSizeSelector',
+  component: PageSizeSelector,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PageSizeSelector>;
+
+const Container = styled.div`
+  display: block;
+  height: 256px;
+  margin-top: 96px;
+  align-items: center;
+`;
+
+export const BasicExample: Story = {
+  args: {
+    pageItems: 20,
+    perPageRange: 's',
+    onPerPageChange: () => {},
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <Container>
+          <Story />
+        </Container>
+      );
+    },
+  ],
+};

--- a/packages/components/pagination/src/pagination.readme.mdx
+++ b/packages/components/pagination/src/pagination.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/Pagination/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/pagination/src/pagination.stories.tsx
+++ b/packages/components/pagination/src/pagination.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import styled from '@emotion/styled';
+import Pagination from './pagination';
+
+const meta: Meta<typeof Pagination> = {
+  title: 'components/Pagination/Pagination',
+  component: Pagination,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Pagination>;
+
+const Container = styled.div`
+  display: block;
+  margin-top: 96px;
+  margin-bottom: 96px;
+  align-items: center;
+`;
+
+export const BasicExample: Story = {
+  args: {
+    totalItems: 200,
+    page: 1,
+    onPageChange: () => alert('onPageChange Request'),
+    onPerPageChange: () => alert('onPerPageChange Request'),
+    perPage: 20,
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <Container>
+          <Story />
+        </Container>
+      );
+    },
+  ],
+};

--- a/packages/components/primary-action-dropdown/src/option.tsx
+++ b/packages/components/primary-action-dropdown/src/option.tsx
@@ -19,7 +19,7 @@ type TOption = {
   /**
    * Any React node.
    */
-  iconLeft: ReactNode;
+  iconLeft?: ReactNode;
 };
 
 const Option = (props: TOption) => (

--- a/packages/components/primary-action-dropdown/src/primary-action-dropdown.readme.mdx
+++ b/packages/components/primary-action-dropdown/src/primary-action-dropdown.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/Dropdowns/PrimaryActionDropdown/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/primary-action-dropdown/src/primary-action-dropdown.stories.tsx
+++ b/packages/components/primary-action-dropdown/src/primary-action-dropdown.stories.tsx
@@ -16,6 +16,9 @@ const meta: Meta<typeof PrimaryActionDropdown> = {
     // @ts-ignore
     Option,
   },
+  argTypes: {
+    children: { control: { disable: true } },
+  },
 };
 export default meta;
 

--- a/packages/components/primary-action-dropdown/src/primary-action-dropdown.stories.tsx
+++ b/packages/components/primary-action-dropdown/src/primary-action-dropdown.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import PrimaryActionDropdown, {
+  Option,
+  type TPrimaryActionDropdown,
+} from './index';
+import { PlusBoldIcon } from '@commercetools-uikit/icons';
+
+const meta: Meta<typeof PrimaryActionDropdown> = {
+  title: 'components/Dropdowns/PrimaryActionDropdown',
+  component: PrimaryActionDropdown,
+  subcomponents: {
+    /**
+     * todo: remove once sb fixed the following issue
+     * @link https://github.com/storybookjs/storybook/issues/23170
+     */
+    // @ts-ignore
+    Option,
+  },
+};
+export default meta;
+
+/** Basic usage: */
+type Story = StoryObj<typeof PrimaryActionDropdown>;
+
+export const BasicExample: Story = (args: TPrimaryActionDropdown) => {
+  return (
+    <div style={{ height: 256 }}>
+      <PrimaryActionDropdown {...args}>
+        <Option iconLeft={<PlusBoldIcon />} onClick={() => {}}>
+          Primary option
+        </Option>
+        <Option onClick={() => {}}>Another option</Option>
+        <Option isDisabled={true} onClick={() => {}}>
+          Even another option
+        </Option>
+      </PrimaryActionDropdown>
+    </div>
+  );
+};
+
+BasicExample.args = {};

--- a/packages/components/progress-bar/src/progress-bar.readme.mdx
+++ b/packages/components/progress-bar/src/progress-bar.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/ProgressBar/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/progress-bar/src/progress-bar.stories.tsx
+++ b/packages/components/progress-bar/src/progress-bar.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import ProgressBar, { TProgressBarProps } from './progress-bar';
+
+const meta: Meta<typeof ProgressBar> = {
+  title: 'components/ProgressBar',
+  component: ProgressBar,
+  argTypes: {
+    label: {
+      control: 'text',
+    },
+  },
+};
+export default meta;
+
+type Story = StoryFn<typeof ProgressBar>;
+
+const Template: Story = (args: TProgressBarProps) => {
+  const backgroundColor = args.isInverted ? 'black' : 'transparent';
+  return (
+    <div style={{ backgroundColor, padding: '2em' }}>
+      <ProgressBar {...args} />
+    </div>
+  );
+};
+
+/** `<ProgressBar/>` only without any status label. */
+export const BasicExample = Template.bind({});
+
+BasicExample.args = {
+  progress: 50,
+};
+
+/** `<ProgressBar/>` with status label. */
+export const WithStatusLabel = Template.bind({});
+
+WithStatusLabel.args = {
+  progress: 33,
+  label: '33% complete',
+};

--- a/packages/components/spacings/spacings-inline/src/inline.readme.mdx
+++ b/packages/components/spacings/spacings-inline/src/inline.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="layout/Spacings/SpacingsInline/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/spacings/spacings-inline/src/inline.stories.tsx
+++ b/packages/components/spacings/spacings-inline/src/inline.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import styled from '@emotion/styled';
+import Inline, { TInlineProps } from './inline';
+
+const meta: Meta<typeof Inline> = {
+  title: 'layout/Spacings/SpacingsInline',
+  component: Inline,
+};
+export default meta;
+
+type Story = StoryObj<typeof Inline>;
+
+const PrettyBox = styled.div`
+  background-color: rebeccapurple;
+  color: white;
+  padding: 1em;
+`;
+
+/** `<SpacingsInline/>` displays items - surprise! - inline. It **does not** wrap items onto the next line. */
+export const BasicExample: Story = (args: TInlineProps) => {
+  return (
+    <Inline {...args}>
+      <PrettyBox>First</PrettyBox>
+      <PrettyBox>Second</PrettyBox>
+      <PrettyBox>Third</PrettyBox>
+      <PrettyBox>Fourth</PrettyBox>
+      <PrettyBox>Fifth</PrettyBox>
+    </Inline>
+  );
+};
+BasicExample.args = {};

--- a/packages/components/spacings/spacings-inline/src/inline.tsx
+++ b/packages/components/spacings/spacings-inline/src/inline.tsx
@@ -28,8 +28,15 @@ export type TJustifyContent =
 export type TScale = 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl' | 'xxxl';
 
 export type TInlineProps = {
+  /** sets the amount of spacing between individual items */
   scale: TScale;
+  /**
+   * sets the `align-self` value on all direct children.
+   * https://developer.mozilla.org/en-US/docs/Web/CSS/align-items */
   alignItems: TAlignItem;
+  /**
+   * defines how the browser distributes space between and around content items along the main-axis.
+   * https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content */
   justifyContent: TJustifyContent;
   children: ReactNode;
 };

--- a/packages/components/spacings/spacings-inset-squish/src/inset-squish.readme.mdx
+++ b/packages/components/spacings/spacings-inset-squish/src/inset-squish.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="layout/Spacings/SpacingsInsetSquish/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/spacings/spacings-inset-squish/src/inset-squish.stories.tsx
+++ b/packages/components/spacings/spacings-inset-squish/src/inset-squish.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import styled from '@emotion/styled';
+import SpacingInsetSquish, { TInsetSquishProps } from './inset-squish';
+
+const meta: Meta<typeof SpacingInsetSquish> = {
+  title: 'layout/Spacings/SpacingsInsetSquish',
+  component: SpacingInsetSquish,
+};
+export default meta;
+
+type Story = StoryObj<typeof SpacingInsetSquish>;
+
+const PrettyBox = styled.div`
+  background-color: rebeccapurple;
+  color: white;
+`;
+const NotSoPrettyBox = styled.div`
+  background-color: white;
+  color: black;
+  padding: 1em;
+  text-align: center;
+`;
+
+/** Like `<SpacingsInset/>` but with different `padding`' values on sides (left/right) and ends (top/bottom).  */
+export const BasicExample: Story = (args: TInsetSquishProps) => {
+  return (
+    <PrettyBox>
+      <SpacingInsetSquish {...args}>
+        <NotSoPrettyBox>Child-Element 1</NotSoPrettyBox>
+        <NotSoPrettyBox>Child-Element 2</NotSoPrettyBox>
+      </SpacingInsetSquish>
+    </PrettyBox>
+  );
+};
+
+BasicExample.args = {};

--- a/packages/components/spacings/spacings-inset-squish/src/inset-squish.tsx
+++ b/packages/components/spacings/spacings-inset-squish/src/inset-squish.tsx
@@ -5,7 +5,9 @@ import { filterDataAttributes } from '@commercetools-uikit/utils';
 
 export type TScale = 's' | 'm' | 'l';
 export type TInsetSquishProps = {
+  /** sets the amount of `padding` applied around the children */
   scale: TScale;
+  /** sets the height of the component to 100% of the available width ('expanded') or 'auto' */
   height: 'collapsed' | 'expanded';
   children: ReactNode;
 };

--- a/packages/components/spacings/spacings-inset/src/inset.readme.mdx
+++ b/packages/components/spacings/spacings-inset/src/inset.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="layout/Spacings/SpacingsInset/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/spacings/spacings-inset/src/inset.stories.tsx
+++ b/packages/components/spacings/spacings-inset/src/inset.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import styled from '@emotion/styled';
+import SpacingInset, { TInsetProps } from './inset';
+
+const meta: Meta<typeof SpacingInset> = {
+  title: 'layout/Spacings/SpacingsInset',
+  component: SpacingInset,
+};
+export default meta;
+
+type Story = StoryObj<typeof SpacingInset>;
+
+const PrettyBox = styled.div`
+  background-color: rebeccapurple;
+  color: white;
+`;
+const NotSoPrettyBox = styled.div`
+  background-color: white;
+  color: black;
+  padding: 1em;
+  text-align: center;
+`;
+/** Adds css `padding` around its' children. */
+export const BasicExample: Story = (args: TInsetProps) => {
+  return (
+    <PrettyBox>
+      <SpacingInset {...args}>
+        <NotSoPrettyBox>Child-Element 1</NotSoPrettyBox>
+        <NotSoPrettyBox>Child-Element 2</NotSoPrettyBox>
+      </SpacingInset>
+    </PrettyBox>
+  );
+};
+
+BasicExample.args = {};

--- a/packages/components/spacings/spacings-inset/src/inset.tsx
+++ b/packages/components/spacings/spacings-inset/src/inset.tsx
@@ -23,7 +23,9 @@ const getPadding = (scale?: TScale) => {
 };
 
 export type TInsetProps = {
+  /** sets the amount of `padding` applied around the children */
   scale: TScale;
+  /** sets the height of the component to 100% of the available width ('expanded') or 'auto' */
   height: 'collapsed' | 'expanded';
   children?: ReactNode;
 };

--- a/packages/components/spacings/spacings-stack/src/stack.readme.mdx
+++ b/packages/components/spacings/spacings-stack/src/stack.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="layout/Spacings/SpacingsStack/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/spacings/spacings-stack/src/stack.stories.tsx
+++ b/packages/components/spacings/spacings-stack/src/stack.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Stack, { TStackProps } from './stack';
+import styled from '@emotion/styled';
+
+const meta: Meta<typeof Stack> = {
+  title: 'layout/Spacings/SpacingsStack',
+  component: Stack,
+};
+export default meta;
+
+type Story = StoryObj<typeof Stack>;
+
+const PrettyBox = styled.div`
+  background-color: rebeccapurple;
+  color: white;
+  padding: 1em;
+`;
+
+/** `<Stack/>` consumes 100% of the available width and stacks (and sizes) it's child-elements vertically within. */
+export const BasicExample: Story = (args: TStackProps) => {
+  return (
+    <Stack {...args}>
+      <PrettyBox>First</PrettyBox>
+      <PrettyBox>Second</PrettyBox>
+      <PrettyBox>Third</PrettyBox>
+      <PrettyBox>Fourth</PrettyBox>
+    </Stack>
+  );
+};
+
+BasicExample.args = {};

--- a/packages/components/spacings/spacings-stack/src/stack.tsx
+++ b/packages/components/spacings/spacings-stack/src/stack.tsx
@@ -20,7 +20,11 @@ export type TAlignItem =
 export type TScale = 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl' | 'xxxl';
 
 export type TStackProps = {
+  /** specifies the spacing between individual items */
   scale: TScale;
+  /**
+   * sets the `align-self` value on all direct children.
+   * https://developer.mozilla.org/en-US/docs/Web/CSS/align-items */
   alignItems: TAlignItem;
   children: ReactNode;
 };

--- a/packages/components/stamp/src/stamp.readme.mdx
+++ b/packages/components/stamp/src/stamp.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/Stamp/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/stamp/src/stamp.stories.tsx
+++ b/packages/components/stamp/src/stamp.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { iconArgType } from '@/storybook-helpers';
+import Stamp from './stamp';
+
+const meta: Meta<typeof Stamp> = {
+  title: 'components/Stamp',
+  component: Stamp,
+  argTypes: {
+    icon: iconArgType,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Stamp>;
+
+/** Stamps are visual labels which hold small amounts of information regarding an item.
+ * (E.g Indicating if a product is published in a list). */
+export const BasicExample: Story = {
+  args: {
+    label: 'Hello, world!',
+    // @ts-ignore
+    icon: 'WorldIcon',
+  },
+};

--- a/packages/components/stamp/src/stamp.stories.tsx
+++ b/packages/components/stamp/src/stamp.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof Stamp> = {
   component: Stamp,
   argTypes: {
     icon: iconArgType,
+    children: { control: { disable: true } },
   },
 };
 

--- a/packages/components/stamp/src/stamp.tsx
+++ b/packages/components/stamp/src/stamp.tsx
@@ -24,7 +24,7 @@ export type TStampProps = {
   isCondensed: boolean;
   /**
    * Content to render within the stamp.
-   * This property has been **deprecated** in favor of `label`.
+   * @deprecated in favor of `label`.
    */
   children?: ReactNode;
   /**

--- a/packages/components/tag/src/tag-list/tag-list.stories.tsx
+++ b/packages/components/tag/src/tag-list/tag-list.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import TagList from './tag-list';
+import Tag from './../tag';
+
+const fruits = [
+  'apples',
+  'bananas',
+  'cherries',
+  'grapes',
+  'oranges',
+  'peaches',
+  'pears',
+  'plums',
+  'strawberries',
+  'watermelons',
+  'blueberries',
+  'blackberries',
+  'raspberries',
+  'mangoes',
+  'pineapples',
+  'pomegranates',
+  'kiwis',
+  'lemons',
+  'limes',
+  'papayas',
+  'apricots',
+  'nectarines',
+  'figs',
+  'dates',
+  'coconuts',
+  'cantaloupes',
+  'honeydews',
+  'tangerines',
+  'clementines',
+  'persimmons',
+  'cranberries',
+  'guavas',
+  'lychees',
+  'jackfruits',
+  'dragonfruits',
+  'passionfruits',
+  'mulberries',
+  'gooseberries',
+  'elderberries',
+  'starfruits',
+];
+
+const meta: Meta<typeof TagList> = {
+  title: 'components/Tags/TagList',
+  component: TagList,
+};
+export default meta;
+
+type Story = StoryObj<typeof TagList>;
+
+/** Displays `<Tag>`s as inline-items, items will wrap onto the next line if necessary. */
+export const BasicExample: Story = {
+  args: {
+    children: fruits.map((tag, index) => <Tag key={index}>{tag}</Tag>),
+  },
+};

--- a/packages/components/tag/src/tag.readme.mdx
+++ b/packages/components/tag/src/tag.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/Tags/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/tag/src/tag.stories.tsx
+++ b/packages/components/tag/src/tag.stories.tsx
@@ -1,0 +1,28 @@
+import { BrowserRouter as Router } from 'react-router-dom';
+import type { Meta, StoryObj } from '@storybook/react';
+import Tag, { TTagProps } from './tag';
+
+const meta: Meta<typeof Tag> = {
+  title: 'components/Tags/Tag',
+  component: Tag,
+};
+export default meta;
+
+type Story = StoryObj<typeof Tag>;
+
+/** Displays a single `<Tag/>`.*/
+export const BasicExample: Story = (args: TTagProps) => {
+  return (
+    <Router>
+      <Tag {...args} />
+    </Router>
+  );
+};
+
+BasicExample.args = {
+  type: 'normal',
+  isDisabled: false,
+  to: '/project-key/products/icecream',
+  onRemove: () => alert('Remove tag request'),
+  children: 'Ice Cream',
+};

--- a/packages/components/text/src/stories/body.stories.tsx
+++ b/packages/components/text/src/stories/body.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { BodyProxy } from './../text.proxies';
+
+const meta: Meta<typeof BodyProxy> = {
+  title: 'Text & Media/Text/Text.Body',
+  component: BodyProxy,
+};
+export default meta;
+
+type Story = StoryObj<typeof BodyProxy>;
+
+/** `<Text.Body/>` wraps your text with a `<p>` tag by default. It is used for displaying regular (lengthy) text-content. */
+export const BasicExample: Story = {
+  args: {
+    children: 'Hello World!',
+  },
+};

--- a/packages/components/text/src/stories/caption.stories.tsx
+++ b/packages/components/text/src/stories/caption.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CaptionProxy } from './../text.proxies';
+
+const meta: Meta<typeof CaptionProxy> = {
+  title: 'Text & Media/Text/Text.Caption',
+  component: CaptionProxy,
+};
+export default meta;
+
+type Story = StoryObj<typeof CaptionProxy>;
+
+/** Wraps the text in the smallest available font size and accepts `tone` and `fontWeight` props. */
+export const BasicExample: Story = {
+  args: {
+    children: 'Hello Caption!',
+  },
+};

--- a/packages/components/text/src/stories/detail.stories.tsx
+++ b/packages/components/text/src/stories/detail.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import { WrapProxy } from './../text.proxies';
+
+const meta: Meta<typeof WrapProxy> = {
+  title: 'Text & Media/Text/Text.Wrap',
+  component: WrapProxy,
+};
+export default meta;
+
+type Story = StoryFn<typeof WrapProxy>;
+
+/** Wraps the given text in its container. And for long text, text will be wrapped to new line. */
+export const BasicExample: Story = (args) => {
+  return (
+    <div style={{ width: 256 }}>
+      <WrapProxy {...args} />
+    </div>
+  );
+};
+
+BasicExample.args = {
+  children:
+    'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+};

--- a/packages/components/text/src/stories/headline.stories.tsx
+++ b/packages/components/text/src/stories/headline.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { HeadlineProxy } from './../text.proxies';
+
+const meta: Meta<typeof HeadlineProxy> = {
+  title: 'Text & Media/Text/Text.Headline',
+  component: HeadlineProxy,
+};
+export default meta;
+
+type Story = StoryObj<typeof HeadlineProxy>;
+
+/** Wraps the given text in the given (via `as`-property) HTML header tag. */
+export const BasicExample: Story = {
+  args: {
+    as: 'h1',
+    children: 'Hello Headline!',
+  },
+};

--- a/packages/components/text/src/stories/subheadline.stories.tsx
+++ b/packages/components/text/src/stories/subheadline.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { SubheadlineProxy } from './../text.proxies';
+
+const meta: Meta<typeof SubheadlineProxy> = {
+  title: 'Text & Media/Text/Text.Subheadline',
+  component: SubheadlineProxy,
+};
+export default meta;
+
+type Story = StoryObj<typeof SubheadlineProxy>;
+
+/** Wraps the given text in the given (via `as`-property) HTML header tag. */
+export const BasicExample: Story = {
+  args: {
+    as: 'h4',
+    children: 'Hello Subheadline!',
+  },
+};

--- a/packages/components/text/src/stories/wrap.stories.tsx
+++ b/packages/components/text/src/stories/wrap.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryFn } from '@storybook/react';
+import { DetailProxy } from './../text.proxies';
+
+const meta: Meta<typeof DetailProxy> = {
+  title: 'Text & Media/Text/Text.Detail',
+  component: DetailProxy,
+};
+export default meta;
+
+type Story = StoryFn<typeof DetailProxy>;
+
+/** Wraps the given text in a `<small>` semantic tag. It accepts a tone prop to properly style the text. */
+export const BasicExample: Story = (args) => {
+  return <DetailProxy {...args} />;
+};
+
+BasicExample.args = {
+  children: 'Hello Detail!',
+};

--- a/packages/components/text/src/text.proxies.tsx
+++ b/packages/components/text/src/text.proxies.tsx
@@ -1,0 +1,38 @@
+/**
+ * Storybook can not handle the current formatting of the text.tsx file.
+ * This file was created as a workaround, to allow those components to still
+ * be properly parsed by & displayed in Storybook.
+ */
+
+import Text, {
+  TBodyProps,
+  TCaptionProps,
+  TDetailProps,
+  THeadlineProps,
+  TSubheadlineProps,
+  TWrapProps,
+} from './text';
+
+export const HeadlineProxy = (props: THeadlineProps) => (
+  <Text.Headline {...props} />
+);
+HeadlineProxy.displayName = 'Text.Headline';
+
+export const SubheadlineProxy = (props: TSubheadlineProps) => (
+  <Text.Subheadline {...props} />
+);
+SubheadlineProxy.displayName = 'Text.Subheadline';
+
+export const WrapProxy = (props: TWrapProps) => <Text.Wrap {...props} />;
+WrapProxy.displayName = 'Text.Wrap';
+
+export const BodyProxy = (props: TBodyProps) => <Text.Body {...props} />;
+BodyProxy.displayName = 'Text.Body';
+
+export const DetailProxy = (props: TDetailProps) => <Text.Detail {...props} />;
+DetailProxy.displayName = 'Text.Detail';
+
+export const CaptionProxy = (props: TCaptionProps) => (
+  <Text.Caption {...props} />
+);
+CaptionProxy.displayName = 'Text.Caption';

--- a/packages/components/text/src/text.readme.mdx
+++ b/packages/components/text/src/text.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="Text & Media/Text/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/text/src/text.tsx
+++ b/packages/components/text/src/text.tsx
@@ -178,6 +178,22 @@ const Wrap = (props: TWrapProps) => {
 };
 Wrap.displayName = 'TextWrap';
 
+/**
+ * Need to duplicate TTone type here because storybook v8 does not parse this:
+ *
+ * type TBodyTone = TTone | 'inverted'
+ * */
+type TBodyTone =
+  | 'primary'
+  | 'secondary'
+  | 'tertiary'
+  | 'information'
+  | 'positive'
+  | 'negative'
+  | 'critical'
+  | 'inherit'
+  | 'inverted';
+
 export type TBodyProps = {
   as?: 'span' | 'p';
   /**
@@ -186,7 +202,7 @@ export type TBodyProps = {
   isBold?: boolean;
   isItalic?: boolean;
   isStrikethrough?: boolean;
-  tone?: TTone | 'inverted';
+  tone?: TBodyTone;
   fontWeight?: TFontWeight;
   truncate?: boolean;
   nowrap?: boolean;
@@ -224,6 +240,17 @@ const Body = (props: TBodyProps) => {
 };
 Body.displayName = 'TextBody';
 
+type TDetailTone =
+  | 'primary'
+  | 'secondary'
+  | 'tertiary'
+  | 'information'
+  | 'positive'
+  | 'negative'
+  | 'critical'
+  | 'inherit'
+  | 'warning'
+  | 'inverted';
 export type TDetailProps = {
   /**
    * @deprecated: use the new `fontWeight` prop
@@ -232,7 +259,7 @@ export type TDetailProps = {
   isItalic?: boolean;
   isStrikethrough?: boolean;
   as?: 'span' | 'small';
-  tone?: TTone | 'warning' | 'inverted';
+  tone?: TDetailTone;
   fontWeight?: TFontWeight;
   truncate?: boolean;
   nowrap?: boolean;
@@ -271,11 +298,22 @@ const Detail = (props: TDetailProps) => {
   );
 };
 Detail.displayName = 'TextDetail';
+type TCaptionTone =
+  | 'primary'
+  | 'secondary'
+  | 'tertiary'
+  | 'information'
+  | 'positive'
+  | 'negative'
+  | 'critical'
+  | 'inherit'
+  | 'warning'
+  | 'inverted';
 
 export type TCaptionProps = {
   isItalic?: boolean;
   isStrikethrough?: boolean;
-  tone?: TTone | 'warning' | 'inverted';
+  tone?: TCaptionTone;
   fontWeight?: TFontWeight;
   truncate?: boolean;
   nowrap?: boolean;

--- a/packages/components/tooltip/src/tooltip.readme.mdx
+++ b/packages/components/tooltip/src/tooltip.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/Tooltip/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/tooltip/src/tooltip.stories.tsx
+++ b/packages/components/tooltip/src/tooltip.stories.tsx
@@ -1,0 +1,138 @@
+import { createPortal } from 'react-dom';
+import { forwardRef, type FC } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import Tooltip, { TTooltipProps } from './tooltip';
+import PrimaryButton from '@commercetools-uikit/primary-button';
+import styled from '@emotion/styled';
+
+const meta: Meta<typeof Tooltip> = {
+  title: 'components/Tooltip',
+  component: Tooltip,
+};
+export default meta;
+
+type Story = StoryObj<typeof Tooltip>;
+
+/** At it's most basic usage, `<Tooltip/>` expects a `title` and `children`-property.
+ * The `children`-property is the element that will trigger the tooltip to be shown.
+ * The `title`-property is the text that will be shown in the tooltip.
+ */
+export const BasicExample: Story = ({ children, ...args }: TTooltipProps) => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: 256,
+      }}
+    >
+      <Tooltip {...args}>
+        <PrimaryButton
+          label="Buy Pizza now!"
+          onClick={() => {}}
+        ></PrimaryButton>
+      </Tooltip>
+    </div>
+  );
+};
+
+BasicExample.args = {
+  title: 'If you buy 🍕, you will also get a free 🍦! ',
+};
+
+/**
+ * Working with disabled child elements
+ * When you use a tooltip with a disabled element, you should define the
+ * style `pointer-events: none` to the disabled element to stop it from capturing events.
+ */
+export const ExampleWithDisabledElements = () => (
+  <Tooltip
+    placement="left"
+    title="You do not have permission to delete the database"
+  >
+    <PrimaryButton
+      isDisabled
+      onClick={() => {}}
+      style={{ pointerEvents: 'none' }}
+      label={'Delete production database'}
+    />
+  </Tooltip>
+);
+
+/**
+ * The tooltip applies event listeners (`onMouseOver`, `onMouseLeave`, `onFocus`,
+ * and `onBlur`) to a wrapping div component around the children element.
+ * By default, this wrapper is displayed with `display: inline-block`.
+ * If you want to customize this behaviour, then you can pass in a custom element.
+ * Be sure to use `React.forwardRef`, as the component needs to pass the `ref` to the wrapper.
+ */
+
+export const ExampleWithCustomWrapper: Story = (args: TTooltipProps) => {
+  // The Wrapper needs to forward the ref to the wrapping element.
+  const Wrapper = forwardRef<
+    HTMLDivElement,
+    React.HTMLAttributes<HTMLDivElement>
+  >((props, ref) => (
+    <div
+      ref={ref}
+      style={{ display: 'block', outline: '1px solid tomato' }}
+      {...props}
+    />
+  ));
+
+  Wrapper.displayName = 'Wrapper';
+
+  return (
+    <Tooltip
+      components={{
+        WrapperComponent: Wrapper,
+      }}
+      {...args}
+    >
+      <PrimaryButton
+        onClick={() => {}}
+        style={{ pointerEvents: 'none' }}
+        label={'Wrapper influences positioning of the tooltip'}
+      />
+    </Tooltip>
+  );
+};
+
+ExampleWithCustomWrapper.args = {
+  title: 'Delete',
+};
+
+/**
+ * You can customize the look and feel of the tooltip by passing in a custom `BodyComponent` via the `components` property.
+ */
+export const CustomTooltipDesign = () => {
+  const CustomBody = styled.div`
+    background: red;
+    color: white;
+    padding: 0.5em;
+  `;
+
+  return (
+    <Tooltip title="Delete" components={{ BodyComponent: CustomBody }}>
+      <PrimaryButton onClick={() => {}} label={'I use a custom tooltip'} />
+    </Tooltip>
+  );
+};
+
+CustomTooltipDesign.args = {
+  title: 'I use a custom BodyComponent',
+};
+
+const Portal: FC = (props) => createPortal(props.children, document.body);
+
+/**
+ * When you are dealing with virtualized components, it can be useful to render
+ * the tooltip into another part of the document.
+ * You can define a TooltipWrapperComponent to do this.
+ */
+export const ExampleWithCustomPortal = () => (
+  <Tooltip title="Delete" components={{ TooltipWrapperComponent: Portal }}>
+    <PrimaryButton onClick={() => {}} label={"I'm using my own Portal"} />
+  </Tooltip>
+);

--- a/packages/components/view-switcher/src/view-switcher.readme.mdx
+++ b/packages/components/view-switcher/src/view-switcher.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw';
+
+<Meta title="components/ViewSwitcher/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/view-switcher/src/view-switcher.stories.tsx
+++ b/packages/components/view-switcher/src/view-switcher.stories.tsx
@@ -9,6 +9,10 @@ const meta: Meta<typeof ViewSwitcher.Group> = {
     // @ts-ignore
     Button: ViewSwitcher.Button,
   },
+  argTypes: {
+    children: { control: false },
+    defaultSelected: { control: false },
+  },
 };
 export default meta;
 

--- a/packages/components/view-switcher/src/view-switcher.stories.tsx
+++ b/packages/components/view-switcher/src/view-switcher.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ViewSwitcher from './index';
+import { WorldIcon } from '@commercetools-uikit/icons';
+
+const meta: Meta<typeof ViewSwitcher.Group> = {
+  title: 'components/ViewSwitcher',
+  component: ViewSwitcher.Group,
+  subcomponents: {
+    // @ts-ignore
+    Button: ViewSwitcher.Button,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ViewSwitcher.Group>;
+
+export const BasicExample: Story = {
+  args: {
+    children: ['1', '2', '3', '4'].map((v) => (
+      <ViewSwitcher.Button value={v} key={v}>
+        {`View ${v}`}
+      </ViewSwitcher.Button>
+    )),
+    defaultSelected: '2',
+  },
+};
+
+/** Hand over an `<Icon/>`  via the `icon` property to display an icon next to the label. */
+export const ExampleWithIcons: Story = {
+  args: {
+    children: ['1', '2', '3', '4'].map((v) => (
+      <ViewSwitcher.Button
+        icon={<WorldIcon />}
+        value={v}
+        key={v}
+      >{`View ${v}`}</ViewSwitcher.Button>
+    )),
+    defaultSelected: '3',
+  },
+};

--- a/storybook/src/docs/philosophy/Fields.mdx
+++ b/storybook/src/docs/philosophy/Fields.mdx
@@ -1,0 +1,110 @@
+import { Meta, Markdown } from '@storybook/blocks';
+
+import { DecisionGroup } from '@/storybook-helpers';
+
+<Meta title="Form/Fields/Readme" />
+
+# Fields
+
+Fields combine a label, an input element and validation messages.
+
+Think of Fields as a form of syntactic sugar expressed as additional components.
+They forward most properties to the underlying components while combining some
+APIs of the components for easier usage.
+
+They are an abstraction which should be used to build forms with.
+In case it's necessary to use slightly different behaviour, it's always possible
+to drop down to the building blocks (label, input element, validation message) to
+achieve customizaion. In most cases this won't be necessary though.
+
+## Forwarding of props
+
+Generally all fields forward most properties to the underlying `FieldLabel`, input component and `FieldErrors` component.
+
+All field components should at least accept these properties
+
+..for the label and error rendering:
+
+| Name                   |  Type                 |
+| ---------------------- | --------------------- |
+| `id`                   | `string`              |
+| `title`                | `string`              |
+| `description`          | `string`              |
+| `hint`                 | `string`              |
+| `hintIcon`             | `node`                |
+| `badge`                | `node`                |
+| `horizontalConstraint` | `string`              |
+| `errors`               | `object`              |
+| `renderError`          | `function`            |
+| `onInfoButtonClick`    | `function`            |
+| `isRequired`           | `boolean`             |
+| `touched`              | `boolean` or `object` |
+
+..for the input:
+
+| Name         |  Type      |
+| ------------ | ---------- |
+| `name`       | `string`   |
+| `value`      | `any`      |
+| `onChange`   | `function` |
+| `isDisabled` | `boolean`  |
+| `data-*`     | `any`      |
+
+## Auto-generated ids
+
+Fields accept an `id` property which is forwarded to the input.
+That `id` is also used as the `htmlFor` attribute of the label.
+This allows focusing the input by clicking the label.
+It's also very useful for screenreaders.
+
+It looks something like this:
+
+```html
+<label htmlFor="age">Age</label> <input type="number" id="age" />
+```
+
+However as `id` is not a required property it might not always be passed to the
+input. We still want to be able to foucs the input by clicking the label in those
+cases though.
+
+So our fields automatically generate an `id` in case no `id` was provided by the parent.
+
+## Usage with Formik
+
+As explained in _"Philosophy > Forms"_, we use Formik to keep track of form state. The formik state may looks like this:
+
+```js
+{
+  values: { firstName: '' },
+  touched: { firstName: true },
+  errors: { firstName: { missing: true } }
+}
+```
+
+Parents then usually pass the value, touched state and errors of a field into the related field component, e.g:
+
+```jsx
+<TextField
+  value={formik.values.firstName}
+  errors={formik.errors.firstName}
+  touched={formik.touched.firstName}
+/>
+```
+
+> Note that some fields don't follow this convention as they were not
+> upgraded to this approach yet. However this is the design goal of fields.
+> The field can then determine whether to render the underlying input in an error state or not, based on `errors` and `touched`.
+> It can also decide whether to show error messages or not, based on the `touched` state. This ensures consistency across forms.
+> It also ensures that we never show a validation message without rendering the related input field in an error state (e.g. with a red border) as well.
+
+Using fields ensures form fields behave the same and reduces the amount of code necessary in the form itself.
+
+## Allowing custom errors
+
+We want parents to be able to render custom errors into our field components.
+
+All fields accept a function called `renderError`.
+This function will get called with every entry in from `props.errors` and can then decide which error to render.
+
+In case `null` is returned for a specific error, the field falls back to handling some default errors itself.
+Every field can have a different set of default errors it knows how to render.

--- a/storybook/src/docs/philosophy/Forms.mdx
+++ b/storybook/src/docs/philosophy/Forms.mdx
@@ -1,0 +1,921 @@
+import { Meta, Markdown } from '@storybook/blocks';
+
+import { DecisionGroup } from '@/storybook-helpers';
+
+<Meta title="Form/Readme" />
+
+# Forms
+
+Most views in web applications are either lists or forms. So it's important to get forms right. It's important to offer good UX, but it's also important to make building and modifying forms straightforward for developers. Offering a consistent solution helps both.
+
+With our approach to forms, we strive to
+
+- **eliminate architectural discrepancy between different forms** by using the same approach for all forms
+- **offer good UX** by embedding the same principles for all forms in our solution
+
+This document tries to outline the reasoning behind our form component philosophy by showing the challenges we faced which led to the current design.
+This document aims to help contributors understand which considerations are relevant when building input components for ui-kit.
+
+It is not intended as a usage-guide of our input components. In fact it doesn't touch our input components for the most part.
+
+## Table of Contents
+
+- [Typical steps of forms](#typical-steps-of-forms)
+- [The flow](#the-flow)
+  - [Fetching initial form data](#fetching-initial-form-data)
+  - [Transforming the fetched data into form values](#transforming-the-fetched-data-into-form-values)
+  - [Modifying the form values draft based on the user input](#modifying-the-form-values-draft-based-on-the-user-input)
+  - [Keeping track of modified fields to know which error messages to display](#keeping-track-of-modified-fields-to-know-which-error-messages-to-display)
+  - [Validating the form as the user interacts with the form](#validating-the-form-as-the-user-interacts-with-the-form)
+  - [Rendering validation errors](#rendering-validation-errors)
+  - [Validating the form on submission](#validating-the-form-on-submission)
+  - [Handling form submission](#handling-form-submission)
+  - [Transforming the form values back into a document which e.g. can be sent to the server](#transforming-the-form-values-back-into-a-document-which-eg-can-be-sent-to-the-server)
+  - [Conclusion](#conclusion)
+- [What this approach means for our input components](#what-this-approach-means-for-our-input-components)
+- [Most important lessons](#most-important-lessons)
+- [Formik disclaimer](#formik-disclaimer)
+- [Solutions recipes:](#solutions-recipes)
+  - [Data conversion](#data-conversion)
+    - [The response shape of the server is inconvenient to build a form on](#the-response-shape-of-the-server-is-inconvenient-to-build-a-form-on)
+    - [Providing defaults (Unifying inconsisent data: empty strings, `undefined` & `null`)](#providing-defaults-unifying-inconsisent-data-empty-strings-undefined--null)
+    - [Handling numbers](#handling-numbers)
+    - [Enriching received data (e.g. adding additional languages to localized strings)](#enriching-received-data-eg-adding-additional-languages-to-localized-strings)
+  - [Validation](#validation)
+    - [Translating error messages](#translating-error-messages)
+    - [Multiple errors on a single field](#multiple-errors-on-a-single-field)
+    - [Mapping async errors after submission back onto the form](#mapping-async-errors-after-submission-back-onto-the-form)
+  - [Single inputs to determine multiple values (e.g. `MoneyInput`)](#single-inputs-to-determine-multiple-values-eg-moneyinput)
+  - [Form values need to be shown in a user-friendly format](#form-values-need-to-be-shown-in-a-user-friendly-format)
+  - [Preventing concurrent modifications](#preventing-concurrent-modifications)
+
+## Typical steps of forms
+
+We want to offer a generic solution to forms. The following problems usually need to be solved (roughly in this order) when building a form:
+
+- fetching initial form data
+- transforming the fetched data into form values
+- modifying the form values draft based on the user input
+- keeping track of modified fields to know which error messages to display
+- validating the form as the user interacts with the form
+- rendering validation errors
+- validating the form on submission
+- handling form submission
+- transforming the form values back into a document which e.g. can be sent to the server
+
+Other problems might arise while building the form. We collected hints on how
+to approach the most common problems at the end of this document. The solution
+always builds on top of the forms approach outlined here.
+
+## The flow
+
+Let's say a user visits a product detail page and wants to change the product name. What does the flow look like?
+
+We'll walk through the architecture we arrived at without going into detail and reasoning at first. Instead we'll walk through specific problems after introducing our form approach to see how to solve them with the architecture we arrived at.
+
+### Fetching initial form data
+
+As our form solution must be able to work with data from any source, we'll not make loading the data part of the form solution. So we may only render our form once the data is fetched as shown by the exemplatory code below:
+
+```js
+// product-details.js
+
+<GetProduct id="party-parrot">
+  {(product) => <ProductDetailsForm initialValues={product} />}
+</GetProduct>
+```
+
+Here we introduced a `GetProduct` component which handles fetching the product. This nicely separates the data source from the form itself. We could pass any `initialValues` to our `ProductDetailsForm`. The `ProductDetailsForm` is oblivious to where the data is coming from. We can change the data source easily. So fetching the data isn't actually part of the form itself.
+
+### Transforming the fetched data into form values
+
+This leads to another concern though: Our backend might currently serve a product as
+
+```js
+{
+  id: 'party-parrot',
+  version: 1,
+  name: 'Party Parrot',
+}
+```
+
+But what if the backend ever changes the response and we then receive the following instead?
+
+```diff
+{
+  id: 'party-parrot',
+  version: 1,
+- name: 'Party Parrot',
++ productName: 'Party Parrot',
+}
+```
+
+Our form would break as `name` no longer exists!
+
+So it makes sense to introduce a different data format for our forms. We'll add a `docToFormValues` function which converts our product document to form values.
+
+```diff
+// product-details.js
+
+<GetProduct id="party-parrot">
+  {product => (
+-   <ProductDetailsForm initialValues={product} />
++   <ProductDetailsForm initialValues={docToFormValues(product)} />
+  )}
+</GetProduct>
+```
+
+Being able to adapt to a changing data format is one upside of using such functions. They are even more useful when we need to convert the document into form values which are easier to work with, e.g. by providing devaults, flattening the values or by converting numbers into strings. We'll look into that later. For now, here's a simple conversion function which does "nothing" yet:
+
+```js
+// conversions.js
+
+// Converts document into form values
+// This is used to transform the original data into form values.
+export const docToFormValues = (doc) => ({
+  id: doc.id,
+  version: doc.version,
+  name: doc.name,
+});
+```
+
+Great, now we know that we're guaranteed a document which looks like this:
+
+```
+{
+  id: String,
+  version: Number,
+  name: String,
+}
+```
+
+### Modifying the form values draft based on the user input
+
+We use [Formik](https://github.com/jaredpalmer/formik) to handle our form state. A very simple form could look like this:
+
+```js
+<GetProduct id="party-parrot">
+  {(product) => (
+    <Formik
+      initialValues={docToFormValues(product)}
+      render={(formik) => (
+        <form onSubmit={formik.handleSubmit}>
+          <input
+            name="name"
+            value={formik.values.name}
+            onChange={formik.handleChange}
+            onBlur={formik.handleBlur}
+          />
+          <button type="submit">Submit</button>
+        </form>
+      )}
+    />
+  )}
+</GetProduct>
+```
+
+As we've set the `name` attribute on the `input`, we can directly use `formik.handleChange` and `formik.handleBlur`. The `input` component will call these functions with an event, from `onChange` and `onBlur` respectively. That event will contain the input's name as `event.target.name`. Formik uses that information to change `formik.values.name` to the new value. It is therefore convenient when our input components call the change handlers with an event, and when that event contains the target.
+
+Formik keeps track of the form values. It initializes the form values based on its `initialValues` property.
+
+So at first Formik state looks something like this:
+
+```js
+{
+  values: {
+    id: 'party-parrot',
+    version: 2,
+    name: 'Party Parrot',
+  },
+  touched: {}
+}
+```
+
+### Keeping track of modified fields to know which error messages to display
+
+In the example above we also added `onBlur`. Just like with `onChange` Formik can read the information from the event passed to `onBlur` to know which form field to mark as touched.
+
+As the user now makes changes to fields and blurs them, Formik's `touched` state gets updated:
+
+```diff
+{
+  values: {
+    id: 'party-parrot',
+    version: 2,
+    name: 'Party Parrot',
+  },
+  touched: {
++    name: true
+  }
+}
+```
+
+This indicates that the "name" field was touched.
+
+You'll notice that Formik handles the `touched` state automatically based on `event.target`'s name. We never told it to set that value specifically. While a user is interacting with the a form, Formik produces a `touched` state solely based on the events `formik.handleBlur` receives.
+
+Knowing which fields have been touched by the user is important information for when we try to figure out which validation error messages to show to the user. More on that later.
+
+### Validating the form as the user interacts with the form
+
+Formik accepts a `validate` function out of the box. We can add it to our example:
+
+```js
+import omitEmpty from 'omit-empty-es';
+
+const validate = (values) => {
+  const errors = { name: {} };
+
+  // We use boolean flags to indicate errors
+  if (values.name.length === 0) errors.name.missing = true;
+
+  // The validation function must return an empty object when no
+  // validation errors were found.
+  return omitEmpty(errors);
+};
+
+<GetProduct id="party-parrot">
+  {(product) => (
+    <Formik
+      initialValues={docToFormValues(product)}
+      validate={validate}
+      render={(formik) => (
+        <form onSubmit={formik.handleSubmit}>
+          <input
+            name="name"
+            value={formik.values.name}
+            onChange={formik.handleChange}
+            onBlur={formik.handleBlur}
+          />
+          <button type="submit">Submit</button>
+        </form>
+      )}
+    />
+  )}
+</GetProduct>;
+```
+
+Whenever validation runs, our `formik` object will now also contain the errors we determined. In the example below the value "Party Parrot" was removed from the _name_ field. That's why `errors.name.missing` is now set to `true`.
+
+```js
+{
+  values: {
+    id: 'party-parrot',
+    version: 2,
+    name: '',
+  },
+  touched: {
+    name: true
+  },
+  errors: {
+    name: { missing: true }
+  }
+}
+```
+
+Multiple conventions are set now:
+
+- We always use objects to contain the errors of a single field. This makes writing validation functions easy, but it also simplifies detecting errors when rendering error messages as we'll see in a bit. It also allows us to have multiple error messages present for a single field at the same time.
+- We always use booleans for errors. We don't provide an error message from the validation function, as that should be part of the display logic. We do this so that we don't need to change our validation function when our rendering logic changes. This decouples them and only the error shape stays as the intersection between them.
+
+### Rendering validation errors
+
+We can now render a form, let users interact with it and determine error messages. But we still need to show the error messages to our users. This can be done using
+
+```js
+import omitEmpty from 'omit-empty-es';
+// Extracted "validate" to keep snippet short.
+// It's the same function as in the last snippet
+import validate from './validate';
+
+<GetProduct id="party-parrot">
+  {(product) => (
+    <Formik
+      initialValues={docToFormValues(product)}
+      validate={validate}
+      render={(formik) => (
+        <form onSubmit={formik.handleSubmit}>
+          <input
+            name="name"
+            value={formik.values.name}
+            onChange={formik.handleChange}
+            onBlur={formik.handleBlur}
+          />
+          {formik.touched.name &&
+            formik.errors.name &&
+            formik.errors.name.missing && <div>A name is required</div>}
+          <button type="submit">Submit</button>
+        </form>
+      )}
+    />
+  )}
+</GetProduct>;
+```
+
+As `formik.touched.name` is only `true` after the user has left the name field, the errror message will not show up while the user is still interacting with the field (for the first time). This prevents scaring users by showing error messages too early.
+
+The second time users change the input value of a field, the error message will go away as users interact with the field. This live validation helps users complete the form.
+
+The ui-kit's `*Field` components have this behaviour baked into them, which you can see in _"Examples > Forms > Fields > Basic Form Example"_.
+
+### Validating the form on submission
+
+In addition to the validation which runs while users fill out values, validation is also triggered when a user submits the form.
+
+In this case, there is another thing we need to be aware of: When a form is submitted, Formik automatically sets the `touched` state of all elements to `true`. This is done so that all error messages become visible. But Formik doesn't actually know about our input elements, it only knows about the stored values. So it tries to derive a `touched` state based on `formik.values`. This can lead to different `touched` states while a user interacts with a form and when the form is submitted. As we don't have any control over the `touched` state generated by Formik on submission, we need to ensure that the `touched` state we produce fits the one Formik will generate. Differences must be avoided to keep the code simple! Differing `touched` states lead to buggy code, unnecessary complexity and prop-type warnings.
+
+### Handling form submission
+
+We can pass an `onSubmit` property to Formik. That function will be called with `values` and `formik`.
+
+```js
+import omitEmpty from 'omit-empty-es';
+import validate from './validate';
+
+<GetProduct id="party-parrot">
+  {(product) => (
+    <Formik
+      initialValues={docToFormValues(product)}
+      validate={validate}
+      onSubmit={(values, formik) => {
+        console.log(values);
+      }}
+      render={/* same as before */}
+    />
+  )}
+</GetProduct>;
+```
+
+We can then do anything from `onSubmit`. Most likely we'll want to make an async call and then reset the form state. We can do that like this:
+
+```js
+<Formik
+  onSubmit={(values, formik) => {
+    return updateProduct(values.id, values.version, { name: values.name }).then(
+      // passing values to resetForm reinitializes the form with the
+      // updated product
+      (updatedProduct) =>
+        formik.resetForm({ values: docToFormValues(updatedProduct) }),
+      (error) => {
+        alert('Could not save product');
+        formik.setSubmitting(false);
+      }
+    );
+  }}
+  /* ... */
+/>
+```
+
+`updateProduct` is an examplatory async function we use to update the product.
+It receives an `id`, `version` and the updated product. When the update is
+successful, it returns a promise which resolves with the updated product.
+Otherwise it rejects the promise with an error.
+
+In this example our users stay on the same page after saving a form. So we need
+to reinitialize our form with the updated form values after a user saves. This
+allows them to make further edits and save again. To do
+so, we can call `formik.resetForm` with the updated form values.
+
+Notice that we're using `docToFormValues` again to convert the updated product returned
+by our `updateProduct` call back to form values.
+
+### Transforming the form values back into a document which e.g. can be sent to the server
+
+As you can see above, we're currently manually piecing together a document
+which we can send to the server. A slight optimization is to move this logic
+into its own function which we'll call `formValuesToDoc`.
+
+The `formValuesToDoc` function is the opposite of `docToFormValues`. We use it to convert
+the form values back into a document.
+
+Right now we have
+
+```js
+updateProduct(values.id, values.version, { name: values.name });
+```
+
+Let's change that call to
+
+```js
+updateProduct(values.id, values.version, formValuesToDoc(values));
+```
+
+by adding a `formValuesToDoc` function to `conversions.js`:
+
+```diff
+// conversions.js
+
+// Converts document into form values
+// This is used to transform the original data into form values.
+export const docToFormValues = doc => ({
+  id: doc.id,
+  version: doc.version,
+  name: doc.name,
+})
+
++// Converts form values back into a document
++// This is used when the form gets submitted.
++export const formValuesToDoc = formValues => ({
++  name: formValues.name,
++})
+```
+
+This `formValuesToDoc` function doesn't seem like a lot now, but it will come
+in handy when we face more difficult problems later on as you'll see in the
+more solution recipes below.
+
+So now we end up with
+
+```diff
+<Formik
+  onSubmit={(values, formik) => {
+    return updateProduct(
+      values.id,
+      values.version,
+-     { name: values.name }
++     formValuesToDoc(values)
+    ).then(
+      // passing values to resetForm reinitializes the form with the
+      // updated product
+      updatedProduct => formik.resetForm({values: docToFormValues(updatedProduct)}),
+      error => {
+        // More on error handling in "Solution Recipies" below
+        alert('Could not save product');
+        formik.setSubmitting(false);
+      }
+    );
+  }}
+  /* ... */
+/>
+```
+
+The `validate` function should guarantee that `formValuesToDoc` always receives
+valid form values and is able to construct a document. `formValuesToDoc` should
+therefore never have to throw an error or fail in any other way.
+
+### Conclusion
+
+This concludes the overview of our forms approach. To sum it up: After getting the initial document, we use `docToFormValues` to convert the document to form values. We then rely on Formik to handle changes to that data and to keep track of the touched values. We let Formik validate user input by providing a custom `validate` function. That `validate` function will return an errors object containing an object for each field, in which boolean flags indicate the specific errors of that field. On form submission, we convert the form values back to a document using `formValuesToDoc`.
+
+## What this approach means for our input components
+
+As the state is managed outside of our input components, our input components need to be [controlled](https://reactjs.org/docs/forms.html#controlled-components). They may not be [uncontrolled](https://reactjs.org/docs/uncontrolled-components.html).
+
+Our input components should let the form handle validation. They should accept an indicator of validation state from the form (e.g. a `hasError` property which they use to display an appropriate border color) instead of trying to determine that state themselves.
+
+The inputs should keep the user-input around and store that in the state. They should not attempt to format user-input while users type (e.g. formatting numbers). More on this in "Solution recipes".
+
+When an input gathers more than one information (e.g. a `MoneyInput` where users can select a currency from a dropdown and enter an amount), the input should not attempt to hide the fact that two separate inputs are used. Use two separate values and touched states. More on this in "Solution recipes". This is a limitation of Formik automatically determining the `touched` state on form submission. See "Solution recipes" for more information.
+
+## Most important lessons
+
+- **Convert data on the way into and out of the form** to keep the form oblivious to the data source
+- **Don't convert user input too early**. Keep user input around while they are editing, otherwise you'll lose some information, e.g. when a user is editing a number.
+- **Validate before converting**. Validation should guarantee that the conversions of form values back into the document succeeds.
+- **Validate form values**: Never attempt to convert the data back into a document and attempt to validate the document. This will couple the vlaidation to the document. Instead, validate the user input (the form values)!
+- **Validate on a form level**: Don't attempt to validate individual inputs. Validation must be the concern of the form itself, as it has the whole overview. It knows all values and knows how they come together.
+- **Only mark error types during validation**: Don't attempt to generate error messages while validating. Use booleans to mark validation errors, e.g. `{ name: { missing: true } }`. This lets you change how the errors are shown, and enables you to localize the error messages with your regular translation tools.
+- **Always detect all validation errors**: Don't stop validation after you found the first validation error. Try to mark all invalid fields as invalid. Decide which errors should be shown during rendering.
+- **Let rendering take care of displaying errors**: During rendering you know which fields have been touched, whether the user attempted a form submission and which fields have validation errors. Decide which validation errors to show during rendering based on all those indicators.
+
+## Formik disclaimer
+
+While we use [Formik](https://github.com/jaredpalmer/formik) to handle our form state, there are some parts of Formik's philosophy we don't agree with.
+Formik is a great library and embraces many good principles when building forms. However, we deviate from a few of their recommendations on purpose:
+
+- It’s impossible to keep track of when an array was touched in some cases (e.g. when an element was removed and the array is now empty), because Formik is trying to auto-generate the touched state on submission. The touched state of an empty array is `{ someArray: [] }`. This means `[]` has to be interpreted as the array having been touched.
+- Formik values can't be objects. Because Formik traverses the `value` and creates one big `touched` state, we can't have a `touched` state for a value which is an object (as money-input would be). Sometimes we would like to make it seem like there is only one input (e.g. for a money-input where users can select a currency and enter an amount, we'd like to have a single `touched` state for the whole thing). Formik forces us to use individual touched states and to handle values individually.
+- Too big of an API with `Form`, `withFormik`, `Field`, `ErrorMessage` and `Formik`. There are many ways to achieve the same thing. We generally try to use `<Formik />` only.
+- The recommendation to generate error messages from the validation function mixes validation and rendering logic. Returning strings from the validation function gets in the way of using an application's localization approach and makes it hard to determine failed validations in case an error needs to be shown in multiple places. It also makes it hard to attach multiple validation errors to a single field. That's why instead of returning a string for a field, we use objects holding booleans per field, e.g. `{ name: { missing: true } }`.
+
+## Solutions recipes:
+
+When building a form, you might run into other challenges along the way. We already
+have solutions for the most common cases which work with our approach to forms.
+They are shown below:
+
+Here are some solution recipes for these cases:
+
+- Data conversion
+  - The response shape of the server is inconvenient to build a form on
+  - Providing defaults (Unifying inconsisent data: empty strings, `undefined` & `null`)
+  - Handling numbers
+  - Enriching received data (e.g. adding additional languages to localized strings)
+- Validation
+  - Translating error messages
+  - Multiple errors on a single field
+  - Mapping async errors after submission back onto the form
+- Single inputs to determine multiple values (e.g. `MoneyInput`)
+- Form values need to be shown in a user-friendly format
+- Preventing concurrent modifications
+
+> More to be written here...
+
+### Data conversion
+
+#### The response shape of the server is inconvenient to build a form on
+
+In case the data source has an inconvienient shape, you can use `docToFormValues` to convert it to something that's easier to work with.
+
+If your document looks like this:
+
+```js
+{
+  id: 'party-parrot',
+  masterVariant: {
+    name: 'Blue Party Parrot'
+  },
+  variants: [
+    { name: 'Red Party Parrot' },
+    { name: 'Green Party Parrot' },
+  ]
+}
+```
+
+and you just want a list of all variants, then you could use `docToFormValues` to
+create a single variant list instead:
+
+```js
+export const docToFormValues = (doc) => ({
+  id: doc.id,
+  variants: [...doc.masterVariant, ...doc.variants],
+});
+```
+
+When your user submits the form, you can use `formValuesToDoc` to split the variants again:
+
+```js
+export const formValuesToDoc = (formValues) => ({
+  id: formValues.id,
+  masterVariant: formValues.variants[0],
+  variants: formValues.variants.slice(1),
+});
+```
+
+This is a bit of a contrived example, but the principle of manipulating data on the way in and out will prove useful in many cases.
+
+#### Providing defaults (Unifying inconsisent data: empty strings, `undefined` & `null`)
+
+Let's say products had an optional field called `description`.
+The server may omit this field if it was not sent, so it could be `undefined`.
+But it could also be an empty string. This leads to different cases representing the same state.
+We can avoid those different cases by converting falsey values to an empty string.
+Then our form only needs to handle strings and doesn't need to worry about `undefined` or `null`:
+
+```diff
+export const docToFormValues = doc => ({
+  id: doc.id,
+  version: doc.version,
+  name: doc.name,
+-  description: doc.description,
++  description: doc.description || '',
+})
+```
+
+Great! We can now build our form without worrying about those falsey edge-cases. We are guaranteed to always receive a string.
+For example, this lets us read `formValues.description.length` without checking whether `formValues.description` is defined first.
+
+This also prevents prop-type warnings. If we were to accept `undefined` as a valid value, then we would ultimately render `<input value={undefined} onChange={Function} />`. This leads to a warning in React as soon as the user enters a value, as the `input` component would then swtich from uncontrolled mode to controlled mode, which should not happen.
+
+#### Handling numbers
+
+Let's now assume that each product has an optional `inventory` field associated with it which contains a number.
+
+```js
+{
+  id: 'party-parrot',
+  version: 1,
+  name: 'Party Parrot',
+  inventory: 10,
+}
+```
+
+When we attempt to use an `<input type="number" />` for this, Formik will see that `event.target.type` is `number` and automatically convert the passed value to a number.
+
+The Formik state would then be
+
+```js
+{
+  values: {
+    id: 'party-parrot',
+    version: 2,
+    name: 'Party Parrot',
+    inventory: 10,
+  },
+}
+```
+
+All browser inputs of type `number` will always only call `onChange` with either a valid number, or an empty string. `onChange` will never be called with an invalid number, `undefined` or a non-empty string.
+
+This works for most cases, but we never get to see the original value entered by the user as the value gets parsed first. We either see a valid number or an empty string. This means we can't differntiate between `-0` and `0`. We also don't know wheter a user entered `9,8` (with a comma) or `9.8` (with a dot) as we will see the number `9.8` either way. We also can't differentiate between the user entering `00001` and `1.000`. We will see `1` in both cases. We also can't distinguish between `2e3` and `2000` as both are converted to `2000`. We also can't distinguish between the invalid `4e`, just `e` and an empty input - as we'll be called with `""` for all invalid values.
+
+The examples above were just for Google Chrome which prevents typing non-numbers. In Firefox it's possible to enter any string into `<input type="number" />` input elements. So it could happen that a user enters "hello" into a numeric input - and our Form thinks the user entered nothing, as Firefox will call `onChange` with an event holding an empty string.
+
+Something to be aware of is that our forms can't distinguish between an empty value and an invalid value in those cases. It might happen that our form state holds an empty string while the input is actually currently displaying an invalid value. You can play around with it in [this CodeSandbox](https://codesandbox.io/s/69rxm1413).
+
+With this disclaimer out of the way, if you're only after a number it's fine to use `<input type="number" />` and let formik convert the value automatically.
+
+If you try to build something with formatted numbers like `12.003,90` or `12,003.90` then you'll have to use `<input type="text" />`. You should only attempt to parse the number and format the value when the field is being blurred - not while the user is typing. Otherwise you could end up destroying the input - e.g. when the user types `00` you'd convert it to just `0` in case you try to format the input too early.
+
+#### Enriching received data (e.g. adding additional languages to localized strings)
+
+Let's now assume our product name should be localized. A name can be set for multiple locales. The data looks like this:
+
+```js
+{
+  id: 'party-parrot',
+  version: 1,
+  name: {
+    en: 'Party Parrot',
+    de: 'Party Papagei',
+    es: 'Loro fiesta',
+  },
+}
+```
+
+Imagine the data of our product is a bit older, and the russian locale has been added to the project in the meantime, while the spanish locale was removed.
+Our goal is to show translations for all locales stored on the product itself (even the outdated spanish one), while also showing input fields all locales currently stored on the product. So ultimately we should be showing `en`, `de`, `es`, `ru` in this case.
+
+We can't simply iterate over the languages defined on the project (`en`, `de`, `ru`) as we'd be missing `es`. And we can't simply iterate over the languages stored on the product (`en`, `de`, `es`) as we'd be missing `ru`.
+
+Assume the project's locales are defined as `projectLocales = ['en', 'de', 'ru']`. We have to merge the locales in `docToFormValues`.
+
+```js
+const docToFormValues = (doc, projectLocales) => ({
+  id: doc.id,
+  version: doc.version,
+  name: createLocalizedString(projectLocales, doc.name),
+});
+```
+
+The `createLocalizedString` function ensures that a `{ [locale]: '' }` entry is set for each locale passed as the first argument, and then merges the already defined translations into that object.
+
+This would produce
+
+```js
+{
+  id: 'party-parrot',
+  version: 1,
+  name: {
+    en: 'Party Parrot',
+    de: 'Party Papagei',
+    es: 'Loro fiesta',
+    ru: '',
+  },
+}
+```
+
+Notice that we're now passing additional information (`projectLocales`) to `docToFormValues`. This is a new pattern which allows us to enrich the recieved document. This approach of passing additional information to `docToFormValues` can be used to enrich form values in many ways.
+
+### Validation
+
+#### Translating error messages
+
+During validation, we create error objects like this:
+
+```js
+{
+  values: { name: '' },
+  touched: { name: true },
+  errors: { name: { missing: true } }
+}
+```
+
+As you can see, we use boolean indicators to mark errors for form fields.
+This allows us to determine how to render an error message from the render function,
+instead of having to determine it within the validation function.
+
+For example, we can do
+
+```js
+<Formik
+  render={(formik) => (
+    <div>
+      <input
+        type="text"
+        name="name"
+        onChange={handleChange}
+        value={formik.values.name}
+      />
+      {formik.touched &&
+        formik.touched.name &&
+        formik.errors &&
+        formik.errors.name &&
+        formik.errors.name.missing && <div>Required field</div>}
+    </div>
+  )}
+/>
+```
+
+> Sidenote: Using the [optional chaining proposal (`?.`)](https://github.com/tc39/proposal-optional-chaining), we can shorten this code to
+>
+> ```js
+> <Formik
+>   render={(formik) => (
+>     <div>
+>       <input
+>         type="text"
+>         name="name"
+>         onChange={handleChange}
+>         value={formik.values.name}
+>       />
+>       {formik.touched?.name && formik.errors?.name?.missing && (
+>         <div>Required field</div>
+>       )}
+>     </div>
+>   )}
+> />
+> ```
+>
+> We can now use any translation approach without having to intertwine it with validation:
+
+```js
+<Formik
+  render={(formik) => (
+    <div>
+      <input
+        type="text"
+        name="name"
+        onChange={handleChange}
+        value={formik.values.name}
+      />
+      {formik.touched?.name && formik.errors?.name?.missing && (
+        <FormattedMessage {...messages.requiredNameError} />
+      )}
+    </div>
+  )}
+/>
+```
+
+Having this control also allows us to render arbitrarily complex error messages right from our code.
+
+#### Multiple errors on a single field
+
+Using objects to keep track of errors for each field also has the benefit of allowing us to keep track of multiple errors for a single field.
+An example error might look like this
+
+```js
+{
+  values: { name: '', password: 'h i' },
+  touched: { name: true, password: true },
+  errors: {
+    name: { missing: true },
+    password: { tooShort: true, containsSpaces: true },
+  }
+}
+```
+
+This allows us to warn a user of multiple errors at once.
+
+#### Mapping async errors after submission back onto the form
+
+Let's assume our product also has a field where users may enter a unique `slug` for the product. As we have millions of products, we can't load all existing slugs upfront so we need to validate when the product is saved.
+Our product data looks like this:
+
+```js
+{
+  id: 'party-parrot',
+  version: 1,
+  name: 'Party Parrot',
+  slug: 'party-parrot'
+}
+```
+
+Let's assume the `updateProduct` function will reject the update with an `{code: 'DuplicateSlugError' }` in case we attempt to save the product.
+We can now pass an `onSubmit` function to Formik which handles this error:
+
+```js
+<Formik
+  onSubmit={(formValues, formik) => {
+    const nextProduct = formValuesToDoc(formValues);
+    return updateProduct({
+      id: formValues.id,
+      version: formValues.version,
+      product: nextProduct,
+    }).then(
+      // When things go smoothly and the slug was not used yet
+      (updatedProduct) => {
+        // Calling resetForm with the updated product will
+        // update the form values and reset the submission state,
+        // touched keys and so on.
+        formik.resetForm({
+          values: docToForm(updatedProduct, props.intl.locale),
+        });
+      },
+      // When the slug was already used, or when any other error happens
+      (error) => {
+        // This is an example where we have to rely on the API
+        // on submission time to ensure correct form values.
+        // The example shows how to map API errors back onto
+        // specific fields within the form.
+        if (error.code === 'DuplicateSlugError') {
+          formik.setErrors({ slug: { duplicate: true } });
+        }
+        // Since we might do things like retrying a request in case
+        // there was an error with it, we are responsible for
+        // resetting the submission state.
+        formik.setSubmitting(false);
+      }
+    );
+  }}
+/>
+```
+
+After a user attempts to submit with a duplicate slug, this will set a Formik
+error like so:
+
+```js
+{
+  values: { name: 'Party Parrot', slug: 'party-parrot' },
+  touched: { name: true, slug: true },
+  errors: { slug: { duplicate: true } }
+}
+```
+
+We can then use this information to render the error. This solves the problem of
+mapping async errors back to the form.
+Of course it's possible to also build async validation while the user fills out
+the form, but this check is the basis of that. It needs to be there in any case,
+as the slug could get duplicated between the time we validate the users input and
+the time the user actually submits the form.
+Something else which could be improved is to validate the slug is using valid
+characters only. We can use our old `validate` function for that. The errors
+can be attached to `errors.slug`.
+
+### Single inputs to determine multiple values (e.g. `MoneyInput`)
+
+Sometimes we want to build input elements which deal with multiple values at once.
+One such element is our [`MoneyInput`](https://uikit.commercetools.com/?selectedKind=Inputs&selectedStory=MoneyInput). It allows to set a currency and an amount by using a dropdown for the currency and an input for the amount.
+The value produced by `MoneyInput` is represented as `{ currencyCode: 'EUR', amount: '2.00' }`
+
+> Sidenote: As the `MoneyInput` uses monetary formatting, we are using a text-input. This allows us to format values properly (e.g. by adding the trailing ".00") without browsers messing with the input. It also allows us to use decimal separators, e.g. for "1,000.00".
+> We can construct our Formik value like this:
+
+```js
+{
+  id: 'party-parrot',
+  version: 1,
+  name: 'Party Parrot',
+  price: { currencyCode: 'EUR', amount: '2.00' }
+}
+```
+
+How do we now build a single input which receives `{ currencyCode: 'EUR', amount: '2.00' }` as its value and is able to change both using Formik's `handleChange`? We want to be able to render `<MoneyInput onChange={handleChange} onBlur={handleBlur} />` to make it as straightforward as using `<input type="text" />`.
+There are two approaches:
+
+- We can ensure `MoneyInput` always calls `onChange` with a full value like `{ currencyCode: 'EUR', amount: '2.00' }`
+- We can adapt the input names to be `price.currencyCode` or `price.amount` respectively. Formik will read that name and set the nested value only.
+  If we were to go with the first approach, we'd need to fake `event.target.name` in `onBlur` as well, otherwise formik would set `{ touched: { price: true } }` instead of `{ touched: { price: { amount: true, currencyCode: true } } }`.
+  That is bad, as Formik will set `{ touched: { price: { amount: true, currencyCode: true } } }` once the form is submitted - so we end up with a `touched` state which changes shape!
+  There is a CodeSandbox which illustrates this problem. Try changing the price and keep an eye on the `touched` state. Then submit the form, and you'll see a different `touched` state.
+  If we were to accept changes to the shape of our `touched` state, we'd need to tak the different shapes into consideration every time we work with the `touched` shape and it just generally makes things harder to follow.
+  So it's better to go with the second approach right away. We amend the names of the inputs by adding the `.amount` and `.currencyCode` suffix to their names and ids. When a parent doesn't pass in a name/id, we omit the property from the underlying input. This has solved that problem nicely for us.
+
+### Form values need to be shown in a user-friendly format
+
+As mentioned above, our `MoneyInput` consists of two parts: an currency selector and an amount input.
+We want the amount to be formatted like a monetary value, e.g. "200.00" or "2,000.00". However, the data we receive from our fictitious API looks like this: `{ currencyCode: 'EUR', centAmount: 200 }` for 2€.
+How do we go about formatting the value properly? As our form values always hold the actual value entered by the user, we need to format the initial value in `docToFormValues` already.
+Our ideal format should:
+
+- use separators based on the users locale (`2.000,00` vs `2,000.00`)
+- apply a number of fraction digits based on the currency as some currencies use more/less than 2 fraction digits (`2,000.00` vs `2,000.000`)
+  A `locale` defines which separators to use. The money value itself already contains a `currencyCode`, which we can use to determine the number of fraction digits.
+  To format the value, we thus only need to pass a `locale` to `docToFormValues`:
+
+```js
+const docToFormValues = (doc, { locale }) => ({
+  id: doc.id,
+  name: doc.name,
+  price: formatMoneyValue(doc.price, locale),
+});
+```
+
+We could now create a `formatMoneyValue` function which takes `{ currencyCode: 'EUR', centAmount: 200 }`, the `locale`, derives the separators and number of fraction digits from these and returns a formatted money. The `MoneyInput` we use would likely want to format the value whenever a users blurs the input field as well, so it could reuse that `formatMoneyValue` function.
+In UI-Kit we provide these conversion functions as static methods on the input elements. For example, you could use `MoneyInput.parseMoneyValue(moneyValue, locale)` to convert the money-value to a human-readable representation.
+
+### Preventing concurrent modifications
+
+This section is about ensuring the document was not modified by someone else after we started editing it, to avoid overwriting their changes.
+Let's say that a user is using our form to edit a product. As you've seen, our products typically have a `version` property associated with them. The version is incremented by the server every time changes are made to that product.
+
+```js
+{
+  id: 'party-parrot',
+  version: 1,
+  name: 'Party Parrot',
+}
+```
+
+When we call `updateProduct`, we provide the `id` and the `version` we modified. When the `version` for that product on the server is newer than the `version` we've sent, we know that somebody else has made changes in the meantime - and our update is rejected as we might be overwriting their changes. In case the our version was outdated, our server responds with a `{ code: 'ConcurrentModificationError' }` error.
+As the data of the product might change at any time (as something could fetch a newer version), we don't want our Form to reinitialize when that data changes. So we generally avoid setting `enableReinitialize` on Formik. This is also useful to ensure that we send the `version` back to the server which we started editing, by making the `id` and `version` part of our form values:
+
+```js
+const docToFormValues = (doc) => ({
+  id: doc.id,
+  version: doc.version,
+  // ...other fields
+});
+```
+
+This lets us read the `id` and `version` from `onSubmit={(values) => { values.id; values.version; }}` when the form is submitted. It also prevents updates to the source data from overwriting the `id` or `version` of the draft we are editing. We can further inspect the error returned from `updateProduct`, check for the `ConcurrentModificationError` and handle it accordingly, e.g. by showing a notification.

--- a/storybook/src/docs/philosophy/Inputs.mdx
+++ b/storybook/src/docs/philosophy/Inputs.mdx
@@ -1,0 +1,194 @@
+# Inputs
+
+import { Meta, Markdown } from '@storybook/blocks';
+
+import { DecisionGroup } from '@/storybook-helpers';
+
+<Meta title="Form/Inputs/Readme" />
+
+This document describes the thinking behind UI Kit input components.
+
+To find out more about how inputs are used in forms, read the _Forms Philosophy_ document.
+
+This is a summary of decisions we made for our inputs. The sections below go into details and reasoning behind those decisions.
+
+- [Summary](#summary)
+- [Controlled vs uncontrolled components](#controlled-vs-uncontrolled-components)
+- [Schools of inputs](#schools-of-inputs)
+  - [Inputs which call the parent with all values](#inputs-which-call-the-parent-with-all-values)
+  - [Inputs which call the parent with valid values only](#inputs-which-call-the-parent-with-valid-values-only)
+- [Error states](#error-states)
+- [Validation messages](#validation-messages)
+- [Handling changes](#handling-changes)
+- [Faking events](#faking-events)
+- [Static methods](#static-methods)
+
+## Summary
+
+Our input components need to adhere to certain rules:
+
+- inputs are always controlled components (see [Controlled vs uncontrolled components](#controlled-vs-uncontrolled-components))
+- inputs leave validation to the form they are used in (see [Schools of inputs](#schools-of-inputs))
+- inputs receive and display an error state (`hasError: Boolean`) (see [Error states](#error-states))
+- inputs do not show validation messages themselves (however they may remove invalid values on blur) (see [Validation messages](#validation-messages))
+- inputs accept a change handler (like `onChange`) which they call with an event containing the changed value (see [Handling changes](#handling-changes))
+- inputs support `id` and `name` properites (and fake them in change/blur events if necessary) (see [Faking events](#faking-events))
+- inputs expose static methods to aid usage in forms (see [Static methods](#static-methods))
+
+## Controlled vs uncontrolled components
+
+All our inputs are [controlled components](https://reactjs.org/docs/forms.html#controlled-components). This means the parent component owns the state and passes the value and a change handler to the input component. The input component is controlled by the parent component.
+
+We never expose uncontrolled components as they don't work with our validation approach or with auto-formatting values on blur.
+
+_The "controlled component" aspect only applies to the value. Other things like an open/closed state may be implemented either way as it's not related to the form logic itself._
+
+## Schools of inputs
+
+When designing inputs, we can either tell the parent about every value entered by the user,
+or we can take an approach where the component tells the parent about valid values only.
+These approaches come with different tradeoffs, which we'll look into below.
+
+In UI Kit, we usually use different approaches depending on the component - but we generally favour the first one.
+
+### Inputs which call the parent with all values
+
+Whenever the user changes the component's value, the component notifies the parent of the changed value by calling a change handler (like `onChange`) with the updated value.
+The parent always knows the exact value the component is seeing. These components can not have any validation built in. The form always needs to validate them.
+
+👍 This is great for validation, as the parent can validate the actual user input.
+
+👍 Validation can change based on the use-case (required value, minimum length, forbidden characters, ..)
+
+👎 All consumers of the component need to repeat the validation logic
+
+### Inputs which call the parent with valid values only
+
+These components have some validation built in, but they typically don't show warnings for invalid values.
+Instead they discard invalid values on blur by calling the change handler with an empty value (usually an empty string).
+
+👍 This prevents consumers from having to repeat validation
+
+👎 Consumers don't always know the current value of an input
+
+👎 It might not be clear to users why the value disappears when the input is blurred
+
+👎 In case of longer values, users lose that value and need to retype everything which can be cumbersome
+
+👎 Not flexible when different validation requirements arise as they are hard-coded in the component
+
+In case this approach is taken, it usually ends up being combined with the first approach.
+Some basic validation which would be the same for all consumers is done by the input itself, while consumers may add additional validation.
+For example, we could have a date input which only calls the parent with parseable dates, while the parent could have its own validation ensuring the date is within a specific range.
+
+This allows the parent not to worry about determining valid/invalid dates while still being able to customize validation. Users won't get validation warnings when they enter invalid dates (the date will just disappear on blur), but they will get validation warnings when the date is outside of a certain range. This allows some flexibility in validation without burdening all consumers with date validation.
+
+## Error states
+
+As our inputs leave validation to the form they are used in, they can't determine themselves whether they are currently valid or not.
+This means the parent needs to tell an input about its validation state. The input can use this information to render itself in an appropriate style (e.g. with a red border in case of an error). Do not try to determine the validation state form within the input.
+
+Usually our inputs are told about the validation state by accepting a `hasError` property which contains a boolean.
+They also accept an additional boolean `hasWarning` property for intermediate cases (usually results in an orange border).
+Ask the design team about the difference between `hasError` and `hasWarning`. In most cases, consumers will use `hasError`.
+
+## Validation messages
+
+The inputs should not show any validation messages at all. The validation messages are usually rendered underneath an input. A Field combines a label, an input and a validation message. That's where things come together. We want to keep inputs usable in any context and the placement of the error message may differ. So we don't include any validation messages in inputs themselves.
+
+Inputs also should never render their own validation messages (e.g. a tooltip). This should always be done by the parents.
+
+## Handling changes
+
+When a user makes a change to an input's value, the input must call the change handler (e.g. `onChange`) to tell the parent about the updated value.
+
+All inputs should call `onChange` with an event containing that value, instead of calling with the value directly.
+
+We do this as the event will contain `event.target.name` or `event.target.id`, which allows Formik to determine the value to change.
+This in turn allows consumers to use our inputs like this:
+
+```jsx
+<TextInput
+  name="firstName"
+  value={formik.values.firstName}
+  onChange={formik.handleChange}
+  onBlur={formik.handleBlur}
+/>
+```
+
+instead of the more elaborate
+
+```jsx
+<TextInput
+  name="firstName"
+  value={formik.values.firstName}
+  onChange={(value) => formik.setFieldValue('firstName', value)}
+  onBlur={() => formik.setFieldTouched('firstName')}
+/>
+```
+
+As you can see, passing up events from `onChange` simplifies the caller side.
+
+In most cases we are able to simply forward the generated event:
+
+```jsx
+const TextInput = (props) => (
+  <input
+    type="text"
+    name={props.name}
+    value={props.value}
+    // change event generated by "input" is forwarded to TextInput's onChange
+    onChange={props.onChange}
+  />
+);
+```
+
+## Faking events
+
+There are case where we can't simply forward the event from the change handler.
+We then need to fake the generated event, for example because building the input on an underlying library which only passes the value:
+
+```jsx
+const MultilineTextInput = (props) => (
+  <AutosizeInput
+    id={props.id}
+    name={props.name}
+    value={props.value}
+    // AutosizeInput only tells us about the value, but we want to emit
+    // an event which formik can read the id and name from.
+    onChange={(value) => {
+      const fakeEvent = { target: { id: props.id, name: props.name, value } };
+      props.onChange(fakeEvent);
+    }}
+    // Pass a fake event up the blur handler
+    onBlur={
+      props.onBlur
+        ? () => {
+            const fakeEvent = { target: { id: props.id, name: props.name } };
+            props.onBlur(fakeEvent);
+          }
+        : undefined
+    }
+  />
+);
+```
+
+## Static methods
+
+Inputs are typically used in forms. It's often necessary to convert a document to
+a form value (more on this in _Philosophy > Forms_) before being able to use it - and sometimes the form value needs to be converted back into an actual value when a form is submitted.
+Another common case is that a form needs to validate input.
+
+Our input elements expose static methods which can be used for these things.
+
+Even a simple `TextInput` might have methods like
+
+- `TextInput.toFormValue(text)` to convert a text to a form value by ensuring that `undefined` and `null` are converted to an empty string
+- `TextInput.isEmpty(text)` to check whether an imput is empty (by checking `text.trim().length === 0`)
+
+Other examples for use-cases of static methods on inputs are to offer a way to:
+
+- convert a value back into a document (e.g. for `MoneyInput`)
+- check whether a price is high precision or not as `MoneyInput` does
+- enrich values for the form (e.g. `LocalizedTextInput` mixes project locales and locales of the value itself)
+- convert dates to a textual representation ( e.g. `DateInput`) and the other way around


### PR DESCRIPTION
## Background
In an effort to switch from Storybook v5 to Storybook v8, the existing stories had to be migrated to a new storybook-format and converted to typescript. 

This pull-request is [part of a batch](https://github.com/commercetools/ui-kit/pull/2875). It contains the typescript-equivalents of existing storybook v5 stories and aims to replicate the same functionality / value. 

## Goal
Feature parity between v8 and v5 storybook. After merging all batches, a product developer who looked at the storybook v5 version yesterday, should be able to look at the v8 version tomorrow and be as productive (or more productive) as before. 

## Review instructions
A thorough **code review** is not required yet. The code was either copied from the existing js-equivalent or quickly written from scratch to replicate what was already there to fit the new story-format. It is expected that those stories contain typescript errors, introduced by the conversion or previously existing. (Another pull-request will take care of those issues at a later stage).

What is expect is a **story review**:

You will need to compare the v5 with the v8 storybook (ideally side-by-side) and make sure that every component in this pull-request has:

- [ ] a readme-file in the same or a parent-folder
- [ ] a props-table displaying available props (and appropriate inputs for them)
- [ ] one or more stories that showcase the same or more functionality as the v5 equivalent

You will find the links to the different storybooks below. 


> If something is missing or irritating, add a comment to the source file here in the pull-request to start a conversation.


