### PR TITLE
refactor(preset): export `DataTableManagerProvider`, `utils` and `selectUtils`

### DIFF
--- a/presets/ui-kit/package.json
+++ b/presets/ui-kit/package.json
@@ -54,6 +54,7 @@
     "@commercetools-uikit/primary-action-dropdown": "19.22.5",
     "@commercetools-uikit/progress-bar": "19.22.5",
     "@commercetools-uikit/quick-filters": "19.22.5",
+    "@commercetools-uikit/select-utils": "19.22.5",
     "@commercetools-uikit/selectable-search-input": "19.22.5",
     "@commercetools-uikit/spacings": "19.22.5",
     "@commercetools-uikit/stamp": "19.22.5",

--- a/presets/ui-kit/src/index.ts
+++ b/presets/ui-kit/src/index.ts
@@ -1,6 +1,8 @@
 import * as i18n from '@commercetools-uikit/i18n';
+import * as utils from '@commercetools-uikit/utils';
+import * as selectUtils from '@commercetools-uikit/select-utils';
 
-export { i18n };
+export { i18n, utils, selectUtils };
 
 // NOTE: to make sure that the following preset packages to not
 // export a `version` property, as export properties cannot be overridden.
@@ -144,6 +146,7 @@ export {
   type TDataTableSettingsProps,
   type TColumnSettingsManagerProps,
   type TDataTableManagerContext,
+  DataTableManagerProvider,
 } from '@commercetools-uikit/data-table-manager';
 export {
   Tag,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2582,6 +2582,7 @@ __metadata:
     "@commercetools-uikit/primary-action-dropdown": 19.22.5
     "@commercetools-uikit/progress-bar": 19.22.5
     "@commercetools-uikit/quick-filters": 19.22.5
+    "@commercetools-uikit/select-utils": 19.22.5
     "@commercetools-uikit/selectable-search-input": 19.22.5
     "@commercetools-uikit/spacings": 19.22.5
     "@commercetools-uikit/stamp": 19.22.5


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

With the following diagram of dependencies
```mermaid
graph TD;
    B("package-b")-->C("@commercetools-frontend/uikit");
    A("app-a")-->C;
    A-->B;
    B-->react;
    A--> react;
    C-->react;
```
and as a maintainer of `package-b`, I want define all `ui-kit` related code used in `package-b` as a single `peerDependency` through `@commercetools-frontend/uikit` . The goal is to provide seamless upgrades of react.

My current issue is `DataTableManagerProvider`, `utils` and `selectUtils` are not exported through `@commercetools-frontend/uikit`. So, this PR tries to export these three to upgrade the react version (and provide backward compatibility) of `package-b`.

## Description

<!-- provide some context -->
