### PR TITLE
FEC-365: Extend UI-kit MoneyInput with Non-Iso Currencies

### DIFF
--- a/.changeset/orange-cities-know.md
+++ b/.changeset/orange-cities-know.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/money-input': minor
+---
+
+Support zero-fraction currency variants (CZK0, HUF0, ILS0, KZT0, TRY0, TWD0) and fix empty-value fraction digits in MoneyInput

--- a/packages/components/inputs/localized-money-input/src/localized-money-input.spec.js
+++ b/packages/components/inputs/localized-money-input/src/localized-money-input.spec.js
@@ -479,6 +479,29 @@ describe('LocalizedMoneyInput.convertToMoneyValues', () => {
       ]);
     });
   });
+
+  describe('when called with a zero-fraction variant currency (CZK0)', () => {
+    it('should return centPrecision with 0 fraction digits when locale is provided', () => {
+      expect(
+        LocalizedMoneyInput.convertToMoneyValues(
+          {
+            CZK0: {
+              currencyCode: 'CZK0',
+              amount: '100',
+            },
+          },
+          'en'
+        )
+      ).toEqual([
+        {
+          type: 'centPrecision',
+          currencyCode: 'CZK0',
+          centAmount: 100,
+          fractionDigits: 0,
+        },
+      ]);
+    });
+  });
 });
 
 describe('LocalizedMoneyInput.parseMoneyValues', () => {

--- a/packages/components/inputs/money-input/src/currencies.ts
+++ b/packages/components/inputs/money-input/src/currencies.ts
@@ -220,6 +220,13 @@ const currencies = {
   ZWL: { fractionDigits: 2 },
   ZWN: { fractionDigits: 2 },
   ZWR: { fractionDigits: 2 },
+  // Zero-fraction variants (non-ISO): base currency with 0 decimal places.
+  CZK0: { fractionDigits: 0 },
+  HUF0: { fractionDigits: 0 },
+  ILS0: { fractionDigits: 0 },
+  KZT0: { fractionDigits: 0 },
+  TRY0: { fractionDigits: 0 },
+  TWD0: { fractionDigits: 0 },
 } as const;
 
 export default currencies;

--- a/packages/components/inputs/money-input/src/money-input.spec.js
+++ b/packages/components/inputs/money-input/src/money-input.spec.js
@@ -395,6 +395,20 @@ describe('MoneyInput.parseMoneyValue', () => {
       ).toEqual({ amount: '12.34', currencyCode: 'EUR' });
     });
   });
+  describe('when called with a zero-fraction variant currency (HUF0)', () => {
+    it('should format amount with 0 fraction digits for display', () => {
+      expect(
+        MoneyInput.parseMoneyValue(
+          {
+            currencyCode: 'HUF0',
+            centAmount: 500,
+            fractionDigits: 0,
+          },
+          'en'
+        )
+      ).toEqual({ amount: '500', currencyCode: 'HUF0' });
+    });
+  });
   describe('when called with a minimal highPrecision price', () => {
     it('should turn it into a value', () => {
       expect(

--- a/packages/components/inputs/money-input/src/money-input.spec.js
+++ b/packages/components/inputs/money-input/src/money-input.spec.js
@@ -109,6 +109,28 @@ describe('MoneyInput.convertToMoneyValue', () => {
     });
   });
 
+  describe('when a zero-fraction variant currency (CZK0) is used', () => {
+    it('should return centPrecision with 0 fraction digits and whole-number centAmount', () => {
+      expect(
+        MoneyInput.convertToMoneyValue(
+          { currencyCode: 'CZK0', amount: '100' },
+          'en'
+        )
+      ).toEqual({
+        type: 'centPrecision',
+        currencyCode: 'CZK0',
+        centAmount: 100,
+        fractionDigits: 0,
+      });
+    });
+    it('should warn that locale is required when locale is not passed', () => {
+      MoneyInput.convertToMoneyValue({ currencyCode: 'CZK0', amount: '50' });
+      expect(consoleWarnMock).toHaveBeenCalledWith(
+        'Warning: MoneyInput: A locale must be provided when currency has no fraction digits (CZK0)'
+      );
+    });
+  });
+
   describe('when no amount is present', () => {
     it('should return an invalid object', () => {
       expect(

--- a/packages/components/inputs/money-input/src/money-input.tsx
+++ b/packages/components/inputs/money-input/src/money-input.tsx
@@ -379,7 +379,7 @@ const createEmptyMoneyValue = (currencyCode: TCurrencyCode): TMoneyValue => ({
   type: 'centPrecision',
   currencyCode,
   centAmount: NaN,
-  fractionDigits: 2,
+  fractionDigits: allCurrencies[currencyCode].fractionDigits,
 });
 
 const getAmountAsNumberFromMoneyValue = (moneyValue: TMoneyValue) =>

--- a/packages/components/inputs/money-input/src/money-input.tsx
+++ b/packages/components/inputs/money-input/src/money-input.tsx
@@ -379,7 +379,7 @@ const createEmptyMoneyValue = (currencyCode: TCurrencyCode): TMoneyValue => ({
   type: 'centPrecision',
   currencyCode,
   centAmount: NaN,
-  fractionDigits: allCurrencies[currencyCode].fractionDigits,
+  fractionDigits: allCurrencies[currencyCode].fractionDigits ?? 2,
 });
 
 const getAmountAsNumberFromMoneyValue = (moneyValue: TMoneyValue) =>


### PR DESCRIPTION
<!--
  This is the general template.

  Add the following to the URL to use a specific template
    ?template=add-new-component.md      Template for adding new components
    ?template=bugfix.md                 Template for bug fixes
    ?template=refactoring.md            Template for refactoring code
--->

#### Summary

<!-- provide a short summary of your changes -->
This PR adds support for non-ISO currency variants (HUF0, KZT0,...) in the currency lookup table from `MoneyInput`

This change is needed so that non-ISO currencies are correctly recognized and handled in the Merchant Center money inputs.

https://commercetools.atlassian.net/browse/FEC-354
<!-- provide some context -->
