### PR TITLE
[PANGOLIN-3857] update z-index for filter menu dropdown

### DIFF
--- a/packages/components/filters/src/filter-menu/filter-menu.tsx
+++ b/packages/components/filters/src/filter-menu/filter-menu.tsx
@@ -111,7 +111,7 @@ export const menuStyles = css`
   will-change: 'transform, opacity';
   margin-top: ${designTokens.spacing10};
   position: relative;
-  z-index: 5;
+  z-index: 10010;
 `;
 
 export const menuBodyStyle = css`


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary
The `portal-container` element for a drawer has a `z-index of 10000` and when the `Filter` component is inside a drawer, the menu dropdown is covered as it has a `z-index of 5`. I updated the z-index of the menu styles for the `Filter` component but if I missed another spot that needs updated here please let me know. 

## Description

https://github.com/user-attachments/assets/fbc467a7-8ab1-482a-be09-4af859091199


