### PR TITLE
Introduce filter appearance for filters visual features

### DIFF
--- a/.changeset/odd-ducks-peel.md
+++ b/.changeset/odd-ducks-peel.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-uikit/select-input': minor
+'@commercetools-uikit/select-utils': minor
+---
+
+Introduce a new prop to handle optional styling for when the select input is used as a filter component

--- a/packages/components/inputs/select-input/src/select-input.tsx
+++ b/packages/components/inputs/select-input/src/select-input.tsx
@@ -7,6 +7,8 @@ import Select, {
   type Props as ReactSelectProps,
 } from 'react-select';
 import Constraints from '@commercetools-uikit/constraints';
+import { SearchIcon } from '@commercetools-uikit/icons';
+
 import {
   ClearIndicator,
   TagRemove,
@@ -49,7 +51,7 @@ export type TSelectInputProps = {
    * Indicates the appearance of the input.
    * Quiet appearance is meant to be used with the `horizontalConstraint="auto"`.
    */
-  appearance?: 'default' | 'quiet';
+  appearance?: 'default' | 'quiet' | 'filter';
   horizontalConstraint?:
     | 3
     | 4
@@ -462,6 +464,9 @@ const SelectInput = (props: TSelectInputProps) => {
                     ),
                   }
                 : {}),
+              ...(props.appearance === 'filter' && {
+                DropdownIndicator: () => <SearchIcon color="neutral60" />,
+              }),
               ...props.components,
             } as ReactSelectProps['components']
           }

--- a/packages/components/inputs/select-utils/src/create-select-styles.ts
+++ b/packages/components/inputs/select-utils/src/create-select-styles.ts
@@ -22,7 +22,7 @@ type TProps = {
   hasValue?: boolean;
   isCondensed?: boolean;
   controlShouldRenderValue?: boolean;
-  appearance?: 'default' | 'quiet';
+  appearance?: 'default' | 'quiet' | 'filter';
   minMenuWidth?:
     | 2
     | 3


### PR DESCRIPTION
#### Summary

This pull request introduces a new prop to handle optional styling for the select input when used as a filter component. The most important changes include the addition of the `filter` appearance option and the incorporation of a search icon when this appearance is selected.

I opened this as a WIP for early reviews and to discuss this approach.

with` appearance: "filter"`
<img width="359" alt="image" src="https://github.com/user-attachments/assets/ea52b963-d90b-47cb-9128-2dbf533cc657">

with `appearance: "default"`
<img width="407" alt="image" src="https://github.com/user-attachments/assets/e740ee6a-eb55-4c57-a63c-a6367580f93f">



This PR is opened also to add any other property we might want to add in the appearance option. 