### PR TITLE
chore(deps): bump webpack from 5.92.1 to 5.94.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "ts-node": "10.9.2",
     "tsc-files": "1.1.4",
     "typescript": "5.5.2",
-    "webpack": "5.92.1"
+    "webpack": "5.94.0"
   },
   "resolutions": {
     "@babel/preset-env": "^7.18.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7839,16 +7839,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint-scope@npm:^3.7.3":
-  version: 3.7.7
-  resolution: "@types/eslint-scope@npm:3.7.7"
-  dependencies:
-    "@types/eslint": "*"
-    "@types/estree": "*"
-  checksum: e2889a124aaab0b89af1bab5959847c5bec09809209255de0e63b9f54c629a94781daa04adb66bffcdd742f5e25a17614fb933965093c0eea64aacda4309380e
-  languageName: node
-  linkType: hard
-
 "@types/eslint@npm:^8.2.2":
   version: 8.56.11
   resolution: "@types/eslint@npm:8.56.11"
@@ -12150,7 +12140,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.12.0, enhanced-resolve@npm:^5.17.0":
+"enhanced-resolve@npm:^5.12.0, enhanced-resolve@npm:^5.17.1":
   version: 5.17.1
   resolution: "enhanced-resolve@npm:5.17.1"
   dependencies:
@@ -23138,7 +23128,7 @@ __metadata:
     ts-node: 10.9.2
     tsc-files: 1.1.4
     typescript: 5.5.2
-    webpack: 5.92.1
+    webpack: 5.94.0
   languageName: unknown
   linkType: soft
 
@@ -23907,11 +23897,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:5.92.1":
-  version: 5.92.1
-  resolution: "webpack@npm:5.92.1"
+"webpack@npm:5.94.0":
+  version: 5.94.0
+  resolution: "webpack@npm:5.94.0"
   dependencies:
-    "@types/eslint-scope": ^3.7.3
     "@types/estree": ^1.0.5
     "@webassemblyjs/ast": ^1.12.1
     "@webassemblyjs/wasm-edit": ^1.12.1
@@ -23920,7 +23909,7 @@ __metadata:
     acorn-import-attributes: ^1.9.5
     browserslist: ^4.21.10
     chrome-trace-event: ^1.0.2
-    enhanced-resolve: ^5.17.0
+    enhanced-resolve: ^5.17.1
     es-module-lexer: ^1.2.1
     eslint-scope: 5.1.1
     events: ^3.2.0
@@ -23940,7 +23929,7 @@ __metadata:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 11bec781260c4180883e98a4a15a08df297aca654ded45e70598f688881dd722f992d680addafe6f6342debede345cddcce2b781c50f5cde29d6c0bc33a82452
+  checksum: 6a3d667be304a69cd6dcb8d676bc29f47642c0d389af514cfcd646eaaa809961bc6989fc4b2621a717dfc461130f29c6e20006d62a32e012dafaa9517813a4e6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Manually update webpack dependency as some CI processes got stuck in ~~dependabots~~ renovatebots' update attempt.