### PR TITLE
chore(uikit preview release): use branch name as preview tag

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -81,6 +81,6 @@ jobs:
           BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}" | tr '/' '-')
           git checkout ${{ github.head_ref }}
           yarn changeset version --snapshot ${BRANCH_NAME}
-          yarn changeset publish --tag preview
+          yarn changeset publish --tag ${BRANCH_NAME}
         env:
           GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}


### PR DESCRIPTION
#### Summary

This pull request includes a change to the `.github/workflows/preview-release.yml` file to improve the handling of branch-specific tags during the publishing process.

## Description

Improvements to branch-specific tags:

* [`.github/workflows/preview-release.yml`](diffhunk://#diff-8b0f7fca9f96bdfd89cc7ae042ef4932a5104af70fceb2b9b497fba2d6406ba3L84-R84): Changed the `yarn changeset publish` command to use `${BRANCH_NAME}` instead of the static `preview` tag, allowing for more dynamic and branch-specific tagging.

