### PR TITLE
feat(Date Input): add `appearance` prop to DateInput, DateTimeInput, and DateRangeInput components

### DIFF
--- a/.changeset/polite-apes-create.md
+++ b/.changeset/polite-apes-create.md
@@ -1,0 +1,29 @@
+---
+'@commercetools-uikit/date-range-input': minor
+'@commercetools-uikit/date-time-input': minor
+'@commercetools-uikit/date-input': minor
+'@commercetools-uikit/calendar-utils': minor
+---
+
+feat: add `appearance` prop with 'filter' option to date input components
+
+To use the date filters, there are some visual modifications that need to happen in the different date inputs to support the designs and ux of the filters pattern. Most of these changes are dependent on new props to set these options when the component is used in a filter component.
+
+Add support for `appearance: 'filter'` to DateInput, DateTimeInput, and DateRangeInput components. When set to 'filter', the components:
+
+- Remove borders and box shadows for a clean, inline appearance
+- Keep the calendar always open (when not disabled or read-only)
+- Maintain transparent backgrounds to blend seamlessly with filter UIs
+
+This follows the same design pattern established in select input components and enables date inputs to be used effectively within filter components and search interfaces.
+
+**New Props:**
+- `appearance?: 'default' | 'filter'` - Controls the visual styling of the date input
+
+**Examples:**
+```jsx
+<DateInput appearance="filter" value="2024-01-15" />
+<DateTimeInput appearance="filter" value="2024-01-15T10:30:00Z" />
+<DateRangeInput appearance="filter" value={['2024-01-15', '2024-01-20']} />
+```
+```

--- a/packages/calendar-utils/src/calendar-body/calendar-body.styles.ts
+++ b/packages/calendar-utils/src/calendar-body/calendar-body.styles.ts
@@ -27,10 +27,13 @@ const getClearSectionStyles = () => {
 };
 
 type TState = {
-  isFocused: boolean;
+  isFocused?: boolean;
 };
 
 const getIconBorderColor = (props: TCalendarBody, state: TState) => {
+  if (props.appearance === 'filter') {
+    return designTokens.colorTransparent;
+  }
   if (props.isDisabled) {
     return designTokens.borderColorForInputWhenDisabled;
   }
@@ -89,13 +92,18 @@ const getCalendarIconContainerStyles = (
       &:active,
       &:hover:not(:disabled)&:not(:read-only),
       &:focus {
-        border-color: ${designTokens.borderColorForInputWhenFocused};
+        border-color: ${props.appearance === 'filter'
+          ? designTokens.colorTransparent
+          : designTokens.borderColorForInputWhenFocused};
       }
     `,
   ];
 };
 
 const getInputBorderColor = (props: TCalendarBody, state: TState) => {
+  if (props.appearance === 'filter') {
+    return designTokens.colorTransparent;
+  }
   if (props.isDisabled) {
     return designTokens.borderColorForInputWhenDisabled;
   }
@@ -108,7 +116,7 @@ const getInputBorderColor = (props: TCalendarBody, state: TState) => {
   if (props.isReadOnly) {
     return designTokens.borderColorForInputWhenReadonly;
   }
-  if ((props.isOpen || state.isFocused) && !props.isReadOnly) {
+  if (props.isOpen || state.isFocused) {
     return designTokens.borderColorForInputWhenFocused;
   }
   return designTokens.borderColorForInput;
@@ -131,6 +139,9 @@ const getInputFontColor = (props: TCalendarBody) => {
 };
 
 const getInputContainerBackgroundColor = (props: TCalendarBody) => {
+  if (props.appearance === 'filter') {
+    return designTokens.colorTransparent;
+  }
   if (props.isDisabled) {
     return designTokens.backgroundColorForInputWhenDisabled;
   }
@@ -164,7 +175,9 @@ const getInputContainerStyles = (props: TCalendarBody, state: TState) => {
 
       &:hover:not(:focus) {
         background-color: ${!props.isDisabled && !props.isReadOnly
-          ? designTokens.backgroundColorForInputWhenHovered
+          ? props.appearance === 'filter'
+            ? designTokens.colorTransparent
+            : designTokens.backgroundColorForInputWhenHovered
           : null};
       }
       &:focus {
@@ -174,10 +187,13 @@ const getInputContainerStyles = (props: TCalendarBody, state: TState) => {
         props.isReadOnly ||
         ((props.isOpen || state.isFocused) && !props.isReadOnly)
           ? ''
+          : props.appearance === 'filter'
+          ? designTokens.colorTransparent
           : designTokens.borderColorForInputWhenFocused};
       }
     `,
     !props.isReadOnly &&
+      props.appearance !== 'filter' &&
       css`
         &:focus-within {
           border-color: ${designTokens.borderColorForInputWhenFocused};
@@ -189,6 +205,7 @@ const getInputContainerStyles = (props: TCalendarBody, state: TState) => {
         }
       `,
     (props.hasError || props.hasWarning) &&
+      props.appearance !== 'filter' &&
       css`
         box-shadow: inset 0 0 0 1px;
       `,

--- a/packages/calendar-utils/src/calendar-body/calendar-body.styles.ts
+++ b/packages/calendar-utils/src/calendar-body/calendar-body.styles.ts
@@ -101,9 +101,6 @@ const getCalendarIconContainerStyles = (
 };
 
 const getInputBorderColor = (props: TCalendarBody, state: TState) => {
-  if (props.appearance === 'filter') {
-    return designTokens.colorTransparent;
-  }
   if (props.isDisabled) {
     return designTokens.borderColorForInputWhenDisabled;
   }

--- a/packages/calendar-utils/src/calendar-body/calendar-body.tsx
+++ b/packages/calendar-utils/src/calendar-body/calendar-body.tsx
@@ -77,6 +77,11 @@ export type TCalendarBody = {
   placeholder?: string;
   /** @deprecated */
   theme?: Theme;
+  /**
+   * Indicates the appearance of the input.
+   * Filter appearance removes borders and box shadows for use in filter components.
+   */
+  appearance?: 'default' | 'filter';
 };
 
 export const CalendarBody = ({

--- a/packages/calendar-utils/src/calendar-menu/calendar-menu.tsx
+++ b/packages/calendar-utils/src/calendar-menu/calendar-menu.tsx
@@ -8,12 +8,23 @@ type TCalendarMenu = {
   hasError?: boolean;
   hasWarning?: boolean;
   footer?: ReactNode;
+  /**
+   * Indicates the appearance of the calendar menu.
+   * Filter appearance removes box shadows and positioning for inline display.
+   */
+  appearance?: 'default' | 'filter';
 };
 
 export default class CalendarMenu extends Component<TCalendarMenu> {
   static displayName = 'CalendarMenu';
   render() {
-    const { hasFooter, hasWarning, hasError, ...rest } = this.props;
+    const {
+      hasFooter,
+      hasWarning,
+      hasError,
+      appearance = 'default',
+      ...rest
+    } = this.props;
 
     return (
       <div
@@ -24,16 +35,20 @@ export default class CalendarMenu extends Component<TCalendarMenu> {
             color: ${designTokens.colorSolid};
             font-family: inherit;
             border: none;
-            box-shadow: 0 2px 5px 0px rgba(0, 0, 0, 0.15);
+            box-shadow: ${appearance === 'filter'
+              ? 'none'
+              : '0 2px 5px 0px rgba(0, 0, 0, 0.15)'};
             border-radius: ${designTokens.borderRadiusForInput};
             margin-top: ${designTokens.spacing10};
             font-size: ${designTokens.fontSize30};
-            position: absolute;
+            position: ${appearance === 'filter' ? 'inherit' : 'absolute'};
             box-sizing: border-box;
             width: 100%;
             background-color: ${designTokens.colorSurface};
             min-width: ${designTokens.constraint5};
-            z-index: 99999; /* copied from flatpickr */
+            z-index: ${appearance === 'filter'
+              ? 'inherit'
+              : '99999'}; /* copied from flatpickr */
           `,
           !hasFooter &&
             css`

--- a/packages/components/inputs/date-input/src/date-input.stories.tsx
+++ b/packages/components/inputs/date-input/src/date-input.stories.tsx
@@ -5,6 +5,12 @@ import { useEffect, useState } from 'react';
 const meta: Meta<typeof DateInput> = {
   title: 'Form/Inputs/DateInput',
   component: DateInput,
+  argTypes: {
+    appearance: {
+      control: { type: 'select' },
+      options: ['default', 'filter'],
+    },
+  },
   decorators: [
     (Story) => (
       <div style={{ minHeight: 350 }}>
@@ -43,5 +49,33 @@ export const BasicExample: Story = {
     id: 'date-input',
     horizontalConstraint: 7,
     value: '',
+    appearance: 'default',
+  },
+};
+
+export const FilterAppearance: Story = {
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [value, setValue] = useState<string>(args.value);
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useEffect(() => {
+      setValue(args.value || '');
+    }, [args.value]);
+
+    return (
+      <div>
+        <DateInput
+          {...args}
+          value={value}
+          onChange={(e) => setValue(e.target.value || '')}
+        />
+      </div>
+    );
+  },
+  args: {
+    id: 'date-input-filter',
+    horizontalConstraint: 7,
+    value: '',
+    appearance: 'filter',
   },
 };

--- a/packages/components/inputs/date-input/src/date-input.tsx
+++ b/packages/components/inputs/date-input/src/date-input.tsx
@@ -135,6 +135,11 @@ export type TDateInput = {
    * A maximum selectable date. Must either be an empty string or a date formatted as "YYYY-MM-DD".
    */
   maxValue?: string;
+  /**
+   * Indicates the appearance of the input.
+   * Filter appearance removes borders and box shadows, and calendar is always open.
+   */
+  appearance?: 'default' | 'filter';
 };
 
 const DateInput = (props: TDateInput) => {
@@ -145,6 +150,7 @@ const DateInput = (props: TDateInput) => {
     number | null | undefined
   >(props.value === '' ? null : getDateInMonth(props.value) - 1);
   const inputRef = useRef<HTMLInputElement>(null);
+  const appearance = props.appearance || 'default';
 
   if (!props.isReadOnly) {
     warning(
@@ -277,6 +283,7 @@ const DateInput = (props: TDateInput) => {
             <div onFocus={props.onFocus} onBlur={handleBlur}>
               <CalendarBody
                 inputRef={inputRef}
+                appearance={appearance}
                 inputProps={getInputProps({
                   /* ARIA */
                   'aria-invalid': props['aria-invalid'],
@@ -376,11 +383,15 @@ const DateInput = (props: TDateInput) => {
                 hasError={props.hasError}
                 hasWarning={props.hasWarning}
               />
-              {isOpen && !props.isDisabled && !props.isReadOnly && (
+              {((isOpen && !props.isDisabled && !props.isReadOnly) ||
+                (appearance === 'filter' &&
+                  !props.isDisabled &&
+                  !props.isReadOnly)) && (
                 <CalendarMenu
                   {...getMenuProps()}
                   hasError={props.hasError}
                   hasWarning={props.hasWarning}
+                  appearance={appearance}
                 >
                   <CalendarHeader
                     monthLabel={getMonthCalendarLabel(

--- a/packages/components/inputs/date-input/src/date-input.visualspec.js
+++ b/packages/components/inputs/date-input/src/date-input.visualspec.js
@@ -33,4 +33,9 @@ describe('DateInput', () => {
     await input.type('2017');
     await queries.findByText(doc, '2017');
   });
+  it('Filter Appearance', async () => {
+    await page.goto(`${globalThis.HOST}/date-input--filter-appearance`);
+    await page.waitForSelector('text/November');
+    await percySnapshot(page, 'DateInput - Filter Appearance');
+  });
 });

--- a/packages/components/inputs/date-range-input/src/date-range-input.stories.tsx
+++ b/packages/components/inputs/date-range-input/src/date-range-input.stories.tsx
@@ -6,6 +6,12 @@ import { useState } from 'react';
 const meta: Meta<typeof DateRangeInputProxy> = {
   title: 'Form/Inputs/DateRangeInput',
   component: DateRangeInputProxy,
+  argTypes: {
+    appearance: {
+      control: { type: 'select' },
+      options: ['default', 'filter'],
+    },
+  },
 };
 export default meta;
 
@@ -32,4 +38,27 @@ export const BasicExample: Story = (args: TDateRangeInputProps) => {
 BasicExample.args = {
   horizontalConstraint: 10,
   isClearable: true,
+  appearance: 'default',
+};
+
+export const FilterAppearance: Story = (args: TDateRangeInputProps) => {
+  const [value, setValue] = useState<DateRangeArray>([
+    '2024-11-13',
+    '2024-11-16',
+  ]);
+  return (
+    <div style={{ height: 400 }}>
+      <DateRangeInput
+        {...args}
+        onChange={(e) => setValue(e.target.value as DateRangeArray)}
+        value={value}
+      />
+    </div>
+  );
+};
+
+FilterAppearance.args = {
+  horizontalConstraint: 10,
+  isClearable: true,
+  appearance: 'filter',
 };

--- a/packages/components/inputs/date-range-input/src/date-range-input.tsx
+++ b/packages/components/inputs/date-range-input/src/date-range-input.tsx
@@ -192,6 +192,11 @@ export type TDateRangeInputProps = {
    * Indicates the input field has warning
    */
   hasWarning?: boolean;
+  /**
+   * Indicates the appearance of the input.
+   * Filter appearance removes borders and box shadows, and calendar is always open.
+   */
+  appearance?: 'default' | 'filter';
 } & WrappedComponentProps;
 
 type TDateRangeInputState = {
@@ -285,6 +290,8 @@ class DateRangeInput extends Component<
     });
   };
   render() {
+    const appearance = this.props.appearance || 'default';
+
     return (
       <Constraints.Horizontal max={this.props.horizontalConstraint}>
         <Downshift
@@ -445,6 +452,7 @@ class DateRangeInput extends Component<
               <div onFocus={this.props.onFocus} onBlur={this.handleBlur}>
                 <CalendarBody
                   inputRef={this.inputRef}
+                  appearance={appearance}
                   inputProps={getInputProps({
                     /* ARIA */
                     'aria-invalid': this.props['aria-invalid'],
@@ -543,11 +551,15 @@ class DateRangeInput extends Component<
                   hasError={this.props.hasError}
                   hasWarning={this.props.hasWarning}
                 />
-                {isOpen && !this.props.isDisabled && (
+                {((isOpen && !this.props.isDisabled) ||
+                  (appearance === 'filter' &&
+                    !this.props.isDisabled &&
+                    !this.props.isReadOnly)) && (
                   <CalendarMenu
                     {...getMenuProps()}
                     hasError={this.props.hasError}
                     hasWarning={this.props.hasWarning}
+                    appearance={appearance}
                   >
                     <CalendarHeader
                       monthLabel={getMonthCalendarLabel(

--- a/packages/components/inputs/date-time-input/src/date-time-input.stories.tsx
+++ b/packages/components/inputs/date-time-input/src/date-time-input.stories.tsx
@@ -17,6 +17,10 @@ const meta: Meta<typeof DateTimeInputWrapper> = {
         'Europe/Amsterdam',
       ],
     },
+    appearance: {
+      control: { type: 'select' },
+      options: ['default', 'filter'],
+    },
   },
 };
 export default meta;
@@ -40,4 +44,25 @@ export const BasicExample: Story = (args: TDateTimeInputProps) => {
 BasicExample.args = {
   timeZone: 'UTC',
   horizontalConstraint: 8,
+  appearance: 'default',
+};
+
+export const FilterAppearance: Story = (args: TDateTimeInputProps) => {
+  const [value, setValue] = useState<string>('');
+
+  return (
+    <div style={{ height: 400 }}>
+      <DateTimeInputWrapper
+        {...args}
+        onChange={(e) => setValue(e.target.value || '')}
+        value={value}
+      />
+    </div>
+  );
+};
+
+FilterAppearance.args = {
+  timeZone: 'UTC',
+  horizontalConstraint: 8,
+  appearance: 'filter',
 };

--- a/packages/components/inputs/date-time-input/src/date-time-input.tsx
+++ b/packages/components/inputs/date-time-input/src/date-time-input.tsx
@@ -180,9 +180,14 @@ export type TDateTimeInputProps = {
   hasWarning?: boolean;
   /**
    * The time that will be used by default when a user selects a calendar day.
-   * It must follow the “HH:mm” pattern (eg: 04:30, 13:25, 23:59)
+   * It must follow the "HH:mm" pattern (eg: 04:30, 13:25, 23:59)
    */
   defaultDaySelectionTime?: string;
+  /**
+   * Indicates the appearance of the input.
+   * Filter appearance removes borders and box shadows, and calendar is always open.
+   */
+  appearance?: 'default' | 'filter';
 } & WrappedComponentProps;
 
 type TDateTimeInputState = {
@@ -280,6 +285,8 @@ class DateTimeInput extends Component<
         'DateTimeInput: `onChange` is required when input is not read only.'
       );
     }
+
+    const appearance = this.props.appearance || 'default';
 
     return (
       <Constraints.Horizontal max={this.props.horizontalConstraint}>
@@ -417,6 +424,7 @@ class DateTimeInput extends Component<
               <div onFocus={this.props.onFocus} onBlur={this.handleBlur}>
                 <CalendarBody
                   inputRef={this.inputRef}
+                  appearance={appearance}
                   inputProps={getInputProps({
                     /* ARIA */
                     'aria-invalid': this.props['aria-invalid'],
@@ -567,12 +575,14 @@ class DateTimeInput extends Component<
                   hasError={this.props.hasError}
                   hasWarning={this.props.hasWarning}
                 />
-                {isOpen && !this.props.isDisabled && (
+                {((isOpen && !this.props.isDisabled) ||
+                  (appearance === 'filter' && !this.props.isDisabled)) && (
                   <CalendarMenu
                     {...getMenuProps()}
                     hasFooter={true}
                     hasError={this.props.hasError}
                     hasWarning={this.props.hasWarning}
+                    appearance={appearance}
                   >
                     <CalendarHeader
                       monthLabel={getMonthCalendarLabel(

--- a/packages/components/inputs/date-time-input/src/date-time-input.visualspec.js
+++ b/packages/components/inputs/date-time-input/src/date-time-input.visualspec.js
@@ -13,4 +13,9 @@ describe('DateTimeInput', () => {
     // TODO: uncomment when issue with Percy is resolved
     // await percySnapshot(page, 'DateTimeInput - open');
   });
+  it('Filter Appearance', async () => {
+    await page.goto(`${globalThis.HOST}/date-time-input--filter-appearance`);
+    await page.waitForSelector('text/November');
+    await percySnapshot(page, 'DateTimeInput - Filter Appearance');
+  });
 });


### PR DESCRIPTION
#### Summary

Feat: add `appearance` prop to date input components for filter styling

Introduce a new `appearance` prop with a ‘filter’ option for DateInput, DateTimeInput, and DateRangeInput components. This allows for a cleaner, inline appearance suitable for filter components, removing borders and box shadows, and keeping the calendar always open. Update styles and documentation accordingly.

To use the date filters, there are some visual modifications that need to happen in the different date inputs to support the designs and ux of the filters pattern. Most of these changes are dependent on new props to set these options when the component is used in a filter component.

Add support for `appearance: 'filter'` to DateInput, DateTimeInput, and DateRangeInput components. When set to 'filter', the components:

- Remove borders and box shadows for a clean, inline appearance
- Keep the calendar always open (when not disabled or read-only)
- Maintain transparent backgrounds to blend seamlessly with filter UIs

This follows the same design pattern established in select input components and enables date inputs to be used effectively within filter components and search interfaces.

**New Props:**
- `appearance?: 'default' | 'filter'` - Controls the visual styling of the date input

**Examples:**
```jsx
<DateInput appearance="filter" value="2024-01-15" />
<DateTimeInput appearance="filter" value="2024-01-15T10:30:00Z" />
<DateRangeInput appearance="filter" value={['2024-01-15', '2024-01-20']} />
```

