### PR TITLE
fix(SelectInput): improve TSelectInputProps and TSelectFieldProps types

### DIFF
--- a/.changeset/twenty-dots-kiss.md
+++ b/.changeset/twenty-dots-kiss.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-uikit/select-field': patch
+'@commercetools-uikit/select-input': patch
+---
+
+Improve TSelectInputProps and TSelectFieldProps types

--- a/packages/components/fields/select-field/src/select-field.tsx
+++ b/packages/components/fields/select-field/src/select-field.tsx
@@ -31,8 +31,8 @@ export type TOptionObject = {
 export type TOptions = TOption[] | TOptionObject[];
 export type TCustomEvent = {
   target: {
-    id?: ReactSelectProps['inputId'];
-    name?: ReactSelectProps['name'];
+    id?: ReactSelectProps<TOption>['inputId'];
+    name?: ReactSelectProps<TOption>['name'];
     value?: string | string[] | null;
   };
   persist: () => void;
@@ -111,13 +111,13 @@ export type TSelectFieldProps = {
    * <br/>
    * [Props from React select was used](https://react-select.com/props)
    */
-  'aria-label'?: ReactSelectProps['aria-label'];
+  'aria-label'?: ReactSelectProps<TOption>['aria-label'];
   /**
    * HTML ID of an element that should be used as the label (for assistive tech)
    * <br/>
    * [Props from React select was used](https://react-select.com/props)
    */
-  'aria-labelledby'?: ReactSelectProps['aria-labelledby'];
+  'aria-labelledby'?: ReactSelectProps<TOption>['aria-labelledby'];
   /**
    * Focus the control when it is mounted
    */
@@ -131,19 +131,19 @@ export type TSelectFieldProps = {
    * <br/>
    * [Props from React select was used](https://react-select.com/props)
    */
-  components?: ReactSelectProps['components'];
+  components?: ReactSelectProps<TOption>['components'];
   /**
    * Control whether the selected values should be rendered in the control
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  controlShouldRenderValue?: ReactSelectProps['controlShouldRenderValue'];
+  controlShouldRenderValue?: ReactSelectProps<TOption>['controlShouldRenderValue'];
   /**
    * Custom method to filter whether an option should be displayed in the menu
    * <br/>
    * [Props from React select was used](https://react-select.com/props)
    */
-  filterOption?: ReactSelectProps['filterOption'];
+  filterOption?: ReactSelectProps<TOption>['filterOption'];
   /**
    * The id to set on the SelectContainer component
    */
@@ -169,7 +169,7 @@ export type TSelectFieldProps = {
    * <br/>
    * [Props from React select was used](https://react-select.com/props)
    */
-  isOptionDisabled?: ReactSelectProps['isOptionDisabled'];
+  isOptionDisabled?: ReactSelectProps<TOption>['isOptionDisabled'];
   /**
    * Support multiple selected options
    */
@@ -187,7 +187,7 @@ export type TSelectFieldProps = {
    * <br/>
    * [Props from React select was used](https://react-select.com/props)
    */
-  menuPortalTarget?: ReactSelectProps['menuPortalTarget'];
+  menuPortalTarget?: ReactSelectProps<TOption>['menuPortalTarget'];
   /**
    * z-index value for the menu portal
    * <br>
@@ -209,7 +209,7 @@ export type TSelectFieldProps = {
    * <br/>
    * [Props from React select was used](https://react-select.com/props)
    */
-  noOptionsMessage?: ReactSelectProps['noOptionsMessage'];
+  noOptionsMessage?: ReactSelectProps<TOption>['noOptionsMessage'];
   /**
    * Handle blur events on the control
    */
@@ -225,13 +225,13 @@ export type TSelectFieldProps = {
    * <br/>
    * [Props from React select was used](https://react-select.com/props)
    */
-  onFocus?: ReactSelectProps['onFocus'];
+  onFocus?: ReactSelectProps<TOption>['onFocus'];
   /**
    * Handle change events on the input
    * <br/>
    * [Props from React select was used](https://react-select.com/props)
    */
-  onInputChange?: ReactSelectProps['onInputChange'];
+  onInputChange?: ReactSelectProps<TOption>['onInputChange'];
   /**
    * Array of options that populate the select menu
    */
@@ -246,17 +246,15 @@ export type TSelectFieldProps = {
    *  <br/>
    * [Props from React select was used](https://react-select.com/props)
    */
-  tabIndex?: ReactSelectProps['tabIndex'];
+  tabIndex?: ReactSelectProps<TOption>['tabIndex'];
   /**
    * Select the currently focused option when the user presses tab
    */
   tabSelectsValue?: boolean;
   /**
    * The value of the select; reflected by the selected option
-   * <br/>
-   * [Props from React select was used](https://react-select.com/props)
    */
-  value?: ReactSelectProps['value'];
+  value?: string | string[] | null;
 
   // LabelField
   /**
@@ -303,7 +301,7 @@ export type TSelectFieldProps = {
    * <br/>
    * [Props from React select was used](https://react-select.com/props)
    */
-  inputValue?: ReactSelectProps['inputValue'];
+  inputValue?: ReactSelectProps<TOption>['inputValue'];
 };
 
 type TFieldState = Pick<TSelectFieldProps, 'id'>;

--- a/packages/components/inputs/select-input/src/select-input.tsx
+++ b/packages/components/inputs/select-input/src/select-input.tsx
@@ -344,8 +344,6 @@ export type TSelectInputProps = {
   tabSelectsValue?: ReactSelectProps<TOption>['tabSelectsValue'];
   /**
    * The value of the select; reflected by the selected option
-   * <br>
-   * [Props from React select was used](https://react-select.com/props)
    */
   value?: string | string[] | null;
   /**

--- a/packages/components/inputs/select-input/src/select-input.tsx
+++ b/packages/components/inputs/select-input/src/select-input.tsx
@@ -45,8 +45,8 @@ export type TOptions = TOption[] | TOptionObject[];
 
 export type TCustomEvent = {
   target: {
-    id?: ReactSelectProps['inputId'];
-    name?: ReactSelectProps['name'];
+    id?: ReactSelectProps<TOption>['inputId'];
+    name?: ReactSelectProps<TOption>['name'];
     value?: string | string[] | null;
   };
   persist: () => void;
@@ -107,25 +107,25 @@ export type TSelectInputProps = {
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  'aria-label'?: ReactSelectProps['aria-label'];
+  'aria-label'?: ReactSelectProps<TOption>['aria-label'];
   /**
    * HTML ID of an element that should be used as the label (for assistive tech)
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  'aria-labelledby'?: ReactSelectProps['aria-labelledby'];
+  'aria-labelledby'?: ReactSelectProps<TOption>['aria-labelledby'];
   /**
    * Indicate if the value entered in the input is invalid.
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  'aria-invalid'?: ReactSelectProps['aria-invalid'];
+  'aria-invalid'?: ReactSelectProps<TOption>['aria-invalid'];
   /**
    * HTML ID of an element containing an error message related to the input.
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  'aria-errormessage'?: ReactSelectProps['aria-errormessage'];
+  'aria-errormessage'?: ReactSelectProps<TOption>['aria-errormessage'];
   /**
    * Focus the control when it is mounted
    */
@@ -135,7 +135,7 @@ export type TSelectInputProps = {
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  backspaceRemovesValue?: ReactSelectProps['backspaceRemovesValue'];
+  backspaceRemovesValue?: ReactSelectProps<TOption>['backspaceRemovesValue'];
   // blurInputOnSelect: PropTypes.bool,
   // captureMenuScroll: PropTypes.bool,
   // className: PropTypes.string,
@@ -147,7 +147,7 @@ export type TSelectInputProps = {
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  components?: ReactSelectProps['components'];
+  components?: ReactSelectProps<TOption>['components'];
   /**
    * Whether the input and options are rendered with condensed paddings
    */
@@ -157,7 +157,7 @@ export type TSelectInputProps = {
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  controlShouldRenderValue?: ReactSelectProps['controlShouldRenderValue'];
+  controlShouldRenderValue?: ReactSelectProps<TOption>['controlShouldRenderValue'];
   // delimiter: PropTypes.string,
   // escapeClearsValue: PropTypes.bool,
   /**
@@ -165,7 +165,7 @@ export type TSelectInputProps = {
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  filterOption?: ReactSelectProps['filterOption'];
+  filterOption?: ReactSelectProps<TOption>['filterOption'];
   // formatGroupLabel: PropTypes.func,
   // formatOptionLabel: PropTypes.func,
   // getOptionLabel: PropTypes.func,
@@ -175,67 +175,67 @@ export type TSelectInputProps = {
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  hideSelectedOptions?: ReactSelectProps['hideSelectedOptions'];
+  hideSelectedOptions?: ReactSelectProps<TOption>['hideSelectedOptions'];
   /**
    * Used as HTML id property. An id is generated automatically when not provided.
    * This forwarded as react-select's "inputId"
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  id?: ReactSelectProps['inputId'];
+  id?: ReactSelectProps<TOption>['inputId'];
   /**
    * The value of the search input
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  inputValue?: ReactSelectProps['inputValue'];
+  inputValue?: ReactSelectProps<TOption>['inputValue'];
   /**
    * The id to set on the SelectContainer component
    * This is forwarded as react-select's "id"
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  containerId?: ReactSelectProps['id'];
+  containerId?: ReactSelectProps<TOption>['id'];
   // instanceId: PropTypes.string,
   /**
    * Is the select value clearable
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  isClearable?: ReactSelectProps['isClearable'];
+  isClearable?: ReactSelectProps<TOption>['isClearable'];
   /**
    * Is the select disabled
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  isDisabled?: ReactSelectProps['isDisabled'];
+  isDisabled?: ReactSelectProps<TOption>['isDisabled'];
   // isLoading: PropTypes.bool,
   /**
    * Override the built-in logic to detect whether an option is disabled
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  isOptionDisabled?: ReactSelectProps['isOptionDisabled'];
+  isOptionDisabled?: ReactSelectProps<TOption>['isOptionDisabled'];
   // isOptionSelected: PropTypes.func,
   /**
    * Support multiple selected options
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  isMulti?: ReactSelectProps['isMulti'];
+  isMulti?: ReactSelectProps<TOption>['isMulti'];
   // isRtl: PropTypes.bool,
   /**
    * Whether to enable search functionality
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  isSearchable?: ReactSelectProps['isSearchable'];
+  isSearchable?: ReactSelectProps<TOption>['isSearchable'];
   /**
    * Can be used to enforce the select input to be opened
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  menuIsOpen?: ReactSelectProps['menuIsOpen'];
+  menuIsOpen?: ReactSelectProps<TOption>['menuIsOpen'];
   // loadingMessage: PropTypes.func,
   // minMenuHeight: PropTypes.number,
   /**
@@ -243,7 +243,7 @@ export type TSelectInputProps = {
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  maxMenuHeight?: ReactSelectProps['maxMenuHeight'];
+  maxMenuHeight?: ReactSelectProps<TOption>['maxMenuHeight'];
   // menuPlacement: PropTypes.oneOf(['auto', 'bottom', 'top']),
   // menuPosition: PropTypes.oneOf(['absolute', 'fixed']),
   /**
@@ -251,7 +251,7 @@ export type TSelectInputProps = {
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  menuPortalTarget?: ReactSelectProps['menuPortalTarget'];
+  menuPortalTarget?: ReactSelectProps<TOption>['menuPortalTarget'];
   /**
    * z-index value for the menu portal
    * <br>
@@ -263,19 +263,19 @@ export type TSelectInputProps = {
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  menuShouldBlockScroll?: ReactSelectProps['menuShouldBlockScroll'];
+  menuShouldBlockScroll?: ReactSelectProps<TOption>['menuShouldBlockScroll'];
   /**
    * Whether the menu should close after a value is selected. Defaults to `true`.
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  closeMenuOnSelect?: ReactSelectProps['closeMenuOnSelect'];
+  closeMenuOnSelect?: ReactSelectProps<TOption>['closeMenuOnSelect'];
   /**
    * Name of the HTML Input (optional - without this, no input will be rendered)
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  name?: ReactSelectProps['name'];
+  name?: ReactSelectProps<TOption>['name'];
   /**
    * Can be used to render a custom value when there are no options (either because of no search results, or all options have been used, or there were none in the first place). Gets called with { inputValue: String }.
    * <br />
@@ -283,7 +283,7 @@ export type TSelectInputProps = {
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  noOptionsMessage?: ReactSelectProps['noOptionsMessage'];
+  noOptionsMessage?: ReactSelectProps<TOption>['noOptionsMessage'];
   /**
    * Handle blur events on the control
    */
@@ -299,13 +299,13 @@ export type TSelectInputProps = {
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  onFocus?: ReactSelectProps['onFocus'];
+  onFocus?: ReactSelectProps<TOption>['onFocus'];
   /**
    * Handle change events on the input
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  onInputChange?: ReactSelectProps['onInputChange'];
+  onInputChange?: ReactSelectProps<TOption>['onInputChange'];
   // onKeyDown: PropTypes.func,
   // onMenuOpen: PropTypes.func,
   // onMenuClose: PropTypes.func,
@@ -326,7 +326,7 @@ export type TSelectInputProps = {
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  placeholder?: ReactSelectProps['placeholder'];
+  placeholder?: ReactSelectProps<TOption>['placeholder'];
   // screenReaderStatus: PropTypes.func,
   // styles: PropTypes.objectOf(PropTypes.func),
   // theme: PropTypes.object,
@@ -335,19 +335,19 @@ export type TSelectInputProps = {
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  tabIndex?: ReactSelectProps['tabIndex'];
+  tabIndex?: ReactSelectProps<TOption>['tabIndex'];
   /**
    * Select the currently focused option when the user presses tab
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  tabSelectsValue?: ReactSelectProps['tabSelectsValue'];
+  tabSelectsValue?: ReactSelectProps<TOption>['tabSelectsValue'];
   /**
    * The value of the select; reflected by the selected option
    * <br>
    * [Props from React select was used](https://react-select.com/props)
    */
-  value?: ReactSelectProps['value'];
+  value?: string | string[] | null;
   /**
    * The min width (a range of values from the horizontalConrtaint set of values) for which the select-input menu
    * is allowed to shrink. If unset, the menu will shrink to a default value.
@@ -437,17 +437,14 @@ const SelectInput = ({
 
   const selectedOptions = props.isMulti
     ? ((props.value || []) as string[])
-        // Pass the options in the order selected by the use, so that the
+        // Pass the options in the order selected by the user, so that the
         // sorting is not lost
-        .map((value: string) =>
-          optionsWithoutGroups.find(
-            (option) => (option as TOption).value === value
-          )
+        .map((value) =>
+          optionsWithoutGroups.find((option) => option.value === value)
         )
-        .filter(Boolean)
+        .filter((option): option is TOption => Boolean(option))
     : optionsWithoutGroups.find(
-        (option) =>
-          has(option, 'value') && (option as TOption).value === props.value
+        (option) => has(option, 'value') && option.value === props.value
       ) || null;
 
   return (
@@ -492,7 +489,7 @@ const SelectInput = ({
                 ? optionStyleCheckboxComponents(appearance)
                 : {}),
               ...props.components,
-            } as ReactSelectProps['components']
+            } as ReactSelectProps<TOption>['components']
           }
           menuIsOpen={
             props.isReadOnly
@@ -518,7 +515,7 @@ const SelectInput = ({
               horizontalConstraint: props.horizontalConstraint,
               minMenuWidth: props.minMenuWidth,
               maxMenuWidth: props.maxMenuWidth,
-            }) as ReactSelectProps['styles']
+            }) as ReactSelectProps<TOption>['styles']
           }
           filterOption={props.filterOption}
           // react-select uses "id" (for the container) and "inputId" (for the input),


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

`TSelectInputProps` and `TSelectFieldProps` are using `unknown` as the option type for `ReactSelectProps` (the default value).
This PR switches to `ReactSelectProps<TOption>` to properly check the provided props downstream and avoid issues with TS errors.

## Description

<!-- provide some context -->
