### PR TITLE
test(money-input): update to accept new thousands separator for de-CH…

### DIFF
--- a/packages/components/inputs/money-input/src/money-input.spec.js
+++ b/packages/components/inputs/money-input/src/money-input.spec.js
@@ -341,7 +341,12 @@ describe('MoneyInput.parseMoneyValue', () => {
           },
           'de-CH'
         )
-      ).toEqual({ amount: '1’234.567', currencyCode: 'EUR' });
+        // The Unicode locale data (CLDR) changed the de-CH thousands separator from a right single quote (U+2019)
+        // to a plain apostrophe (U+0027) in Node 24.13.1+. Accept both to stay compatible across Node versions.
+      ).toEqual({
+        amount: expect.stringMatching(/^1[\u2019’]234\.567$/),
+        currencyCode: 'EUR',
+      });
     });
   });
 

--- a/packages/components/inputs/money-input/src/money-input.spec.js
+++ b/packages/components/inputs/money-input/src/money-input.spec.js
@@ -344,7 +344,7 @@ describe('MoneyInput.parseMoneyValue', () => {
         // The Unicode locale data (CLDR) changed the de-CH thousands separator from a right single quote (U+2019)
         // to a plain apostrophe (U+0027) in Node 24.13.1+. Accept both to stay compatible across Node versions.
       ).toEqual({
-        amount: expect.stringMatching(/^1[\u2019’]234\.567$/),
+        amount: expect.stringMatching(/^1[\u2019\u0027]234\.567$/),
         currencyCode: 'EUR',
       });
     });


### PR DESCRIPTION
Fix for the CI error seen [here](https://github.com/commercetools/ui-kit/actions/runs/23054651440/job/66964583927?pr=3223#step:10:71)
*****

 A test for de-CH locale formatting in MoneyInput.parseMoneyValue started failing in CI but not locally. 
 The two failure values looked identical in the diff, which made it difficult to diagnose.

Root cause: The Swiss de-CH locale uses an apostrophe as a thousands separator, but the exact character depends on the Unicode locale data (CLDR) bundled with Node.js. 
Two different characters were in play:
- a right single quote (’, U+2019) and 
- a plain apostrophe (', U+0027) 

But why now?

- May 2025 - Test written against Node 22 / ICU 77.1, which produced U+2019 for de-CH. Hardcoded that character in the assertion, because... it's the whole point of that assertion. 
- Sep 2025  - CLDR 48 changed the de-CH thousands separator from U+2019 to U+0027.
- Jan 2026 - ICU 78.2 shipped with the CLDR 48 change.
- Feb 10, 2026 — Node 24.13.1 released, bundling ICU 78.2.
- Last week - CI picked up Node 24.13.1+ (the workflow uses an unpinned node-version: '24'), causing toLocaleString('de-CH') to produce U+0027 instead of U+2019. (Local machines on Node 24.13.0 were
  unaffected).

The test description already acknowledged both characters as valid for de-CH. Updated the assertion to use a regex character class [\u2019'] which explicitly accepts either the right single quote or the plain apostrophe so the test is accurate across Node versions.