### PR TITLE
chore(deps): resolve dependencies to rollup v2.79.1 to version 2.79.2…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       # Change the default separator (/) to a hyphen (-)
       separator: "-"
     open-pull-requests-limit: 5
+    schedule:
+      interval: "weekly"
     commit-message:
       prefix: "fix"
       scope: "deps"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,6 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     security-updates-only: true
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "Europe/Berlin"
     pull-request-branch-name:
       # Change the default separator (/) to a hyphen (-)
       separator: "-"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,6 @@ updates:
   # Enables security PR generation for all packages, based on yarn.lock alerts.
   - package-ecosystem: "npm"
     directory: "/"
-    security-updates-only: true
     pull-request-branch-name:
       # Change the default separator (/) to a hyphen (-)
       separator: "-"
@@ -12,7 +11,6 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "fix"
-      scope: "deps"
-      include: "dependency-name"
+      include: "scope"
     allow:
       - dependency-type: "all"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,14 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     security-updates-only: true
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
     pull-request-branch-name:
       # Change the default separator (/) to a hyphen (-)
-      separator: "-"  
+      separator: "-"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "fix"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "json5": "^2.0.0",
     "react-from-dom": "0.6.2",
     "path-to-regexp@^1.7.0": "^3.3.0",
-    "path-to-regexp@2.2.1": "^3.3.0"
+    "path-to-regexp@2.2.1": "^3.3.0",
+    "rollup@^2.79.1": "^2.79.2"
   },
   "engines": {
     "node": ">=22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22129,9 +22129,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^2.79.1":
-  version: 2.79.1
-  resolution: "rollup@npm:2.79.1"
+"rollup@npm:^2.79.2":
+  version: 2.79.2
+  resolution: "rollup@npm:2.79.2"
   dependencies:
     fsevents: ~2.3.2
   dependenciesMeta:
@@ -22139,7 +22139,7 @@ __metadata:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: 6a2bf167b3587d4df709b37d149ad0300692cc5deb510f89ac7bdc77c8738c9546ae3de9322b0968e1ed2b0e984571f5f55aae28fa7de4cfcb1bc5402a4e2be6
+  checksum: df7aa4c8b95245dede157b06ab71e1921de6080757d30e9bf31f8fb142064d12dda865e2bafbab4349588f43425b2965a290c9a5da1c048246a70fc21734ebd7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The `@preconstruct/cli` package does require v2.79.1 of `rollup`, the latest fixed v2 version is v2.79.2.

- [security issue](https://github.com/commercetools/ui-kit/security/dependabot/205)
- [ticket](https://commercetools.atlassian.net/browse/FCT-1441)

Resolution works:
![image](https://github.com/user-attachments/assets/d040d066-7e8c-4ee4-ab7e-585c9287a369)

Let's see what CI says.