### PR TITLE
chore(uikit default props codemod): codemod to refactor default props in uikit as a preparation for react 18 miigration.

### DIFF
--- a/codemods/default-props-replacer/default-props-replacer.js
+++ b/codemods/default-props-replacer/default-props-replacer.js
@@ -1,0 +1,209 @@
+export default function transformer(fileInfo, api) {
+  const jscodeshift = api.jscodeshift;
+
+  const root = jscodeshift(fileInfo.source);
+
+  root
+    .find(jscodeshift.AssignmentExpression, {
+      left: {
+        type: 'MemberExpression',
+        property: { name: 'defaultProps' },
+      },
+    })
+    .forEach((path) => {
+      const componentName = path.node.left.object.name;
+      const defaultPropsNode = path.node.right;
+
+      // Check if `defaultProps` is assigned via a variable
+      if (defaultPropsNode.type === 'Identifier') {
+        const defaultPropsVariable = root.find(jscodeshift.VariableDeclarator, {
+          id: { name: defaultPropsNode.name },
+        });
+
+        if (defaultPropsVariable.size() > 0) {
+          const defaultPropsObject = defaultPropsVariable.get(0).node.init;
+          if (
+            defaultPropsObject &&
+            defaultPropsObject.type === 'ObjectExpression'
+          ) {
+            applyDefaultProps(componentName, defaultPropsObject.properties);
+            defaultPropsVariable.remove();
+          }
+        }
+      } else if (defaultPropsNode.type === 'ObjectExpression') {
+        applyDefaultProps(componentName, defaultPropsNode.properties);
+      }
+
+      // Remove the `defaultProps` assignment
+      jscodeshift(path).remove();
+    });
+
+  function getTypeName(path) {
+    const initNode = path.node.init || path.node;
+    const params = initNode.params;
+    let typeName;
+
+    if (params.length > 0 && params[0].type === 'Identifier') {
+      const typeAnnotation = params[0].typeAnnotation;
+
+      if (
+        typeAnnotation &&
+        typeAnnotation.type === 'TSTypeAnnotation' &&
+        typeAnnotation.typeAnnotation.type === 'TSTypeReference'
+      ) {
+        // Extract the type name (e.g., TCalendarBody)
+        typeName = typeAnnotation.typeAnnotation.typeName.name;
+        return typeName;
+      }
+    }
+    return typeName;
+  }
+
+  // Process function declarations
+  root.find(jscodeshift.FunctionDeclaration).forEach((path) => {
+    getTypeName(path);
+  });
+
+  // Helper to apply default props to a component
+  function applyDefaultProps(componentName, defaultProps) {
+    let destructuredKeys = [];
+    const component = root.find(jscodeshift.FunctionDeclaration, {
+      id: { name: componentName },
+    });
+
+    const arrowFunction = root.find(jscodeshift.VariableDeclarator, {
+      id: { name: componentName },
+      init: { type: 'ArrowFunctionExpression' },
+    });
+
+    const updateParams = (compPath) => {
+      const typeName = `${getTypeName(compPath)}`;
+      const params =
+        compPath.node.type === 'FunctionDeclaration'
+          ? compPath.node.params
+          : compPath.node.init?.params;
+
+      if (!params || params.length === 0) {
+        // No existing parameters, create a new destructured parameter
+        const functionParams = jscodeshift.identifier(
+          `{${defaultProps
+            .map((prop) => {
+              const keyValueAssignment = jscodeshift.assignmentPattern(
+                jscodeshift.identifier(prop.key.name),
+                prop.value
+              );
+              destructuredKeys.push(prop.key.name);
+              return `${keyValueAssignment.left.name} = ${keyValueAssignment.right.value}`;
+            })
+            .join(', ')}, ...props}`
+        );
+
+        if (compPath.node.type === 'FunctionDeclaration') {
+          compPath.node.params = [functionParams];
+          compPath.node.params[0].typeAnnotation = jscodeshift.tsTypeAnnotation(
+            jscodeshift.tsTypeReference(jscodeshift.identifier(typeName))
+          );
+        } else if (compPath.node.init?.type === 'ArrowFunctionExpression') {
+          compPath.node.init.params = [functionParams];
+          compPath.node.init.params.typeAnnotation =
+            jscodeshift.tsTypeAnnotation(
+              jscodeshift.tsTypeReference(jscodeshift.identifier(typeName))
+            );
+        }
+      } else {
+        const propsParam = params[0];
+
+        if (propsParam.type === 'ObjectPattern') {
+          defaultProps.forEach((prop) => {
+            const keyName = prop.key.name;
+            const defaultValue = prop.value;
+            const existingProp = propsParam.properties.find(
+              (p) => p.key.name === keyName
+            );
+
+            if (!existingProp) {
+              propsParam.properties.push(
+                jscodeshift.property(
+                  'init',
+                  jscodeshift.identifier(keyName),
+                  jscodeshift.assignmentPattern(
+                    jscodeshift.identifier(keyName),
+                    defaultValue
+                  )
+                )
+              );
+            }
+          });
+        } else {
+          const functionParams = jscodeshift.identifier(
+            `{${defaultProps
+              .map((prop) => {
+                const keyValueAssignment = jscodeshift.assignmentPattern(
+                  jscodeshift.identifier(prop.key.name),
+                  prop.value
+                );
+                destructuredKeys.push(prop.key.name);
+                if (typeof prop.value.value === 'string') {
+                  return `${keyValueAssignment.left.name} = '${keyValueAssignment.right.value}'`;
+                }
+                return `${keyValueAssignment.left.name} = ${keyValueAssignment.right.value}`;
+              })
+              .join(', ')}, ...props}`
+          );
+
+          const initNode = compPath.node.init || compPath.node;
+
+          initNode.params[0] = functionParams;
+          initNode.params[0].typeAnnotation = jscodeshift.tsTypeAnnotation(
+            jscodeshift.tsTypeReference(jscodeshift.identifier(typeName))
+          );
+        }
+      }
+
+      // Process arrow function components
+      root.find(jscodeshift.VariableDeclarator).forEach((path) => {
+        if (
+          path.node.init &&
+          path.node.init.type === 'ArrowFunctionExpression'
+        ) {
+          if (destructuredKeys.length > 0) {
+            replacePropsUsage(destructuredKeys, root);
+          }
+        }
+      });
+
+      // Process function declarations
+      root.find(jscodeshift.FunctionDeclaration).forEach((path) => {
+        if (destructuredKeys.length > 0) {
+          replacePropsUsage(destructuredKeys, root);
+        }
+      });
+
+      // Replace `props.<name>` usage with `<name>` if destructured
+      function replacePropsUsage(destructuredKeys, astRoot) {
+        astRoot
+          .find(jscodeshift.MemberExpression, {
+            object: { type: 'Identifier', name: 'props' },
+          })
+          .forEach((memberPath) => {
+            const propertyName = memberPath.node.property.name;
+            if (destructuredKeys.includes(propertyName)) {
+              jscodeshift(memberPath).replaceWith(
+                jscodeshift.identifier(propertyName)
+              );
+            }
+          });
+      }
+    };
+
+    if (component.size() > 0) {
+      component.forEach(updateParams);
+    }
+
+    if (arrowFunction.size() > 0) {
+      arrowFunction.forEach(updateParams);
+    }
+  }
+
+  return root.toSource();
+}


### PR DESCRIPTION
This pull request introduces a new codemod, a transformer function  to replace the `defaultProps` assignments in React components with destructured function parameters. The most important changes include the implementation of the transformer function, the handling of `defaultProps` assigned via variables, and the replacement of `props.<name>` usage with `<name>` if destructured.

Key changes:

* Implementation of the transformer function: 
  - Added the `transformer` function to process the file and apply transformations.
  - Utilized `jscodeshift` to traverse and manipulate the AST.

* Handling of `defaultProps`:
  - Added logic to handle `defaultProps` assigned via variables and directly as object expressions.
  - Removed the `defaultProps` assignment after processing.

* Replacement of `props.<name>` usage:
  - Added a helper function `replacePropsUsage` to replace `props.<name>` usage with `<name>` if destructured.