### PR TITLE
fix(money-input): auto menu placement

### DIFF
--- a/.changeset/pretty-walls-repeat.md
+++ b/.changeset/pretty-walls-repeat.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/money-input': patch
+---
+
+Fix: Auto menu placement for money input

--- a/packages/components/inputs/money-input/src/money-input.tsx
+++ b/packages/components/inputs/money-input/src/money-input.tsx
@@ -830,6 +830,7 @@ const MoneyInput = ({
             onFocus={handleCurrencyFocus}
             menuPortalTarget={props.menuPortalTarget}
             menuShouldBlockScroll={props.menuShouldBlockScroll}
+            menuPlacement="auto"
             onBlur={handleCurrencyBlur}
             onChange={handleCurrencyChange}
             data-testid="currency-dropdown"


### PR DESCRIPTION
#### Summary

- Added auto menu placement to money input to match select input

#### Description

Without auto menu placement, the money select input is causing extra/infinite scrolling in various scenarios within Merchant Center. This change will resolve the issue with custom fields being unable to select a currency value within the stores modal.
