### PR TITLE
fix(renovate): revert skip percy rule and set renovate prs to not automatically rebase

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": ["config:base", ":preserveSemverRanges", "schedule:weekly"],
   "separateMajorMinor": true,
-  "prTitle": "Renovate: {{depName}} is updating from {{currentVersion}} to {{newVersion}} [skip percy]",
+  "rebaseWhen": "never",
   "packageRules": [
     {
       "sourceUrlPrefixes": ["https://github.com/gregberge/svgr"],

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,8 +60,6 @@ jobs:
         run: yarn visual-testing-app:build
 
       - name: Running Visual Regression Tests for UI components
-      # This step is skipped if the event is a pull request, and the title contains "[skip percy]"
-        if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip percy]') }}
       # aa-exec:
       # ubuntu-24.04, the image used for `ubuntu-latest` as of Oct 14 2024(https://github.com/actions/runner-images/issues/10636),
       # introduced security measures in its app-armor security  (https://github.com/puppeteer/puppeteer/issues/12818#issuecomment-2247844464)


### PR DESCRIPTION
#### Summary

Reverts [this PR](https://github.com/commercetools/ui-kit/pull/3164) and sets renovate to never automatically rebase PRs

