### PR TITLE
FCT 1305 - Bundle types with preset packages

### DIFF
--- a/.changeset/neat-mails-sleep.md
+++ b/.changeset/neat-mails-sleep.md
@@ -1,0 +1,11 @@
+---
+'@commercetools-uikit/quick-filters': patch
+'@commercetools-uikit/filters': patch
+'@commercetools-uikit/spacings': patch
+'@commercetools-uikit/buttons': patch
+'@commercetools-uikit/fields': patch
+'@commercetools-uikit/inputs': patch
+'@commercetools-frontend/ui-kit': patch
+---
+
+Bundles types with UI Kit preset packages, Filters package, QuickFilters package

--- a/packages/components/filters/src/export-types.ts
+++ b/packages/components/filters/src/export-types.ts
@@ -1,1 +1,6 @@
-export type { TFiltersProps } from './filters';
+export type {
+  TFiltersProps,
+  TFilterConfiguration,
+  TFilterGroupConfiguration,
+  TAppliedFilter,
+} from './filters';

--- a/packages/components/filters/src/filters.tsx
+++ b/packages/components/filters/src/filters.tsx
@@ -39,7 +39,7 @@ interface TAddFilterOptionGroup extends TOptionObject {
   key: string;
 }
 
-type TAppliedFilter = {
+export type TAppliedFilter = {
   /**
    * unique identifier for the filter
    */
@@ -106,7 +106,7 @@ export type TFilterConfiguration = {
   isDisabled?: boolean;
 };
 
-type TFilterGroupConfiguration = {
+export type TFilterGroupConfiguration = {
   /**
    * unique identifier for the filter group
    */

--- a/packages/components/filters/src/index.ts
+++ b/packages/components/filters/src/index.ts
@@ -1,2 +1,3 @@
 export { default } from './filters';
 export { default as version } from './version';
+export * from './export-types';

--- a/packages/components/quick-filters/src/index.ts
+++ b/packages/components/quick-filters/src/index.ts
@@ -1,2 +1,4 @@
 export { default } from './quick-filters';
 export { default as version } from './version';
+
+export * from './export-types';

--- a/presets/buttons/src/index.ts
+++ b/presets/buttons/src/index.ts
@@ -1,7 +1,28 @@
-export { default as AccessibleButton } from '@commercetools-uikit/accessible-button';
-export { default as FlatButton } from '@commercetools-uikit/flat-button';
-export { default as PrimaryButton } from '@commercetools-uikit/primary-button';
-export { default as IconButton } from '@commercetools-uikit/icon-button';
-export { default as LinkButton } from '@commercetools-uikit/link-button';
-export { default as SecondaryButton } from '@commercetools-uikit/secondary-button';
-export { default as SecondaryIconButton } from '@commercetools-uikit/secondary-icon-button';
+export {
+  default as AccessibleButton,
+  type TAccessibleButtonProps,
+} from '@commercetools-uikit/accessible-button';
+export {
+  default as FlatButton,
+  type TFlatButtonProps,
+} from '@commercetools-uikit/flat-button';
+export {
+  default as PrimaryButton,
+  type TPrimaryButtonProps,
+} from '@commercetools-uikit/primary-button';
+export {
+  default as IconButton,
+  type TIconButtonProps,
+} from '@commercetools-uikit/icon-button';
+export {
+  default as LinkButton,
+  type TLinkButtonProps,
+} from '@commercetools-uikit/link-button';
+export {
+  default as SecondaryButton,
+  type TSecondaryButtonProps,
+} from '@commercetools-uikit/secondary-button';
+export {
+  default as SecondaryIconButton,
+  type TSecondaryButtonIconProps,
+} from '@commercetools-uikit/secondary-icon-button';

--- a/presets/fields/src/index.ts
+++ b/presets/fields/src/index.ts
@@ -1,17 +1,65 @@
-export { default as TextField } from '@commercetools-uikit/text-field';
-export { default as DateField } from '@commercetools-uikit/date-field';
-export { default as DateTimeField } from '@commercetools-uikit/date-time-field';
-export { default as DateRangeField } from '@commercetools-uikit/date-range-field';
-export { default as TimeField } from '@commercetools-uikit/time-field';
-export { default as MultilineTextField } from '@commercetools-uikit/multiline-text-field';
-export { default as LocalizedTextField } from '@commercetools-uikit/localized-text-field';
-export { default as LocalizedMultilineTextField } from '@commercetools-uikit/localized-multiline-text-field';
-export { default as NumberField } from '@commercetools-uikit/number-field';
-export { default as MoneyField } from '@commercetools-uikit/money-field';
-export { default as SelectField } from '@commercetools-uikit/select-field';
-export { default as AsyncSelectField } from '@commercetools-uikit/async-select-field';
+export {
+  default as TextField,
+  type TTextFieldProps,
+} from '@commercetools-uikit/text-field';
+export {
+  default as DateField,
+  type TDateFieldProps,
+} from '@commercetools-uikit/date-field';
+export {
+  default as DateTimeField,
+  type TDateTimeFieldProps,
+} from '@commercetools-uikit/date-time-field';
+export {
+  default as DateRangeField,
+  type TDateRangeFieldProps,
+} from '@commercetools-uikit/date-range-field';
+export {
+  default as TimeField,
+  type TTimeFieldProps,
+} from '@commercetools-uikit/time-field';
+export {
+  default as MultilineTextField,
+  type TMultiTextFieldProps,
+} from '@commercetools-uikit/multiline-text-field';
+export {
+  default as LocalizedTextField,
+  type TLocalizedTextFieldProps,
+} from '@commercetools-uikit/localized-text-field';
+export {
+  default as LocalizedMultilineTextField,
+  type TLocalizedMultilineTextFieldProps,
+} from '@commercetools-uikit/localized-multiline-text-field';
+export {
+  default as NumberField,
+  type TNumberFieldProps,
+} from '@commercetools-uikit/number-field';
+export {
+  default as MoneyField,
+  type TMoneyFieldProps,
+} from '@commercetools-uikit/money-field';
+export {
+  default as SelectField,
+  type TSelectFieldProps,
+} from '@commercetools-uikit/select-field';
+export {
+  default as AsyncSelectField,
+  type TAsyncSelectFieldProps,
+} from '@commercetools-uikit/async-select-field';
 export { default as CreatableSelectField } from '@commercetools-uikit/creatable-select-field';
-export { default as AsyncCreatableSelectField } from '@commercetools-uikit/async-creatable-select-field';
-export { default as PasswordField } from '@commercetools-uikit/password-field';
-export { default as RadioField } from '@commercetools-uikit/radio-field';
-export { default as SearchSelectField } from '@commercetools-uikit/search-select-field';
+export {
+  default as AsyncCreatableSelectField,
+  type TAsyncCreatableSelectFieldProps,
+} from '@commercetools-uikit/async-creatable-select-field';
+export {
+  default as PasswordField,
+  type TPasswordField,
+} from '@commercetools-uikit/password-field';
+export {
+  default as RadioField,
+  type TRadioFieldProps,
+} from '@commercetools-uikit/radio-field';
+export {
+  default as SearchSelectField,
+  type TSearchSelectFieldProps,
+} from '@commercetools-uikit/search-select-field';

--- a/presets/inputs/src/index.ts
+++ b/presets/inputs/src/index.ts
@@ -1,24 +1,103 @@
-export { default as AsyncCreatableSelectInput } from '@commercetools-uikit/async-creatable-select-input';
-export { default as AsyncSelectInput } from '@commercetools-uikit/async-select-input';
-export { default as CreatableSelectInput } from '@commercetools-uikit/creatable-select-input';
-export { default as DateInput } from '@commercetools-uikit/date-input';
-export { default as DateRangeInput } from '@commercetools-uikit/date-range-input';
-export { default as DateTimeInput } from '@commercetools-uikit/date-time-input';
-export { default as LocalizedMultilineTextInput } from '@commercetools-uikit/localized-multiline-text-input';
-export { default as LocalizedTextInput } from '@commercetools-uikit/localized-text-input';
-export { default as MoneyInput } from '@commercetools-uikit/money-input';
-export { default as LocalizedMoneyInput } from '@commercetools-uikit/localized-money-input';
-export { default as MultilineTextInput } from '@commercetools-uikit/multiline-text-input';
-export { default as NumberInput } from '@commercetools-uikit/number-input';
-export { default as PasswordInput } from '@commercetools-uikit/password-input';
-export { default as SelectInput } from '@commercetools-uikit/select-input';
-export { default as TextInput } from '@commercetools-uikit/text-input';
-export { default as RichTextInput } from '@commercetools-uikit/rich-text-input';
-export { default as LocalizedRichTextInput } from '@commercetools-uikit/localized-rich-text-input';
-export { default as TimeInput } from '@commercetools-uikit/time-input';
-export { default as ToggleInput } from '@commercetools-uikit/toggle-input';
-export { default as CheckboxInput } from '@commercetools-uikit/checkbox-input';
-export { default as RadioInput } from '@commercetools-uikit/radio-input';
-export { default as SearchSelectInput } from '@commercetools-uikit/search-select-input';
-export { default as SearchTextInput } from '@commercetools-uikit/search-text-input';
-export { default as SelectableSearchInput } from '@commercetools-uikit/selectable-search-input';
+export {
+  default as AsyncCreatableSelectInput,
+  type TAsyncCreatableSelectInputProps,
+} from '@commercetools-uikit/async-creatable-select-input';
+export {
+  default as AsyncSelectInput,
+  type TAsyncSelectInputProps,
+} from '@commercetools-uikit/async-select-input';
+export {
+  default as CreatableSelectInput,
+  type TCreatableSelectInputProps,
+} from '@commercetools-uikit/creatable-select-input';
+export {
+  default as DateInput,
+  type TDateInput,
+} from '@commercetools-uikit/date-input';
+export {
+  default as DateRangeInput,
+  type TDateRangeInputProps,
+} from '@commercetools-uikit/date-range-input';
+export {
+  default as DateTimeInput,
+  type TDateTimeInputProps,
+} from '@commercetools-uikit/date-time-input';
+export {
+  default as LocalizedMultilineTextInput,
+  type TLocalizedMultilineTextInputProps,
+} from '@commercetools-uikit/localized-multiline-text-input';
+export {
+  default as LocalizedTextInput,
+  type TLocalizedTextInputProps,
+} from '@commercetools-uikit/localized-text-input';
+export {
+  default as MoneyInput,
+  type TCurrencyCode,
+  type TMoneyValue,
+  type TValue,
+} from '@commercetools-uikit/money-input';
+export {
+  default as LocalizedMoneyInput,
+  type TLocalizedMoneyInputProps,
+} from '@commercetools-uikit/localized-money-input';
+export {
+  default as MultilineTextInput,
+  type TMultilineTextInputProps,
+} from '@commercetools-uikit/multiline-text-input';
+export {
+  default as NumberInput,
+  type TNumberInputProps,
+} from '@commercetools-uikit/number-input';
+export {
+  default as PasswordInput,
+  type TPasswordInputProps,
+} from '@commercetools-uikit/password-input';
+export {
+  default as SelectInput,
+  type TSelectInputProps,
+  type TOption,
+  type TOptionObject,
+  type TOptions,
+  type TCustomEvent,
+} from '@commercetools-uikit/select-input';
+export {
+  default as TextInput,
+  type TTextInputProps,
+} from '@commercetools-uikit/text-input';
+export {
+  default as RichTextInput,
+  type TRichTextInputProps,
+} from '@commercetools-uikit/rich-text-input';
+export {
+  default as LocalizedRichTextInput,
+  type TLocalizedRichTextInputProps,
+} from '@commercetools-uikit/localized-rich-text-input';
+export {
+  default as TimeInput,
+  type TTimeInputProps,
+} from '@commercetools-uikit/time-input';
+export {
+  default as ToggleInput,
+  type TToggleInputProps,
+} from '@commercetools-uikit/toggle-input';
+export {
+  default as CheckboxInput,
+  type TCheckboxProps,
+} from '@commercetools-uikit/checkbox-input';
+export {
+  default as RadioInput,
+  type TGroupProps,
+  type TOptionProps,
+} from '@commercetools-uikit/radio-input';
+export {
+  default as SearchSelectInput,
+  type TSearchSelectInputProps,
+} from '@commercetools-uikit/search-select-input';
+export {
+  default as SearchTextInput,
+  type TSearchTextInputProps,
+} from '@commercetools-uikit/search-text-input';
+export {
+  default as SelectableSearchInput,
+  type TSelectableSearchInputProps,
+} from '@commercetools-uikit/selectable-search-input';

--- a/presets/spacings/src/index.ts
+++ b/presets/spacings/src/index.ts
@@ -1,1 +1,5 @@
-export { default } from './spacings';
+export { default, type TSpacings } from './spacings';
+export type { TInlineProps } from '@commercetools-uikit/spacings-inline';
+export type { TInsetProps } from '@commercetools-uikit/spacings-inset';
+export type { TInsetSquishProps } from '@commercetools-uikit/spacings-inset-squish';
+export type { TStackProps } from '@commercetools-uikit/spacings-stack';

--- a/presets/spacings/src/spacings.ts
+++ b/presets/spacings/src/spacings.ts
@@ -3,7 +3,7 @@ import Inset from '@commercetools-uikit/spacings-inset';
 import InsetSquish from '@commercetools-uikit/spacings-inset-squish';
 import Stack from '@commercetools-uikit/spacings-stack';
 
-type TSpacings = {
+export type TSpacings = {
   Inline: typeof Inline;
   Inset: typeof Inset;
   InsetSquish: typeof InsetSquish;

--- a/presets/ui-kit/src/index.ts
+++ b/presets/ui-kit/src/index.ts
@@ -9,45 +9,134 @@ export * from '@commercetools-uikit/fields';
 export * from '@commercetools-uikit/icons';
 export * from '@commercetools-uikit/inputs';
 
-export { default as LeadingIcon } from '@commercetools-uikit/icons/leading-icon';
-export { default as CustomIcon } from '@commercetools-uikit/icons/custom-icon';
-export { default as InlineSvg } from '@commercetools-uikit/icons/inline-svg';
-export { default as AccessibleHidden } from '@commercetools-uikit/accessible-hidden';
-export { default as Avatar } from '@commercetools-uikit/avatar';
-export { default as Card } from '@commercetools-uikit/card';
+export {
+  default as LeadingIcon,
+  type TLeadingIconProps,
+} from '@commercetools-uikit/icons/leading-icon';
+export {
+  default as CustomIcon,
+  type TCustomIconProps,
+} from '@commercetools-uikit/icons/custom-icon';
+export {
+  default as InlineSvg,
+  type InlineSvgProps,
+} from '@commercetools-uikit/icons/inline-svg';
+export {
+  default as AccessibleHidden,
+  type TAccessibleHiddenProps,
+} from '@commercetools-uikit/accessible-hidden';
+export {
+  default as Avatar,
+  type TAvatarProps,
+} from '@commercetools-uikit/avatar';
+export { default as Card, type TCardProps } from '@commercetools-uikit/card';
 export { default as Link } from '@commercetools-uikit/link';
-export { default as Collapsible } from '@commercetools-uikit/collapsible';
-export { default as CollapsibleMotion } from '@commercetools-uikit/collapsible-motion';
-export { default as CollapsiblePanel } from '@commercetools-uikit/collapsible-panel';
-export { default as Constraints } from '@commercetools-uikit/constraints';
-export { ContentNotification } from '@commercetools-uikit/notifications';
+export {
+  default as Collapsible,
+  type TCollapsibleProps,
+} from '@commercetools-uikit/collapsible';
+export {
+  default as CollapsibleMotion,
+  type TCollapsibleMotionProps,
+  type TContainerStyles,
+  type TRenderFunctionOptions,
+} from '@commercetools-uikit/collapsible-motion';
+export {
+  default as CollapsiblePanel,
+  type TCollapsiblePanel,
+} from '@commercetools-uikit/collapsible-panel';
+export {
+  default as Constraints,
+  type THorizontalProps,
+  type TMaxProp,
+} from '@commercetools-uikit/constraints';
+export {
+  ContentNotification,
+  type TContentNotificationProps,
+} from '@commercetools-uikit/notifications';
 export {
   default as PrimaryActionDropdown,
   Option as PrimaryActionDropdownOption,
+  type TPrimaryActionDropdown,
 } from '@commercetools-uikit/primary-action-dropdown';
-export { default as DropdownMenu } from '@commercetools-uikit/dropdown-menu';
-export { default as FieldLabel } from '@commercetools-uikit/field-label';
-export { default as FieldErrors } from '@commercetools-uikit/field-errors';
+export {
+  default as DropdownMenu,
+  type TDropdownMenuProps,
+  type TDropdownMenuContextProps,
+  type TDropdownContentMenuProps,
+  type TDropdownListMenuProps,
+  type TDropdownListMenuItemProps,
+  type TDropdownTriggerProps,
+} from '@commercetools-uikit/dropdown-menu';
+export {
+  default as FieldLabel,
+  type TFieldLabelProps,
+} from '@commercetools-uikit/field-label';
+export {
+  default as FieldErrors,
+  type TFieldErrors,
+} from '@commercetools-uikit/field-errors';
+/** TODO: Add Types w/next release */
 export { default as Filters } from '@commercetools-uikit/filters';
-export { default as Grid } from '@commercetools-uikit/grid';
-export { default as Label } from '@commercetools-uikit/label';
-export { default as LoadingSpinner } from '@commercetools-uikit/loading-spinner';
-export { ErrorMessage, WarningMessage } from '@commercetools-uikit/messages';
+export {
+  default as Grid,
+  type TGridItemProps,
+  type TGridProps,
+} from '@commercetools-uikit/grid';
+export { default as Label, type TLabelProps } from '@commercetools-uikit/label';
+export {
+  default as LoadingSpinner,
+  type TLoadingSpinnerProps,
+} from '@commercetools-uikit/loading-spinner';
+export {
+  ErrorMessage,
+  WarningMessage,
+  type TAdditionalInfoProps,
+  type TErrorMessageProps,
+  type TIntlMessageDescriptor,
+} from '@commercetools-uikit/messages';
 export {
   PageNavigator,
   PageSizeSelector,
   Pagination,
+  type TPaginationProps,
 } from '@commercetools-uikit/pagination';
-export { default as ProgressBar } from '@commercetools-uikit/progress-bar';
+export {
+  default as ProgressBar,
+  type TProgressBarProps,
+} from '@commercetools-uikit/progress-bar';
+/** TODO: Add Types w/next release */
 export { default as QuickFilters } from '@commercetools-uikit/quick-filters';
+/** TODO: Add Types w/next release */
 export { default as Spacings } from '@commercetools-uikit/spacings';
-export { default as Stamp } from '@commercetools-uikit/stamp';
+export {
+  default as Stamp,
+  type TStampProps,
+  type TTone as TStampTone,
+} from '@commercetools-uikit/stamp';
 export { default as DataTable } from '@commercetools-uikit/data-table';
 export { default as DataTableManager } from '@commercetools-uikit/data-table-manager';
-export { Tag, TagList } from '@commercetools-uikit/tag';
-export { default as Tooltip } from '@commercetools-uikit/tooltip';
-export { default as Text } from '@commercetools-uikit/text';
-export { default as ViewSwitcher } from '@commercetools-uikit/view-switcher';
+export {
+  Tag,
+  TagList,
+  type TTagProps,
+  type TTagListProps,
+  type TTagBodyProps,
+} from '@commercetools-uikit/tag';
+export {
+  default as Tooltip,
+  type TTooltipProps,
+  type TComponents,
+} from '@commercetools-uikit/tooltip';
+export {
+  default as Text,
+  type TBasicTextProps,
+  type TTone as TTextTone,
+} from '@commercetools-uikit/text';
+export {
+  default as ViewSwitcher,
+  type TViewSwitcherProps,
+} from '@commercetools-uikit/view-switcher';
 
 // Expose certain useful hooks
 export {


### PR DESCRIPTION
This pull request includes several updates to the `@commercetools-uikit` packages to bundle types with UI Kit preset packages, Filters package, and QuickFilters package. The primary changes involve exporting additional types alongside the default exports in various components and presets.

### Type Exports:

* Added type exports to the `filters` package (`TFilterConfiguration`, `TFilterGroupConfiguration`, `TAppliedFilter`) in `export-types.ts` and `filters.tsx` files. [[1]](diffhunk://#diff-99a157b3db59f4b9bf29c700c2dec8fcf18d6a39a73f44fb31d5699e5ddab72cL1-R6) [[2]](diffhunk://#diff-2c89551fd766ebeb1c64333f7b36ae736640275f3c9b920670ee8f00d6e66899L42-R42) [[3]](diffhunk://#diff-2c89551fd766ebeb1c64333f7b36ae736640275f3c9b920670ee8f00d6e66899L109-R109)
* Updated `index.ts` files in `filters` and `quick-filters` packages to export all types from `export-types.ts`. [[1]](diffhunk://#diff-f3fa0dda35d8d575c3921220eaa1ef1014ef6772dc85f7203b64c1dea9928405R3) [[2]](diffhunk://#diff-d2e31d614baf3c2111f860714946bfd92a8637c6e3d07bf619dcfe1bde070aafR3-R4)

### Presets Updates:

* Added type exports to the `buttons` preset package for various button components.
* Added type exports to the `fields` preset package for various field components.
* Added type exports to the `inputs` preset package for various input components.
* Added type exports to the `spacings` preset package for spacing components. [[1]](diffhunk://#diff-465fe86d5c461d6bdfe66f8572df81484e3ca441a85c6fcd663ea590aeda1389L1-R5) [[2]](diffhunk://#diff-f47bffe8f39f8951a4a425eab5c5d0236cf85ef720b54e9f17c736a1320a92e2L6-R6)

### UI Kit Preset:

* Updated `ui-kit` preset package to include type exports for various components, including icons, dropdown menu, field label, field errors, grid, label, loading spinner, messages, pagination, progress bar, stamp, tag, tooltip, text, and view switcher.

### Changeset:

* Created a changeset file to document the patches applied to `@commercetools-uikit/quick-filters`, `@commercetools-uikit/filters`, `@commercetools-uikit/spacings`, `@commercetools-uikit/buttons`, `@commercetools-uikit/fields`, `@commercetools-uikit/inputs`, and `@commercetools-frontend/ui-kit`.
