### PR TITLE
fix: compat with emotion `v11.14`

### DIFF
--- a/.changeset/curvy-colts-brake.md
+++ b/.changeset/curvy-colts-brake.md
@@ -6,4 +6,4 @@
 '@commercetools-uikit/select-input': patch
 ---
 
-Ensure compatibility with Emotion's generated import declarations from `v11.14.0`
+We are now using `moduleResolution: bundler` which attempts to optimize to avoid long paths. The re-exported components from `react-select` need to be explicitly typed now, to avoid TypeScript having to infer an internal import path.

--- a/.changeset/curvy-colts-brake.md
+++ b/.changeset/curvy-colts-brake.md
@@ -1,0 +1,9 @@
+---
+'@commercetools-uikit/async-creatable-select-input': patch
+'@commercetools-uikit/creatable-select-input': patch
+'@commercetools-uikit/async-select-input': patch
+'@commercetools-uikit/flat-button': patch
+'@commercetools-uikit/select-input': patch
+---
+
+Ensure compatibility with Emotion's generated import declarations from `v11.14.0`

--- a/packages/components/buttons/flat-button/src/flat-button.tsx
+++ b/packages/components/buttons/flat-button/src/flat-button.tsx
@@ -177,10 +177,12 @@ const FlatButton = <TStringOrComponent extends ElementType = 'button'>({
       buttonAttributes={buttonAttributes}
     >
       {props.icon && iconPosition === 'left' && (
+        // @ts-ignore: relates to https://github.com/emotion-js/emotion/issues/3245
         <ButtonIcon<TStringOrComponent> {...buttonIconProps} />
       )}
       <span>{props.label}</span>
       {props.icon && iconPosition === 'right' && (
+        // @ts-ignore: relates to https://github.com/emotion-js/emotion/issues/3245
         <ButtonIcon<TStringOrComponent> {...buttonIconProps} />
       )}
     </AccessibleButton>

--- a/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input.tsx
+++ b/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input.tsx
@@ -1,10 +1,32 @@
-import type { ReactNode } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 import { useIntl } from 'react-intl';
 import isEmpty from 'lodash/isEmpty';
 import {
   components as defaultComponents,
+  type ClearIndicatorProps,
+  type ContainerProps,
+  type ControlProps,
+  type DropdownIndicatorProps,
+  type GroupHeadingProps,
+  type GroupProps,
+  type IndicatorsContainerProps,
+  type InputProps,
+  type MenuListProps,
+  type MultiValueGenericProps,
+  type MultiValueProps,
+  type MultiValueRemoveProps,
+  type NoticeProps,
+  type OptionProps,
+  type PlaceholderProps,
+  type SingleValueProps,
+  type ValueContainerProps,
   type ActionMeta,
   type GroupBase,
+  type LoadingIndicatorProps,
+  type MenuProps,
+  type CommonPropsAndClassName,
+  type MenuPlacement,
+  type MenuPosition,
 } from 'react-select';
 import AsyncCreatableSelect, {
   type AsyncCreatableProps,
@@ -539,39 +561,114 @@ AsyncCreatableSelectInput.isTouched = (touched: unknown) => Boolean(touched);
  */
 
 // custom
-AsyncCreatableSelectInput.ClearIndicator = customizedComponents.ClearIndicator;
-AsyncCreatableSelectInput.Control = defaultComponents.Control;
-AsyncCreatableSelectInput.CrossIcon = defaultComponents.CrossIcon;
-AsyncCreatableSelectInput.DownChevron = defaultComponents.DownChevron;
+AsyncCreatableSelectInput.ClearIndicator =
+  customizedComponents.ClearIndicator as ComponentType<
+    ClearIndicatorProps<{}, false, GroupBase<{}>>
+  >;
+AsyncCreatableSelectInput.Control = defaultComponents.Control as ComponentType<
+  ControlProps<{}, false, GroupBase<{}>>
+>;
+AsyncCreatableSelectInput.CrossIcon =
+  defaultComponents.CrossIcon as ComponentType<
+    JSX.IntrinsicElements['svg'] & {
+      size?: number;
+    }
+  >;
+AsyncCreatableSelectInput.DownChevron =
+  defaultComponents.DownChevron as ComponentType<
+    JSX.IntrinsicElements['svg'] & {
+      size?: number;
+    }
+  >;
 // custom
 AsyncCreatableSelectInput.DropdownIndicator =
-  customizedComponents.DropdownIndicator;
-AsyncCreatableSelectInput.Group = defaultComponents.Group;
-AsyncCreatableSelectInput.GroupHeading = defaultComponents.GroupHeading;
+  customizedComponents.DropdownIndicator as ComponentType<
+    DropdownIndicatorProps<{}, false, GroupBase<{}>>
+  >;
+AsyncCreatableSelectInput.Group = defaultComponents.Group as ComponentType<
+  GroupProps<{}, false, GroupBase<{}>>
+>;
+AsyncCreatableSelectInput.GroupHeading =
+  defaultComponents.GroupHeading as ComponentType<
+    GroupHeadingProps<{}, false, GroupBase<{}>>
+  >;
 AsyncCreatableSelectInput.IndicatorSeparator =
-  defaultComponents.IndicatorSeparator;
+  defaultComponents.IndicatorSeparator as ComponentType<
+    LoadingIndicatorProps<{}, false, GroupBase<{}>>
+  >;
 AsyncCreatableSelectInput.IndicatorsContainer =
-  defaultComponents.IndicatorsContainer;
-AsyncCreatableSelectInput.Input = defaultComponents.Input;
+  defaultComponents.IndicatorsContainer as ComponentType<
+    IndicatorsContainerProps<{}, false, GroupBase<{}>>
+  >;
+AsyncCreatableSelectInput.Input = defaultComponents.Input as ComponentType<
+  InputProps<{}, false, GroupBase<{}>>
+>;
 // custom
 AsyncCreatableSelectInput.LoadingIndicator =
-  customizedComponents.LoadingIndicator;
-AsyncCreatableSelectInput.LoadingMessage = defaultComponents.LoadingMessage;
-AsyncCreatableSelectInput.Menu = defaultComponents.Menu;
-AsyncCreatableSelectInput.MenuList = defaultComponents.MenuList;
-AsyncCreatableSelectInput.MenuPortal = defaultComponents.MenuPortal;
-AsyncCreatableSelectInput.MultiValue = defaultComponents.MultiValue;
+  customizedComponents.LoadingIndicator as ComponentType<
+    LoadingIndicatorProps<{}, false, GroupBase<{}>>
+  >;
+AsyncCreatableSelectInput.LoadingMessage =
+  defaultComponents.LoadingMessage as ComponentType<
+    NoticeProps<{}, false, GroupBase<{}>>
+  >;
+AsyncCreatableSelectInput.Menu = defaultComponents.Menu as ComponentType<
+  MenuProps<{}, false, GroupBase<{}>>
+>;
+AsyncCreatableSelectInput.MenuList =
+  defaultComponents.MenuList as ComponentType<
+    MenuListProps<{}, false, GroupBase<{}>>
+  >;
+AsyncCreatableSelectInput.MenuPortal =
+  defaultComponents.MenuPortal as ComponentType<
+    CommonPropsAndClassName<{}, false, GroupBase<{}>> & {
+      appendTo: HTMLElement | undefined;
+      children: ReactNode;
+      controlElement: HTMLDivElement | null;
+      innerProps: JSX.IntrinsicElements['div'];
+      menuPlacement: MenuPlacement;
+      menuPosition: MenuPosition;
+    }
+  >;
+AsyncCreatableSelectInput.MultiValue =
+  defaultComponents.MultiValue as ComponentType<
+    MultiValueProps<{}, false, GroupBase<{}>>
+  >;
 AsyncCreatableSelectInput.MultiValueContainer =
-  defaultComponents.MultiValueContainer;
-AsyncCreatableSelectInput.MultiValueLabel = defaultComponents.MultiValueLabel;
+  defaultComponents.MultiValueContainer as ComponentType<
+    MultiValueGenericProps<{}, false, GroupBase<{}>>
+  >;
+AsyncCreatableSelectInput.MultiValueLabel =
+  defaultComponents.MultiValueLabel as ComponentType<
+    MultiValueGenericProps<{}, false, GroupBase<{}>>
+  >;
 // custom
 AsyncCreatableSelectInput.MultiValueRemove =
-  customizedComponents.MultiValueRemove;
-AsyncCreatableSelectInput.NoOptionsMessage = defaultComponents.NoOptionsMessage;
-AsyncCreatableSelectInput.Option = defaultComponents.Option;
-AsyncCreatableSelectInput.Placeholder = defaultComponents.Placeholder;
-AsyncCreatableSelectInput.SelectContainer = defaultComponents.SelectContainer;
-AsyncCreatableSelectInput.SingleValue = defaultComponents.SingleValue;
-AsyncCreatableSelectInput.ValueContainer = defaultComponents.ValueContainer;
+  customizedComponents.MultiValueRemove as ComponentType<
+    MultiValueRemoveProps<{}, false, GroupBase<{}>>
+  >;
+AsyncCreatableSelectInput.NoOptionsMessage =
+  defaultComponents.NoOptionsMessage as ComponentType<
+    NoticeProps<{}, false, GroupBase<{}>>
+  >;
+AsyncCreatableSelectInput.Option = defaultComponents.Option as ComponentType<
+  OptionProps<{}, false, GroupBase<{}>>
+>;
+AsyncCreatableSelectInput.Placeholder =
+  defaultComponents.Placeholder as ComponentType<
+    PlaceholderProps<{}, false, GroupBase<{}>>
+  >;
+AsyncCreatableSelectInput.SelectContainer =
+  defaultComponents.SelectContainer as ComponentType<
+    ContainerProps<{}, false, GroupBase<{}>>
+  >;
+AsyncCreatableSelectInput.SingleValue =
+  defaultComponents.SingleValue as ComponentType<
+    SingleValueProps<{}, false, GroupBase<{}>>
+  >;
+AsyncCreatableSelectInput.ValueContainer =
+  defaultComponents.ValueContainer as ComponentType<
+    ValueContainerProps<{}, false, GroupBase<{}>>
+  >;
 
 export default AsyncCreatableSelectInput;

--- a/packages/components/inputs/async-select-input/src/async-select-input.tsx
+++ b/packages/components/inputs/async-select-input/src/async-select-input.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, FocusEvent } from 'react';
+import type { ReactNode, FocusEvent, ComponentType } from 'react';
 import { useIntl } from 'react-intl';
 import isEmpty from 'lodash/isEmpty';
 import {
@@ -6,6 +6,28 @@ import {
   type ActionMeta,
   type GroupBase,
   type OptionsOrGroups,
+  type ClearIndicatorProps,
+  type ContainerProps,
+  type ControlProps,
+  type DropdownIndicatorProps,
+  type GroupHeadingProps,
+  type GroupProps,
+  type IndicatorsContainerProps,
+  type InputProps,
+  type MenuListProps,
+  type MultiValueGenericProps,
+  type MultiValueProps,
+  type MultiValueRemoveProps,
+  type NoticeProps,
+  type OptionProps,
+  type PlaceholderProps,
+  type SingleValueProps,
+  type ValueContainerProps,
+  type LoadingIndicatorProps,
+  type MenuProps,
+  type CommonPropsAndClassName,
+  type MenuPlacement,
+  type MenuPosition,
 } from 'react-select';
 import AsyncSelect, { type AsyncProps } from 'react-select/async';
 import { filterDataAttributes, warning } from '@commercetools-uikit/utils';
@@ -553,33 +575,106 @@ AsyncSelectInput.isTouched = (touched: unknown) => Boolean(touched);
  */
 
 // custom
-AsyncSelectInput.ClearIndicator = customizedComponents.ClearIndicator;
-AsyncSelectInput.Control = defaultComponents.Control;
-AsyncSelectInput.CrossIcon = defaultComponents.CrossIcon;
-AsyncSelectInput.DownChevron = defaultComponents.DownChevron;
+AsyncSelectInput.ClearIndicator =
+  customizedComponents.ClearIndicator as ComponentType<
+    ClearIndicatorProps<{}, false, GroupBase<{}>>
+  >;
+AsyncSelectInput.Control = defaultComponents.Control as ComponentType<
+  ControlProps<{}, false, GroupBase<{}>>
+>;
+AsyncSelectInput.CrossIcon = defaultComponents.CrossIcon as ComponentType<
+  JSX.IntrinsicElements['svg'] & {
+    size?: number;
+  }
+>;
+AsyncSelectInput.DownChevron = defaultComponents.DownChevron as ComponentType<
+  JSX.IntrinsicElements['svg'] & {
+    size?: number;
+  }
+>;
 // custom
-AsyncSelectInput.DropdownIndicator = customizedComponents.DropdownIndicator;
-AsyncSelectInput.Group = defaultComponents.Group;
-AsyncSelectInput.GroupHeading = defaultComponents.GroupHeading;
-AsyncSelectInput.IndicatorSeparator = defaultComponents.IndicatorSeparator;
-AsyncSelectInput.IndicatorsContainer = defaultComponents.IndicatorsContainer;
-AsyncSelectInput.Input = defaultComponents.Input;
+AsyncSelectInput.DropdownIndicator =
+  customizedComponents.DropdownIndicator as ComponentType<
+    DropdownIndicatorProps<{}, false, GroupBase<{}>>
+  >;
+AsyncSelectInput.Group = defaultComponents.Group as ComponentType<
+  GroupProps<{}, false, GroupBase<{}>>
+>;
+AsyncSelectInput.GroupHeading = defaultComponents.GroupHeading as ComponentType<
+  GroupHeadingProps<{}, false, GroupBase<{}>>
+>;
+AsyncSelectInput.IndicatorSeparator =
+  defaultComponents.IndicatorSeparator as ComponentType<
+    LoadingIndicatorProps<{}, false, GroupBase<{}>>
+  >;
+AsyncSelectInput.IndicatorsContainer =
+  defaultComponents.IndicatorsContainer as ComponentType<
+    IndicatorsContainerProps<{}, false, GroupBase<{}>>
+  >;
+AsyncSelectInput.Input = defaultComponents.Input as ComponentType<
+  InputProps<{}, false, GroupBase<{}>>
+>;
 // custom
-AsyncSelectInput.LoadingIndicator = customizedComponents.LoadingIndicator;
-AsyncSelectInput.LoadingMessage = defaultComponents.LoadingMessage;
-AsyncSelectInput.Menu = defaultComponents.Menu;
-AsyncSelectInput.MenuList = defaultComponents.MenuList;
-AsyncSelectInput.MenuPortal = defaultComponents.MenuPortal;
-AsyncSelectInput.MultiValue = defaultComponents.MultiValue;
-AsyncSelectInput.MultiValueContainer = defaultComponents.MultiValueContainer;
-AsyncSelectInput.MultiValueLabel = defaultComponents.MultiValueLabel;
+AsyncSelectInput.LoadingIndicator =
+  customizedComponents.LoadingIndicator as ComponentType<
+    LoadingIndicatorProps<{}, false, GroupBase<{}>>
+  >;
+AsyncSelectInput.LoadingMessage =
+  defaultComponents.LoadingMessage as ComponentType<
+    NoticeProps<{}, false, GroupBase<{}>>
+  >;
+AsyncSelectInput.Menu = defaultComponents.Menu as ComponentType<
+  MenuProps<{}, false, GroupBase<{}>>
+>;
+AsyncSelectInput.MenuList = defaultComponents.MenuList as ComponentType<
+  MenuListProps<{}, false, GroupBase<{}>>
+>;
+AsyncSelectInput.MenuPortal = defaultComponents.MenuPortal as ComponentType<
+  CommonPropsAndClassName<{}, false, GroupBase<{}>> & {
+    appendTo: HTMLElement | undefined;
+    children: ReactNode;
+    controlElement: HTMLDivElement | null;
+    innerProps: JSX.IntrinsicElements['div'];
+    menuPlacement: MenuPlacement;
+    menuPosition: MenuPosition;
+  }
+>;
+AsyncSelectInput.MultiValue = defaultComponents.MultiValue as ComponentType<
+  MultiValueProps<{}, false, GroupBase<{}>>
+>;
+AsyncSelectInput.MultiValueContainer =
+  defaultComponents.MultiValueContainer as ComponentType<
+    MultiValueGenericProps<{}, false, GroupBase<{}>>
+  >;
+AsyncSelectInput.MultiValueLabel =
+  defaultComponents.MultiValueLabel as ComponentType<
+    MultiValueGenericProps<{}, false, GroupBase<{}>>
+  >;
 // custom
-AsyncSelectInput.MultiValueRemove = customizedComponents.MultiValueRemove;
-AsyncSelectInput.NoOptionsMessage = defaultComponents.NoOptionsMessage;
-AsyncSelectInput.Option = defaultComponents.Option;
-AsyncSelectInput.Placeholder = defaultComponents.Placeholder;
-AsyncSelectInput.SelectContainer = defaultComponents.SelectContainer;
-AsyncSelectInput.SingleValue = defaultComponents.SingleValue;
-AsyncSelectInput.ValueContainer = defaultComponents.ValueContainer;
+AsyncSelectInput.MultiValueRemove =
+  customizedComponents.MultiValueRemove as ComponentType<
+    MultiValueRemoveProps<{}, false, GroupBase<{}>>
+  >;
+AsyncSelectInput.NoOptionsMessage =
+  defaultComponents.NoOptionsMessage as ComponentType<
+    NoticeProps<{}, false, GroupBase<{}>>
+  >;
+AsyncSelectInput.Option = defaultComponents.Option as ComponentType<
+  OptionProps<{}, false, GroupBase<{}>>
+>;
+AsyncSelectInput.Placeholder = defaultComponents.Placeholder as ComponentType<
+  PlaceholderProps<{}, false, GroupBase<{}>>
+>;
+AsyncSelectInput.SelectContainer =
+  defaultComponents.SelectContainer as ComponentType<
+    ContainerProps<{}, false, GroupBase<{}>>
+  >;
+AsyncSelectInput.SingleValue = defaultComponents.SingleValue as ComponentType<
+  SingleValueProps<{}, false, GroupBase<{}>>
+>;
+AsyncSelectInput.ValueContainer =
+  defaultComponents.ValueContainer as ComponentType<
+    ValueContainerProps<{}, false, GroupBase<{}>>
+  >;
 
 export default AsyncSelectInput;

--- a/packages/components/inputs/creatable-select-input/src/creatable-select-input.tsx
+++ b/packages/components/inputs/creatable-select-input/src/creatable-select-input.tsx
@@ -1,10 +1,32 @@
-import type { ReactNode } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 import { useIntl } from 'react-intl';
 import isEmpty from 'lodash/isEmpty';
 import {
   components as defaultComponents,
-  type GroupBase,
+  type ClearIndicatorProps,
+  type ContainerProps,
+  type ControlProps,
+  type DropdownIndicatorProps,
+  type GroupHeadingProps,
+  type GroupProps,
+  type IndicatorsContainerProps,
+  type InputProps,
+  type MenuListProps,
+  type MultiValueGenericProps,
+  type MultiValueProps,
+  type MultiValueRemoveProps,
+  type NoticeProps,
+  type OptionProps,
+  type PlaceholderProps,
+  type SingleValueProps,
+  type ValueContainerProps,
   type ActionMeta,
+  type GroupBase,
+  type LoadingIndicatorProps,
+  type MenuProps,
+  type CommonPropsAndClassName,
+  type MenuPlacement,
+  type MenuPosition,
 } from 'react-select';
 import CreatableSelect, { type CreatableProps } from 'react-select/creatable';
 import Constraints from '@commercetools-uikit/constraints';
@@ -514,34 +536,110 @@ CreatableSelectInput.isTouched = (touched: unknown) => Boolean(touched);
  */
 
 // custom
-CreatableSelectInput.ClearIndicator = customizedComponents.ClearIndicator;
-CreatableSelectInput.Control = defaultComponents.Control;
-CreatableSelectInput.CrossIcon = defaultComponents.CrossIcon;
-CreatableSelectInput.DownChevron = defaultComponents.DownChevron;
+CreatableSelectInput.ClearIndicator =
+  customizedComponents.ClearIndicator as ComponentType<
+    ClearIndicatorProps<{}, false, GroupBase<{}>>
+  >;
+CreatableSelectInput.Control = defaultComponents.Control as ComponentType<
+  ControlProps<{}, false, GroupBase<{}>>
+>;
+CreatableSelectInput.CrossIcon = defaultComponents.CrossIcon as ComponentType<
+  JSX.IntrinsicElements['svg'] & {
+    size?: number;
+  }
+>;
+CreatableSelectInput.DownChevron =
+  defaultComponents.DownChevron as ComponentType<
+    JSX.IntrinsicElements['svg'] & {
+      size?: number;
+    }
+  >;
 // custom
-CreatableSelectInput.DropdownIndicator = customizedComponents.DropdownIndicator;
-CreatableSelectInput.Group = defaultComponents.Group;
-CreatableSelectInput.GroupHeading = defaultComponents.GroupHeading;
-CreatableSelectInput.IndicatorSeparator = defaultComponents.IndicatorSeparator;
+CreatableSelectInput.DropdownIndicator =
+  customizedComponents.DropdownIndicator as ComponentType<
+    DropdownIndicatorProps<{}, false, GroupBase<{}>>
+  >;
+CreatableSelectInput.Group = defaultComponents.Group as ComponentType<
+  GroupProps<{}, false, GroupBase<{}>>
+>;
+CreatableSelectInput.GroupHeading =
+  defaultComponents.GroupHeading as ComponentType<
+    GroupHeadingProps<{}, false, GroupBase<{}>>
+  >;
+CreatableSelectInput.IndicatorSeparator =
+  defaultComponents.IndicatorSeparator as ComponentType<
+    LoadingIndicatorProps<{}, false, GroupBase<{}>>
+  >;
 CreatableSelectInput.IndicatorsContainer =
-  defaultComponents.IndicatorsContainer;
-CreatableSelectInput.Input = defaultComponents.Input;
-CreatableSelectInput.LoadingIndicator = defaultComponents.LoadingIndicator;
-CreatableSelectInput.LoadingMessage = defaultComponents.LoadingMessage;
-CreatableSelectInput.Menu = defaultComponents.Menu;
-CreatableSelectInput.MenuList = defaultComponents.MenuList;
-CreatableSelectInput.MenuPortal = defaultComponents.MenuPortal;
-CreatableSelectInput.MultiValue = defaultComponents.MultiValue;
-CreatableSelectInput.MultiValueContainer =
-  defaultComponents.MultiValueContainer;
-CreatableSelectInput.MultiValueLabel = defaultComponents.MultiValueLabel;
+  defaultComponents.IndicatorsContainer as ComponentType<
+    IndicatorsContainerProps<{}, false, GroupBase<{}>>
+  >;
+CreatableSelectInput.Input = defaultComponents.Input as ComponentType<
+  InputProps<{}, false, GroupBase<{}>>
+>;
 // custom
-CreatableSelectInput.MultiValueRemove = customizedComponents.MultiValueRemove;
-CreatableSelectInput.NoOptionsMessage = defaultComponents.NoOptionsMessage;
-CreatableSelectInput.Option = defaultComponents.Option;
-CreatableSelectInput.Placeholder = defaultComponents.Placeholder;
-CreatableSelectInput.SelectContainer = defaultComponents.SelectContainer;
-CreatableSelectInput.SingleValue = defaultComponents.SingleValue;
-CreatableSelectInput.ValueContainer = defaultComponents.ValueContainer;
+CreatableSelectInput.LoadingIndicator =
+  defaultComponents.LoadingIndicator as ComponentType<
+    LoadingIndicatorProps<{}, false, GroupBase<{}>>
+  >;
+CreatableSelectInput.LoadingMessage =
+  defaultComponents.LoadingMessage as ComponentType<
+    NoticeProps<{}, false, GroupBase<{}>>
+  >;
+CreatableSelectInput.Menu = defaultComponents.Menu as ComponentType<
+  MenuProps<{}, false, GroupBase<{}>>
+>;
+CreatableSelectInput.MenuList = defaultComponents.MenuList as ComponentType<
+  MenuListProps<{}, false, GroupBase<{}>>
+>;
+CreatableSelectInput.MenuPortal = defaultComponents.MenuPortal as ComponentType<
+  CommonPropsAndClassName<{}, false, GroupBase<{}>> & {
+    appendTo: HTMLElement | undefined;
+    children: ReactNode;
+    controlElement: HTMLDivElement | null;
+    innerProps: JSX.IntrinsicElements['div'];
+    menuPlacement: MenuPlacement;
+    menuPosition: MenuPosition;
+  }
+>;
+CreatableSelectInput.MultiValue = defaultComponents.MultiValue as ComponentType<
+  MultiValueProps<{}, false, GroupBase<{}>>
+>;
+CreatableSelectInput.MultiValueContainer =
+  defaultComponents.MultiValueContainer as ComponentType<
+    MultiValueGenericProps<{}, false, GroupBase<{}>>
+  >;
+CreatableSelectInput.MultiValueLabel =
+  defaultComponents.MultiValueLabel as ComponentType<
+    MultiValueGenericProps<{}, false, GroupBase<{}>>
+  >;
+// custom
+CreatableSelectInput.MultiValueRemove =
+  customizedComponents.MultiValueRemove as ComponentType<
+    MultiValueRemoveProps<{}, false, GroupBase<{}>>
+  >;
+CreatableSelectInput.NoOptionsMessage =
+  defaultComponents.NoOptionsMessage as ComponentType<
+    NoticeProps<{}, false, GroupBase<{}>>
+  >;
+CreatableSelectInput.Option = defaultComponents.Option as ComponentType<
+  OptionProps<{}, false, GroupBase<{}>>
+>;
+CreatableSelectInput.Placeholder =
+  defaultComponents.Placeholder as ComponentType<
+    PlaceholderProps<{}, false, GroupBase<{}>>
+  >;
+CreatableSelectInput.SelectContainer =
+  defaultComponents.SelectContainer as ComponentType<
+    ContainerProps<{}, false, GroupBase<{}>>
+  >;
+CreatableSelectInput.SingleValue =
+  defaultComponents.SingleValue as ComponentType<
+    SingleValueProps<{}, false, GroupBase<{}>>
+  >;
+CreatableSelectInput.ValueContainer =
+  defaultComponents.ValueContainer as ComponentType<
+    ValueContainerProps<{}, false, GroupBase<{}>>
+  >;
 
 export default CreatableSelectInput;

--- a/packages/components/inputs/select-input/src/select-input.tsx
+++ b/packages/components/inputs/select-input/src/select-input.tsx
@@ -1,10 +1,33 @@
-import type { ReactNode } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 import { useIntl } from 'react-intl';
 import isEmpty from 'lodash/isEmpty';
 import has from 'lodash/has';
 import Select, {
   components as defaultComponents,
   type Props as ReactSelectProps,
+  type ClearIndicatorProps,
+  type ContainerProps,
+  type ControlProps,
+  type DropdownIndicatorProps,
+  type GroupHeadingProps,
+  type GroupProps,
+  type IndicatorsContainerProps,
+  type InputProps,
+  type MenuListProps,
+  type MultiValueGenericProps,
+  type MultiValueProps,
+  type MultiValueRemoveProps,
+  type NoticeProps,
+  type OptionProps,
+  type PlaceholderProps,
+  type SingleValueProps,
+  type ValueContainerProps,
+  type GroupBase,
+  type LoadingIndicatorProps,
+  type MenuProps,
+  type CommonPropsAndClassName,
+  type MenuPlacement,
+  type MenuPosition,
 } from 'react-select';
 import Constraints from '@commercetools-uikit/constraints';
 import {
@@ -632,30 +655,105 @@ SelectInput.isTouched = (touched: boolean | unknown[]) => Boolean(touched);
  * Expose react-select components for customization purposes.
  */
 
-SelectInput.ClearIndicator = customizedComponents.ClearIndicator;
-SelectInput.Control = defaultComponents.Control;
-SelectInput.CrossIcon = defaultComponents.CrossIcon;
-SelectInput.DownChevron = defaultComponents.DownChevron;
-SelectInput.DropdownIndicator = customizedComponents.DropdownIndicator;
-SelectInput.Group = defaultComponents.Group;
-SelectInput.GroupHeading = defaultComponents.GroupHeading;
-SelectInput.IndicatorSeparator = defaultComponents.IndicatorSeparator;
-SelectInput.IndicatorsContainer = defaultComponents.IndicatorsContainer;
-SelectInput.Input = defaultComponents.Input;
-SelectInput.LoadingIndicator = defaultComponents.LoadingIndicator;
-SelectInput.LoadingMessage = defaultComponents.LoadingMessage;
-SelectInput.Menu = defaultComponents.Menu;
-SelectInput.MenuList = defaultComponents.MenuList;
-SelectInput.MenuPortal = defaultComponents.MenuPortal;
-SelectInput.MultiValue = defaultComponents.MultiValue;
-SelectInput.MultiValueContainer = defaultComponents.MultiValueContainer;
-SelectInput.MultiValueLabel = defaultComponents.MultiValueLabel;
-SelectInput.MultiValueRemove = customizedComponents.MultiValueRemove;
-SelectInput.NoOptionsMessage = defaultComponents.NoOptionsMessage;
-SelectInput.Option = defaultComponents.Option;
-SelectInput.Placeholder = defaultComponents.Placeholder;
-SelectInput.SelectContainer = defaultComponents.SelectContainer;
-SelectInput.SingleValue = defaultComponents.SingleValue;
-SelectInput.ValueContainer = defaultComponents.ValueContainer;
+// custom
+SelectInput.ClearIndicator =
+  customizedComponents.ClearIndicator as ComponentType<
+    ClearIndicatorProps<{}, false, GroupBase<{}>>
+  >;
+SelectInput.Control = defaultComponents.Control as ComponentType<
+  ControlProps<{}, false, GroupBase<{}>>
+>;
+SelectInput.CrossIcon = defaultComponents.CrossIcon as ComponentType<
+  JSX.IntrinsicElements['svg'] & {
+    size?: number;
+  }
+>;
+SelectInput.DownChevron = defaultComponents.DownChevron as ComponentType<
+  JSX.IntrinsicElements['svg'] & {
+    size?: number;
+  }
+>;
+// custom
+SelectInput.DropdownIndicator =
+  customizedComponents.DropdownIndicator as ComponentType<
+    DropdownIndicatorProps<{}, false, GroupBase<{}>>
+  >;
+SelectInput.Group = defaultComponents.Group as ComponentType<
+  GroupProps<{}, false, GroupBase<{}>>
+>;
+SelectInput.GroupHeading = defaultComponents.GroupHeading as ComponentType<
+  GroupHeadingProps<{}, false, GroupBase<{}>>
+>;
+SelectInput.IndicatorSeparator =
+  defaultComponents.IndicatorSeparator as ComponentType<
+    LoadingIndicatorProps<{}, false, GroupBase<{}>>
+  >;
+SelectInput.IndicatorsContainer =
+  defaultComponents.IndicatorsContainer as ComponentType<
+    IndicatorsContainerProps<{}, false, GroupBase<{}>>
+  >;
+SelectInput.Input = defaultComponents.Input as ComponentType<
+  InputProps<{}, false, GroupBase<{}>>
+>;
+// custom
+SelectInput.LoadingIndicator =
+  defaultComponents.LoadingIndicator as ComponentType<
+    LoadingIndicatorProps<{}, false, GroupBase<{}>>
+  >;
+SelectInput.LoadingMessage = defaultComponents.LoadingMessage as ComponentType<
+  NoticeProps<{}, false, GroupBase<{}>>
+>;
+SelectInput.Menu = defaultComponents.Menu as ComponentType<
+  MenuProps<{}, false, GroupBase<{}>>
+>;
+SelectInput.MenuList = defaultComponents.MenuList as ComponentType<
+  MenuListProps<{}, false, GroupBase<{}>>
+>;
+SelectInput.MenuPortal = defaultComponents.MenuPortal as ComponentType<
+  CommonPropsAndClassName<{}, false, GroupBase<{}>> & {
+    appendTo: HTMLElement | undefined;
+    children: ReactNode;
+    controlElement: HTMLDivElement | null;
+    innerProps: JSX.IntrinsicElements['div'];
+    menuPlacement: MenuPlacement;
+    menuPosition: MenuPosition;
+  }
+>;
+SelectInput.MultiValue = defaultComponents.MultiValue as ComponentType<
+  MultiValueProps<{}, false, GroupBase<{}>>
+>;
+SelectInput.MultiValueContainer =
+  defaultComponents.MultiValueContainer as ComponentType<
+    MultiValueGenericProps<{}, false, GroupBase<{}>>
+  >;
+SelectInput.MultiValueLabel =
+  defaultComponents.MultiValueLabel as ComponentType<
+    MultiValueGenericProps<{}, false, GroupBase<{}>>
+  >;
+// custom
+SelectInput.MultiValueRemove =
+  customizedComponents.MultiValueRemove as ComponentType<
+    MultiValueRemoveProps<{}, false, GroupBase<{}>>
+  >;
+SelectInput.NoOptionsMessage =
+  defaultComponents.NoOptionsMessage as ComponentType<
+    NoticeProps<{}, false, GroupBase<{}>>
+  >;
+SelectInput.Option = defaultComponents.Option as ComponentType<
+  OptionProps<{}, false, GroupBase<{}>>
+>;
+SelectInput.Placeholder = defaultComponents.Placeholder as ComponentType<
+  PlaceholderProps<{}, false, GroupBase<{}>>
+>;
+SelectInput.SelectContainer =
+  defaultComponents.SelectContainer as ComponentType<
+    ContainerProps<{}, false, GroupBase<{}>>
+  >;
+SelectInput.SingleValue = defaultComponents.SingleValue as ComponentType<
+  SingleValueProps<{}, false, GroupBase<{}>>
+>;
+SelectInput.ValueContainer = defaultComponents.ValueContainer as ComponentType<
+  ValueContainerProps<{}, false, GroupBase<{}>>
+>;
 
 export default SelectInput;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "jsxImportSource": "@emotion/react",
     "lib": ["ESNext", "DOM"],
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5282,22 +5282,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/babel-plugin@npm:^11.11.0, @emotion/babel-plugin@npm:^11.12.0":
-  version: 11.12.0
-  resolution: "@emotion/babel-plugin@npm:11.12.0"
+"@emotion/babel-plugin@npm:^11.11.0, @emotion/babel-plugin@npm:^11.12.0, @emotion/babel-plugin@npm:^11.13.5":
+  version: 11.13.5
+  resolution: "@emotion/babel-plugin@npm:11.13.5"
   dependencies:
     "@babel/helper-module-imports": ^7.16.7
     "@babel/runtime": ^7.18.3
     "@emotion/hash": ^0.9.2
     "@emotion/memoize": ^0.9.0
-    "@emotion/serialize": ^1.2.0
+    "@emotion/serialize": ^1.3.3
     babel-plugin-macros: ^3.1.0
     convert-source-map: ^1.5.0
     escape-string-regexp: ^4.0.0
     find-root: ^1.1.0
     source-map: ^0.5.7
     stylis: 4.2.0
-  checksum: b5d4b3dfe97e6763794a42b5c3a027a560caa1aa6dcaf05c18e5969691368dd08245c077bad7397dcc720b53d29caeaaec1888121e68cfd9ab02ff52f6fef662
+  checksum: c41df7e6c19520e76d1939f884be878bf88b5ba00bd3de9d05c5b6c5baa5051686ab124d7317a0645de1b017b574d8139ae1d6390ec267fbe8e85a5252afb542
   languageName: node
   linkType: hard
 
@@ -5315,29 +5315,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/cache@npm:^11.13.0, @emotion/cache@npm:^11.4.0":
-  version: 11.13.1
-  resolution: "@emotion/cache@npm:11.13.1"
+"@emotion/cache@npm:^11.13.5, @emotion/cache@npm:^11.14.0, @emotion/cache@npm:^11.4.0":
+  version: 11.14.0
+  resolution: "@emotion/cache@npm:11.14.0"
   dependencies:
     "@emotion/memoize": ^0.9.0
     "@emotion/sheet": ^1.4.0
-    "@emotion/utils": ^1.4.0
+    "@emotion/utils": ^1.4.2
     "@emotion/weak-memoize": ^0.4.0
     stylis: 4.2.0
-  checksum: 94b161786a03a08a1e30257478fad9a9be1ac8585ddca0c6410d7411fd474fc8b0d6d1167d7d15bdb012d1fd8a1220ac2bbc79501ad9b292b83c17da0874d7de
+  checksum: 0a81591541ea43bc7851742e6444b7800d72e98006f94e775ae6ea0806662d14e0a86ff940f5f19d33b4bb2c427c882aa65d417e7322a6e0d5f20fe65ed920c9
   languageName: node
   linkType: hard
 
 "@emotion/css@npm:^11.10.5":
-  version: 11.13.0
-  resolution: "@emotion/css@npm:11.13.0"
+  version: 11.13.5
+  resolution: "@emotion/css@npm:11.13.5"
   dependencies:
-    "@emotion/babel-plugin": ^11.12.0
-    "@emotion/cache": ^11.13.0
-    "@emotion/serialize": ^1.3.0
+    "@emotion/babel-plugin": ^11.13.5
+    "@emotion/cache": ^11.13.5
+    "@emotion/serialize": ^1.3.3
     "@emotion/sheet": ^1.4.0
-    "@emotion/utils": ^1.4.0
-  checksum: e0c3a9999068a78a7697c8bf7fa181380a81547d35a17b5d2728fb1b463643eb0c7fac22cec2aa49ac668ecd3c4c55449eb4c708abd566f4fb0d89731b9c3daa
+    "@emotion/utils": ^1.4.2
+  checksum: 1f96c612603f2a6ad3e288c6ec90ac457e75e09b8a0bd4fb6e9bc1cd552ed9edd4a1e40880060ed30a285e1141e354a3b41a815f22871d2178a882e3c1f79426
   languageName: node
   linkType: hard
 
@@ -5348,21 +5348,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/is-prop-valid@npm:1.3.1":
+"@emotion/is-prop-valid@npm:1.3.1, @emotion/is-prop-valid@npm:^1.3.0":
   version: 1.3.1
   resolution: "@emotion/is-prop-valid@npm:1.3.1"
   dependencies:
     "@emotion/memoize": ^0.9.0
   checksum: fe6549d54f389e1a17cb02d832af7ee85fb6ea126fc18d02ca47216e8ff19332c1983f4a0ba68602cfcd3b325ffd4ebf0b2d0c6270f1e7e6fe3fca4ba7741e1a
-  languageName: node
-  linkType: hard
-
-"@emotion/is-prop-valid@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@emotion/is-prop-valid@npm:1.3.0"
-  dependencies:
-    "@emotion/memoize": ^0.9.0
-  checksum: d3e36e493de3b4446634010c46cb8b99fa8ca271a8e7efba9cecf59a672ce1ebcfea8e8c7a0627dcafae87b4ab0d58c70fcf4589b849ca48e0d1e9f6c899e8be
   languageName: node
   linkType: hard
 
@@ -5374,15 +5365,15 @@ __metadata:
   linkType: hard
 
 "@emotion/react@npm:^11.10.5, @emotion/react@npm:^11.8.1":
-  version: 11.13.0
-  resolution: "@emotion/react@npm:11.13.0"
+  version: 11.14.0
+  resolution: "@emotion/react@npm:11.14.0"
   dependencies:
     "@babel/runtime": ^7.18.3
-    "@emotion/babel-plugin": ^11.12.0
-    "@emotion/cache": ^11.13.0
-    "@emotion/serialize": ^1.3.0
-    "@emotion/use-insertion-effect-with-fallbacks": ^1.1.0
-    "@emotion/utils": ^1.4.0
+    "@emotion/babel-plugin": ^11.13.5
+    "@emotion/cache": ^11.14.0
+    "@emotion/serialize": ^1.3.3
+    "@emotion/use-insertion-effect-with-fallbacks": ^1.2.0
+    "@emotion/utils": ^1.4.2
     "@emotion/weak-memoize": ^0.4.0
     hoist-non-react-statics: ^3.3.1
   peerDependencies:
@@ -5390,20 +5381,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: aa6bff49ac0c15a97cc310a36e89146c4851dcb84ba25bc284d68e19a9b9d5d78235b74915a58404d59cfa369ddaf33dc280d881ca089e4ad70310dce87e0853
+  checksum: 3cf023b11d132b56168713764d6fced8e5a1f0687dfe0caa2782dfd428c8f9e30f9826a919965a311d87b523cd196722aaf75919cd0f6bd0fd57f8a6a0281500
   languageName: node
   linkType: hard
 
-"@emotion/serialize@npm:^1.2.0, @emotion/serialize@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@emotion/serialize@npm:1.3.0"
+"@emotion/serialize@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "@emotion/serialize@npm:1.3.3"
   dependencies:
     "@emotion/hash": ^0.9.2
     "@emotion/memoize": ^0.9.0
-    "@emotion/unitless": ^0.9.0
-    "@emotion/utils": ^1.4.0
+    "@emotion/unitless": ^0.10.0
+    "@emotion/utils": ^1.4.2
     csstype: ^3.0.2
-  checksum: d428da474862dcf9852106fe0d00b341425db47f904fb65ab0fd55a50cd5bb4ef5b8183bb24a4de32640d825fc40d3fd525fc8dd946a0bc74207cd73c2ae0205
+  checksum: 510331233767ae4e09e925287ca2c7269b320fa1d737ea86db5b3c861a734483ea832394c0c1fe5b21468fe335624a75e72818831d303ba38125f54f44ba02e7
   languageName: node
   linkType: hard
 
@@ -5415,45 +5406,45 @@ __metadata:
   linkType: hard
 
 "@emotion/styled@npm:^11.10.5":
-  version: 11.13.0
-  resolution: "@emotion/styled@npm:11.13.0"
+  version: 11.14.0
+  resolution: "@emotion/styled@npm:11.14.0"
   dependencies:
     "@babel/runtime": ^7.18.3
-    "@emotion/babel-plugin": ^11.12.0
+    "@emotion/babel-plugin": ^11.13.5
     "@emotion/is-prop-valid": ^1.3.0
-    "@emotion/serialize": ^1.3.0
-    "@emotion/use-insertion-effect-with-fallbacks": ^1.1.0
-    "@emotion/utils": ^1.4.0
+    "@emotion/serialize": ^1.3.3
+    "@emotion/use-insertion-effect-with-fallbacks": ^1.2.0
+    "@emotion/utils": ^1.4.2
   peerDependencies:
     "@emotion/react": ^11.0.0-rc.0
     react: ">=16.8.0"
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: f5b951059418f57bc8ea32b238afb25965ece3314f2ffd1b14ce049ba3c066a424990dfbfabbf57bb88e044eaa80bf19f620ac988adda3d2fc483177be6da05e
+  checksum: 9c1b842e942e69fb6037d1ab161046d2bcfeff95fd2ccfdab30acaaf6b89dc07b14bb00f8cc8ec14df11e6746c8e4e1d781bc54d10bd739aab44966ded64d4fb
   languageName: node
   linkType: hard
 
-"@emotion/unitless@npm:^0.9.0":
-  version: 0.9.0
-  resolution: "@emotion/unitless@npm:0.9.0"
-  checksum: 0859ee8621dab89dd91754726644abcbea23b849960fe55c1265e5990a5cb5fde2a73e99b230cd7f72898c5468dee5dcb287bcb246e07dc0cb2816628e781498
+"@emotion/unitless@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "@emotion/unitless@npm:0.10.0"
+  checksum: d79346df31a933e6d33518e92636afeb603ce043f3857d0a39a2ac78a09ef0be8bedff40130930cb25df1beeee12d96ee38613963886fa377c681a89970b787c
   languageName: node
   linkType: hard
 
-"@emotion/use-insertion-effect-with-fallbacks@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@emotion/use-insertion-effect-with-fallbacks@npm:1.1.0"
+"@emotion/use-insertion-effect-with-fallbacks@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@emotion/use-insertion-effect-with-fallbacks@npm:1.2.0"
   peerDependencies:
     react: ">=16.8.0"
-  checksum: 63665191773b27de66807c53b90091ef0d10d5161381f62726cfceecfe1d8c944f18594b8021805fc81575b64246fd5ab9c75d60efabec92f940c1c410530949
+  checksum: 8ff6aec7f2924526ff8c8f8f93d4b8236376e2e12c435314a18c9a373016e24dfdf984e82bbc83712b8e90ff4783cd765eb39fc7050d1a43245e5728740ddd71
   languageName: node
   linkType: hard
 
-"@emotion/utils@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "@emotion/utils@npm:1.4.0"
-  checksum: 212af0b0d6bcaa63c76e1a36e35bee4d3579359316c03bf970faabb5427a4c0aab3e2346a721bac54f0c8e027958e759c5682be78f308755a1d9753e83963621
+"@emotion/utils@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "@emotion/utils@npm:1.4.2"
+  checksum: 04cf76849c6401205c058b82689fd0ec5bf501aed6974880fe9681a1d61543efb97e848f4c38664ac4a9068c7ad2d1cb84f73bde6cf95f1208aa3c28e0190321
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When upgrading to Emotion `v11.14.0`, we get some type errors from the generated declaration files about imports `import("@emotion/react/types/jsx-namespace").EmotionJSX.Element`.

I reported the issue: https://github.com/emotion-js/emotion/issues/3310.

Then I tried looking at using different options of the `moduleResolution` option. It seems that the "better" choice would be to use the `bundler` option, which actually might be more appropriate anyway for a component library.

I went ahead and asked Gemini for some clarification:

```
Q: For a component library, is it recommended to use `moduleResolution: bundler`?

A: For a component library, `moduleResolution: bundler` is generally a good choice and often recommended, especially if you're targeting modern JavaScript environments and want to optimize for bundle size and code splitting. However, there are some nuances to consider.

Advantages of `moduleResolution: bundler`:

* Optimized Bundles:  Bundlers like Webpack, Rollup, or Parcel are designed to analyze your code and create highly optimized bundles.  They can eliminate dead code (tree-shaking), minify code, and perform code splitting to load only the necessary parts of your library on demand. This leads to smaller bundle sizes and faster load times for users of your library.

* Modern JavaScript Features: `moduleResolution: bundler` works seamlessly with modern JavaScript features like ES modules (`import/export`), which are essential for code splitting and efficient bundling.

* Dependency Management: Bundlers handle dependency resolution efficiently, ensuring that the correct versions of your library's dependencies are included in the bundle.  They also help avoid issues with conflicting dependencies.

* Flexibility: Bundlers offer a lot of flexibility in terms of how you configure your build process. You can customize how your library is bundled, how assets are handled, and much more.

Recommendation:

For most component libraries, `moduleResolution: bundler` is the recommended approach.  The benefits of optimized bundles, modern JavaScript support, and dependency management usually outweigh the added complexity.  Choose a bundler that suits your needs (Webpack, Rollup, or Parcel are all good options).  If your library is exceptionally small and you have very specific constraints, you might consider `moduleResolution: node` or classic, but this is less common.

Key takeaway: The "not portable" error you were getting is directly related to the way `moduleResolution: bundler` works and its desire to avoid long paths.  So, sticking with bundler is still the right choice, and the solutions provided earlier (type annotations or importing types) are the correct way to address the error within the bundler context.
```