### PR TITLE
feat(filters): allow auto menu width for filter menu

### DIFF
--- a/.changeset/thin-taxis-film.md
+++ b/.changeset/thin-taxis-film.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/filters': minor
+---
+
+Filter menus can now expand beyond the default constraint width when needed, allowing the menu to grow horizontally with respect to its content

--- a/packages/components/filters/README.md
+++ b/packages/components/filters/README.md
@@ -197,6 +197,10 @@ export default FiltersExample;
    * indicates whether the filter is disabled
    */
   isDisabled?: boolean;
+  /**
+   * controls whether menu is wider than the default width. Set to true to allow the menu to be wider than the default width.
+   */
+  hasWideMenu?: boolean;
 }
 ```
 

--- a/packages/components/filters/src/filter-menu/filter-menu.tsx
+++ b/packages/components/filters/src/filter-menu/filter-menu.tsx
@@ -96,7 +96,7 @@ export type TFilterMenuProps = {
   /**
    * controls whether menu is expanded
    */
-  allowAutoMenuWidth?: boolean;
+  hasWideMenu?: boolean;
 };
 
 export const menuStyles = (props: Partial<TFilterMenuProps> = {}) => css`
@@ -104,7 +104,9 @@ export const menuStyles = (props: Partial<TFilterMenuProps> = {}) => css`
   flex-direction: column;
   align-items: flex-start;
   gap: ${designTokens.spacing30};
-  width: ${props.allowAutoMenuWidth ? 'auto' : designTokens.constraint7};
+  width: ${props.hasWideMenu
+    ? designTokens.constraint14
+    : designTokens.constraint7};
   max-height: ${designTokens.constraint10};
   padding: ${designTokens.spacing20} ${designTokens.spacing30};
   background-color: ${designTokens.colorSurface};

--- a/packages/components/filters/src/filter-menu/filter-menu.tsx
+++ b/packages/components/filters/src/filter-menu/filter-menu.tsx
@@ -93,14 +93,18 @@ export type TFilterMenuProps = {
    * controls whether menu is open on initial render
    */
   defaultOpen?: boolean;
+  /**
+   * controls whether menu is expanded
+   */
+  allowAutoMenuWidth?: boolean;
 };
 
-export const menuStyles = css`
+export const menuStyles = (props: Partial<TFilterMenuProps> = {}) => css`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   gap: ${designTokens.spacing30};
-  width: ${designTokens.constraint7};
+  width: ${props.allowAutoMenuWidth ? 'auto' : designTokens.constraint7};
   max-height: ${designTokens.constraint10};
   padding: ${designTokens.spacing20} ${designTokens.spacing30};
   background-color: ${designTokens.colorSurface};
@@ -168,7 +172,7 @@ function FilterMenu(props: TFilterMenuProps) {
         <Popover.Content
           side="bottom"
           align="start"
-          css={menuStyles}
+          css={() => menuStyles(props)}
           onOpenAutoFocus={focusMenuBody}
         >
           <Header

--- a/packages/components/filters/src/filters.stories.tsx
+++ b/packages/components/filters/src/filters.stories.tsx
@@ -22,6 +22,7 @@ import {
   FRUIT_OPTIONS,
   OPERATOR_OPTIONS,
 } from './fixtures/constants';
+import Spacings from '@commercetools-uikit/spacings';
 
 type TFiltersPropsWithCustomArgs = TFiltersProps & {
   label?: string;
@@ -245,12 +246,19 @@ export const BasicExample: Story = (props: TFiltersPropsWithCustomArgs) => {
       key: 'secondaryColors',
       label: 'Secondary Colors',
       groupKey: FILTER_GROUP_KEYS.secondaryColors,
+      hasWideMenu: true,
       filterMenuConfiguration: {
         renderMenuBody: () => (
-          <SecondaryColorsInput
-            value={secondaryColorValue}
-            onChange={setSecondaryColorValue}
-          />
+          <Spacings.Inline>
+            <SecondaryColorsInput
+              value={secondaryColorValue}
+              onChange={setSecondaryColorValue}
+            />
+            <SecondaryColorsInput
+              value={secondaryColorValue}
+              onChange={setSecondaryColorValue}
+            />
+          </Spacings.Inline>
         ),
         onClearRequest: clearSecondaryColorFilter,
       },
@@ -647,6 +655,112 @@ export const DateFiltersExample: Story = () => {
         • Dynamic component switching (DateInput ↔ DateRangeInput based on
         operator)
         <br />
+      </p>
+      <Filters
+        renderSearchComponent={<SearchInputComponent />}
+        filters={filters}
+        filterGroups={FILTER_GROUPS}
+        appliedFilters={appliedFilters}
+        onClearAllRequest={clearAllFilters}
+        defaultOpen={true}
+      />
+    </div>
+  );
+};
+
+export const WithMultipleMenuInputs: Story = () => {
+  const [pendingDateValue, setPendingDateValue] = useState<string | string[]>(
+    ''
+  );
+  // Applied values (after clicking apply)
+  const [appliedDateValue, setAppliedDateValue] = useState<
+    TFiltersProps['appliedFilters']
+  >([]);
+
+  const getDateAppliedValue = (): TFiltersProps['appliedFilters'] => {
+    if (pendingDateValue && !Array.isArray(pendingDateValue)) {
+      return [
+        {
+          filterKey: 'date',
+          values: [
+            {
+              value: pendingDateValue,
+              label: pendingDateValue,
+            },
+          ],
+        },
+      ];
+    }
+    return [];
+  };
+
+  // Clear functions for pending values
+  const clearDateFilter = () => {
+    setAppliedDateValue([]);
+  };
+
+  // Clear all filters
+  const clearAllFilters = () => {
+    clearDateFilter();
+  };
+
+  // Check if apply button should be enabled
+  const isDateApplyEnabled = () => {
+    return pendingDateValue && !Array.isArray(pendingDateValue);
+  };
+
+  // generate 'appliedFilters' state based on applied values
+  const appliedFilters: TFiltersProps['appliedFilters'] = [...appliedDateValue];
+
+  const filters = [
+    {
+      key: 'date',
+      label: 'Date',
+      hasWideMenu: true,
+      filterMenuConfiguration: {
+        renderMenuBody: () => (
+          <Spacings.Inline>
+            <DateFilterWithOperator
+              value={pendingDateValue}
+              onChange={setPendingDateValue}
+              operator="is"
+            />
+            <DateFilterWithOperator
+              value={pendingDateValue}
+              onChange={setPendingDateValue}
+              operator="is not"
+            />
+          </Spacings.Inline>
+        ),
+        renderApplyButton: () => (
+          <PrimaryButton
+            onClick={() => {
+              setAppliedDateValue(getDateAppliedValue());
+            }}
+            isDisabled={!isDateApplyEnabled()}
+            label="Apply"
+            size="10"
+          />
+        ),
+        onClearRequest: clearDateFilter,
+      },
+    },
+  ];
+
+  return (
+    <div style={{ minHeight: 400 }}>
+      <h3 style={{ marginBottom: '16px' }}>
+        Filters with multiple menu inputs
+      </h3>
+      <p
+        style={{
+          marginBottom: '32px',
+          color: '#808080',
+          lineHeight: '1.5',
+        }}
+      >
+        This example demonstrates the use of multiple menu inputs in a single
+        filter to showcase a wider menu width when `hasWideMenu` is `true`.
       </p>
       <Filters
         renderSearchComponent={<SearchInputComponent />}

--- a/packages/components/filters/src/filters.tsx
+++ b/packages/components/filters/src/filters.tsx
@@ -105,6 +105,10 @@ export type TFilterConfiguration = {
    * indicates whether the filter is disabled
    */
   isDisabled?: boolean;
+  /**
+   * controls whether menu is expanded
+   */
+  allowAutoMenuWidth?: boolean;
 };
 
 export type TFilterGroupConfiguration = {
@@ -349,6 +353,7 @@ function Filters({
                     operatorLabel={activeFilterConfig.operatorLabel}
                     isPersistent={activeFilterConfig.isPersistent}
                     isDisabled={activeFilterConfig.isDisabled}
+                    allowAutoMenuWidth={activeFilterConfig.allowAutoMenuWidth}
                     renderMenuBody={
                       activeFilterConfig.filterMenuConfiguration.renderMenuBody
                     }
@@ -407,7 +412,10 @@ function Filters({
                   <Popover.Content
                     side="bottom"
                     align="start"
-                    css={[menuStyles, menuBodyStyle]}
+                    css={[
+                      () => menuStyles({ allowAutoMenuWidth: false }),
+                      menuBodyStyle,
+                    ]}
                   >
                     <SelectInput
                       id="ui-kit-add-filters-select"

--- a/packages/components/filters/src/filters.tsx
+++ b/packages/components/filters/src/filters.tsx
@@ -106,9 +106,9 @@ export type TFilterConfiguration = {
    */
   isDisabled?: boolean;
   /**
-   * controls whether menu is expanded
+   * controls whether menu is wider than the default width. Set to true to allow the menu to be wider than the default width.
    */
-  allowAutoMenuWidth?: boolean;
+  hasWideMenu?: boolean;
 };
 
 export type TFilterGroupConfiguration = {
@@ -353,7 +353,7 @@ function Filters({
                     operatorLabel={activeFilterConfig.operatorLabel}
                     isPersistent={activeFilterConfig.isPersistent}
                     isDisabled={activeFilterConfig.isDisabled}
-                    allowAutoMenuWidth={activeFilterConfig.allowAutoMenuWidth}
+                    hasWideMenu={activeFilterConfig.hasWideMenu}
                     renderMenuBody={
                       activeFilterConfig.filterMenuConfiguration.renderMenuBody
                     }
@@ -413,7 +413,7 @@ function Filters({
                     side="bottom"
                     align="start"
                     css={[
-                      () => menuStyles({ allowAutoMenuWidth: false }),
+                      () => menuStyles({ hasWideMenu: false }),
                       menuBodyStyle,
                     ]}
                   >


### PR DESCRIPTION
This pull request introduces a new feature to control the width of filter menus dynamically and updates related components to accommodate this functionality. The changes primarily involve adding a new `allowAutoMenuWidth` property and modifying the `menuStyles` function to respect this property.

### New Feature: Dynamic Menu Width

* `packages/components/filters/src/filter-menu/filter-menu.tsx`:
  - Added a new `allowAutoMenuWidth` property to the `TFilterMenuProps` type, allowing the menu width to adjust automatically.
  - Updated the `menuStyles` function to conditionally set the menu width to `auto` if `allowAutoMenuWidth` is true.
  - Modified the `FilterMenu` component to pass the `props` object to the `menuStyles` function for dynamic styling.

* `packages/components/filters/src/filters.tsx`:
  - Added the `allowAutoMenuWidth` property to the `TFilterConfiguration` type to propagate this feature through the filter configuration.
  - Passed the `allowAutoMenuWidth` property to the `FilterMenu` component in the `Filters` component to enable dynamic width control.
  - Ensured the default behavior of the menu width remains consistent by explicitly setting `allowAutoMenuWidth: false` in certain contexts.
 