### PR TITLE
Fix DataTable cell alignment props not working

### DIFF
--- a/.changeset/tasty-ties-sin.md
+++ b/.changeset/tasty-ties-sin.md
@@ -1,0 +1,6 @@
+---
+'@commercetools-uikit/data-table': patch
+---
+
+Fix DataTable cell alignment props not working.
+verticalCellAlignment and horizontalCellAlignment were not passed from DataRow to DataCell, causing default alignment to apply instead.

--- a/packages/components/data-table/src/data-table.tsx
+++ b/packages/components/data-table/src/data-table.tsx
@@ -388,6 +388,8 @@ const DataTable = <Row extends TRow = TRow>({
                 {...props}
                 itemRenderer={itemRenderer}
                 isCondensed={condensedValue}
+                verticalCellAlignment={verticalCellAlignment}
+                horizontalCellAlignment={horizontalCellAlignment}
                 columns={columnsData}
                 row={row}
                 key={row.id}


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

<!-- provide a short summary of your changes -->

This PR fixes DataTable cell alignment for row cell content.

We observed in list pages across the MC that `DataTable` cells aren’t vertically centered when there’s a mix of text, icons, or buttons.

You can also see this directly in Storybook, where changing vertical or horizontal alignment props has no effect.
https://uikit.commercetools.com/?path=/docs/components-datatable--props
## Description

<!-- provide some context -->
