### PR TITLE
ci(preview-release): migrate workflow to pnpm ahead of FEC-924

### DIFF
--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -36,39 +36,47 @@ jobs:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
           token: ${{ steps.generate_github_token.outputs.token }}
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node (uses version in .nvmrc)
         uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
+          # Disable v6's built-in package-manager auto-cache: combined with
+          # `registry-url`, it picks up the runner's pre-installed yarn 1
+          # instead of pnpm and fails before any of our steps run. We manage
+          # the pnpm store cache explicitly via actions/cache below.
+          package-manager-cache: false
 
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      - name: Get pnpm store
+        id: pnpm-store
+        run: echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v5
         with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock', 'patches/*.patch') }}
+          path: ${{ steps.pnpm-store.outputs.dir }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml', 'patches/*.patch') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
+            ${{ runner.os }}-pnpm-
 
       - name: Install dependencies
-        run: yarn install --immutable
+        run: pnpm install --frozen-lockfile
 
       - name: Building packages
-        run: yarn build
+        run: pnpm build
 
       - name: Building package READMEs
-        run: yarn generate-readmes
+        run: pnpm generate-readmes
         env:
           CI: true
 
       - name: Publishing preview releases to npm registry
         run: |
           PREVIEW_TAG=$(echo "$BRANCH_NAME" | sed -e 's/[^a-zA-Z0-9-]/-/g')
-          yarn changeset version --snapshot ${PREVIEW_TAG}
-          yarn changeset publish --tag ${PREVIEW_TAG}
+          pnpm changeset version --snapshot ${PREVIEW_TAG}
+          pnpm changeset publish --tag ${PREVIEW_TAG}
         env:
           GITHUB_TOKEN: ${{ steps.generate_github_token.outputs.token }}
           BRANCH_NAME: ${{ steps.comment-branch.outputs.head_ref }}


### PR DESCRIPTION
## Summary

Replaces the yarn-based steps in `.github/workflows/preview-release-on-comment.yml` with the pnpm equivalents that the FEC-924 migration branch (#3239) needs to publish a `[preview_deployment]` snapshot.

## Why this lands ahead of the full migration

GitHub resolves `uses: ./.github/workflows/...` references against the calling workflow's commit. For `issue_comment` events that's **always the default branch** (`main`), regardless of which PR triggered the comment. The `[preview_deployment]` comment on #3239 therefore runs `main`'s version of this file — currently the yarn version — against the pnpm-only PR branch's code, and fails immediately at `yarn config get cacheFolder`.

This precursor swaps just that one workflow so #3239 can publish a snapshot for canary validation by `merchant-center-application-kit` before the full migration merges.

## Scope

- **Only** `.github/workflows/preview-release-on-comment.yml` is changed.
- No code, no lockfile, no package.json change.
- No artifacts published as a result of this PR landing.

## What changes in the workflow

- Add `Install pnpm` step (`pnpm/action-setup@v4`).
- Add `package-manager-cache: false` to `actions/setup-node@v6` — v6's auto-cache combined with `registry-url` picks the runner's pre-installed yarn 1 over pnpm and aborts before any of the workflow's own steps run.
- Swap `Get yarn cache` for `Get pnpm store`; update the `actions/cache@v5` key and path accordingly.
- Swap `yarn install --immutable` → `pnpm install --frozen-lockfile`; `yarn build` → `pnpm build`; `yarn generate-readmes` → `pnpm generate-readmes`; `yarn changeset version/publish` → `pnpm changeset version/publish`.

## Side effects

Between this PR merging and #3239 merging, `[preview_deployment]` will only work on **pnpm-based** PRs. There are currently no other open developer PRs that rely on `[preview_deployment]`.

`main.yml` and `publish-release.yml` are untouched — they remain yarn-based and keep working until the full migration lands.

## Refs

- Tracks Jira [FEC-924](https://commercetools.atlassian.net/browse/FEC-924) acceptance criterion #4 (Changesets publish flow publishes a snapshot/canary).
- Blocks: #3239 (the migration PR).

[FEC-924]: https://commercetools.atlassian.net/browse/FEC-924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ