### PR TITLE
fix: dependency version reference

### DIFF
--- a/.changeset/grumpy-nails-smash.md
+++ b/.changeset/grumpy-nails-smash.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/select-utils': patch
+---
+
+Fix dependency version reference

--- a/packages/components/inputs/select-utils/package.json
+++ b/packages/components/inputs/select-utils/package.json
@@ -22,7 +22,7 @@
     "@babel/runtime": "^7.20.13",
     "@babel/runtime-corejs3": "^7.20.13",
     "@commercetools-uikit/accessible-button": "19.15.0",
-    "@commercetools-uikit/checkbox-input": "workspace:^",
+    "@commercetools-uikit/checkbox-input": "19.15.0",
     "@commercetools-uikit/design-system": "19.15.0",
     "@commercetools-uikit/icons": "19.15.0",
     "@commercetools-uikit/spacings": "19.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2785,7 +2785,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@commercetools-uikit/checkbox-input@19.15.0, @commercetools-uikit/checkbox-input@workspace:^, @commercetools-uikit/checkbox-input@workspace:packages/components/inputs/checkbox-input":
+"@commercetools-uikit/checkbox-input@19.15.0, @commercetools-uikit/checkbox-input@workspace:packages/components/inputs/checkbox-input":
   version: 0.0.0-use.local
   resolution: "@commercetools-uikit/checkbox-input@workspace:packages/components/inputs/checkbox-input"
   dependencies:
@@ -4453,7 +4453,7 @@ __metadata:
     "@babel/runtime": ^7.20.13
     "@babel/runtime-corejs3": ^7.20.13
     "@commercetools-uikit/accessible-button": 19.15.0
-    "@commercetools-uikit/checkbox-input": "workspace:^"
+    "@commercetools-uikit/checkbox-input": 19.15.0
     "@commercetools-uikit/design-system": 19.15.0
     "@commercetools-uikit/icons": 19.15.0
     "@commercetools-uikit/spacings": 19.15.0


### PR DESCRIPTION
Regression from #2975 

Causes the error

```
Couldn't find any versions for "@commercetools-uikit/checkbox-input" that matches "workspace:^"
```