### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge-blocking-labels.yml
+++ b/.github/workflows/merge-blocking-labels.yml
@@ -1,5 +1,8 @@
 name: Label Checker
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
This PR is in response to CodeQL alert: [Workflow does not contain permissions ](https://github.com/commercetools/ui-kit/security/code-scanning/8)

Added the least privilege permission (contents: read) at the root of the workflow so it applies globally to all jobs, including those without their own permissions key. We can extend this if needed.

