### PR TITLE
FCT-1548 - Security - Add minimal permissions to the GITHUB_TOKEN - `workflow/main`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build_lint_and_test:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This PR is in response to CodeQL alert: [ Workflow does not contain permissions ](https://github.com/commercetools/ui-kit/security/code-scanning/7)

I've added the least privilege permission (`contents: read`) at the root of the workflow so it applies globally to all jobs, including those without their own permissions key. We can extend this if needed.