### PR TITLE
fix(deps): skip percy for renovate prs [skip percy]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": ["config:base", ":preserveSemverRanges", "schedule:weekly"],
   "separateMajorMinor": true,
+  "prTitle": "Renovate: {{depName}} is updating from {{currentVersion}} to {{newVersion}} [skip percy]",
   "packageRules": [
     {
       "sourceUrlPrefixes": ["https://github.com/gregberge/svgr"],

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,7 @@ jobs:
         run: yarn visual-testing-app:build
 
       - name: Running Visual Regression Tests for UI components
+  if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip percy]') }}
       # aa-exec:
       # ubuntu-24.04, the image used for `ubuntu-latest` as of Oct 14 2024(https://github.com/actions/runner-images/issues/10636),
       # introduced security measures in its app-armor security  (https://github.com/puppeteer/puppeteer/issues/12818#issuecomment-2247844464)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,7 @@ jobs:
         run: yarn visual-testing-app:build
 
       - name: Running Visual Regression Tests for UI components
+      # This step is skipped if the event is a pull request, and the title contains "[skip percy]"
         if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip percy]') }}
       # aa-exec:
       # ubuntu-24.04, the image used for `ubuntu-latest` as of Oct 14 2024(https://github.com/actions/runner-images/issues/10636),

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,8 @@ jobs:
           CI: true
 
       - name: Building Visual Regression Tests application for UI components
+      # This step is skipped if the event is a pull request, and the title contains "[skip percy]"
+        if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip percy]') }}
         run: yarn visual-testing-app:build
 
       - name: Running Visual Regression Tests for UI components

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         run: yarn visual-testing-app:build
 
       - name: Running Visual Regression Tests for UI components
-  if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip percy]') }}
+        if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip percy]') }}
       # aa-exec:
       # ubuntu-24.04, the image used for `ubuntu-latest` as of Oct 14 2024(https://github.com/actions/runner-images/issues/10636),
       # introduced security measures in its app-armor security  (https://github.com/puppeteer/puppeteer/issues/12818#issuecomment-2247844464)


### PR DESCRIPTION
_**NOTE: We'll also need to update the Repo>Branch settings to make Percy checks not required; Percy will still run for all PRs created by a human developer(or anything that isn't Renovate).**_

#### Summary

This pull request introduces improvements to the automation of dependency updates and the workflow for visual regression testing. The main focus is on making Renovate PRs more descriptive and enabling the ability to skip visual regression tests for specific PRs.

**Renovate automation enhancements:**

* Updated `.github/renovate.json` to set a custom PR title format for Renovate dependency updates, including `[skip percy]` in the title to indicate when visual regression tests should be skipped.

**Visual regression workflow improvements:**

* Modified `.github/workflows/main.yml` so that visual regression tests are automatically skipped when the PR title contains `[skip percy]`, allowing for more efficient CI runs when appropriate.
