### PR TITLE
FCT-1500: Adjust legacy CSS reset

### DIFF
--- a/.changeset/swift-foxes-melt.md
+++ b/.changeset/swift-foxes-melt.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/design-system': minor
+---
+
+Added an @layer reset directive to the reset-stylesheet for compatibility with nimbus

--- a/design-system/materials/resets.css
+++ b/design-system/materials/resets.css
@@ -1,41 +1,43 @@
-*,
-*::before,
-*::after {
-  box-sizing: inherit;
-}
+@layer reset {
+  *,
+  *::before,
+  *::after {
+    box-sizing: inherit;
+  }
 
-html,
-body {
-  color: var(--color-solid);
-  font-family: var(--font-family);
-  margin: 0;
-  padding: 0;
-}
+  html,
+  body {
+    color: var(--color-solid);
+    font-family: var(--font-family);
+    margin: 0;
+    padding: 0;
+  }
 
-html {
-  box-sizing: border-box;
-}
+  html {
+    box-sizing: border-box;
+  }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  margin: 0;
-}
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin: 0;
+  }
 
-button {
-  cursor: pointer;
-}
+  button {
+    cursor: pointer;
+  }
 
-a {
-  color: var(--color-primary);
-  cursor: pointer;
-  text-decoration: none;
-  transition: color 0.2s ease-in;
-}
+  a {
+    color: var(--color-primary);
+    cursor: pointer;
+    text-decoration: none;
+    transition: color 0.2s ease-in;
+  }
 
-p {
-  margin: 0;
+  p {
+    margin: 0;
+  }
 }


### PR DESCRIPTION
To make sure the nimbus styles take precedence over existing ui-kit styles, the reset styles of ui-kit will have to be wrapped in an @layer directive that nimbus is using as well, otherwise those reset styles will be applied on-top of all nimbus styles, which already lead to links missing their underlines.