### PR TITLE
Proposal for keeping events simulation in tests clean

### DIFF
--- a/packages/components/dropdowns/dropdown-menu/src/dropdown-menu.spec.tsx
+++ b/packages/components/dropdowns/dropdown-menu/src/dropdown-menu.spec.tsx
@@ -1,6 +1,6 @@
+import { act } from 'react';
 import SecondaryButton from '@commercetools-uikit/secondary-button';
-
-import { act, screen, render, fireEvent } from '../../../../../test/test-utils';
+import { screen, render, fireEvent } from '../../../../../test/test-utils';
 import DropdownMenu from './dropdown-menu';
 
 describe('DropdownMenu', () => {

--- a/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.spec.js
+++ b/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.spec.js
@@ -94,7 +94,7 @@ it('should call onFocus when the input is focused', async () => {
   const asyncCreatableSelectField = await findByLabelText(
     'AsyncCreatableSelectField'
   );
-  fireEvent.asyncFocus(asyncCreatableSelectField);
+  await fireEvent.asyncFocus(asyncCreatableSelectField);
   expect(asyncCreatableSelectField).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -105,9 +105,9 @@ it('should call onBlur when input loses focus', async () => {
   const asyncCreatableSelectField = await findByLabelText(
     'AsyncCreatableSelectField'
   );
-  fireEvent.asyncFocus(asyncCreatableSelectField);
+  await fireEvent.asyncFocus(asyncCreatableSelectField);
   expect(asyncCreatableSelectField).toHaveFocus();
-  fireEvent.asyncBlur(asyncCreatableSelectField);
+  await fireEvent.asyncBlur(asyncCreatableSelectField);
   expect(asyncCreatableSelectField).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.spec.js
+++ b/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { render, fireEvent, waitFor } from '../../../../../test/test-utils';
 import AsyncCreatableSelectField from './async-creatable-select-field';
@@ -94,7 +94,7 @@ it('should call onFocus when the input is focused', async () => {
   const asyncCreatableSelectField = await findByLabelText(
     'AsyncCreatableSelectField'
   );
-  await act(async () => asyncCreatableSelectField.focus());
+  fireEvent.asyncFocus(asyncCreatableSelectField);
   expect(asyncCreatableSelectField).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -105,9 +105,9 @@ it('should call onBlur when input loses focus', async () => {
   const asyncCreatableSelectField = await findByLabelText(
     'AsyncCreatableSelectField'
   );
-  await act(async () => asyncCreatableSelectField.focus());
+  fireEvent.asyncFocus(asyncCreatableSelectField);
   expect(asyncCreatableSelectField).toHaveFocus();
-  await act(async () => asyncCreatableSelectField.blur());
+  fireEvent.asyncBlur(asyncCreatableSelectField);
   expect(asyncCreatableSelectField).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/async-select-field/src/async-select-field.spec.js
+++ b/packages/components/fields/async-select-field/src/async-select-field.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { render, fireEvent, waitFor } from '../../../../../test/test-utils';
 import AsyncSelectField from './async-select-field';
@@ -87,7 +87,7 @@ it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { findByLabelText } = renderAsyncSelectField({ onFocus });
   const asyncSelectField = await findByLabelText('AsyncSelectField');
-  await act(async () => asyncSelectField.focus());
+  fireEvent.asyncFocus(asyncSelectField);
   expect(asyncSelectField).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -96,9 +96,9 @@ it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { findByLabelText } = renderAsyncSelectField({ onBlur });
   const asyncSelectField = await findByLabelText('AsyncSelectField');
-  await act(async () => asyncSelectField.focus());
+  fireEvent.asyncFocus(asyncSelectField);
   expect(asyncSelectField).toHaveFocus();
-  await act(async () => asyncSelectField.blur());
+  fireEvent.asyncBlur(asyncSelectField.blur());
   expect(asyncSelectField).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/async-select-field/src/async-select-field.spec.js
+++ b/packages/components/fields/async-select-field/src/async-select-field.spec.js
@@ -87,7 +87,7 @@ it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { findByLabelText } = renderAsyncSelectField({ onFocus });
   const asyncSelectField = await findByLabelText('AsyncSelectField');
-  fireEvent.asyncFocus(asyncSelectField);
+  await fireEvent.asyncFocus(asyncSelectField);
   expect(asyncSelectField).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -96,9 +96,9 @@ it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { findByLabelText } = renderAsyncSelectField({ onBlur });
   const asyncSelectField = await findByLabelText('AsyncSelectField');
-  fireEvent.asyncFocus(asyncSelectField);
+  await fireEvent.asyncFocus(asyncSelectField);
   expect(asyncSelectField).toHaveFocus();
-  fireEvent.asyncBlur(asyncSelectField.blur());
+  await fireEvent.asyncBlur(asyncSelectField);
   expect(asyncSelectField).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/creatable-select-field/src/creatable-select-field.spec.js
+++ b/packages/components/fields/creatable-select-field/src/creatable-select-field.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { render, fireEvent } from '../../../../../test/test-utils';
 import CreatableSelectField from './creatable-select-field';
@@ -77,7 +77,7 @@ it('should have an HTML name', () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderCreatableSelectField({ onFocus });
-  await act(async () => getByLabelText('CreatableSelectField').focus());
+  fireEvent.asyncFocus(getByLabelText('CreatableSelectField'));
   expect(getByLabelText('CreatableSelectField')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -85,9 +85,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderCreatableSelectField({ onBlur });
-  await act(async () => getByLabelText('CreatableSelectField').focus());
+  fireEvent.asyncFocus(getByLabelText('CreatableSelectField'));
   expect(getByLabelText('CreatableSelectField')).toHaveFocus();
-  await act(async () => getByLabelText('CreatableSelectField').blur());
+  fireEvent.asyncBlur(getByLabelText('CreatableSelectField'));
   expect(getByLabelText('CreatableSelectField')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/creatable-select-field/src/creatable-select-field.spec.js
+++ b/packages/components/fields/creatable-select-field/src/creatable-select-field.spec.js
@@ -77,7 +77,7 @@ it('should have an HTML name', () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderCreatableSelectField({ onFocus });
-  fireEvent.asyncFocus(getByLabelText('CreatableSelectField'));
+  await fireEvent.asyncFocus(getByLabelText('CreatableSelectField'));
   expect(getByLabelText('CreatableSelectField')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -85,9 +85,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderCreatableSelectField({ onBlur });
-  fireEvent.asyncFocus(getByLabelText('CreatableSelectField'));
+  await fireEvent.asyncFocus(getByLabelText('CreatableSelectField'));
   expect(getByLabelText('CreatableSelectField')).toHaveFocus();
-  fireEvent.asyncBlur(getByLabelText('CreatableSelectField'));
+  await fireEvent.asyncBlur(getByLabelText('CreatableSelectField'));
   expect(getByLabelText('CreatableSelectField')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/date-field/src/date-field.spec.js
+++ b/packages/components/fields/date-field/src/date-field.spec.js
@@ -69,7 +69,7 @@ it('should have an HTML name', () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderDateField({ onFocus });
-  fireEvent.asyncFocus(getByLabelText('DateField'));
+  await fireEvent.asyncFocus(getByLabelText('DateField'));
   expect(getByLabelText('DateField')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -77,9 +77,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderDateField({ onBlur });
-  fireEvent.asyncFocus(getByLabelText('DateField'));
+  await fireEvent.asyncFocus(getByLabelText('DateField'));
   expect(getByLabelText('DateField')).toHaveFocus();
-  fireEvent.asyncBlur(getByLabelText('DateField'));
+  await fireEvent.asyncBlur(getByLabelText('DateField'));
   expect(getByLabelText('DateField')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/date-field/src/date-field.spec.js
+++ b/packages/components/fields/date-field/src/date-field.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { render, fireEvent } from '../../../../../test/test-utils';
 import DateField from './date-field';
@@ -69,7 +69,7 @@ it('should have an HTML name', () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderDateField({ onFocus });
-  await act(async () => getByLabelText('DateField').focus());
+  fireEvent.asyncFocus(getByLabelText('DateField'));
   expect(getByLabelText('DateField')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -77,9 +77,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderDateField({ onBlur });
-  await act(async () => getByLabelText('DateField').focus());
+  fireEvent.asyncFocus(getByLabelText('DateField'));
   expect(getByLabelText('DateField')).toHaveFocus();
-  await act(async () => getByLabelText('DateField').blur());
+  fireEvent.asyncBlur(getByLabelText('DateField'));
   expect(getByLabelText('DateField')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/date-range-field/src/date-range-field.spec.js
+++ b/packages/components/fields/date-range-field/src/date-range-field.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { render, fireEvent } from '../../../../../test/test-utils';
 import DateRangeField from './date-range-field';
@@ -69,7 +69,7 @@ it('should have an HTML name', () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderDateRangeField({ onFocus });
-  await act(async () => getByLabelText('DateRangeField').focus());
+  fireEvent.asyncFocus(getByLabelText('DateRangeField'));
   expect(getByLabelText('DateRangeField')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -77,9 +77,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderDateRangeField({ onBlur });
-  await act(async () => getByLabelText('DateRangeField').focus());
+  fireEvent.asyncFocus(getByLabelText('DateRangeField'));
   expect(getByLabelText('DateRangeField')).toHaveFocus();
-  await act(async () => getByLabelText('DateRangeField').blur());
+  fireEvent.asyncBlur(getByLabelText('DateRangeField'));
   expect(getByLabelText('DateRangeField')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/date-range-field/src/date-range-field.spec.js
+++ b/packages/components/fields/date-range-field/src/date-range-field.spec.js
@@ -69,7 +69,7 @@ it('should have an HTML name', () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderDateRangeField({ onFocus });
-  fireEvent.asyncFocus(getByLabelText('DateRangeField'));
+  await fireEvent.asyncFocus(getByLabelText('DateRangeField'));
   expect(getByLabelText('DateRangeField')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -77,9 +77,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderDateRangeField({ onBlur });
-  fireEvent.asyncFocus(getByLabelText('DateRangeField'));
+  await fireEvent.asyncFocus(getByLabelText('DateRangeField'));
   expect(getByLabelText('DateRangeField')).toHaveFocus();
-  fireEvent.asyncBlur(getByLabelText('DateRangeField'));
+  await fireEvent.asyncBlur(getByLabelText('DateRangeField'));
   expect(getByLabelText('DateRangeField')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/date-time-field/src/date-time-field.spec.js
+++ b/packages/components/fields/date-time-field/src/date-time-field.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { render, fireEvent } from '../../../../../test/test-utils';
 import DateTimeField from './date-time-field';
@@ -70,7 +70,7 @@ it('should have an HTML name', () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderDateTimeField({ onFocus });
-  await act(async () => getByLabelText('DateTimeField').focus());
+  fireEvent.asyncFocus(getByLabelText('DateTimeField'));
   expect(getByLabelText('DateTimeField')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -78,9 +78,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderDateTimeField({ onBlur });
-  await act(async () => getByLabelText('DateTimeField').focus());
+  fireEvent.asyncFocus(getByLabelText('DateTimeField'));
   expect(getByLabelText('DateTimeField')).toHaveFocus();
-  await act(async () => getByLabelText('DateTimeField').blur());
+  fireEvent.asyncBlur(getByLabelText('DateTimeField'));
   expect(getByLabelText('DateTimeField')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/date-time-field/src/date-time-field.spec.js
+++ b/packages/components/fields/date-time-field/src/date-time-field.spec.js
@@ -70,7 +70,7 @@ it('should have an HTML name', () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderDateTimeField({ onFocus });
-  fireEvent.asyncFocus(getByLabelText('DateTimeField'));
+  await fireEvent.asyncFocus(getByLabelText('DateTimeField'));
   expect(getByLabelText('DateTimeField')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -78,9 +78,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderDateTimeField({ onBlur });
-  fireEvent.asyncFocus(getByLabelText('DateTimeField'));
+  await fireEvent.asyncFocus(getByLabelText('DateTimeField'));
   expect(getByLabelText('DateTimeField')).toHaveFocus();
-  fireEvent.asyncBlur(getByLabelText('DateTimeField'));
+  await fireEvent.asyncBlur(getByLabelText('DateTimeField'));
   expect(getByLabelText('DateTimeField')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/localized-multiline-text-field/src/localized-multiline-text-field.spec.js
+++ b/packages/components/fields/localized-multiline-text-field/src/localized-multiline-text-field.spec.js
@@ -99,7 +99,7 @@ it('should have an HTML name for every input when all inputs are visible', () =>
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderLocalizedMultilineTextField({ onFocus });
-  fireEvent.asyncFocus(getByLabelText('EN'));
+  await fireEvent.asyncFocus(getByLabelText('EN'));
   expect(getByLabelText('EN')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -107,9 +107,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderLocalizedMultilineTextField({ onBlur });
-  fireEvent.asyncFocus(getByLabelText('EN'));
+  await fireEvent.asyncFocus(getByLabelText('EN'));
   expect(getByLabelText('EN')).toHaveFocus();
-  fireEvent.asyncBlur(getByLabelText('EN'));
+  await fireEvent.asyncBlur(getByLabelText('EN'));
   expect(getByLabelText('EN')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/localized-multiline-text-field/src/localized-multiline-text-field.spec.js
+++ b/packages/components/fields/localized-multiline-text-field/src/localized-multiline-text-field.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { render, fireEvent } from '../../../../../test/test-utils';
 import LocalizedMultilineTextField from './localized-multiline-text-field';
@@ -99,7 +99,7 @@ it('should have an HTML name for every input when all inputs are visible', () =>
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderLocalizedMultilineTextField({ onFocus });
-  await act(async () => getByLabelText('EN').focus());
+  fireEvent.asyncFocus(getByLabelText('EN'));
   expect(getByLabelText('EN')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -107,9 +107,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderLocalizedMultilineTextField({ onBlur });
-  await act(async () => getByLabelText('EN').focus());
+  fireEvent.asyncFocus(getByLabelText('EN'));
   expect(getByLabelText('EN')).toHaveFocus();
-  await act(async () => getByLabelText('EN').blur());
+  fireEvent.asyncBlur(getByLabelText('EN'));
   expect(getByLabelText('EN')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/money-field/src/money-field.spec.js
+++ b/packages/components/fields/money-field/src/money-field.spec.js
@@ -91,7 +91,7 @@ it('should pass autocomplete', () => {
 it('should call onFocus when amount input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderMoneyField({ onFocus });
-  fireEvent.asyncFocus(getByLabelText('Amount'));
+  await fireEvent.asyncFocus(getByLabelText('Amount'));
   expect(getByLabelText('Amount')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -99,7 +99,7 @@ it('should call onFocus when amount input is focused', async () => {
 it('should call onFocus when currency select is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderMoneyField({ onFocus });
-  fireEvent.asyncFocus(getByLabelText('EUR'));
+  await fireEvent.asyncFocus(getByLabelText('EUR'));
   expect(getByLabelText('EUR')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -107,9 +107,9 @@ it('should call onFocus when currency select is focused', async () => {
 it('should call onBlur when amount input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderMoneyField({ onBlur });
-  fireEvent.asyncFocus(getByLabelText('Amount'));
+  await fireEvent.asyncFocus(getByLabelText('Amount'));
   expect(getByLabelText('Amount')).toHaveFocus();
-  fireEvent.asyncBlur(getByLabelText('Amount'));
+  await fireEvent.asyncBlur(getByLabelText('Amount'));
   expect(getByLabelText('Amount')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });
@@ -117,9 +117,9 @@ it('should call onBlur when amount input loses focus', async () => {
 it('should call onBlur when currency select loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderMoneyField({ onBlur });
-  fireEvent.asyncFocus(getByLabelText('EUR'));
+  await fireEvent.asyncFocus(getByLabelText('EUR'));
   expect(getByLabelText('EUR')).toHaveFocus();
-  fireEvent.asyncBlur(getByLabelText('EUR'));
+  await fireEvent.asyncBlur(getByLabelText('EUR'));
   expect(getByLabelText('EUR')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/money-field/src/money-field.spec.js
+++ b/packages/components/fields/money-field/src/money-field.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { render, fireEvent } from '../../../../../test/test-utils';
 import MoneyField from './money-field';
@@ -91,7 +91,7 @@ it('should pass autocomplete', () => {
 it('should call onFocus when amount input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderMoneyField({ onFocus });
-  await act(async () => getByLabelText('Amount').focus());
+  fireEvent.asyncFocus(getByLabelText('Amount'));
   expect(getByLabelText('Amount')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -99,7 +99,7 @@ it('should call onFocus when amount input is focused', async () => {
 it('should call onFocus when currency select is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderMoneyField({ onFocus });
-  await act(async () => getByLabelText('EUR').focus());
+  fireEvent.asyncFocus(getByLabelText('EUR'));
   expect(getByLabelText('EUR')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -107,9 +107,9 @@ it('should call onFocus when currency select is focused', async () => {
 it('should call onBlur when amount input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderMoneyField({ onBlur });
-  await act(async () => getByLabelText('Amount').focus());
+  fireEvent.asyncFocus(getByLabelText('Amount'));
   expect(getByLabelText('Amount')).toHaveFocus();
-  await act(async () => getByLabelText('Amount').blur());
+  fireEvent.asyncBlur(getByLabelText('Amount'));
   expect(getByLabelText('Amount')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });
@@ -117,9 +117,9 @@ it('should call onBlur when amount input loses focus', async () => {
 it('should call onBlur when currency select loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderMoneyField({ onBlur });
-  await act(async () => getByLabelText('EUR').focus());
+  fireEvent.asyncFocus(getByLabelText('EUR'));
   expect(getByLabelText('EUR')).toHaveFocus();
-  await act(async () => getByLabelText('EUR').blur());
+  fireEvent.asyncBlur(getByLabelText('EUR'));
   expect(getByLabelText('EUR')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/multiline-text-field/src/multiline-text-field.spec.js
+++ b/packages/components/fields/multiline-text-field/src/multiline-text-field.spec.js
@@ -68,7 +68,7 @@ it('should have an HTML name', () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderMultilineTextField({ onFocus });
-  fireEvent.asyncFocus(getByLabelText('MultilineTextField'));
+  await fireEvent.asyncFocus(getByLabelText('MultilineTextField'));
   expect(getByLabelText('MultilineTextField')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -76,9 +76,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderMultilineTextField({ onBlur });
-  fireEvent.asyncFocus(getByLabelText('MultilineTextField'));
+  await fireEvent.asyncFocus(getByLabelText('MultilineTextField'));
   expect(getByLabelText('MultilineTextField')).toHaveFocus();
-  fireEvent.asyncBlur(getByLabelText('MultilineTextField'));
+  await fireEvent.asyncBlur(getByLabelText('MultilineTextField'));
   expect(getByLabelText('MultilineTextField')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/multiline-text-field/src/multiline-text-field.spec.js
+++ b/packages/components/fields/multiline-text-field/src/multiline-text-field.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { render, fireEvent } from '../../../../../test/test-utils';
 import MultilineTextField from './multiline-text-field';
@@ -68,7 +68,7 @@ it('should have an HTML name', () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderMultilineTextField({ onFocus });
-  await act(async () => getByLabelText('MultilineTextField').focus());
+  fireEvent.asyncFocus(getByLabelText('MultilineTextField'));
   expect(getByLabelText('MultilineTextField')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -76,9 +76,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderMultilineTextField({ onBlur });
-  await act(async () => getByLabelText('MultilineTextField').focus());
+  fireEvent.asyncFocus(getByLabelText('MultilineTextField'));
   expect(getByLabelText('MultilineTextField')).toHaveFocus();
-  await act(async () => getByLabelText('MultilineTextField').blur());
+  fireEvent.asyncBlur(getByLabelText('MultilineTextField'));
   expect(getByLabelText('MultilineTextField')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/search-select-field/src/search-select-field.spec.js
+++ b/packages/components/fields/search-select-field/src/search-select-field.spec.js
@@ -84,7 +84,7 @@ it('should have an HTML name', () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   renderSearchSelectField({ onFocus });
-  fireEvent.asyncFocus(screen.getByLabelText('SearchSelectField'));
+  await fireEvent.asyncFocus(screen.getByLabelText('SearchSelectField'));
   expect(screen.getByLabelText('SearchSelectField')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -92,9 +92,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   renderSearchSelectField({ onBlur });
-  fireEvent.asyncFocus(screen.getByLabelText('SearchSelectField'));
+  await fireEvent.asyncFocus(screen.getByLabelText('SearchSelectField'));
   expect(screen.getByLabelText('SearchSelectField')).toHaveFocus();
-  fireEvent.asyncBlur(screen.getByLabelText('SearchSelectField'));
+  await fireEvent.asyncBlur(screen.getByLabelText('SearchSelectField'));
   expect(screen.getByLabelText('SearchSelectField')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/search-select-field/src/search-select-field.spec.js
+++ b/packages/components/fields/search-select-field/src/search-select-field.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
   render,
@@ -84,7 +84,7 @@ it('should have an HTML name', () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   renderSearchSelectField({ onFocus });
-  await act(async () => screen.getByLabelText('SearchSelectField').focus());
+  fireEvent.asyncFocus(screen.getByLabelText('SearchSelectField'));
   expect(screen.getByLabelText('SearchSelectField')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -92,9 +92,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   renderSearchSelectField({ onBlur });
-  await act(async () => screen.getByLabelText('SearchSelectField').focus());
+  fireEvent.asyncFocus(screen.getByLabelText('SearchSelectField'));
   expect(screen.getByLabelText('SearchSelectField')).toHaveFocus();
-  await act(async () => screen.getByLabelText('SearchSelectField').blur());
+  fireEvent.asyncBlur(screen.getByLabelText('SearchSelectField'));
   expect(screen.getByLabelText('SearchSelectField')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/select-field/src/select-field.spec.js
+++ b/packages/components/fields/select-field/src/select-field.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { render, fireEvent } from '../../../../../test/test-utils';
 import SelectField from './select-field';
@@ -79,7 +79,7 @@ it('should have an HTML name', () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderSelectField({ onFocus });
-  await act(async () => getByLabelText('SelectField').focus());
+  fireEvent.asyncFocus(getByLabelText('SelectField'));
   expect(getByLabelText('SelectField')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -87,9 +87,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderSelectField({ onBlur });
-  await act(async () => getByLabelText('SelectField').focus());
+  fireEvent.asyncFocus(getByLabelText('SelectField'));
   expect(getByLabelText('SelectField')).toHaveFocus();
-  await act(async () => getByLabelText('SelectField').blur());
+  fireEvent.asyncBlur(getByLabelText('SelectField'));
   expect(getByLabelText('SelectField')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/fields/select-field/src/select-field.spec.js
+++ b/packages/components/fields/select-field/src/select-field.spec.js
@@ -79,7 +79,7 @@ it('should have an HTML name', () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderSelectField({ onFocus });
-  fireEvent.asyncFocus(getByLabelText('SelectField'));
+  await fireEvent.asyncFocus(getByLabelText('SelectField'));
   expect(getByLabelText('SelectField')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -87,9 +87,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderSelectField({ onBlur });
-  fireEvent.asyncFocus(getByLabelText('SelectField'));
+  await fireEvent.asyncFocus(getByLabelText('SelectField'));
   expect(getByLabelText('SelectField')).toHaveFocus();
-  fireEvent.asyncBlur(getByLabelText('SelectField'));
+  await fireEvent.asyncBlur(getByLabelText('SelectField'));
   expect(getByLabelText('SelectField')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input.spec.js
+++ b/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input.spec.js
@@ -91,7 +91,7 @@ it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { findByLabelText } = renderInput({ onFocus });
   const input = await findByLabelText('Fruit');
-  fireEvent.asyncFocus(input);
+  await fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -100,9 +100,9 @@ it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { findByLabelText } = renderInput({ onBlur });
   const input = await findByLabelText('Fruit');
-  fireEvent.asyncFocus(input);
+  await fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
-  fireEvent.asyncBlur(input);
+  await fireEvent.asyncBlur(input);
   expect(input).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input.spec.js
+++ b/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { render, fireEvent, waitFor } from '../../../../../test/test-utils';
 import AsyncCreatableSelectInput from './async-creatable-select-input';
@@ -91,7 +91,7 @@ it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { findByLabelText } = renderInput({ onFocus });
   const input = await findByLabelText('Fruit');
-  await act(async () => input.focus());
+  fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -100,9 +100,9 @@ it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { findByLabelText } = renderInput({ onBlur });
   const input = await findByLabelText('Fruit');
-  await act(async () => input.focus());
+  fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
-  await act(async () => input.blur());
+  fireEvent.asyncBlur(input);
   expect(input).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/async-select-input/src/async-select-input.spec.js
+++ b/packages/components/inputs/async-select-input/src/async-select-input.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
   render,
@@ -108,7 +108,7 @@ it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { findByLabelText } = renderInput({ onFocus });
   const input = await findByLabelText('Fruit');
-  await act(async () => input.focus());
+  fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -117,9 +117,9 @@ it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { findByLabelText } = renderInput({ onBlur });
   const input = await findByLabelText('Fruit');
-  await act(async () => input.focus());
+  fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
-  await act(async () => input.blur());
+  fireEvent.asyncBlur(input);
   expect(input).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/async-select-input/src/async-select-input.spec.js
+++ b/packages/components/inputs/async-select-input/src/async-select-input.spec.js
@@ -108,7 +108,7 @@ it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { findByLabelText } = renderInput({ onFocus });
   const input = await findByLabelText('Fruit');
-  fireEvent.asyncFocus(input);
+  await fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -117,9 +117,9 @@ it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { findByLabelText } = renderInput({ onBlur });
   const input = await findByLabelText('Fruit');
-  fireEvent.asyncFocus(input);
+  await fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
-  fireEvent.asyncBlur(input);
+  await fireEvent.asyncBlur(input);
   expect(input).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/creatable-select-input/src/creatable-select-input.spec.js
+++ b/packages/components/inputs/creatable-select-input/src/creatable-select-input.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { render, fireEvent } from '../../../../../test/test-utils';
 import CreatableSelectInput from './creatable-select-input';
@@ -86,7 +86,7 @@ it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { findByLabelText } = renderInput({ onFocus });
   const input = await findByLabelText('Fruit');
-  await act(async () => input.focus());
+  fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -95,9 +95,9 @@ it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { findByLabelText } = renderInput({ onBlur });
   const input = await findByLabelText('Fruit');
-  await act(async () => input.focus());
+  fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
-  await act(async () => input.blur());
+  fireEvent.asyncBlur(input);
   expect(input).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/creatable-select-input/src/creatable-select-input.spec.js
+++ b/packages/components/inputs/creatable-select-input/src/creatable-select-input.spec.js
@@ -86,7 +86,7 @@ it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { findByLabelText } = renderInput({ onFocus });
   const input = await findByLabelText('Fruit');
-  fireEvent.asyncFocus(input);
+  await fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -95,9 +95,9 @@ it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { findByLabelText } = renderInput({ onBlur });
   const input = await findByLabelText('Fruit');
-  fireEvent.asyncFocus(input);
+  await fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
-  fireEvent.asyncBlur(input);
+  await fireEvent.asyncBlur(input);
   expect(input).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/date-input/src/date-input.spec.js
+++ b/packages/components/inputs/date-input/src/date-input.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
   screen,
@@ -67,7 +67,7 @@ it('should have an HTML name', () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { container } = renderDateInput({ onFocus });
-  await act(async () => container.querySelector('input').focus());
+  fireEvent.asyncFocus(container.querySelector('input'));
   expect(container.querySelector('input')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -75,9 +75,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { container } = renderDateInput({ onBlur });
-  await act(async () => container.querySelector('input').focus());
+  fireEvent.asyncFocus(container.querySelector('input'));
   expect(container.querySelector('input')).toHaveFocus();
-  await act(async () => container.querySelector('input').blur());
+  fireEvent.asyncBlur(container.querySelector('input'));
   expect(container.querySelector('input')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/date-input/src/date-input.spec.js
+++ b/packages/components/inputs/date-input/src/date-input.spec.js
@@ -67,7 +67,7 @@ it('should have an HTML name', () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { container } = renderDateInput({ onFocus });
-  fireEvent.asyncFocus(container.querySelector('input'));
+  await fireEvent.asyncFocus(container.querySelector('input'));
   expect(container.querySelector('input')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -75,9 +75,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { container } = renderDateInput({ onBlur });
-  fireEvent.asyncFocus(container.querySelector('input'));
+  await fireEvent.asyncFocus(container.querySelector('input'));
   expect(container.querySelector('input')).toHaveFocus();
-  fireEvent.asyncBlur(container.querySelector('input'));
+  await fireEvent.asyncBlur(container.querySelector('input'));
   expect(container.querySelector('input')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/date-range-input/src/date-range-input.spec.js
+++ b/packages/components/inputs/date-range-input/src/date-range-input.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { screen, render, fireEvent } from '../../../../../test/test-utils';
 import DateRangeInput from './date-range-input';
@@ -72,7 +72,7 @@ it('should have an HTML name', async () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { container } = renderDateRangeInput({ onFocus });
-  await act(async () => container.querySelector('input').focus());
+  fireEvent.asyncFocus(container.querySelector('input'));
   expect(container.querySelector('input')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -80,9 +80,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { container } = renderDateRangeInput({ onBlur });
-  await act(async () => container.querySelector('input').focus());
+  fireEvent.asyncFocus(container.querySelector('input'));
   expect(container.querySelector('input')).toHaveFocus();
-  await act(async () => container.querySelector('input').blur());
+  fireEvent.asyncBlur(container.querySelector('input'));
   expect(container.querySelector('input')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/date-range-input/src/date-range-input.spec.js
+++ b/packages/components/inputs/date-range-input/src/date-range-input.spec.js
@@ -72,7 +72,7 @@ it('should have an HTML name', async () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { container } = renderDateRangeInput({ onFocus });
-  fireEvent.asyncFocus(container.querySelector('input'));
+  await fireEvent.asyncFocus(container.querySelector('input'));
   expect(container.querySelector('input')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -80,9 +80,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { container } = renderDateRangeInput({ onBlur });
-  fireEvent.asyncFocus(container.querySelector('input'));
+  await fireEvent.asyncFocus(container.querySelector('input'));
   expect(container.querySelector('input')).toHaveFocus();
-  fireEvent.asyncBlur(container.querySelector('input'));
+  await fireEvent.asyncBlur(container.querySelector('input'));
   expect(container.querySelector('input')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/date-time-input/src/date-time-input.spec.js
+++ b/packages/components/inputs/date-time-input/src/date-time-input.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
   screen,
@@ -68,7 +68,7 @@ it('should have an HTML name', () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { container } = renderDateTimeInput({ onFocus });
-  await act(async () => container.querySelector('input').focus());
+  fireEvent.asyncFocus(container.querySelector('input'));
   expect(container.querySelector('input')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -76,9 +76,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { container } = renderDateTimeInput({ onBlur });
-  await act(async () => container.querySelector('input').focus());
+  fireEvent.asyncFocus(container.querySelector('input'));
   expect(container.querySelector('input')).toHaveFocus();
-  await act(async () => container.querySelector('input').blur());
+  fireEvent.asyncBlur(container.querySelector('input'));
   expect(container.querySelector('input')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });
@@ -176,7 +176,7 @@ describe('date picker keyboard navigation', () => {
 
     expect(screen.getByText('September')).toBeInTheDocument();
 
-    await act(async () => dateInput.focus());
+    fireEvent.asyncFocus(dateInput);
 
     // ArrowUp
     fireEvent.keyDown(dateInput, { keyCode: 38 });

--- a/packages/components/inputs/date-time-input/src/date-time-input.spec.js
+++ b/packages/components/inputs/date-time-input/src/date-time-input.spec.js
@@ -68,7 +68,7 @@ it('should have an HTML name', () => {
 it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { container } = renderDateTimeInput({ onFocus });
-  fireEvent.asyncFocus(container.querySelector('input'));
+  await fireEvent.asyncFocus(container.querySelector('input'));
   expect(container.querySelector('input')).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -76,9 +76,9 @@ it('should call onFocus when the input is focused', async () => {
 it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { container } = renderDateTimeInput({ onBlur });
-  fireEvent.asyncFocus(container.querySelector('input'));
+  await fireEvent.asyncFocus(container.querySelector('input'));
   expect(container.querySelector('input')).toHaveFocus();
-  fireEvent.asyncBlur(container.querySelector('input'));
+  await fireEvent.asyncBlur(container.querySelector('input'));
   expect(container.querySelector('input')).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });
@@ -176,7 +176,7 @@ describe('date picker keyboard navigation', () => {
 
     expect(screen.getByText('September')).toBeInTheDocument();
 
-    fireEvent.asyncFocus(dateInput);
+    await fireEvent.asyncFocus(dateInput);
 
     // ArrowUp
     fireEvent.keyDown(dateInput, { keyCode: 38 });

--- a/packages/components/inputs/localized-money-input/src/localized-money-input.spec.js
+++ b/packages/components/inputs/localized-money-input/src/localized-money-input.spec.js
@@ -102,9 +102,9 @@ it('should call onBlur when input loses focus', async () => {
     onBlur,
   });
   const input = getByLabelText('CAD');
-  fireEvent.asyncFocus(input);
+  await fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
-  fireEvent.asyncBlur(input);
+  await fireEvent.asyncBlur(input);
   expect(input).not.toHaveFocus();
 });
 

--- a/packages/components/inputs/localized-money-input/src/localized-money-input.spec.js
+++ b/packages/components/inputs/localized-money-input/src/localized-money-input.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { render, fireEvent } from '../../../../../test/test-utils';
 import LocalizedMoneyInput from './localized-money-input';
@@ -102,9 +102,9 @@ it('should call onBlur when input loses focus', async () => {
     onBlur,
   });
   const input = getByLabelText('CAD');
-  await act(async () => input.focus());
+  fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
-  await act(async () => input.blur());
+  fireEvent.asyncBlur(input);
   expect(input).not.toHaveFocus();
 });
 

--- a/packages/components/inputs/localized-multiline-text-input/src/localized-multiline-text-input.spec.js
+++ b/packages/components/inputs/localized-multiline-text-input/src/localized-multiline-text-input.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { render, fireEvent } from '../../../../../test/test-utils';
 import LocalizedMultilineTextInput from './localized-multiline-text-input';
@@ -93,7 +93,7 @@ it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderLocalizedMultilineTextInput({ onFocus });
   const input = getByLabelText('EN');
-  await act(async () => input.focus());
+  fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -102,9 +102,9 @@ it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderLocalizedMultilineTextInput({ onBlur });
   const input = getByLabelText('EN');
-  await act(async () => input.focus());
+  fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
-  await act(async () => input.blur());
+  fireEvent.asyncBlur(input);
   expect(input).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/localized-multiline-text-input/src/localized-multiline-text-input.spec.js
+++ b/packages/components/inputs/localized-multiline-text-input/src/localized-multiline-text-input.spec.js
@@ -93,7 +93,7 @@ it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderLocalizedMultilineTextInput({ onFocus });
   const input = getByLabelText('EN');
-  fireEvent.asyncFocus(input);
+  await fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -102,9 +102,9 @@ it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderLocalizedMultilineTextInput({ onBlur });
   const input = getByLabelText('EN');
-  fireEvent.asyncFocus(input);
+  await fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
-  fireEvent.asyncBlur(input);
+  await fireEvent.asyncBlur(input);
   expect(input).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/localized-text-input/src/localized-text-input.spec.js
+++ b/packages/components/inputs/localized-text-input/src/localized-text-input.spec.js
@@ -86,7 +86,7 @@ it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderLocalizedTextInput({ onFocus });
   const input = getByLabelText('EN');
-  fireEvent.asyncFocus(input);
+  await fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -95,9 +95,9 @@ it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderLocalizedTextInput({ onBlur });
   const input = getByLabelText('EN');
-  fireEvent.asyncFocus(input);
+  await fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
-  fireEvent.asyncBlur(input);
+  await fireEvent.asyncBlur(input);
   expect(input).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/localized-text-input/src/localized-text-input.spec.js
+++ b/packages/components/inputs/localized-text-input/src/localized-text-input.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { render, fireEvent } from '../../../../../test/test-utils';
 import LocalizedTextInput from './localized-text-input';
@@ -86,7 +86,7 @@ it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { getByLabelText } = renderLocalizedTextInput({ onFocus });
   const input = getByLabelText('EN');
-  await act(async () => input.focus());
+  fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -95,9 +95,9 @@ it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { getByLabelText } = renderLocalizedTextInput({ onBlur });
   const input = getByLabelText('EN');
-  await act(async () => input.focus());
+  fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
-  await act(async () => input.blur());
+  fireEvent.asyncBlur(input);
   expect(input).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/money-input/src/money-input.spec.js
+++ b/packages/components/inputs/money-input/src/money-input.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import MoneyInput from './money-input';
 import { screen, render, fireEvent } from '../../../../../test/test-utils';
@@ -482,7 +482,7 @@ describe('MoneyInput', () => {
         onFocus={onFocus}
       />
     );
-    await act(async () => screen.getByLabelText('EUR').focus());
+    await fireEvent.asyncFocus(screen.getByLabelText('EUR'));
     expect(screen.getByLabelText('EUR')).toHaveFocus();
     expect(onFocus).toHaveBeenCalledWith({
       target: { id: 'some-id.currencyCode', name: 'some-name.currencyCode' },
@@ -497,9 +497,9 @@ describe('MoneyInput', () => {
         onBlur={onBlur}
       />
     );
-    await act(async () => screen.getByLabelText('Amount').focus());
+    await fireEvent.asyncFocus(screen.getByLabelText('Amount'));
     expect(screen.getByLabelText('Amount')).toHaveFocus();
-    await act(async () => screen.getByLabelText('Amount').blur());
+    await fireEvent.asyncBlur(screen.getByLabelText('Amount'));
     expect(screen.getByLabelText('Amount')).not.toHaveFocus();
 
     // onBlur should be called twice as we want to mark both,
@@ -521,9 +521,9 @@ describe('MoneyInput', () => {
         onBlur={onBlur}
       />
     );
-    await act(async () => screen.getByLabelText('EUR').focus());
+    await fireEvent.asyncFocus(screen.getByLabelText('EUR'));
     expect(screen.getByLabelText('EUR')).toHaveFocus();
-    await act(async () => screen.getByLabelText('EUR').blur());
+    await fireEvent.asyncBlur(screen.getByLabelText('EUR'));
     expect(screen.getByLabelText('EUR')).not.toHaveFocus();
 
     // onBlur should be called twice as we want to mark both,
@@ -545,10 +545,10 @@ describe('MoneyInput', () => {
         onBlur={onBlur}
       />
     );
-    await act(async () => screen.getByLabelText('EUR').focus());
+    await fireEvent.asyncFocus(screen.getByLabelText('EUR'));
     expect(screen.getByLabelText('EUR')).toHaveFocus();
 
-    await act(async () => screen.getByLabelText('Amount').focus());
+    await fireEvent.asyncFocus(screen.getByLabelText('Amount'));
     expect(screen.getByLabelText('EUR')).not.toHaveFocus();
     expect(screen.getByLabelText('Amount')).toHaveFocus();
 
@@ -564,10 +564,10 @@ describe('MoneyInput', () => {
       />
     );
 
-    await act(async () => screen.getByLabelText('Amount').focus());
+    await fireEvent.asyncFocus(screen.getByLabelText('Amount'));
     expect(screen.getByLabelText('Amount')).toHaveFocus();
 
-    await act(async () => screen.getByLabelText('EUR').focus());
+    await fireEvent.asyncFocus(screen.getByLabelText('EUR'));
     expect(screen.getByLabelText('EUR')).toHaveFocus();
     expect(screen.getByLabelText('Amount')).not.toHaveFocus();
 
@@ -706,8 +706,7 @@ describe('MoneyInput', () => {
         { locale: 'en' }
       );
 
-      //
-      await act(async () => screen.getByLabelText('Amount').focus());
+      await fireEvent.asyncFocus(screen.getByLabelText('Amount'));
       fireEvent.blur(screen.getByLabelText('Amount'));
 
       // We can't use .toHaveAttribute() as the attribute
@@ -742,7 +741,7 @@ describe('MoneyInput', () => {
         />
       );
       const input = screen.getByLabelText('EUR');
-      await act(async () => input.focus());
+      await fireEvent.asyncFocus(input);
       expect(input).toHaveFocus();
       expect(onFocus).toHaveBeenCalledWith({
         target: { id: 'some-id.amount', name: 'some-name.amount' },

--- a/packages/components/inputs/multiline-text-input/src/multiline-text-input.spec.js
+++ b/packages/components/inputs/multiline-text-input/src/multiline-text-input.spec.js
@@ -143,7 +143,7 @@ describe('MultilineTextInput', () => {
     const onFocus = jest.fn();
     render(<TestComponent onFocus={onFocus} />);
     const textArea = screen.getByLabelText('Description');
-    fireEvent.asyncFocus(textArea);
+    await fireEvent.asyncFocus(textArea);
     expect(textArea).toHaveFocus();
     expect(onFocus).toHaveBeenCalled();
   });
@@ -152,9 +152,9 @@ describe('MultilineTextInput', () => {
     const onBlur = jest.fn();
     render(<TestComponent onBlur={onBlur} />);
     const textArea = screen.getByLabelText('Description');
-    fireEvent.asyncFocus(textArea);
+    await fireEvent.asyncFocus(textArea);
     expect(textArea).toHaveFocus();
-    fireEvent.asyncBlur(textArea);
+    await fireEvent.asyncBlur(textArea);
     expect(onBlur).toHaveBeenCalled();
   });
 

--- a/packages/components/inputs/multiline-text-input/src/multiline-text-input.spec.js
+++ b/packages/components/inputs/multiline-text-input/src/multiline-text-input.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { screen, render, fireEvent } from '../../../../../test/test-utils';
 import MultilineTextInput from './multiline-text-input';
@@ -143,7 +143,7 @@ describe('MultilineTextInput', () => {
     const onFocus = jest.fn();
     render(<TestComponent onFocus={onFocus} />);
     const textArea = screen.getByLabelText('Description');
-    await act(async () => textArea.focus());
+    fireEvent.asyncFocus(textArea);
     expect(textArea).toHaveFocus();
     expect(onFocus).toHaveBeenCalled();
   });
@@ -152,9 +152,9 @@ describe('MultilineTextInput', () => {
     const onBlur = jest.fn();
     render(<TestComponent onBlur={onBlur} />);
     const textArea = screen.getByLabelText('Description');
-    await act(async () => textArea.focus());
+    fireEvent.asyncFocus(textArea);
     expect(textArea).toHaveFocus();
-    await act(async () => textArea.blur());
+    fireEvent.asyncBlur(textArea);
     expect(onBlur).toHaveBeenCalled();
   });
 

--- a/packages/components/inputs/search-select-input/src/search-select-input.spec.js
+++ b/packages/components/inputs/search-select-input/src/search-select-input.spec.js
@@ -82,7 +82,7 @@ it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   renderInput({ onFocus });
   const input = screen.getByLabelText('Fruit');
-  fireEvent.asyncFocus(input);
+  await fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -91,9 +91,9 @@ it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   renderInput({ onBlur });
   const input = screen.getByLabelText('Fruit');
-  fireEvent.asyncFocus(input);
+  await fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
-  fireEvent.asyncBlur(input);
+  await fireEvent.asyncBlur(input);
   expect(input).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/search-select-input/src/search-select-input.spec.js
+++ b/packages/components/inputs/search-select-input/src/search-select-input.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { render, fireEvent, screen } from '../../../../../test/test-utils';
 import SearchSelectInput from './search-select-input';
@@ -82,7 +82,7 @@ it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   renderInput({ onFocus });
   const input = screen.getByLabelText('Fruit');
-  await act(async () => input.focus());
+  fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -91,9 +91,9 @@ it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   renderInput({ onBlur });
   const input = screen.getByLabelText('Fruit');
-  await act(async () => input.focus());
+  fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
-  await act(async () => input.blur());
+  fireEvent.asyncBlur(input);
   expect(input).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/select-input/src/select-input.spec.js
+++ b/packages/components/inputs/select-input/src/select-input.spec.js
@@ -1,4 +1,4 @@
-import { Component, act } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { render, fireEvent, within } from '../../../../../test/test-utils';
 import SelectInput from './select-input';
@@ -98,7 +98,7 @@ it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { findByLabelText } = renderInput({ onFocus });
   const input = await findByLabelText('Fruit');
-  await act(async () => input.focus());
+  fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -107,9 +107,9 @@ it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { findByLabelText } = renderInput({ onBlur });
   const input = await findByLabelText('Fruit');
-  await act(async () => input.focus());
+  fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
-  await act(async () => input.blur());
+  fireEvent.asyncBlur(input);
   expect(input).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/select-input/src/select-input.spec.js
+++ b/packages/components/inputs/select-input/src/select-input.spec.js
@@ -98,7 +98,7 @@ it('should call onFocus when the input is focused', async () => {
   const onFocus = jest.fn();
   const { findByLabelText } = renderInput({ onFocus });
   const input = await findByLabelText('Fruit');
-  fireEvent.asyncFocus(input);
+  await fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
   expect(onFocus).toHaveBeenCalled();
 });
@@ -107,9 +107,9 @@ it('should call onBlur when input loses focus', async () => {
   const onBlur = jest.fn();
   const { findByLabelText } = renderInput({ onBlur });
   const input = await findByLabelText('Fruit');
-  fireEvent.asyncFocus(input);
+  await fireEvent.asyncFocus(input);
   expect(input).toHaveFocus();
-  fireEvent.asyncBlur(input);
+  await fireEvent.asyncBlur(input);
   expect(input).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/selectable-search-input/src/selectable-search-input.spec.tsx
+++ b/packages/components/inputs/selectable-search-input/src/selectable-search-input.spec.tsx
@@ -1,4 +1,4 @@
-import { useState, act } from 'react';
+import { useState } from 'react';
 import SelectableSearchInput, {
   type TSelectableSearchInputProps,
   type TCustomEvent,
@@ -191,7 +191,7 @@ describe('SelectableSearchInput', () => {
       />
     );
 
-    await act(async () => screen.getByLabelText('Bar').focus());
+    fireEvent.asyncFocus(screen.getByLabelText('Bar'));
     expect(onFocus).toHaveBeenCalledWith({
       target: {
         id: 'test-id.dropdown',

--- a/packages/components/inputs/selectable-search-input/src/selectable-search-input.spec.tsx
+++ b/packages/components/inputs/selectable-search-input/src/selectable-search-input.spec.tsx
@@ -191,7 +191,7 @@ describe('SelectableSearchInput', () => {
       />
     );
 
-    fireEvent.asyncFocus(screen.getByLabelText('Bar'));
+    await fireEvent.asyncFocus(screen.getByLabelText('Bar'));
     expect(onFocus).toHaveBeenCalledWith({
       target: {
         id: 'test-id.dropdown',
@@ -200,7 +200,7 @@ describe('SelectableSearchInput', () => {
     });
   });
 
-  it('should render custom dropdown component', async () => {
+  it('should render custom dropdown component', () => {
     const onFocus = jest.fn();
 
     const Option = (props: OptionProps) => {
@@ -228,7 +228,7 @@ describe('SelectableSearchInput', () => {
     ).toHaveTextContent('Custom text');
   });
 
-  it('should call onBlur twice when input loses focus for outside element', async () => {
+  it('should call onBlur twice when input loses focus for outside element', () => {
     const onBlur = jest.fn();
     render(
       <TestComponent

--- a/packages/components/pagination/src/pagination.spec.js
+++ b/packages/components/pagination/src/pagination.spec.js
@@ -120,7 +120,7 @@ describe('per page selector interaction', () => {
 
     const perPageSelector = await screen.findByLabelText(/Items per page/);
 
-    fireEvent.asyncFocus(perPageSelector);
+    await fireEvent.asyncFocus(perPageSelector);
     fireEvent.keyDown(perPageSelector, { key: 'ArrowDown' });
     fireEvent.click(screen.getByText('50'));
     expect(onPerPageChange).toHaveBeenCalledWith(50);

--- a/packages/components/pagination/src/pagination.spec.js
+++ b/packages/components/pagination/src/pagination.spec.js
@@ -1,4 +1,3 @@
-import { act } from 'react';
 import { screen, render, fireEvent } from '../../../../test/test-utils';
 import Pagination from './pagination';
 
@@ -121,7 +120,7 @@ describe('per page selector interaction', () => {
 
     const perPageSelector = await screen.findByLabelText(/Items per page/);
 
-    await act(async () => perPageSelector.focus());
+    fireEvent.asyncFocus(perPageSelector);
     fireEvent.keyDown(perPageSelector, { key: 'ArrowDown' });
     fireEvent.click(screen.getByText('50'));
     expect(onPerPageChange).toHaveBeenCalledWith(50);

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,6 +1,7 @@
 /* eslint-disable global-require */
 
-import { render } from '@testing-library/react';
+import { act } from 'react';
+import { fireEvent as originalFireEvent, render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
@@ -44,7 +45,7 @@ const customRender = (
 // re-export everything
 export {
   act,
-  fireEvent,
+  // fireEvent,
   screen,
   waitFor,
   waitForElementToBeRemoved,
@@ -53,3 +54,13 @@ export {
 
 // override render method
 export { customRender as render };
+
+// Custom events for async focus and blur.
+// This helps abstractinv the act() call from the tests.
+originalFireEvent.asyncFocus = (element) => {
+  return act(async () => element.focus());
+};
+originalFireEvent.asyncBlur = (element) => {
+  return act(async () => element.blur());
+};
+export { originalFireEvent as fireEvent };

--- a/test/test-utils.tsx
+++ b/test/test-utils.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable global-require */
 
-import { act } from 'react';
-import { fireEvent as originalFireEvent, render } from '@testing-library/react';
+import { act, type ReactNode } from 'react';
+import { fireEvent, render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 
-const getMessagesForLocale = (locale) => {
+const getMessagesForLocale = (locale: string) => {
   switch (locale) {
     case 'de':
       return require('@commercetools-uikit/i18n/compiled-data/de.json');
@@ -22,7 +22,7 @@ const getMessagesForLocale = (locale) => {
 };
 
 const customRender = (
-  node,
+  node: ReactNode,
   {
     locale = 'en',
     route = '/',
@@ -45,7 +45,6 @@ const customRender = (
 // re-export everything
 export {
   act,
-  // fireEvent,
   screen,
   waitFor,
   waitForElementToBeRemoved,
@@ -57,6 +56,11 @@ export { customRender as render };
 
 // Custom events for async focus and blur.
 // This helps abstractinv the act() call from the tests.
+type TCustomFireEventApi = typeof fireEvent & {
+  asyncFocus: (element: HTMLElement) => Promise<void>;
+  asyncBlur: (element: HTMLElement) => Promise<void>;
+};
+const originalFireEvent = fireEvent as TCustomFireEventApi;
 originalFireEvent.asyncFocus = (element) => {
   return act(async () => element.focus());
 };


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

Proposal for keeping events simulation in tests clean

## Description

This PR is just to demonstrate a proposal I would like to make regarding the changes required in our tests because of React 19 being stricter with some events simulation (`blur`, `focus`).

This is the reasoning for the stricter rules:
* React 18 introduced automatic batching and stricter rules around state updates. Testing tools must ensure that any React state updates are wrapped in act() to simulate real-world behavior properly.
* When you call focus() on an element, it might trigger event listeners or React updates (e.g., onFocus) that could internally cause state updates. React now expects such state updates to be wrapped in act() during tests.

So now we need to use `act()` for handling those events but we haven't used that function until now in our tests and I found it usually confuses developers about its nature.
My proposal here is to abstract that usage from the tests and add it to the tests helpers so we just use the `fireEvent` API for all events simulation (although awaiting for those events is something we will need anyway).