### PR TITLE
FCT-1528 - Configure Dependabot for Security Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  # Enables security PR generation for all packages, based on yarn.lock alerts.
+  - package-ecosystem: "npm"
+    directory: "/"
+    package-manager: "yarn"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "🤖 Type: Dependencies"
+      - "🔒 Security Update"
+    commit-message:
+      prefix: "fix"
+      include: "scope"
+    pull-request-title-format: "fix(deps): [%{severity}] update %{dependency_name} to fix %{advisory_id}"
+    allow:
+      - dependency-type: "all"


### PR DESCRIPTION

Added `dependabot.yml` config file to control how we automate security vulnerability PRs arising from security alerts.
Necessary to ensure security updates are properly tracked and managed.
Though we currently have a backlog, the logic is for long-term.

**Please see additional commentary in the file itself.

****
TL;DR version: 
- Dependabot ~will~ should automatically start working once this is merged. 
- This only handles security updates (we already have Renovate for regular updates).
- All security alerts will still be visible in the `Security` tab, but only 5 will be converted to PRs at a time (by severity, not age).
  - For the leftover existing alerts (14 in total), there should be a "create dependabot security update" button w/in the alert which can trigger an associated PR manually.
   - The alert & pr will be linked
   - When a Dependabot PR is merged and closed, the corresponding security alert will be automatically resolved/closed in the Security tab & show as `fixed`.
 - Hey Valorie, what if Dependabot doesn't automagically find a solution for an existing alert? A PR will not be created, but the alert will remain under the `Security` tab.


