### PR TITLE
POC: react router migration compatibility mode setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "react-dom": "17.0.2",
     "react-intl": "^6.3.2",
     "react-router-dom": "5.3.4",
+    "react-router-dom-v5-compat": "^6.26.2",
     "react-test-renderer": "17.0.2",
     "react-value": "0.2.0",
     "replace": "1.2.2",

--- a/packages/components/icons/src/icons.visualroute.jsx
+++ b/packages/components/icons/src/icons.visualroute.jsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { Switch, Route } from 'react-router-dom';
+import { Routes, Route } from "react-router-dom-v5-compat";
 import { designTokens } from '@commercetools-uikit/design-system';
 import * as icons from '@commercetools-uikit/icons';
 import CustomIcon from '@commercetools-uikit/icons/custom-icon';
@@ -83,7 +83,7 @@ const renderIcon = (iconName, color, size) => {
 };
 
 export const component = () => (
-  <Switch>
+  <Routes>
     <Route path={routePath} exact>
       <ul>
         {colors.map((color) => (
@@ -247,5 +247,5 @@ export const component = () => (
         </Spec>
       </Suite>
     </Route>
-  </Switch>
+  </Routes>
 );

--- a/packages/components/inputs/select-input/src/select-input.visualroute.jsx
+++ b/packages/components/inputs/select-input/src/select-input.visualroute.jsx
@@ -3,6 +3,7 @@ import { Route, Switch } from 'react-router-dom';
 import { SelectInput } from '@commercetools-frontend/ui-kit';
 import { Suite, Spec } from '../../../../../test/percy';
 import { WorldIcon } from '../../../icons';
+import { CompatRoute } from "react-router-dom-v5-compat";
 
 const defaultOptions = [
   { value: 'one', label: 'One' },
@@ -286,15 +287,15 @@ const OpenRouteWithOptionGroupsAndDivider = () => (
 
 export const component = () => (
   <Switch>
-    <Route path={`${routePath}/open`} component={OpenRoute} />
-    <Route
+    <CompatRoute path={`${routePath}/open`} element={<OpenRoute/>} />
+    <CompatRoute
       path={`${routePath}/open-with-option-groups`}
-      component={OpenRouteWithOptionGroups}
+      element={<OpenRouteWithOptionGroups/>}
     />
-    <Route
+    <CompatRoute
       path={`${routePath}/open-with-option-groups-and-divider`}
-      component={OpenRouteWithOptionGroupsAndDivider}
+      element={<OpenRouteWithOptionGroupsAndDivider/>}
     />
-    <Route path={routePath} render={() => <DefaultRoute />} />
+    <CompatRoute path={routePath} render={() => <DefaultRoute />} />
   </Switch>
 );

--- a/visual-testing-app/src/App.tsx
+++ b/visual-testing-app/src/App.tsx
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 import './globals.css';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import { CompatRouter } from 'react-router-dom-v5-compat';
 import { ThemeProvider } from '@commercetools-uikit/design-system';
 
 interface TRouteComponent {
@@ -46,40 +47,42 @@ const App = () => {
     <>
       <ThemeProvider />
       <Router>
-        <Switch>
-          <Route
-            path="/"
-            exact
-            component={() => (
-              <div>
-                <h1>Visual Testing App</h1>
-                <ul>
-                  {allSortedComponents.map((Component) => (
-                    <li key={Component.routePath}>
-                      <a href={Component.routePath}>{Component.routePath}</a>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-          />
-          {allSortedComponents.map((Component) => (
+        <CompatRouter>
+          <Switch>
             <Route
-              key={Component.routePath}
-              path={Component.routePath}
-              // eslint-disable-next-line react/jsx-pascal-case
-              render={() => <Component.component />}
+              path="/"
+              exact
+              component={() => (
+                <div>
+                  <h1>Visual Testing App</h1>
+                  <ul>
+                    {allSortedComponents.map((Component) => (
+                      <li key={Component.routePath}>
+                        <a href={Component.routePath}>{Component.routePath}</a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
             />
-          ))}
-          <Route
-            component={() => (
-              <div>
-                <p>No route found</p>
-                <a href="/">Show all routes</a>
-              </div>
-            )}
-          />
-        </Switch>
+            {allSortedComponents.map((Component) => (
+              <Route
+                key={Component.routePath}
+                path={Component.routePath}
+                // eslint-disable-next-line react/jsx-pascal-case
+                render={() => <Component.component />}
+              />
+            ))}
+            <Route
+              component={() => (
+                <div>
+                  <p>No route found</p>
+                  <a href="/">Show all routes</a>
+                </div>
+              )}
+            />
+          </Switch>
+        </CompatRouter>
       </Router>
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -6386,6 +6386,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@remix-run/router@npm:1.19.2":
+  version: 1.19.2
+  resolution: "@remix-run/router@npm:1.19.2"
+  checksum: fb2f297b392c75b34c73981e1ef3ce31edd88448bc4ffc2fbc3386e705470d7537ca89e901ec57c07f3cca3a771151f58f7ed6bfcb3e8ef929596637984f068b
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-alias@npm:^3.1.1":
   version: 3.1.9
   resolution: "@rollup/plugin-alias@npm:3.1.9"
@@ -14340,6 +14347,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"history@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "history@npm:5.3.0"
+  dependencies:
+    "@babel/runtime": ^7.7.6
+  checksum: d73c35df49d19ac172f9547d30a21a26793e83f16a78386d99583b5bf1429cc980799fcf1827eb215d31816a6600684fba9686ce78104e23bd89ec239e7c726f
+  languageName: node
+  linkType: hard
+
 "hoist-non-react-statics@npm:^3.1.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.1, hoist-non-react-statics@npm:^3.3.2":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
@@ -20011,6 +20027,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-router-dom-v5-compat@npm:^6.26.2":
+  version: 6.26.2
+  resolution: "react-router-dom-v5-compat@npm:6.26.2"
+  dependencies:
+    "@remix-run/router": 1.19.2
+    history: ^5.3.0
+    react-router: 6.26.2
+  peerDependencies:
+    react: ">=16.8"
+    react-dom: ">=16.8"
+    react-router-dom: 4 || 5
+  checksum: b3b6bd75dbf2dbabcaefcc184332096ef43be07c471a598339f297f0bb1e718a70030d785c93c175808ff61e8d8bd3d8f5c5f8d22f5a18d609fbc4b046c6482e
+  languageName: node
+  linkType: hard
+
 "react-router-dom@npm:5.3.4":
   version: 5.3.4
   resolution: "react-router-dom@npm:5.3.4"
@@ -20044,6 +20075,17 @@ __metadata:
   peerDependencies:
     react: ">=15"
   checksum: 892d4e274a23bf4f39abc2efca54472fb646d3aed4b584020cf49654d2f50d09a2bacebe7c92b4ec7cb8925077376dfcd0664bad6442a73604397cefec9f01f9
+  languageName: node
+  linkType: hard
+
+"react-router@npm:6.26.2":
+  version: 6.26.2
+  resolution: "react-router@npm:6.26.2"
+  dependencies:
+    "@remix-run/router": 1.19.2
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 80ad9db316ad11761b7d5de0c9ed61f3e4345d8984929db802d37d9a6a2174b42a952b0b01ba45833b00f8cd7b5755f198d2f0a8a62a486ebbfbacabbe379be5
   languageName: node
   linkType: hard
 
@@ -23115,6 +23157,7 @@ __metadata:
     react-dom: 17.0.2
     react-intl: ^6.3.2
     react-router-dom: 5.3.4
+    react-router-dom-v5-compat: ^6.26.2
     react-test-renderer: 17.0.2
     react-value: 0.2.0
     replace: 1.2.2


### PR DESCRIPTION
#### Summary

This is a very small POC to see how the `react-router-dom-v5-compat` [package](https://github.com/remix-run/react-router/discussions/8753) works and if it would be a good fit for us to leverage as we migrate from react-router v5 -> v6. It was mentioned at the very top of the official [React-Router migration from v5 docs](https://reactrouter.com/en/main/upgrading/v5#backwards-compatibility-package), and I didn't see it discussed (good or bad) in the RFC, so I assumed if it had been considered and rejected already, that would have been documented in the RFC.

It seems to allow us to use the new v6 API's at the same time we use v5 features which allows for a gradual migration without breakages.

## Description

The first commit sets up the package.

The second commit shows examples of a file fully migrated to using v6 only features. It also includes a file that demonstrates mixed v5 and v6 features in a single file.

## Other notes
I tried to do this POC on app kit which probably has more interesting routes, but it's been a minute since I've worked in that project and I couldn't get it running and it was past Europe time zone to get chapter help. So I decided to try it in UI kit at least, but it's hard for me to test as I think these files are the Percy visual test files? I was going to open a PR anyways for people to review the code that was required to do this, but I'm watching to see if the visual tests pass, because I've never run these locally as I don't have the access to update them anyways.
