### PR TITLE
fix(data-table-manager): include type declarations for libraries

### DIFF
--- a/.changeset/eighty-lizards-sing.md
+++ b/.changeset/eighty-lizards-sing.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/data-table-manager': patch
+---
+
+Include types declarations for libraries"

--- a/packages/components/data-table-manager/package.json
+++ b/packages/components/data-table-manager/package.json
@@ -52,14 +52,14 @@
     "@commercetools-uikit/utils": "19.11.0",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
+    "@types/debounce-promise": "^3.1.6",
+    "@types/react-beautiful-dnd": "^13.1.3",
     "debounce-promise": "^3.1.2",
     "lodash": "4.17.21",
     "prop-types": "15.8.1",
     "react-beautiful-dnd": "13.1.1"
   },
   "devDependencies": {
-    "@types/debounce-promise": "^3.1.6",
-    "@types/react-beautiful-dnd": "^13.1.3",
     "formik": "^2.2.9",
     "react": "17.0.2",
     "react-dom": "17.0.2",


### PR DESCRIPTION
The libraries `debounce-promise` and `react-beautiful-dnd` are used normally and therefore the type declaration packages should be declared as normal dependencies as well.

<img width="712" alt="image" src="https://github.com/user-attachments/assets/c9bdf1b4-0e21-40df-905c-8ea72aa4fe43">
