### PR TITLE
feat(pagination): add 'xs' range option for page size selector

### DIFF
--- a/.changeset/afraid-mangos-count.md
+++ b/.changeset/afraid-mangos-count.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/pagination': minor
+---
+
+added 'xs' option to pageRangeSize selector

--- a/packages/components/pagination/src/page-size-selector/page-size-selector.tsx
+++ b/packages/components/pagination/src/page-size-selector/page-size-selector.tsx
@@ -7,7 +7,7 @@ import { warning } from '@commercetools-uikit/utils';
 import Label from '@commercetools-uikit/label';
 import messages from './messages';
 
-export type TPageRangeSize = 's' | 'm' | 'l';
+export type TPageRangeSize = 'xs' | 's' | 'm' | 'l';
 
 export type TPageSizeSelectorProps = {
   /**
@@ -17,6 +17,8 @@ export type TPageSizeSelectorProps = {
 
   /**
    * Range of items per page.
+   * <br/>
+   * `XS: 5,10,15,20`
    * <br/>
    * `SMALL: 20,50`
    * <br/>
@@ -39,6 +41,8 @@ export type TPageSizeSelectorProps = {
 
 const mapRangeToListOfOptions = (perPageRange: TPageRangeSize) => {
   switch (perPageRange) {
+    case 'xs':
+      return [5, 10, 15, 20];
     case 's':
       return [20, 50];
     case 'm':
@@ -47,7 +51,7 @@ const mapRangeToListOfOptions = (perPageRange: TPageRangeSize) => {
       return [200, 500];
     default:
       throw new Error(
-        `Invalid page range "${perPageRange}", expected one of "s,m,l".`
+        `Invalid page range "${perPageRange}", expected one of "xs,s,m,l".`
       );
   }
 };

--- a/packages/components/pagination/src/pagination.spec.js
+++ b/packages/components/pagination/src/pagination.spec.js
@@ -138,7 +138,7 @@ describe('validation', () => {
         />
       )
     ).toThrowErrorMatchingInlineSnapshot(
-      `"Invalid page range "wrong", expected one of "s,m,l"."`
+      `"Invalid page range "wrong", expected one of "xs,s,m,l"."`
     );
   });
   describe.each`

--- a/packages/components/pagination/src/pagination.stories.tsx
+++ b/packages/components/pagination/src/pagination.stories.tsx
@@ -23,7 +23,7 @@ export const BasicExample: Story = {
     totalItems: 200,
     page: 1,
     onPageChange: () => alert('onPageChange Request'),
-    onPerPageChange: () => alert('onPerPageChange Request'),
+    onPerPageChange: (v) => alert(`onPerPageChange Request: ${v}`),
     perPage: 20,
   },
   decorators: [

--- a/packages/components/pagination/src/pagination.tsx
+++ b/packages/components/pagination/src/pagination.tsx
@@ -27,6 +27,8 @@ export type TPaginationProps = {
   /**
    * Range of items per page.
    * <br/>
+   * `xs: 5,10,15,20`
+   * <br/>
    * `s: 20,50`
    * <br/>
    * `m: 20,50,100`


### PR DESCRIPTION
This pull request enhances the `PageSizeSelector` component by introducing a new `xs` page range size option and updating related functionality and documentation. Additionally, it improves the `onPerPageChange` handler in the pagination story for better debugging.

### Enhancements to `PageSizeSelector`:

* Added a new `xs` page range size to `TPageRangeSize`, with options `[5, 10, 15, 20]`, and updated its usage in `mapRangeToListOfOptions` and the error message for invalid ranges in `page-size-selector.tsx`. [[1]](diffhunk://#diff-7854cf71084bba076bcbad561f56760ab578b5e00844262b8bd7598e644534ccL10-R10) [[2]](diffhunk://#diff-7854cf71084bba076bcbad561f56760ab578b5e00844262b8bd7598e644534ccR44-R45) [[3]](diffhunk://#diff-7854cf71084bba076bcbad561f56760ab578b5e00844262b8bd7598e644534ccL50-R54)
* Updated the JSDoc comments for `TPageSizeSelectorProps` to include details about the new `xs` range.

### Improvements to Pagination Stories:

* Modified the `onPerPageChange` handler in `pagination.stories.tsx` to display the selected value in the alert message for better debugging.

### Documentation Updates:

* Updated the JSDoc comments for `TPaginationProps` in `pagination.tsx` to reflect the addition of the `xs` range.