### PR TITLE
FCT-1548 - [Security] Add minimal permissions to the GITHUB_TOKEN - `workflow/merge-blocking-labels`

### DIFF
--- a/.github/workflows/merge-blocking-labels.yml
+++ b/.github/workflows/merge-blocking-labels.yml
@@ -11,6 +11,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+permissions:
+  contents: read
+
 jobs:
   check_labels:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION


This PR is in response to CodeQL alert: [Workflow does not contain permissions
](https://github.com/commercetools/ui-kit/security/code-scanning/8)

Added the least privilege permission (contents: read) at the root of the workflow so it applies globally to all jobs, including those without their own permissions key. We can extend this if needed.
