### PR TITLE
FCT 1305 - add types bundled in child packages in previous release to preset

### DIFF
--- a/.changeset/curly-mirrors-eat.md
+++ b/.changeset/curly-mirrors-eat.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-frontend/ui-kit': patch
+---
+
+Add types for Filters, QuickFilters, Spacings, DataTable, and DataTableManager components to UI Kit preset

--- a/presets/ui-kit/src/index.ts
+++ b/presets/ui-kit/src/index.ts
@@ -77,7 +77,13 @@ export {
   type TFieldErrors,
 } from '@commercetools-uikit/field-errors';
 /** TODO: Add Types w/next release */
-export { default as Filters } from '@commercetools-uikit/filters';
+export {
+  default as Filters,
+  type TFiltersProps,
+  type TFilterConfiguration,
+  type TFilterGroupConfiguration,
+  type TAppliedFilter,
+} from '@commercetools-uikit/filters';
 export {
   default as Grid,
   type TGridItemProps,
@@ -106,16 +112,39 @@ export {
   type TProgressBarProps,
 } from '@commercetools-uikit/progress-bar';
 /** TODO: Add Types w/next release */
-export { default as QuickFilters } from '@commercetools-uikit/quick-filters';
+export {
+  default as QuickFilters,
+  type TQuickFiltersProps,
+} from '@commercetools-uikit/quick-filters';
 /** TODO: Add Types w/next release */
-export { default as Spacings } from '@commercetools-uikit/spacings';
+export {
+  default as Spacings,
+  type TSpacings,
+  type TInlineProps,
+  type TInsetProps,
+  type TInsetSquishProps,
+  type TStackProps,
+} from '@commercetools-uikit/spacings';
 export {
   default as Stamp,
   type TStampProps,
   type TTone as TStampTone,
 } from '@commercetools-uikit/stamp';
-export { default as DataTable } from '@commercetools-uikit/data-table';
-export { default as DataTableManager } from '@commercetools-uikit/data-table-manager';
+export {
+  default as DataTable,
+  type TRow,
+  type TColumn,
+  type TDataTableProps,
+} from '@commercetools-uikit/data-table';
+export {
+  default as DataTableManager,
+  type TDataTableManagerProps,
+  type TColumnProps,
+  type TColumnData,
+  type TDataTableSettingsProps,
+  type TColumnSettingsManagerProps,
+  type TDataTableManagerContext,
+} from '@commercetools-uikit/data-table-manager';
 export {
   Tag,
   TagList,


### PR DESCRIPTION

This pull request includes changes to the `@commercetools-frontend/ui-kit` preset to add types for various components. The most important changes include adding type definitions for Filters, QuickFilters, Spacings, DataTable, and DataTableManager components.

Type definitions added:

* [`.changeset/curly-mirrors-eat.md`](diffhunk://#diff-f09120dfc81040d161f631db4b445dd8c6b39e093865d74927eb7605d8aa4b94R1-R5): Added a patch note indicating the addition of types for Filters, QuickFilters, Spacings, DataTable, and DataTableManager components to the UI Kit preset.

* `presets/ui-kit/src/index.ts`: 
  * Added type definitions for `Filters` including `TFiltersProps`, `TFilterConfiguration`, `TFilterGroupConfiguration`, and `TAppliedFilter`.
  * Added type definitions for `QuickFilters` including `TQuickFiltersProps`.
  * Added type definitions for `Spacings` including `TSpacings`, `TInlineProps`, `TInsetProps`, `TInsetSquishProps`, and `TStackProps`.
  * Added type definitions for `DataTable` including `TRow`, `TColumn`, and `TDataTableProps`.
  * Added type definitions for `DataTableManager` including `TDataTableManagerProps`, `TColumnProps`, `TColumnData`, `TDataTableSettingsProps`, `TColumnSettingsManagerProps`, and `TDataTableManagerContext`.