### PR TITLE
FCT-1112 | display story only when running storybook locally

### DIFF
--- a/packages/components/dropdowns/dropdown-menu/src/dropdown-menu.readme.mdx
+++ b/packages/components/dropdowns/dropdown-menu/src/dropdown-menu.readme.mdx
@@ -1,6 +1,6 @@
 import { Meta, Markdown } from '@storybook/blocks';
 import ReadMe from './../README.md?raw';
 
-<Meta title="components/Dropdowns/DropdownMenu/Readme" />
+<Meta tags={['local-dev']} title="components/Dropdowns/DropdownMenu/Readme" />
 
 <Markdown>{ReadMe}</Markdown>

--- a/packages/components/dropdowns/dropdown-menu/src/dropdown-menu.readme.mdx
+++ b/packages/components/dropdowns/dropdown-menu/src/dropdown-menu.readme.mdx
@@ -1,6 +1,6 @@
 import { Meta, Markdown } from '@storybook/blocks';
 import ReadMe from './../README.md?raw';
 
-<Meta tags={['local-dev']} title="components/Dropdowns/DropdownMenu/Readme" />
+<Meta title="components/Dropdowns/DropdownMenu/Readme" />
 
 <Markdown>{ReadMe}</Markdown>

--- a/packages/components/filters/filter-menu/src/filter-menu.readme.mdx
+++ b/packages/components/filters/filter-menu/src/filter-menu.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw'
+
+<Meta tags={['local-dev']} title="components/Filters/FilterMenu/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/filters/filter-menu/src/filter-menu.stories.tsx
+++ b/packages/components/filters/filter-menu/src/filter-menu.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import FilterMenu from './filter-menu';
+
+const meta: Meta<typeof FilterMenu> = {
+  title: 'components/Filters/FilterMenu',
+  component: FilterMenu,
+  tags: ['local-dev'],
+  argTypes: {
+    label: {
+      control: 'text',
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof FilterMenu>;
+
+export const BasicExample: Story = {
+  args: {
+    label: 'A label text',
+  },
+};

--- a/packages/components/filters/filters-list/src/filters-list.readme.mdx
+++ b/packages/components/filters/filters-list/src/filters-list.readme.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/blocks';
+import ReadMe from './../README.md?raw'
+
+<Meta tags={['local-dev']} title="components/Filters/FiltersList/Readme" />
+
+<Markdown>{ReadMe}</Markdown>

--- a/packages/components/filters/filters-list/src/filters-list.stories.tsx
+++ b/packages/components/filters/filters-list/src/filters-list.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import FiltersList from './filters-list';
+
+const meta: Meta<typeof FiltersList> = {
+  title: 'components/Filters/FiltersList',
+  component: FiltersList,
+  tags: ['local-dev'],
+  argTypes: {
+    label: {
+      control: 'text',
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof FiltersList>;
+
+export const BasicExample: Story = {
+  args: {
+    label: 'A list of filters',
+  },
+};

--- a/storybook/.storybook/manager.ts
+++ b/storybook/.storybook/manager.ts
@@ -3,4 +3,18 @@ import { cocoTheme } from './theme';
 
 addons.setConfig({
   theme: cocoTheme,
+  sidebar: {
+    filters: {
+      // if the item is tagged with local-dev-only, don't show it in the sidebar in production
+      // see: https://github.com/storybookjs/storybook/issues/9209#issuecomment-1866309500
+      // this cannot be done with `!dev` tag because the Storybook.Meta tag array will only take string literals
+      // see: https://github.com/storybookjs/storybook/discussions/24192
+      patterns: (item) => {
+        if (process.env.NODE_ENV === 'production') {
+          return !item.tags?.includes('local-dev');
+        }
+        return true;
+      },
+    },
+  },
 });

--- a/storybook/README.md
+++ b/storybook/README.md
@@ -20,6 +20,30 @@ yarn start
 
 This will open storybook in your browser. You can now start adding new components or modifying existing ones.
 
+### Using Storybook as a component playground for local development
+
+When building a new component, storybook can be used to provide a "component playground" that builds a story that is only displayed while running storybook locally. This can be very useful for quick iteration and debugging.
+
+In order to specify that a story should only be available locally, add a `'local-dev'` tag to the `tags` option in the story's `meta` configuration.
+
+For example
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof ExampleComponent> = {
+  ...
+  tags: ['local-dev'],
+  ...
+};
+
+...
+
+export default meta;
+```
+
+When the component is ready to be released, remove the `local-dev` tag for the story in order for it to show up in the production storybook documentation.
+
 ## Creating a build
 
 To create a storybook production-build, run the following command:

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -34,6 +34,6 @@
     "start": "storybook dev -p 6006",
     "build-and-serve": "yarn build & yarn serve",
     "build": "NODE_ENV=production storybook build",
-    "serve": "serve"
+    "serve": "serve ./storybook-static"
   }
 }


### PR DESCRIPTION
feat(local only storybook): add ability to only display a story in the sidebar when running storybook locally by adding a 'local-dev' tag to the story meta

this is a POC - feedback welcome