### PR TITLE
FCT-1072 - implement filters `Badge` component

### DIFF
--- a/packages/components/filters/README.md
+++ b/packages/components/filters/README.md
@@ -42,6 +42,6 @@ export default Example;
 
 ## Properties
 
-| Props   | Type     | Required | Default | Description          |
-| ------- | -------- | :------: | ------- | -------------------- |
-| `label` | `string` |    ✅    |         | This is a stub prop! |
+| Props   | Type     | Required | Default | Description         |
+| ------- | -------- | :------: | ------- | ------------------- |
+| `label` | `string` |          |         | This is a stub prop |

--- a/packages/components/filters/package.json
+++ b/packages/components/filters/package.json
@@ -21,7 +21,9 @@
   "dependencies": {
     "@babel/runtime": "^7.20.13",
     "@babel/runtime-corejs3": "^7.20.13",
+    "@commercetools-uikit/design-system": "workspace:^",
     "@commercetools-uikit/dropdown-menu": "workspace:^",
+    "@commercetools-uikit/utils": "workspace:^",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "prop-types": "15.8.1",

--- a/packages/components/filters/src/badge/badge.spec.tsx
+++ b/packages/components/filters/src/badge/badge.spec.tsx
@@ -1,12 +1,13 @@
 import { screen, render } from '../../../../../test/test-utils';
 import Badge from './badge';
 
-/**
- * THIS IS A PLACEHOLDER, PLEASE UPDATE IT
- */
-describe('FilterMenu Badge', () => {
+const defaultProps = {
+  label: '+1',
+  id: 'test-badge',
+};
+describe('Filters Badge', () => {
   it('should render the badge', async () => {
-    await render(<Badge />);
-    await screen.findByText('badge');
+    await render(<Badge {...defaultProps} />);
+    await screen.findByRole('status', { name: '+1' });
   });
 });

--- a/packages/components/filters/src/badge/badge.spec.tsx
+++ b/packages/components/filters/src/badge/badge.spec.tsx
@@ -8,6 +8,7 @@ const defaultProps = {
 describe('Filters Badge', () => {
   it('should render the badge', async () => {
     await render(<Badge {...defaultProps} />);
-    await screen.findByRole('status', { name: '+1' });
+    const badge = await screen.findByRole('status');
+    expect(badge.textContent).toEqual('+1');
   });
 });

--- a/packages/components/filters/src/badge/badge.tsx
+++ b/packages/components/filters/src/badge/badge.tsx
@@ -44,7 +44,7 @@ const disabledBageStyles = css`
 function Badge(props: TBadgeProps) {
   return (
     <span
-      aria-label={props['aria-label'] ? props['aria-label'] : props.label}
+      aria-label={props['aria-label']}
       css={[badgeStyles, props.isDisabled && disabledBageStyles]}
       id={props.id}
       role="status"

--- a/packages/components/filters/src/badge/badge.tsx
+++ b/packages/components/filters/src/badge/badge.tsx
@@ -34,6 +34,7 @@ const badgeStyles = css`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  height: ${designTokens.spacing40};
 `;
 
 const disabledBageStyles = css`

--- a/packages/components/filters/src/badge/badge.tsx
+++ b/packages/components/filters/src/badge/badge.tsx
@@ -1,5 +1,56 @@
-function Badge() {
-  return <div>badge</div>;
+import { css } from '@emotion/react';
+import { designTokens } from '@commercetools-uikit/design-system';
+
+export type TBadgeProps = {
+  /**
+   * CSS ID for badge, used to specify relationship with parent in parent's `aria-controls` property
+   * see https://www.w3.org/TR/wai-aria-1.1/#status
+   */
+  id: string;
+  /**
+   * If `true`, indicates that the element is in a disabled state.
+   */
+  isDisabled?: boolean;
+  /**
+   * String to be displayed in badge, generally a count of some kind
+   */
+  label: string;
+
+  /**
+   * Optional descriptive explanation of label (e.g. "+4 additional filters applied")
+   */
+  ['aria-label']?: string;
+};
+
+const badgeStyles = css`
+  font-size: ${designTokens.fontSize20};
+  font-weight: ${designTokens.fontWeight500};
+  line-height: ${designTokens.lineHeight20};
+  color: ${designTokens.colorSurface};
+  background-color: ${designTokens.colorInfo};
+  padding: 0 calc(${designTokens.spacing05} + ${designTokens.spacing10});
+  border-radius: ${designTokens.borderRadius20};
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const disabledBageStyles = css`
+  background-color: ${designTokens.colorNeutral};
+`;
+
+function Badge(props: TBadgeProps) {
+  return (
+    <span
+      aria-label={props['aria-label'] ? props['aria-label'] : props.label}
+      css={[badgeStyles, props.isDisabled && disabledBageStyles]}
+      id={props.id}
+      role="status"
+    >
+      {props.label}
+    </span>
+  );
 }
 
 export default Badge;

--- a/packages/components/filters/src/filter-menu/trigger-button/trigger-button.tsx
+++ b/packages/components/filters/src/filter-menu/trigger-button/trigger-button.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '../../badge';
 import { Chip } from '../chip';
 
 export type TFilterMenuTriggerButtonProps = {
@@ -9,7 +8,6 @@ const TriggerButton = (props: TFilterMenuTriggerButtonProps) => {
   return (
     <button>
       <div>{props.label}</div>
-      <Badge />
       <Chip />
     </button>
   );

--- a/packages/components/filters/src/filters.stories.tsx
+++ b/packages/components/filters/src/filters.stories.tsx
@@ -1,10 +1,10 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import Filters from './filters';
 
 const meta: Meta<typeof Filters> = {
   title: 'components/Filters',
   component: Filters,
-  tags: ['local-dev'],
+  // tags: ['local-dev'],
   argTypes: {
     label: {
       control: 'text',
@@ -13,10 +13,8 @@ const meta: Meta<typeof Filters> = {
 };
 export default meta;
 
-type Story = StoryObj<typeof Filters>;
+type Story = StoryFn<typeof Filters>;
 
-export const BasicExample: Story = {
-  args: {
-    label: 'A component for applying multiple filter controls',
-  },
+export const BasicExample: Story = () => {
+  return <Filters label={'test'} />;
 };

--- a/packages/components/filters/src/filters.stories.tsx
+++ b/packages/components/filters/src/filters.stories.tsx
@@ -4,7 +4,7 @@ import Filters from './filters';
 const meta: Meta<typeof Filters> = {
   title: 'components/Filters',
   component: Filters,
-  // tags: ['local-dev'],
+  tags: ['local-dev'],
   argTypes: {
     label: {
       control: 'text',

--- a/packages/components/filters/src/filters.tsx
+++ b/packages/components/filters/src/filters.tsx
@@ -1,4 +1,4 @@
-import { Badge } from './badge';
+import { designTokens } from '@commercetools-uikit/design-system';
 
 export type TFiltersProps = {
   /**
@@ -9,12 +9,8 @@ export type TFiltersProps = {
 
 function Filters(props: TFiltersProps) {
   return (
-    <div style={{ display: 'flex', gap: '8px' }}>
+    <div style={{ display: 'flex', gap: designTokens.spacing20 }}>
       <div>{props.label}</div>
-      active:
-      <Badge label="+2" id={`${props.label}-total-applied-filters`} />
-      disabled:
-      <Badge label="+2" id={`${props.label}-applied-filter-count`} isDisabled />
     </div>
   );
 }

--- a/packages/components/filters/src/filters.tsx
+++ b/packages/components/filters/src/filters.tsx
@@ -10,6 +10,7 @@ export type TFiltersProps = {
 function Filters(props: TFiltersProps) {
   return (
     <div style={{ display: 'flex', gap: '8px' }}>
+      <div>{props.label}</div>
       active:
       <Badge label="+2" id={`${props.label}-total-applied-filters`} />
       disabled:

--- a/packages/components/filters/src/filters.tsx
+++ b/packages/components/filters/src/filters.tsx
@@ -1,3 +1,5 @@
+import { Badge } from './badge';
+
 export type TFiltersProps = {
   /**
    * This is a stub prop
@@ -6,6 +8,13 @@ export type TFiltersProps = {
 };
 
 function Filters(props: TFiltersProps) {
-  return <div>{props.label}</div>;
+  return (
+    <div style={{ display: 'flex', gap: '8px' }}>
+      active:
+      <Badge label="+2" id={`${props.label}-total-applied-filters`} />
+      disabled:
+      <Badge label="+2" id={`${props.label}-applied-filter-count`} isDisabled />
+    </div>
+  );
 }
 export default Filters;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3089,7 +3089,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@commercetools-uikit/design-system@19.12.0, @commercetools-uikit/design-system@workspace:design-system":
+"@commercetools-uikit/design-system@19.12.0, @commercetools-uikit/design-system@workspace:^, @commercetools-uikit/design-system@workspace:design-system":
   version: 0.0.0-use.local
   resolution: "@commercetools-uikit/design-system@workspace:design-system"
   dependencies:
@@ -3229,7 +3229,9 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.20.13
     "@babel/runtime-corejs3": ^7.20.13
+    "@commercetools-uikit/design-system": "workspace:^"
     "@commercetools-uikit/dropdown-menu": "workspace:^"
+    "@commercetools-uikit/utils": "workspace:^"
     "@emotion/react": ^11.10.5
     "@emotion/styled": ^11.10.5
     prop-types: 15.8.1
@@ -4668,7 +4670,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@commercetools-uikit/utils@19.12.0, @commercetools-uikit/utils@workspace:packages/utils":
+"@commercetools-uikit/utils@19.12.0, @commercetools-uikit/utils@workspace:^, @commercetools-uikit/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@commercetools-uikit/utils@workspace:packages/utils"
   dependencies:


### PR DESCRIPTION
This PR implements the `Badge` component in the `filters` package.  

It implements the styles and states [specified in figma](https://www.figma.com/design/b2S3GGpScVDuf15VAGEqeL/Filter-pattern?node-id=2339-6256&m=dev), along with the proper accessibility attributes for the `status` role, [as specified here](https://w3c.github.io/aria/#status).

### Badge Component Implementation:
* [`packages/components/filters/src/badge/badge.tsx`](diffhunk://#diff-3a3cc1bc670245d29b7b51e03ec6378bdee6231c14135a350bea94098e7edaddL1-R53): Fully implemented the `Badge` component with properties for `id`, `isDisabled`, `label`, and `aria-label`. Added styles using `@emotion/react` and `designTokens` from `@commercetools-uikit/design-system`.


### Test Updates:
* [`packages/components/filters/src/badge/badge.spec.tsx`](diffhunk://#diff-d7ea2b19bec24e727a07922300c734f05a6f72d8e74552aa3c5f7832fb5840d0L4-R11): Updated the test for the `Badge` component to use `defaultProps` and check for the `status` role.

### Documentation and Dependency Updates:
* [`packages/components/filters/README.md`](diffhunk://#diff-018b1db07883ff17d596ba7a4ce8a57c65b0a44894b7c1476408706435d8e6daL46-R47): Fixed the table formatting in the properties section.
* [`packages/components/filters/package.json`](diffhunk://#diff-a9b33f9c36305865b265a930a2124d31f24065710b96c192e7ea15a789867dfeR24-R26): Added dependencies for `@commercetools-uikit/design-system` and `@commercetools-uikit/utils`.…ibutes, implement unit test, show states in storybook story


**PLEASE NOTE: The `Filters` storybook must be updated to have a `local-dev` tag before merging this PR to `main` so that the `Filters` docs do not get published to the prod site, these docs are published for this PR as a courtesy to the reviewers.**
[
The badge can be seen here](https://ui-kit-git-fct-1072-badge-commercetools.vercel.app/?path=/docs/components-filters--props)