### PR TITLE
chore(tooling): npx skills update

### DIFF
--- a/.agents/skills/agent-restore-context-setup/SKILL.md
+++ b/.agents/skills/agent-restore-context-setup/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: agent-restore-context-setup
+description: Set up the restore-context hook so skills can resume workflows after /clear and /compact. Use when setting up a new project or after cloning a repo that uses restore-context skills.
+disable-model-invocation: false
+allowed-tools: Bash, Grep, Glob, Read, Edit, Write
+scope:
+  - knowledge
+---
+
+# Setup Restore Context
+
+Set up a generic `SessionStart` hook that re-injects context after `/clear` or
+`/compact`. Any skill that writes a `.agent-restore-context-<name>` file in the
+project root will have its contents automatically injected into the fresh
+conversation.
+
+## How It Works
+
+1. Skills write `.agent-restore-context-<skill-name>` files with resume prompts.
+2. A `SessionStart` hook with matcher `clear|compact` runs `agent-restore-context.sh`.
+3. The script globs for `.agent-restore-context-*` and outputs their contents.
+4. The model receives that output and follows the resume instructions.
+5. Skills manage their own file lifecycle (write/delete).
+
+> **Security:** The contents of `.agent-restore-context-*` files are injected
+> verbatim into the model's context on every session start after `/clear` or
+> `/compact`. Treat these files with the same trust as other executable config.
+> Only skills running in your project should write them — this is why the
+> `.gitignore` entry in step 5 is important.
+
+## Process
+
+### 1. Detect Layout
+
+Determine which configuration layer the project uses:
+
+| Check                       | Layout   | Skills directory  |
+| --------------------------- | -------- | ----------------- |
+| `.agents/` directory exists | `agents` | `.agents/skills/` |
+| Only `.claude/` exists      | `claude` | `.claude/skills/` |
+
+Settings files always live under `.claude/` regardless of layout.
+
+> **Note:** When installed via the skills CLI targeting the Claude Code agent,
+> the skill is placed under `.claude/skills/`. When targeting a universal agent
+> (Amp, Cline, Cursor, etc.), it is placed under `.agents/skills/`.
+
+### 2. Check if Already Configured
+
+Read `.claude/settings.json` and `.claude/settings.local.json` (if it exists).
+Search both for `restore-context`. If found in either file, report that the hook
+is already configured and stop.
+
+### 3. Locate the Hook Script
+
+Find the script by checking both potential locations in order:
+
+1. `.claude/skills/agent-restore-context-setup/resources/agent-restore-context.sh`
+2. `.agents/skills/agent-restore-context-setup/resources/agent-restore-context.sh`
+
+Use whichever path exists. If neither exists, stop and report that the skill
+files could not be found — the user may need to re-install the skill.
+
+Verify the script is executable. If not executable, run `chmod +x`.
+
+> **Optional — symlink for dual-layout projects:** If both
+> `.claude/skills/` and `.agents/skills/` directories exist but the skill is
+> only in one of them, you may create a symlink at the missing location so
+> both layouts share a single copy. For example, if the script was found under
+> `.claude/skills/`, create a symlink under `.agents/skills/`:
+>
+> ```bash
+> ln -s ../../.claude/skills/agent-restore-context-setup \
+>       .agents/skills/agent-restore-context-setup
+> ```
+>
+> Reverse the paths if the script was found under `.agents/skills/` instead.
+> This is optional — the hook only needs the one resolved path to work.
+
+### 4. Register the Hook
+
+#### Choose settings file
+
+Ask the user:
+
+> "Should I add the restore-context hook to `.claude/settings.json`
+> (shared — committed to the repo, takes effect for all teammates once pushed)
+> or `.claude/settings.local.json` (local only — never committed, affects only
+> your machine)?"
+>
+> **Recommendation:** choose `settings.json` if you want the whole team to
+> benefit from the hook. Choose `settings.local.json` if you are the only one
+> who will use this workflow, or if teammates install their skills to different
+> paths.
+
+If the chosen settings file does not exist, create it as an empty JSON object
+(`{}`) before merging.
+
+Use the resolved script path from step 3 (relative to the project root), then
+merge the following into the chosen file's `hooks` object. Do **not** overwrite
+existing hooks — add to or create the `SessionStart` array:
+
+```json
+{
+  "SessionStart": [
+    {
+      "matcher": "clear|compact",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash <resolved-script-path>"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Where `<resolved-script-path>` is the relative path found in step 3, e.g.
+`.claude/skills/agent-restore-context-setup/resources/agent-restore-context.sh`
+or `.agents/skills/agent-restore-context-setup/resources/agent-restore-context.sh`.
+
+### 5. Add Gitignore Entry
+
+Check `.gitignore` for `.agent-restore-context-*`. If the pattern is already
+present, skip this step. If `.gitignore` does not exist, check whether the
+project is a git repo (`git rev-parse --is-inside-work-tree`). If it is,
+create `.gitignore`; if not, skip this step entirely. Once the file exists,
+append:
+
+```
+# Restore context files (used by skills to resume workflows after /clear and /compact)
+.agent-restore-context-*
+```
+
+### 6. Confirm
+
+Report to the user:
+
+- Where the hook was registered (which settings file)
+- The path to the script
+- That any skill can now write `.agent-restore-context-<name>` files to use
+  this pattern
+
+## Guidelines
+
+- Always read target files before modifying them
+- Do not create `.agents/` or `.agents/skills/` directories — only use them if
+  they already exist
+- This skill is idempotent — safe to run multiple times

--- a/.agents/skills/agent-restore-context-setup/resources/agent-restore-context.sh
+++ b/.agents/skills/agent-restore-context-setup/resources/agent-restore-context.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Restore context after /clear or /compact.
+# Outputs the contents of any .agent-restore-context-* files in the project root.
+# Each skill manages its own file lifecycle.
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+for file in "$PROJECT_DIR"/.agent-restore-context-*; do
+  [ -f "$file" ] || continue
+  cat "$file"
+  echo ""
+done
+
+exit 0

--- a/.agents/skills/agent-restore-context/SKILL.md
+++ b/.agents/skills/agent-restore-context/SKILL.md
@@ -2,8 +2,10 @@
 name: agent-restore-context
 description: Manage restore context files so skills can survive /clear and /compact. Use to write, delete, check, or list .agent-restore-context-* files.
 disable-model-invocation: false
-argument-hint: <action> [<skill-name>] [-- <content>]
+argument-hint: '<action> [<skill-name>] [-- <content>]'
 allowed-tools: Bash, Grep, Glob, Read, Edit, Write
+scope:
+  - knowledge
 ---
 
 # Agent Restore Context

--- a/.agents/skills/jira-implement-task/SKILL.md
+++ b/.agents/skills/jira-implement-task/SKILL.md
@@ -2,8 +2,10 @@
 name: jira-implement-task
 description: Fetch Jira ticket, create branch, implement changes, commit, push, open PR.
 disable-model-invocation: false
-argument-hint: <ticket-key>
+argument-hint: '<ticket-key>'
 allowed-tools: Bash, Grep, Glob, Read, Edit, Write, Agent
+scope:
+  - jira
 ---
 
 # Implement Jira Task

--- a/.agents/skills/pr-review-navigator/SKILL.md
+++ b/.agents/skills/pr-review-navigator/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: pr-review-navigator
-description: Generate AI-assisted navigation aids to help humans start reviewing a pull request more efficiently.
+description: Generate AI-assisted navigation aids to help humans start reviewing a pull request more efficiently. Use when starting a PR review to get oriented on large or unfamiliar changes.
 disable-model-invocation: false
 argument-hint: '[pr-number] [--comment]'
 allowed-tools: Bash, Grep, Glob, Read
+scope:
+  - github
+  - review
 ---
 
 # PR Review Navigator

--- a/.agents/skills/remember/SKILL.md
+++ b/.agents/skills/remember/SKILL.md
@@ -2,8 +2,10 @@
 name: remember
 description: Persist guidelines, conventions, and architectural decisions into the repository's knowledge base. Use when told to remember something for future sessions.
 disable-model-invocation: false
-argument-hint: <guideline, convention, or architectural decision to persist>
+argument-hint: '<guideline, convention, or architectural decision to persist>'
 allowed-tools: Bash, Grep, Glob, Read, Edit, Write
+scope:
+  - knowledge
 ---
 
 # Remember

--- a/.agents/skills/renovate-migrate/SKILL.md
+++ b/.agents/skills/renovate-migrate/SKILL.md
@@ -4,6 +4,9 @@ description: Perform migrations for Renovate dependency upgrades based on breaki
 disable-model-invocation: false
 argument-hint: '[pr-number] [--comment] [--push]'
 allowed-tools: Bash, Grep, Glob, Read, Edit, Write, WebFetch
+scope:
+  - dependencies
+  - migration
 ---
 
 # Renovate Dependency Migration

--- a/.agents/skills/renovate-review/SKILL.md
+++ b/.agents/skills/renovate-review/SKILL.md
@@ -4,6 +4,9 @@ description: Review Renovate dependency upgrade PRs to assess safety and effort.
 disable-model-invocation: false
 argument-hint: '[pr-number] [--comment]'
 allowed-tools: Bash, Grep, Glob, Read, WebFetch
+scope:
+  - dependencies
+  - review
 ---
 
 # Renovate Dependency Upgrade Review

--- a/.agents/skills/repo-healthcheck-node/SKILL.md
+++ b/.agents/skills/repo-healthcheck-node/SKILL.md
@@ -4,6 +4,9 @@ description: Verify a Node.js/TypeScript repo's development environment is corre
 disable-model-invocation: false
 argument-hint: '[--fix]'
 allowed-tools: Bash, Grep, Glob, Read
+scope:
+  - node
+  - maintenance
 ---
 
 # Repo Healthcheck — Node.js

--- a/.agents/skills/repo-maintenance-node/SKILL.md
+++ b/.agents/skills/repo-maintenance-node/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: repo-maintenance-node
-description: Perform a broad Node/TypeScript repository health sweep — formatting, linting, type errors, dead code, dependency hygiene, and open Renovate PRs.
+description: Perform a broad Node/TypeScript repository health sweep — formatting, linting, type errors, dead code, dependency hygiene, and open Renovate PRs. Use when cleaning up a repo or preparing for a release.
 disable-model-invocation: false
 argument-hint: '[--dry-run] [--section formatting|dead-code|deps|renovate]'
 allowed-tools: Bash, Grep, Glob, Read, Agent
+scope:
+  - node
+  - maintenance
 ---
 
 # Node/TypeScript Repository Maintenance

--- a/.agents/skills/security-auditor/SKILL.md
+++ b/.agents/skills/security-auditor/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: security-auditor
-description: Perform comprehensive security audit of a repository with detailed findings and step-by-step PoCs. Reports all web and API security vulnerabilities.
+description: Perform comprehensive security audit of a repository with detailed findings and step-by-step PoCs. Use when assessing a repo's security posture or investigating potential vulnerabilities.
 disable-model-invocation: false
 argument-hint: '[--path <directory>] [--focus <category>]'
 allowed-tools: Task, Bash, Grep, Glob, Read, Write
+scope:
+  - security
 ---
 
 # Security Audit

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,17 @@
 {
   "enableAllProjectMcpServers": true,
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .agents/skills/agent-restore-context-setup/resources/agent-restore-context.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|MultiEdit|Write",

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ fail-tests-because-there-was-an-unhandled-rejection.lock
 
 # Metals
 .metals
+
+# Restore context files (used by skills to resume workflows after /clear and /compact)
+.agent-restore-context-*

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,42 +4,52 @@
     "agent-restore-context": {
       "source": "commercetools/agent-skills",
       "sourceType": "github",
-      "computedHash": "955add57553422e5c35504927a4d19948956df33e5203f6676044d41db23a89a"
+      "computedHash": "1f4e26744547f31912552bbce5c99f28958e2a4f2dcb057864afc500bc1a30a3"
+    },
+    "agent-restore-context-setup": {
+      "source": "commercetools/agent-skills",
+      "sourceType": "github",
+      "computedHash": "3a5050bd8f95d2939de716b131135c86ef905cdc939fd0390574970cb817ea95"
+    },
+    "jira-implement-task": {
+      "source": "commercetools/agent-skills",
+      "sourceType": "github",
+      "computedHash": "be9e804c16446497340e6097a547362f93377e784cd060a463b95ce2ef3f52cc"
     },
     "pr-review-navigator": {
       "source": "commercetools/agent-skills",
       "sourceType": "github",
-      "computedHash": "7e07bd27b2019b6f8b40458f0e9d68f33f5aa35501c42aef7d05147b7b6722ae"
+      "computedHash": "ada61f525d251ccc27f31432e36e1f765d5282511a421d9ed6abaf03f5e071a0"
     },
     "remember": {
       "source": "commercetools/agent-skills",
       "sourceType": "github",
-      "computedHash": "6c90f38c7dc90853cde33e54c78ace5486f66862b139bd2d9c6082b88a70a3e3"
+      "computedHash": "3498ae3be3e77bc67fd008f0fae2ca376325b7ef362d5f2bbf8e9b5c8a9e6a79"
     },
     "renovate-migrate": {
       "source": "commercetools/agent-skills",
       "sourceType": "github",
-      "computedHash": "9abfafafee247f87f3528fc197f36c49c42e0c625c0bd3ff2a7d20f5f40ca284"
+      "computedHash": "32778832b30d488b335e41252046dad52668b9386970a6682785dcbf455068f9"
     },
     "renovate-review": {
       "source": "commercetools/agent-skills",
       "sourceType": "github",
-      "computedHash": "fcbfd6b908e152a680d4a1404d072e0788a83e97251688e719b8569b39cf0a14"
+      "computedHash": "5f460b17ca823c3ce2d509ae7b2e8de41e99258c35270a2c8cc48593983a2999"
     },
     "repo-healthcheck-node": {
       "source": "commercetools/agent-skills",
       "sourceType": "github",
-      "computedHash": "88439b482c743721e7e3c546125257973987cbd43e5b784169bf7f689aecdfce"
+      "computedHash": "5caa1ca2f1e165610af8499d78a9a61edafbb8908f9086da0bbaba96cd81490a"
     },
     "repo-maintenance-node": {
       "source": "commercetools/agent-skills",
       "sourceType": "github",
-      "computedHash": "9c4dd7478e45279f51380e471132debcf0f6d2e687b7293d54e58f0908cb61dd"
+      "computedHash": "f293326074b7094a03d9c3ca9d99a5a2121b1f4afe5c8342aad8f20b2b4b246c"
     },
     "security-auditor": {
       "source": "commercetools/agent-skills",
       "sourceType": "github",
-      "computedHash": "8243178ee8b26923ef5b125ff12f7d7c5bbb7e5f5eefdfff1237554b7cd18951"
+      "computedHash": "fb7f81f96ee3d358e51254879a03d6cd095b829fba0d4b93bae8bcb2859e2e7e"
     }
   }
 }


### PR DESCRIPTION
- Installed the `agent-restore-context-setup` companion skill & wired it up w/in the `SessionStart` hook in `.claude/settings.json`, completing the `restore-context` infrastructure so long-running skills (e.g. jira-implement-task) can resume after `/clear` or `/compact`
                                                                                            
- Added `.agent-restore-context-*` to `.gitignore` to keep ephemeral session state files out of VC.

- Ran `npx skills update` to refresh all existing skill definitions from upstream `commercetools/agent-skills` (looking at you https://github.com/commercetools/agent-skills/pull/18)

- Registered `jira-implement-task` in `skills-lock.json`
