### PR TITLE
FCT 1079 - filters `Chip`

### DIFF
--- a/packages/components/filters/src/filter-menu/chip/chip.spec.tsx
+++ b/packages/components/filters/src/filter-menu/chip/chip.spec.tsx
@@ -1,12 +1,10 @@
 import { screen, render } from '../../../../../../test/test-utils';
 import Chip from './chip';
 
-/**
- * THIS IS A PLACEHOLDER, PLEASE UPDATE IT
- */
 describe('FilterMenu Chip', () => {
   it('should render the chip', async () => {
-    await render(<Chip />);
-    await screen.findByText('chip');
+    await render(<Chip label="test" />);
+    const chip = await screen.findByRole('listitem');
+    expect(chip.textContent).toEqual('test');
   });
 });

--- a/packages/components/filters/src/filter-menu/chip/chip.tsx
+++ b/packages/components/filters/src/filter-menu/chip/chip.tsx
@@ -1,5 +1,39 @@
-function Chip() {
-  return <div>chip</div>;
+import { type ReactNode } from 'react';
+import { designTokens } from '@commercetools-uikit/design-system';
+import { css } from '@emotion/react';
+
+export type TFilterMenuChipProps = {
+  isDisabled?: boolean;
+  label: ReactNode;
+};
+
+const chipStyles = css`
+  font-size: ${designTokens.fontSize20};
+  font-weight: ${designTokens.fontWeight400};
+  line-height: ${designTokens.lineHeight20};
+  color: ${designTokens.colorPrimary20};
+  background-color: ${designTokens.colorPrimary95};
+  padding: 0 ${designTokens.spacing20};
+  border-radius: calc(
+    ${designTokens.borderRadius20} - ${designTokens.borderRadius4}
+  );
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  list-style: none;
+`;
+
+const disabledChipStyles = css`
+  color: ${designTokens.colorNeutral60};
+  background-color: ${designTokens.colorNeutral90};
+`;
+
+function Chip(props: TFilterMenuChipProps) {
+  return (
+    <li css={[chipStyles, props.isDisabled && disabledChipStyles]}>
+      {props.label}
+    </li>
+  );
 }
 
 export default Chip;

--- a/packages/components/filters/src/filter-menu/chip/chip.tsx
+++ b/packages/components/filters/src/filter-menu/chip/chip.tsx
@@ -25,7 +25,7 @@ const chipStyles = css`
 `;
 
 const disabledChipStyles = css`
-  color: ${designTokens.colorNeutral50};
+  color: ${designTokens.colorNeutral40};
   background-color: ${designTokens.colorNeutral90};
 `;
 

--- a/packages/components/filters/src/filter-menu/chip/chip.tsx
+++ b/packages/components/filters/src/filter-menu/chip/chip.tsx
@@ -13,6 +13,7 @@ const chipStyles = css`
   line-height: ${designTokens.lineHeight20};
   color: ${designTokens.colorPrimary20};
   background-color: ${designTokens.colorPrimary95};
+  height: ${designTokens.spacing40};
   padding: 0 ${designTokens.spacing20};
   border-radius: calc(
     ${designTokens.borderRadius20} - ${designTokens.borderRadius4}
@@ -24,7 +25,7 @@ const chipStyles = css`
 `;
 
 const disabledChipStyles = css`
-  color: ${designTokens.colorNeutral60};
+  color: ${designTokens.colorNeutral50};
   background-color: ${designTokens.colorNeutral90};
 `;
 

--- a/packages/components/filters/src/filter-menu/trigger-button/trigger-button.tsx
+++ b/packages/components/filters/src/filter-menu/trigger-button/trigger-button.tsx
@@ -1,5 +1,3 @@
-import { Chip } from '../chip';
-
 export type TFilterMenuTriggerButtonProps = {
   label: string;
 };
@@ -8,7 +6,6 @@ const TriggerButton = (props: TFilterMenuTriggerButtonProps) => {
   return (
     <button>
       <div>{props.label}</div>
-      <Chip />
     </button>
   );
 };

--- a/packages/components/filters/src/filters.stories.tsx
+++ b/packages/components/filters/src/filters.stories.tsx
@@ -4,7 +4,7 @@ import Filters from './filters';
 const meta: Meta<typeof Filters> = {
   title: 'components/Filters',
   component: Filters,
-  // tags: ['local-dev'],
+  tags: ['local-dev'],
   argTypes: {
     label: {
       control: 'text',

--- a/packages/components/filters/src/filters.stories.tsx
+++ b/packages/components/filters/src/filters.stories.tsx
@@ -4,7 +4,7 @@ import Filters from './filters';
 const meta: Meta<typeof Filters> = {
   title: 'components/Filters',
   component: Filters,
-  tags: ['local-dev'],
+  // tags: ['local-dev'],
   argTypes: {
     label: {
       control: 'text',

--- a/packages/components/filters/src/filters.tsx
+++ b/packages/components/filters/src/filters.tsx
@@ -1,4 +1,5 @@
 import { designTokens } from '@commercetools-uikit/design-system';
+import { Chip } from './filter-menu/chip';
 
 export type TFiltersProps = {
   /**
@@ -11,6 +12,10 @@ function Filters(props: TFiltersProps) {
   return (
     <div style={{ display: 'flex', gap: designTokens.spacing20 }}>
       <div>{props.label}</div>
+      <ul style={{ display: 'flex', gap: designTokens.spacing20 }}>
+        <Chip label="active" />
+        <Chip label="disabled" isDisabled />
+      </ul>
     </div>
   );
 }

--- a/packages/components/filters/src/filters.tsx
+++ b/packages/components/filters/src/filters.tsx
@@ -1,5 +1,4 @@
 import { designTokens } from '@commercetools-uikit/design-system';
-import { Chip } from './filter-menu/chip';
 
 export type TFiltersProps = {
   /**
@@ -12,10 +11,7 @@ function Filters(props: TFiltersProps) {
   return (
     <div style={{ display: 'flex', gap: designTokens.spacing20 }}>
       <div>{props.label}</div>
-      <ul style={{ display: 'flex', gap: designTokens.spacing20 }}>
-        <Chip label="active" />
-        <Chip label="disabled" isDisabled />
-      </ul>
+      <div style={{ display: 'flex', gap: designTokens.spacing20 }}></div>
     </div>
   );
 }


### PR DESCRIPTION
This PR implements the `Chip` component with necessary styles and state as [specified in figma](https://www.figma.com/design/b2S3GGpScVDuf15VAGEqeL/Filter-pattern?node-id=2339-6256&m=dev).  

The `Chip` is implemented as an `li`, and should be used as a child of a `ul` component, as it is meant to list the selected filter values in a `FilterMenu`.

### Component Enhancements:

* **Chip Component**: Refactored to accept `label` and `isDisabled` props, and styled using `@commercetools-uikit/design-system` and `@emotion/react`.
* **FilterMenu Chip Test**: Updated the test for the `Chip` component to check for the `label` prop and role attribute.

**PLEASE NOTE: The Filters storybook must be updated to have a local-dev tag before merging this PR to main so that the Filters docs do not get published to the prod site, these docs are published for this PR as a courtesy to the reviewers.**
[
Chip can be seen here](https://ui-kit-git-fct-1078-chip-commercetools.vercel.app/?path=/docs/components-filters--props)