### PR TITLE
fix(pnpm): link workspace packages by name+version to unblock release flow

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,15 @@
 # Hoist all dependencies to root node_modules (matches previous Yarn behavior).
 # TODO: tighten with public-hoist-pattern[] for specific packages later.
 shamefully-hoist=true
+
+# Link internal workspace packages by name+version match, matching yarn 3's
+# default behavior. Without this, pnpm 10 (link-workspace-packages defaults to
+# false) treats internal deps with concrete versions like
+# "@commercetools-uikit/hooks": "20.5.0" as registry specifiers and fetches
+# tarballs from npm instead of using the local workspace. That breaks the
+# release flow: when changesets/action bumps cross-workspace dep specifiers to
+# the next unpublished version and then runs `pnpm install` to refresh the
+# lockfile, the install fails because the bumped version doesn't exist on npm
+# yet. It also silently masks local edits to workspace packages.
+link-workspace-packages=true
+prefer-workspace-packages=true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,7 +327,7 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../packages/hooks
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -477,7 +477,7 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../utils
     devDependencies:
       moment-timezone:
         specifier: 0.6.0
@@ -493,34 +493,34 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../components/buttons/accessible-button
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../design-system
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../hooks
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../components/icons
       '@commercetools-uikit/input-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../components/inputs/input-utils
       '@commercetools-uikit/secondary-icon-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../components/buttons/secondary-icon-button
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../components/spacings/spacings-inline
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../components/text
       '@commercetools-uikit/tooltip':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../components/tooltip
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -573,10 +573,10 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -601,10 +601,10 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -635,19 +635,19 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../accessible-button
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-inline
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -675,19 +675,19 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../accessible-button
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -715,19 +715,19 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../accessible-button
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-inline
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -758,19 +758,19 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../accessible-button
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-inline
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -798,19 +798,19 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../accessible-button
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-inline
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -841,19 +841,19 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../accessible-button
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -881,13 +881,13 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/spacings-inset':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../spacings/spacings-inset
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -915,10 +915,10 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../hooks
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -943,10 +943,10 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../hooks
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -971,31 +971,31 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../buttons/accessible-button
       '@commercetools-uikit/collapsible-motion':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../collapsible-motion
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../hooks
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../icons
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../presets/spacings
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1023,10 +1023,10 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1048,25 +1048,25 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../buttons/accessible-button
       '@commercetools-uikit/data-table-manager':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../data-table-manager
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../hooks
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../icons
       '@commercetools-uikit/secondary-icon-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../buttons/secondary-icon-button
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1097,70 +1097,70 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../buttons/accessible-button
       '@commercetools-uikit/accessible-hidden':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react@19.2.0)
+        version: link:../accessible-hidden
       '@commercetools-uikit/async-select-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../inputs/async-select-input
       '@commercetools-uikit/card':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)
+        version: link:../card
       '@commercetools-uikit/collapsible-motion':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../collapsible-motion
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/dropdown-menu':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../dropdowns/dropdown-menu
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../field-label
       '@commercetools-uikit/grid':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react@19.2.0)
+        version: link:../grid
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../hooks
       '@commercetools-uikit/icon-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../buttons/icon-button
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../icons
       '@commercetools-uikit/primary-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../buttons/primary-button
       '@commercetools-uikit/radio-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../inputs/radio-input
       '@commercetools-uikit/secondary-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)
+        version: link:../buttons/secondary-button
       '@commercetools-uikit/secondary-icon-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../buttons/secondary-icon-button
       '@commercetools-uikit/select-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../inputs/select-input
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../presets/spacings
       '@commercetools-uikit/tag':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../tag
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../text
       '@commercetools-uikit/tooltip':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../tooltip
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1203,28 +1203,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../buttons/accessible-button
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../hooks
       '@commercetools-uikit/secondary-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)
+        version: link:../../buttons/secondary-button
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-inline
       '@commercetools-uikit/spacings-stack':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-stack
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1249,7 +1249,7 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/messages':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../messages
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1274,34 +1274,34 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/icon-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../buttons/icon-button
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../icons
       '@commercetools-uikit/label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../label
       '@commercetools-uikit/secondary-icon-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../buttons/secondary-icon-button
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../spacings/spacings-inline
       '@commercetools-uikit/spacings-stack':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../spacings/spacings-stack
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1326,7 +1326,7 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/messages':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../messages
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1351,28 +1351,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/async-creatable-select-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../inputs/async-creatable-select-input
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/field-errors':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-errors
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-label
       '@commercetools-uikit/field-warnings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-warnings
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1397,28 +1397,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/async-select-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../inputs/async-select-input
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/field-errors':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-errors
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-label
       '@commercetools-uikit/field-warnings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-warnings
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1443,28 +1443,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/creatable-select-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../inputs/creatable-select-input
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/field-errors':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-errors
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-label
       '@commercetools-uikit/field-warnings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-warnings
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1489,28 +1489,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/date-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../inputs/date-input
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/field-errors':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-errors
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-label
       '@commercetools-uikit/field-warnings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-warnings
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1535,28 +1535,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/date-range-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../inputs/date-range-input
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/field-errors':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-errors
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-label
       '@commercetools-uikit/field-warnings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-warnings
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1581,28 +1581,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/date-time-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../inputs/date-time-input
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/field-errors':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-errors
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-label
       '@commercetools-uikit/field-warnings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-warnings
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1627,28 +1627,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/field-errors':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-errors
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-label
       '@commercetools-uikit/field-warnings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-warnings
       '@commercetools-uikit/localized-multiline-text-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../inputs/localized-multiline-text-input
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1673,28 +1673,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/field-errors':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-errors
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-label
       '@commercetools-uikit/field-warnings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-warnings
       '@commercetools-uikit/localized-text-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../inputs/localized-text-input
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1719,28 +1719,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/field-errors':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-errors
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-label
       '@commercetools-uikit/field-warnings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-warnings
       '@commercetools-uikit/money-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../inputs/money-input
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1768,28 +1768,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/field-errors':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-errors
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-label
       '@commercetools-uikit/field-warnings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-warnings
       '@commercetools-uikit/multiline-text-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../inputs/multiline-text-input
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1814,28 +1814,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/field-errors':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-errors
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-label
       '@commercetools-uikit/field-warnings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-warnings
       '@commercetools-uikit/number-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../inputs/number-input
       '@commercetools-uikit/spacings-stack':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-stack
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1860,40 +1860,40 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/field-errors':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-errors
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-label
       '@commercetools-uikit/field-warnings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-warnings
       '@commercetools-uikit/flat-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../buttons/flat-button
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../hooks
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/password-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../inputs/password-input
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-inline
       '@commercetools-uikit/spacings-stack':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-stack
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1918,28 +1918,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/field-errors':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-errors
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-label
       '@commercetools-uikit/field-warnings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-warnings
       '@commercetools-uikit/radio-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../inputs/radio-input
       '@commercetools-uikit/spacings-stack':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-stack
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -1964,31 +1964,31 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/field-errors':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-errors
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-label
       '@commercetools-uikit/field-warnings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-warnings
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../hooks
       '@commercetools-uikit/search-select-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../inputs/search-select-input
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -2013,28 +2013,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/field-errors':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-errors
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-label
       '@commercetools-uikit/field-warnings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-warnings
       '@commercetools-uikit/select-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../inputs/select-input
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -2059,31 +2059,31 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/field-errors':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-errors
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-label
       '@commercetools-uikit/field-warnings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-warnings
       '@commercetools-uikit/messages':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../messages
       '@commercetools-uikit/spacings-stack':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-stack
       '@commercetools-uikit/text-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../inputs/text-input
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -2108,28 +2108,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/field-errors':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-errors
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-label
       '@commercetools-uikit/field-warnings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../field-warnings
       '@commercetools-uikit/spacings-stack':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-stack
       '@commercetools-uikit/time-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../inputs/time-input
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -2154,31 +2154,31 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/collapsible-motion':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../collapsible-motion
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/flat-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../buttons/flat-button
       '@commercetools-uikit/icon-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../buttons/icon-button
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../icons
       '@commercetools-uikit/secondary-icon-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../buttons/secondary-icon-button
       '@commercetools-uikit/select-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../inputs/select-input
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../presets/spacings
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -2240,10 +2240,10 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -2274,28 +2274,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/loading-spinner':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../loading-spinner
       '@commercetools-uikit/select-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../select-utils
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/is-prop-valid':
         specifier: 1.4.0
         version: 1.4.0
@@ -2332,28 +2332,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/loading-spinner':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../loading-spinner
       '@commercetools-uikit/select-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../select-utils
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -2387,19 +2387,19 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/input-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../input-utils
       '@commercetools-uikit/select-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../select-utils
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -2424,25 +2424,25 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/select-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../select-utils
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -2476,43 +2476,43 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../buttons/accessible-button
       '@commercetools-uikit/calendar-time-utils':
         specifier: 20.5.0
-        version: 20.5.0(moment-timezone@0.6.0)(react@19.2.0)
+        version: link:../../../calendar-time-utils
       '@commercetools-uikit/calendar-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../../calendar-utils
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../hooks
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/secondary-icon-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../buttons/secondary-icon-button
       '@commercetools-uikit/select-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../select-utils
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-inline
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../text
       '@commercetools-uikit/tooltip':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../tooltip
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -2549,43 +2549,43 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../buttons/accessible-button
       '@commercetools-uikit/calendar-time-utils':
         specifier: 20.5.0
-        version: 20.5.0(moment-timezone@0.6.0)(react@19.2.0)
+        version: link:../../../calendar-time-utils
       '@commercetools-uikit/calendar-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../../calendar-utils
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../hooks
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/secondary-icon-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../buttons/secondary-icon-button
       '@commercetools-uikit/select-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../select-utils
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-inline
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../text
       '@commercetools-uikit/tooltip':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../tooltip
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -2622,43 +2622,43 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../buttons/accessible-button
       '@commercetools-uikit/calendar-time-utils':
         specifier: 20.5.0
-        version: 20.5.0(moment-timezone@0.6.0)(react@19.2.0)
+        version: link:../../../calendar-time-utils
       '@commercetools-uikit/calendar-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../../calendar-utils
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../hooks
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/secondary-icon-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../buttons/secondary-icon-button
       '@commercetools-uikit/select-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../select-utils
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-inline
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../text
       '@commercetools-uikit/tooltip':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../tooltip
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -2695,16 +2695,16 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/flat-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../buttons/flat-button
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -2729,43 +2729,43 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/flat-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../buttons/flat-button
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../hooks
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/input-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../input-utils
       '@commercetools-uikit/localized-utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../localized-utils
       '@commercetools-uikit/messages':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../messages
       '@commercetools-uikit/money-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../money-input
       '@commercetools-uikit/select-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../select-utils
       '@commercetools-uikit/spacings-stack':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-stack
       '@commercetools-uikit/tooltip':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../tooltip
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -2796,37 +2796,37 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/flat-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../buttons/flat-button
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../hooks
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/input-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../input-utils
       '@commercetools-uikit/localized-utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../localized-utils
       '@commercetools-uikit/messages':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../messages
       '@commercetools-uikit/spacings-stack':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-stack
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -2860,49 +2860,49 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/collapsible-motion':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../collapsible-motion
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/flat-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../buttons/flat-button
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../hooks
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/input-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../input-utils
       '@commercetools-uikit/localized-utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../localized-utils
       '@commercetools-uikit/messages':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../messages
       '@commercetools-uikit/rich-text-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../rich-text-utils
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-inline
       '@commercetools-uikit/spacings-stack':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-stack
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../text
       '@commercetools-uikit/tooltip':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../tooltip
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -2954,40 +2954,40 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/flat-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../buttons/flat-button
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../hooks
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/input-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../input-utils
       '@commercetools-uikit/localized-utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../localized-utils
       '@commercetools-uikit/messages':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../messages
       '@commercetools-uikit/spacings-stack':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-stack
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../text
       '@commercetools-uikit/text-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../text-input
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3012,28 +3012,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../hooks
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/input-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../input-utils
       '@commercetools-uikit/select-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../select-utils
       '@commercetools-uikit/tooltip':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../tooltip
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3067,37 +3067,37 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/flat-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../buttons/flat-button
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../hooks
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/input-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../input-utils
       '@commercetools-uikit/secondary-icon-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../buttons/secondary-icon-button
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-inline
       '@commercetools-uikit/spacings-stack':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-stack
       '@commercetools-uikit/tooltip':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../tooltip
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3128,16 +3128,16 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/input-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../input-utils
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3159,16 +3159,16 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/input-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../input-utils
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3190,28 +3190,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/input-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../input-utils
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-inline
       '@commercetools-uikit/spacings-inset':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-inset
       '@commercetools-uikit/spacings-stack':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-stack
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3236,40 +3236,40 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/collapsible-motion':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../collapsible-motion
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/flat-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../buttons/flat-button
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../hooks
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/input-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../input-utils
       '@commercetools-uikit/rich-text-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../rich-text-utils
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-inline
       '@commercetools-uikit/spacings-stack':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-stack
       '@commercetools-uikit/tooltip':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../tooltip
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3318,22 +3318,22 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/input-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../input-utils
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-inline
       '@commercetools-uikit/tooltip':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../tooltip
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3400,22 +3400,22 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/async-select-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../async-select-input
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/select-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../select-utils
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3443,22 +3443,22 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/input-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../input-utils
       '@commercetools-uikit/secondary-icon-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../buttons/secondary-icon-button
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3480,19 +3480,19 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/select-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../select-utils
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/is-prop-valid':
         specifier: 1.4.0
         version: 1.4.0
@@ -3529,25 +3529,25 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../buttons/accessible-button
       '@commercetools-uikit/checkbox-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../checkbox-input
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../presets/spacings
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3581,31 +3581,31 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../hooks
       '@commercetools-uikit/icon-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../buttons/icon-button
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/input-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../input-utils
       '@commercetools-uikit/secondary-icon-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../buttons/secondary-icon-button
       '@commercetools-uikit/select-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../select-utils
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3639,16 +3639,16 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/input-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../input-utils
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3670,28 +3670,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../buttons/accessible-button
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../hooks
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../icons
       '@commercetools-uikit/input-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../input-utils
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../spacings/spacings-inline
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/is-prop-valid':
         specifier: 1.4.0
         version: 1.4.0
@@ -3719,16 +3719,16 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/input-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../input-utils
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3750,13 +3750,13 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3781,16 +3781,16 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../icons
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../spacings/spacings-inline
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3827,16 +3827,16 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../spacings/spacings-inline
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3858,10 +3858,10 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3886,16 +3886,16 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../buttons/accessible-button
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../icons
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3917,34 +3917,34 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../icons
       '@commercetools-uikit/label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../label
       '@commercetools-uikit/number-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../inputs/number-input
       '@commercetools-uikit/secondary-icon-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../buttons/secondary-icon-button
       '@commercetools-uikit/select-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../inputs/select-input
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../presets/spacings
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -3975,25 +3975,25 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../buttons/accessible-button
       '@commercetools-uikit/buttons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../../presets/buttons
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../hooks
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../icons
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -4021,22 +4021,22 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../spacings/spacings-inline
       '@commercetools-uikit/spacings-stack':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../spacings/spacings-stack
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -4061,10 +4061,10 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/tag':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../tag
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -4089,10 +4089,10 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -4111,10 +4111,10 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -4133,10 +4133,10 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -4155,10 +4155,10 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../../design-system
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -4177,16 +4177,16 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../spacings/spacings-inline
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -4205,25 +4205,25 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../buttons/accessible-button
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../icons
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../presets/spacings
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../text
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -4251,10 +4251,10 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -4282,16 +4282,16 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../constraints
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../hooks
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -4322,13 +4322,13 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../buttons/accessible-button
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../../design-system
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../utils
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -4353,7 +4353,7 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../utils
       '@types/raf-schd':
         specifier: ^4.0.1
         version: 4.0.3
@@ -4396,7 +4396,7 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../utils
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -4427,28 +4427,28 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../packages/components/buttons/accessible-button
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../design-system
       '@commercetools-uikit/flat-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/buttons/flat-button
       '@commercetools-uikit/icon-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/buttons/icon-button
       '@commercetools-uikit/link-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)
+        version: link:../../packages/components/buttons/link-button
       '@commercetools-uikit/primary-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/buttons/primary-button
       '@commercetools-uikit/secondary-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)
+        version: link:../../packages/components/buttons/secondary-button
       '@commercetools-uikit/secondary-icon-button':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/buttons/secondary-icon-button
     devDependencies:
       react:
         specifier: 19.2.0
@@ -4470,55 +4470,55 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/async-creatable-select-field':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/fields/async-creatable-select-field
       '@commercetools-uikit/async-select-field':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/fields/async-select-field
       '@commercetools-uikit/creatable-select-field':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/fields/creatable-select-field
       '@commercetools-uikit/date-field':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/fields/date-field
       '@commercetools-uikit/date-range-field':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/fields/date-range-field
       '@commercetools-uikit/date-time-field':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/fields/date-time-field
       '@commercetools-uikit/localized-multiline-text-field':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/fields/localized-multiline-text-field
       '@commercetools-uikit/localized-text-field':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/fields/localized-text-field
       '@commercetools-uikit/money-field':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/fields/money-field
       '@commercetools-uikit/multiline-text-field':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/fields/multiline-text-field
       '@commercetools-uikit/number-field':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/fields/number-field
       '@commercetools-uikit/password-field':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/fields/password-field
       '@commercetools-uikit/radio-field':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/fields/radio-field
       '@commercetools-uikit/search-select-field':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/fields/search-select-field
       '@commercetools-uikit/select-field':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/fields/select-field
       '@commercetools-uikit/text-field':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/fields/text-field
       '@commercetools-uikit/time-field':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/fields/time-field
     devDependencies:
       react:
         specifier: 19.2.0
@@ -4540,76 +4540,76 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/async-creatable-select-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/async-creatable-select-input
       '@commercetools-uikit/async-select-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/async-select-input
       '@commercetools-uikit/checkbox-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/checkbox-input
       '@commercetools-uikit/creatable-select-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../packages/components/inputs/creatable-select-input
       '@commercetools-uikit/date-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/date-input
       '@commercetools-uikit/date-range-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/date-range-input
       '@commercetools-uikit/date-time-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/date-time-input
       '@commercetools-uikit/localized-money-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/localized-money-input
       '@commercetools-uikit/localized-multiline-text-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/localized-multiline-text-input
       '@commercetools-uikit/localized-rich-text-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/localized-rich-text-input
       '@commercetools-uikit/localized-text-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/localized-text-input
       '@commercetools-uikit/money-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/money-input
       '@commercetools-uikit/multiline-text-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/multiline-text-input
       '@commercetools-uikit/number-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/number-input
       '@commercetools-uikit/password-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/password-input
       '@commercetools-uikit/radio-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/radio-input
       '@commercetools-uikit/rich-text-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/rich-text-input
       '@commercetools-uikit/search-select-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/search-select-input
       '@commercetools-uikit/search-text-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/search-text-input
       '@commercetools-uikit/select-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../packages/components/inputs/select-input
       '@commercetools-uikit/selectable-search-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/selectable-search-input
       '@commercetools-uikit/text-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/text-input
       '@commercetools-uikit/time-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/time-input
       '@commercetools-uikit/toggle-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/toggle-input
     devDependencies:
       react:
         specifier: 19.2.0
@@ -4631,16 +4631,16 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/spacings-inline':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../packages/components/spacings/spacings-inline
       '@commercetools-uikit/spacings-inset':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../packages/components/spacings/spacings-inset
       '@commercetools-uikit/spacings-inset-squish':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../packages/components/spacings/spacings-inset-squish
       '@commercetools-uikit/spacings-stack':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../packages/components/spacings/spacings-stack
     devDependencies:
       react:
         specifier: 19.2.0
@@ -4656,121 +4656,121 @@ importers:
         version: 7.29.2
       '@commercetools-uikit/accessible-hidden':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react@19.2.0)
+        version: link:../../packages/components/accessible-hidden
       '@commercetools-uikit/avatar':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../packages/components/avatar
       '@commercetools-uikit/buttons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../buttons
       '@commercetools-uikit/card':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)
+        version: link:../../packages/components/card
       '@commercetools-uikit/collapsible':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../packages/components/collapsible
       '@commercetools-uikit/collapsible-motion':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../packages/components/collapsible-motion
       '@commercetools-uikit/collapsible-panel':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/collapsible-panel
       '@commercetools-uikit/constraints':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../packages/components/constraints
       '@commercetools-uikit/data-table':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/data-table
       '@commercetools-uikit/data-table-manager':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/data-table-manager
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../design-system
       '@commercetools-uikit/dropdown-menu':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/dropdowns/dropdown-menu
       '@commercetools-uikit/field-errors':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/field-errors
       '@commercetools-uikit/field-label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/field-label
       '@commercetools-uikit/fields':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../fields
       '@commercetools-uikit/filters':
         specifier: 20.5.0
-        version: 20.5.0(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/filters
       '@commercetools-uikit/grid':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react@19.2.0)
+        version: link:../../packages/components/grid
       '@commercetools-uikit/hooks':
         specifier: 20.5.0
-        version: 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../packages/hooks
       '@commercetools-uikit/i18n':
         specifier: 20.5.0
-        version: 20.5.0
+        version: link:../../packages/i18n
       '@commercetools-uikit/icons':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../packages/components/icons
       '@commercetools-uikit/inputs':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../inputs
       '@commercetools-uikit/label':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../packages/components/label
       '@commercetools-uikit/link':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)
+        version: link:../../packages/components/link
       '@commercetools-uikit/loading-spinner':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/loading-spinner
       '@commercetools-uikit/messages':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/messages
       '@commercetools-uikit/notifications':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../packages/components/notifications
       '@commercetools-uikit/pagination':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/pagination
       '@commercetools-uikit/primary-action-dropdown':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/primary-action-dropdown
       '@commercetools-uikit/progress-bar':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/progress-bar
       '@commercetools-uikit/quick-filters':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/quick-filters
       '@commercetools-uikit/select-utils':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/select-utils
       '@commercetools-uikit/selectable-search-input':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/inputs/selectable-search-input
       '@commercetools-uikit/spacings':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../spacings
       '@commercetools-uikit/stamp':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../packages/components/stamp
       '@commercetools-uikit/tag':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+        version: link:../../packages/components/tag
       '@commercetools-uikit/text':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
+        version: link:../../packages/components/text
       '@commercetools-uikit/tooltip':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../packages/components/tooltip
       '@commercetools-uikit/utils':
         specifier: 20.5.0
-        version: 20.5.0(react@19.2.0)
+        version: link:../../packages/utils
       '@commercetools-uikit/view-switcher':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../../packages/components/view-switcher
     devDependencies:
       moment:
         specifier: 2.30.1
@@ -4867,7 +4867,7 @@ importers:
     dependencies:
       '@commercetools-uikit/design-system':
         specifier: 20.5.0
-        version: 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: link:../design-system
       '@emotion/react':
         specifier: ^11.10.5
         version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
@@ -6134,834 +6134,6 @@ packages:
     engines: { node: 18.x || 20.x || >=22.0.0 }
     peerDependencies:
       eslint: ^9.0.0
-
-  '@commercetools-uikit/accessible-button@20.5.0':
-    resolution:
-      {
-        integrity: sha512-lJm/0GPDiiXwwbZB1xS+IGzOhyOj6NIs3THf7EHGbPCwbwwuPisXQuwPg+0I1wyV70Hk8yVe8UDmo/q/mmoxvA==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/accessible-hidden@20.5.0':
-    resolution:
-      {
-        integrity: sha512-Xz9hywpEZQxVQFd38iA6x/GsEJ0cn8M6bNAOe9T+uExKm8VUllMfJaxeAU76nI94GmCPP7kMmc35IXFELTvbQA==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/async-creatable-select-field@20.5.0':
-    resolution:
-      {
-        integrity: sha512-iM7y3WRqEGOr4AKPl0054+R9jtaBPXSz7tNSzphPHKmwRWoCdTy63scQctZ8/apYvw+YSZJXQEwSv+1gH1/EVg==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/async-creatable-select-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-IKlo++poVzC2+woRGOkLQropXe5yaSvaWIMIbKoVSDTth+djvdFXpTOubLCGR9a5T0T+GJXYWzeC+GfyCJ+HJQ==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/async-select-field@20.5.0':
-    resolution:
-      {
-        integrity: sha512-/4XesVMJH0gcrHltnQG3h1NT8442aBfsVRqeqCx6e+c6WcSV6rsfCywLJ+Bb/YA8uO3JP0T4oYE5NJeEJXV/vg==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/async-select-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-Cf3bdKeE3nzFEjveVors63Ld+Hhf7A0HV82tmXO+TNJc5SXd0z9MJNZcfa650qderWq0/B5uf3DYVoZ/XbN7yQ==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/avatar@20.5.0':
-    resolution:
-      {
-        integrity: sha512-ht1wD5uu/jPTZ83Vyjj0i9KAIlVo87pdwEyHpex/tnsxOR/19OTNiUbjvPPIjgNUG4snWXL7Zjbhr4AiQmVBkg==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/buttons@20.5.0':
-    resolution:
-      {
-        integrity: sha512-JiXqut49WbQxwPKNzJ57/FyHV3Xf0jHaSXANEFBDarvGsHeshf2QUj8kcxZR+C95tz1lRPgOImGyv0OATsd5WA==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-      react-router-dom: 5.x
-
-  '@commercetools-uikit/calendar-time-utils@20.5.0':
-    resolution:
-      {
-        integrity: sha512-yxHMOD4qlpuCl9ZAK2r8kTe9Osa/K+y0l6mbhQ8HkX/ml1GWuR+9uPtMXNq7V7YSWcGAQ98EUrw4X3OA9JkwUQ==,
-      }
-    peerDependencies:
-      moment-timezone: 0.6.x
-
-  '@commercetools-uikit/calendar-utils@20.5.0':
-    resolution:
-      {
-        integrity: sha512-3sB8iM5dqV6RBaW3d2vLzDzlLudg3wEXjA/QF99y1t44Sf8zb3Pv6LwXD+r6AhLMllU/vCSRrhsa0MmcPynetQ==,
-      }
-    peerDependencies:
-      moment: 2.x
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/card@20.5.0':
-    resolution:
-      {
-        integrity: sha512-siRrNVhgsu//5K4obv3tQEwdTY7xUhUUn9SepEYMCMVl22zCCxT6L620G/5fDLFnNFoD6IvGbaMUlprl5Omhpg==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-router-dom: 5.x
-
-  '@commercetools-uikit/checkbox-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-bL1jJkvHkZ1Pdpuco9Y0tM/2uXf1YfIrz64BxdJUhDbd6ZLsxft2qfydx2yhEu6lur4fOM5DYhjONH+T+ta7hg==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/collapsible-motion@20.5.0':
-    resolution:
-      {
-        integrity: sha512-rF6joeh3v91sagnw/uri2GoKr4rO3N4PAq8DBylJELqRADbQGPp34OIPPPzKxzzeEznITArMzDKzcNO12QoX9Q==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/collapsible-panel@20.5.0':
-    resolution:
-      {
-        integrity: sha512-HxqrU2C5o8CfjL2Uak6CPdyjHDzgqymLE5iwXI1WMfR1zbgNjiYnyH8Ponope/QP7yTBK/Wp6VFuTHlqNeTkfQ==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/collapsible@20.5.0':
-    resolution:
-      {
-        integrity: sha512-kWhsDodHnFp1djGJCF0G8KQs+i3mhGEhWlzUQWnYE2sX4SBOVZe8sdNwAIMO/2wxqTRxCkHNg9bszXXbR0dINA==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/constraints@20.5.0':
-    resolution:
-      {
-        integrity: sha512-chcptvDNukal3ym3n2ONjBttsd9Eu988CIuClaaeqqYRpjJeadgU38oDysokbCXuI0koe2oLlSxYnUbPbm1nZA==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/creatable-select-field@20.5.0':
-    resolution:
-      {
-        integrity: sha512-8f+/0GMCFN/AsLRxeKgnTIUlDp6u+JIQKGCJej6P5gxbwR9PwVRuEP/+Ywo96e5JsQBzcfnmuuISr9FceOxMVg==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/creatable-select-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-itlLKdBetIvYq8WNK2kFzkBSNk65O0XQiuv7Cj+Cq5u5bVMmhhBU6n4LOHc/X8JL3llsu8vNsu+JTcRAx0B/bQ==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/data-table-manager@20.5.0':
-    resolution:
-      {
-        integrity: sha512-wpVPc8lXeEK+Mb4yCITzWNcf9rSHOE5Gvt337ABUtnzsPA6QdwXX8vrpLw3odLRiaiNOQy75BDhNin8yKc9Hqg==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/data-table@20.5.0':
-    resolution:
-      {
-        integrity: sha512-EE4EDj0al4y9Yp8C4j2SV6zQvLRpL2+SjpYp7W0FzKmd6+RAQ5s4iQ+UoREU0LU6jQUoLx2ZC6MCu3RVuIPEyw==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/date-field@20.5.0':
-    resolution:
-      {
-        integrity: sha512-H1z4J4Mxy7gNMTFDwSURUKvQgA86Sc8laLXsOPQnM3QWjBi3b9r3gzm8K5Ij0aKaHm4BdnlXqQjgh/LL9aIyJw==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/date-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-MCQgM0b5qEHNIdWNuFfXSsGvodiKMYkJDILvvMK8ncbY13QJlxKsa2arx485KuKCSJK0NFa1I15SdPJUVC4m8g==,
-      }
-    peerDependencies:
-      moment: 2.x
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/date-range-field@20.5.0':
-    resolution:
-      {
-        integrity: sha512-tqkTf2SVkELkD9Wf2FJYySIYmMEWyovjg4txI0fGxHsV43Mymq46ToM06pfovNgDm/tRBpka+a07+6YOZqLaXA==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/date-range-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-16QIrsQaZewfe1SOZEoTJjVhHw9KzRPaaA+Ce8HiObJIGVAs1nsoyTSKXIoy31JFHP5NvyT7CYS9v5k6dgvOLQ==,
-      }
-    peerDependencies:
-      moment: 2.x
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/date-time-field@20.5.0':
-    resolution:
-      {
-        integrity: sha512-pKyb6KjkvPyWDZkhgTu8YjG4mBRDoQHoanS0I4F4HxPS2xx/OP5+p4ahc9JWsUcTfuWnI6DdDRJBA4366MdWDw==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/date-time-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-55yfajN4tEx9lqCm4nl7TYj4KI1SmdfTxbogSfwGBgQpme6s1gfq3QPUz7UyToqr/qu2yXSMO3E315wHUCNmYQ==,
-      }
-    peerDependencies:
-      moment: 2.x
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/design-system@20.5.0':
-    resolution:
-      {
-        integrity: sha512-1jb12q55iHSywf+ZSN3UNvyHlRrX+8V4DyHEbn0Xwnug7I/BxmySE+ZJu/JUGzWU+kznwTyp9lTr9fAOgYmuJA==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/dropdown-menu@20.5.0':
-    resolution:
-      {
-        integrity: sha512-eBCoSX6UrIF3AkFM7gCFW/+ZDL6mifnSK/nSm/7ik6hjcs9yc/x700picyQUIBSG43b0VTENjJzphW+RIJ0ruA==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/field-errors@20.5.0':
-    resolution:
-      {
-        integrity: sha512-9RU2UOITalQArotzdFUK5Em5IjVRXZoN8PDMdQV6B9B5FvokS9tM9/2RDJpz3+ympJ5T9/ksfYmwlJRWg3SDVA==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/field-label@20.5.0':
-    resolution:
-      {
-        integrity: sha512-24wLA477/q5Ea3aHz+HHxXzjXP0w3S55h3SsaZmqFdBK8b7iz5C2b1VHgh3xjr8uRm5WYu7xGtV6Z1R31Fhwog==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/field-warnings@20.5.0':
-    resolution:
-      {
-        integrity: sha512-IWl3j0/VYoSPb/hTCvxDO6aaSPvMqZMhHD1Qlk9mdZCe6BvUumeGdTUrKygqaMKdjd141FkQod9IC6LuEJNbMg==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/fields@20.5.0':
-    resolution:
-      {
-        integrity: sha512-ar5H0xfWPFJ9d8/BJFWKX+4bZlw9SvrQEpCNze/wdx9WgeIFcVb9XAJQ4JTXaqczayfIfJio+a8GtjKapWvX3w==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-      react-router-dom: 5.x
-
-  '@commercetools-uikit/filters@20.5.0':
-    resolution:
-      {
-        integrity: sha512-etqJYlwzxE6dAVn3fPh7ZCtMGjHCsxoG8VqUvlunIyXng831OMlf5O/BtG9hbvIdLUfYJtf2KSqmPmSbhWf2ow==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-
-  '@commercetools-uikit/flat-button@20.5.0':
-    resolution:
-      {
-        integrity: sha512-shoiBnys7Zk/XDYWLSS+wCaD7JKVPTnf+iaADSJSZWELfSU0J8v+rZf7DfYVbu66Aio7boKfKPy8gZscpV4ZsA==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/grid@20.5.0':
-    resolution:
-      {
-        integrity: sha512-lU8oXqZN78lKDIsgqmOvQiiQ1ynWfb3MAzaigng29aVYrntI96oTQUL1eixCkDWm+pz6yUrwfOGHjWBkmzu3Tw==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/hooks@20.5.0':
-    resolution:
-      {
-        integrity: sha512-2rmTJ5dBAa21PcVjMcDozhGX4lGhF8U9Hy3k4EiPwlCaVNNFU54e4Cesgey5HYofWGAjpwi1PGpxdjt5JLIUEQ==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-
-  '@commercetools-uikit/i18n@20.5.0':
-    resolution:
-      {
-        integrity: sha512-Ie/Bq5po0Ayllr5hrcNB6Z0Te5E300eBEtVqJhtcPlZ85ogRYeXK89sBNWpJVccKswNZsj+q5h0hmknsnAQgbg==,
-      }
-
-  '@commercetools-uikit/icon-button@20.5.0':
-    resolution:
-      {
-        integrity: sha512-Hy0+Uqr9IFpFBj/Yc6Z1IsTI8PF7EI+QOz46GBHQD45VHkpBtb/KRUcqIlwURB3iiTWBa7yXcZL9CwWzVerSug==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/icons@20.5.0':
-    resolution:
-      {
-        integrity: sha512-0fm1T1KOPDoTUc8suG+fbW5OhB2jDJ3Tg+yMu8/8aMhLoDd1ANSbbDbflQOj0riG0v5f7wWs/nC2pejx3o+GlQ==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/input-utils@20.5.0':
-    resolution:
-      {
-        integrity: sha512-E+FxUoEJ8Cq62QkXH4mLgJ3DsqIXohfzWXQJrNjx/wX6Z/PdnzCwjvRAhv+gn5oDMLcFzih7MJVEcavdtvEqRA==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/inputs@20.5.0':
-    resolution:
-      {
-        integrity: sha512-Hi4HM40l9ZxequL/Tx6zjYebphF7cdYkHSjwL/ffN8vN+wtQ3yIm757159znL4d1e2UiTBpfyUoQPK+nRdl+MQ==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-      react-router-dom: 5.x
-
-  '@commercetools-uikit/label@20.5.0':
-    resolution:
-      {
-        integrity: sha512-zyjbpQHoVHHQpbi/ahW/Z1XkLywokcGhQDqzigqY6e6I7oswGzLyaLH3WS59MLYw9T94hoCGxe6IoB/4QQ0Ehg==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/link-button@20.5.0':
-    resolution:
-      {
-        integrity: sha512-izN5W9+RNTDfBbKViu2g6s85p2H9uO101TQ4dsa4rXHOXLsEQovdWnKhpg0RXxsvksM50BuJXvgngF20KduwXQ==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-      react-router-dom: 5.x
-
-  '@commercetools-uikit/link@20.5.0':
-    resolution:
-      {
-        integrity: sha512-iI6uPw5J9Ln9wx4TpwCAMeW4w7VvURWboE1+4eX2bAroO2+Z5GcPR0EZTRKGJ48nSpcMud8VPeKWVxDnWIC+Nw==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-      react-router-dom: 5.x
-
-  '@commercetools-uikit/loading-spinner@20.5.0':
-    resolution:
-      {
-        integrity: sha512-qPWpa7Mb90bx8JTJGet3uYCetSDMiujlPO6DwSJJJSwBQ700uIvrKsK7dMh9C57NTm05gXMzb7ulE+QH/8OxOQ==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/localized-money-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-w7u9QDOv+BlatQoBTVkueudx/bX2NR/UDTc2V4CwuXOGI3IjQhMbwdH2AA452WzDknhTG+YibQnKodsq/QYtPA==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/localized-multiline-text-field@20.5.0':
-    resolution:
-      {
-        integrity: sha512-3grcmSJdY/PfsmVPsDzu92IeZdRnhvXrXt0p24owcgw+3K2EKUTX3pneSttpf3zALhqfchJpu6ET3NX05uXg0w==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/localized-multiline-text-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-tDocPxmEAW+aND26gL/FttuzBlZ6GmkGi3R7dplKujSHrQIQi/X7ppcfMd3mn+xnzt4Zzsp9lTIxNy3KL+LkPA==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/localized-rich-text-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-soetA9LxLrs48rRG6FjQDBqpSkCdzKEsMMEiR6UBDm+HX7jc3C1FlKXg8oML898tqnW+hrIIICTgBIJZGpfQvA==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/localized-text-field@20.5.0':
-    resolution:
-      {
-        integrity: sha512-l/BhEi2axnNmdwAPNxNVEdhpt2cXigQjr8kKaqmeKIu15CFNtIS0ThgHMyBsoW1vSVW4s2EycQCwqjI6J3TLsA==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/localized-text-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-chc22Sui5S85jc3xQLBlZzRatkh1lAdirKuu+7vERPg0z73makSOtxGcT3x0C14mD+PxrsvbEmgfVJ/n960IHA==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/localized-utils@20.5.0':
-    resolution:
-      {
-        integrity: sha512-Y4zdm8szORTpybzblAiFADMRdfAzBHwR6IipFX9H8kYqcKhrVc++kHvweK7CsHqF+6J7kE7HiAOoLc7bnhibCw==,
-      }
-
-  '@commercetools-uikit/messages@20.5.0':
-    resolution:
-      {
-        integrity: sha512-HpSun1ElEkCpHOcUZ2Fl6WMKIi7UCLuu+ywdahU99cxfJD7XrUYihHRawRTu3cWYOLPcGB58qCR44kale5842w==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/money-field@20.5.0':
-    resolution:
-      {
-        integrity: sha512-qbHDySH6hGcU5X/efbyDVyEQ7a7JDEU+itKz4VAhlNcMrhpLdSrzdo1ZSt3dDmbToabwosjwNtBvIbz0694fCA==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/money-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-0+q3oCJ8IbRy/2nKG1Sq+xjBbTVzIbNkVd7YL3CniOPnVBmZZIlPWXViSmjG5qCDogOvmUXCCTe61Rt7mKEnyw==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/multiline-text-field@20.5.0':
-    resolution:
-      {
-        integrity: sha512-EVARcTvJFfDWjDhat3II2LAF5wogN7/HB4VEDnXlpbFaQ3dvCGLwCazdkZEPY5R8qLHqEckSkXGBSlA3OQQnzQ==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/multiline-text-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-OMI51U5SUTZZ3R4Co5cGb3JdbpIGhmOAhk5LkbdRG1+W5JW2CjtVWV60DBIMksfp2PtHvjt19IzB8kBZ17Uyvw==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/notifications@20.5.0':
-    resolution:
-      {
-        integrity: sha512-eDL3oiY+9rcRvRMpPcibcGkBzNvPk+tX76WyS0qrecBhly0xm48TaQ/Kb0Zd2as9sCRY1qAu7wt0oZ5eEq6EoQ==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/number-field@20.5.0':
-    resolution:
-      {
-        integrity: sha512-GTd/3pX4Hp/TG3bSbmPcPQKwsZ1ai4GUF3IP7Yj57l436AMGYeD1DwsY8a+NJxXhWAkrLGX6yR68XsomR+br3w==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/number-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-Kyzi82OQ5YADts7JRM3SayzZfJ7oJugRuC2WVYFJ3c80FYw+ZwhplsvY2tOHr+wqOiARduym6BAt+lp9nyv2qA==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/pagination@20.5.0':
-    resolution:
-      {
-        integrity: sha512-4kvxJHPWXTHuGpWUrwy1hVtobRO+vbAyiIx50nj19lZ2ftcvI+usKKIGBojE9IlG7tP/dT+LmK9elAjvr8/fqA==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/password-field@20.5.0':
-    resolution:
-      {
-        integrity: sha512-lpMLuPBI70S9yesM72uGynLW7go6pYK5VOam/G86xrpYh/a8NbzdmrxW0by7xjkhj6XGBDE6H1xACThtpL/oNA==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/password-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-voAIF1KnxgSSsSqTn3HvUiNoH2h0NnSXnr+Pxv/A99XO26YhBzBz9tMlSYXfLVGg4e+imwF7wdCT50NjaRgfTQ==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/primary-action-dropdown@20.5.0':
-    resolution:
-      {
-        integrity: sha512-VMbBZaSsNJai2/IMDgaodrhsF2qhc6sEf666XlF+n4OxvOAN+qKxNHOXkuLLtVqLFJybv9MiXMzJLBUPpFJs9w==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/primary-button@20.5.0':
-    resolution:
-      {
-        integrity: sha512-b1YOrSRjXfSDusvLx4UHGMybA6yTtamIp/2c9KZbCPgxuINCLcq2KOKLB4XnyqWAuXkctCQcv2cvK+NDjVbk+Q==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/progress-bar@20.5.0':
-    resolution:
-      {
-        integrity: sha512-/OuOrNjZkpHVYRIp/n803sdidr92OaiFVUYgcdpiR8xH4Fau1mHdcU9/0ILVshukeMHoz5VCTJnjCdNOg55NTw==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/quick-filters@20.5.0':
-    resolution:
-      {
-        integrity: sha512-yxs01dWNrnPfOLeqVlyCVRm7z5s9hLzfjfJedTU8TtRxyxWQ1sQkRVaypCSxA3axwwFMBZ6RSm+a8bqF10/z9g==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/radio-field@20.5.0':
-    resolution:
-      {
-        integrity: sha512-wgUEpnYh5SdjXf+bxk9yARLJWmqr7DY07KGu/EwhLigu7KwFLGbl+eVGwPsPgb0tXFIcmJg4G2z83WLbBTUhJQ==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/radio-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-5uWUZHJWcYY4aQyf0konP1K9Mb9VaSt7R6QcET8sPmn3FA4lxkxiqEsr/WVhnJgbIUXTnU6UWVBgGsvX8e3L8A==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/rich-text-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-x3Ij0C0NyW2GCjL62/ebrf4pm2J7y1C3SJOvyZTmYxO58WCx6eLaiA2NXIkruUfkheoUHWNnFIrDE/CHW3obvQ==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/rich-text-utils@20.5.0':
-    resolution:
-      {
-        integrity: sha512-0dt+vRaQyKiefQoaGz4r0PYCirZ2NgEchy2qnsG82Fvzp4gdaeL16xFIREgY5fc03EXfXA4llhuj2IKl3UOEow==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/search-select-field@20.5.0':
-    resolution:
-      {
-        integrity: sha512-180jLQoF2XU8R9Ay5fJup/RcBgOh8XtdkJ0t/hahdHX0e4ZOWqTu+euvfH4HaU4ZPiyfZz23+C+x00cKSFIvsA==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/search-select-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-3f3xdjjQ4O1/5UIxmuTmC93SQu7tLRGiFwQdzeJ5z1po27iNjSgVOR5gShP1c/pvh5E0B9t/iEOzfjQnGf8uTw==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/search-text-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-5LJWOY+jkANawnCTI3py6upZJGsxWRzx3KQfH57BEapxLnD3XGRM3eYDQ1l6RayR48t87DX2L3TaKKMkTxLZmA==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/secondary-button@20.5.0':
-    resolution:
-      {
-        integrity: sha512-g57oUB9lPy6SkwjtjZu2HHM2NAWkZiyITmOitoyu2Y0VIqODv5NbtZVwMBJ4qriRw/7ckoxL8zVborvW4pJLtw==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-      react-router-dom: 5.x
-
-  '@commercetools-uikit/secondary-icon-button@20.5.0':
-    resolution:
-      {
-        integrity: sha512-H8atmtDSGo0UJkjV/aB5Q+zSOypTHVzbSEFYPRq70hEaMmAYMaXniaXZJCs7gjDBlNqspbQ5ZVejWHvyRqJPFw==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/select-field@20.5.0':
-    resolution:
-      {
-        integrity: sha512-zg5vreZNZIOWzELK4G0Aymn7WR8nB3q70Ms9+u9jttL+CDodEx9IhSaimGOVkpuFDW/qsZE23ctQgukI6qJCSA==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/select-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-INhT7Q55nL5QtBtQs+AJx9AOeSXOQf7r6szWqdDjVOqydcDdmGUd4xVflYy7W79iFrka+kjTblvBBLLVQ2+lKQ==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/select-utils@20.5.0':
-    resolution:
-      {
-        integrity: sha512-igPQ9/oUn+h7BtdvJfaHRv0fCY+aZ7X9pXI/vBcd1bRe6BrWMkQxLvRNw4zjzHcdZqNN3jeJ5Z7Nx2jVu8KVhA==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/selectable-search-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-4CdOfLWC+xuBx8P7pi03g/rPdXW+LseG335U62K/naDxMuz7bffkgLjon2yL4AovuVZDNSbOGHxE/bSF+rBlZw==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-dom: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/spacings-inline@20.5.0':
-    resolution:
-      {
-        integrity: sha512-JQQ2++vnSh/CGpK2npzHWeaBbwEySL+nDJF0FirllU9BevgQd2c94IJSEUAB5yU+6beco00PjppKt5UcCsfiIg==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/spacings-inset-squish@20.5.0':
-    resolution:
-      {
-        integrity: sha512-e5IZGiN+AyCjd3qzhlnzkHBCbcu8tzPmSvfXrQ0M28qutv+cvMnVSk3Tc5IdoRxmWiBWKdnQMNwEmg0G8EESbQ==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/spacings-inset@20.5.0':
-    resolution:
-      {
-        integrity: sha512-kDhuDcN23wsyzA3wfF0OW20rCuB97t5RGxZq6IKA6L568cNRebuONDZubfUJpABuslODuLyKd6xqrXHXXIlhUg==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/spacings-stack@20.5.0':
-    resolution:
-      {
-        integrity: sha512-nwirf5o17iqambBc+LhcHcyHXHd/RC9/dCKF6Sj0zbobmZ68r4Y8NEZQHeGpHJ1DVSNK2yWKVAOh1D6RxozKHA==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/spacings@20.5.0':
-    resolution:
-      {
-        integrity: sha512-2N3dGhbxT6qHD+zC6HMUW4u3wl2rwGa8beIGLbP9DAJ+h9zfzfpUzJ19hknrLnyWRp2gkvZX+TXLa/T1vMevxA==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/stamp@20.5.0':
-    resolution:
-      {
-        integrity: sha512-YRfrVo6YzFJiC/w4j6sVJot9F9XFbvZIOSvELgZc72qRMJ6BDzoBEYEwzGeaLIG9ckrb53BvYjoyiTdlcG6g+w==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/tag@20.5.0':
-    resolution:
-      {
-        integrity: sha512-RyB/tlLkCdiwiAWIt5GWZqKjgmY7ewhi/jy4sBu/uH5w5n//feWG8hU9jMIk/nDvh5dXSIl2SpJ7t4TX/TwXmw==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-router-dom: 5.x
-
-  '@commercetools-uikit/text-field@20.5.0':
-    resolution:
-      {
-        integrity: sha512-/XWlKbzAGzfk7c5rCTGEHkORpcu4u5TMSsZB0p2YzaL3kWUwMuD73WytzIvUhDLpdYH3amXsYXMrr5PyT2ylfA==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/text-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-LiDmzkKdgUsTycjls/TplbX4JdlfAFNpQlP0luxhW2VvCjWtCeNu6eXGiu5/Eh73bsq0PmmiNhppBqFiczr71w==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/text@20.5.0':
-    resolution:
-      {
-        integrity: sha512-JjiCoN5zmN3+A0CDvB52yL73T9/u/jmKs+K3WqOC3mtFsXTPhHZ8SBJrWNOVS70nejHLJmAg+dGbH5h/P6SHKg==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/time-field@20.5.0':
-    resolution:
-      {
-        integrity: sha512-c3JeNUM47q/q6A23Jx5/OKc0fQpq/cbOO3ynUc0eD0+obhE3iGa5e7WpxxqbpjQ7ADIw1/aMm4lmvZYIOIbPuQ==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/time-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-7FbipjuYBRW7ds/5evNmfDXm9qnx77HX+29Dae5nZIBJckhcecaHxXVENnA7FxDAidmaKt+zWAKQA/goPDrRIg==,
-      }
-    peerDependencies:
-      react: 19.x
-      react-intl: 7.x
-
-  '@commercetools-uikit/toggle-input@20.5.0':
-    resolution:
-      {
-        integrity: sha512-vW0l6nlJ0u35N/Vi/T0lITVVhlE6OZgI57AH64/ZPuGfR3m6/4E0aNmZGFFWNqE/kPaEW2nHeXKZI9GeB0VkRg==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/tooltip@20.5.0':
-    resolution:
-      {
-        integrity: sha512-GXzMyUS2G2IBxOZL3Ot61E7rDz8Z4uyD4r9J5qOXwpEgNw7h+CTp8rBGODgL2clpyaE+lpmFHY8vHe9X7Q6mtw==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/utils@20.5.0':
-    resolution:
-      {
-        integrity: sha512-fhy/cOPVWf6NPA21MX1XqiPcJWdeW1uLjqvwqB6oLNGyIfG2qAyVQ6opwgojbvMvY/Zw1wSd+svISHUdkuh9IA==,
-      }
-    peerDependencies:
-      react: 19.x
-
-  '@commercetools-uikit/view-switcher@20.5.0':
-    resolution:
-      {
-        integrity: sha512-s0qwTvO+gWzMJUQ6K4YcudfJUAh6/PVY6oU9Y11Sm/8YBe2Milw3zY/3x1Yv04UcBY1J45Nj763qJd13umUhPg==,
-      }
-    peerDependencies:
-      react: 19.x
 
   '@commitlint/cli@20.1.0':
     resolution:
@@ -12423,12 +11595,6 @@ packages:
         integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==,
       }
     engines: { node: '>= 4' }
-
-  dompurify@3.2.7:
-    resolution:
-      {
-        integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==,
-      }
 
   dompurify@3.3.2:
     resolution:
@@ -20722,2000 +19888,6 @@ snapshots:
       - supports-color
       - ts-jest
 
-  '@commercetools-uikit/accessible-button@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      '@types/react-is': 19.2.0
-      lodash: 4.18.1
-      react: 19.2.0
-      react-is: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/accessible-hidden@20.5.0(@types/react@19.2.14)(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-
-  '@commercetools-uikit/async-creatable-select-field@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/async-creatable-select-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/async-creatable-select-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/loading-spinner': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/async-select-field@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/async-select-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/async-select-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/loading-spinner': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/avatar@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/buttons@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icon-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/link-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/primary-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 5.3.4(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/calendar-time-utils@20.5.0(moment-timezone@0.6.0)(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      moment-timezone: 0.6.0
-    transitivePeerDependencies:
-      - react
-
-  '@commercetools-uikit/calendar-utils@20.5.0(@types/react@19.2.14)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      moment: 2.30.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/card@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inset': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      '@types/react-router-dom': 5.3.3
-      react: 19.2.0
-      react-router-dom: 5.3.4(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/checkbox-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/collapsible-motion@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/collapsible-panel@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/collapsible-motion': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/collapsible@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/constraints@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/creatable-select-field@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/creatable-select-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/creatable-select-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/select-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-
-  '@commercetools-uikit/data-table-manager@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/accessible-hidden': 20.5.0(@types/react@19.2.14)(react@19.2.0)
-      '@commercetools-uikit/async-select-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/card': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/collapsible-motion': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/dropdown-menu': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/grid': 20.5.0(@types/react@19.2.14)(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icon-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/primary-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/radio-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tag': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      '@hello-pangea/dnd': 18.0.1(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@types/debounce-promise': 3.1.9
-      debounce-promise: 3.1.2
-      lodash: 4.18.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-router-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/data-table@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/data-table-manager': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - react-router-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/date-field@20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/date-input': 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - moment
-      - moment-timezone
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/date-input@20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/calendar-time-utils': 20.5.0(moment-timezone@0.6.0)(react@19.2.0)
-      '@commercetools-uikit/calendar-utils': 20.5.0(@types/react@19.2.14)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      downshift: 9.0.10(react@19.2.0)
-      moment: 2.30.1
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-is: 19.2.0
-      warning: 4.0.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - moment-timezone
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/date-range-field@20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/date-range-input': 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - moment
-      - moment-timezone
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/date-range-input@20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/calendar-time-utils': 20.5.0(moment-timezone@0.6.0)(react@19.2.0)
-      '@commercetools-uikit/calendar-utils': 20.5.0(@types/react@19.2.14)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      downshift: 9.0.10(react@19.2.0)
-      moment: 2.30.1
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-is: 19.2.0
-      warning: 4.0.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - moment-timezone
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/date-time-field@20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/date-time-input': 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - moment
-      - moment-timezone
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/date-time-input@20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/calendar-time-utils': 20.5.0(moment-timezone@0.6.0)(react@19.2.0)
-      '@commercetools-uikit/calendar-utils': 20.5.0(@types/react@19.2.14)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      downshift: 9.0.10(react@19.2.0)
-      moment: 2.30.1
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-is: 19.2.0
-      warning: 4.0.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - moment-timezone
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/design-system@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/dropdown-menu@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - react-router-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/field-errors@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/messages': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/field-label@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icon-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/field-warnings@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/messages': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/fields@20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/async-creatable-select-field': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/async-select-field': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/creatable-select-field': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-field': 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-range-field': 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-time-field': 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-multiline-text-field': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-text-field': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/money-field': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/multiline-text-field': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/number-field': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/password-field': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/radio-field': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/search-select-field': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-field': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/text-field': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/time-field': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 5.3.4(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - moment
-      - moment-timezone
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/filters@20.5.0(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/collapsible-motion': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icon-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/secondary-icon-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/flat-button@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/grid@20.5.0(@types/react@19.2.14)(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-
-  '@commercetools-uikit/hooks@20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@types/raf-schd': 4.0.3
-      lodash: 4.18.1
-      raf-schd: 4.0.3
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-
-  '@commercetools-uikit/i18n@20.5.0':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-
-  '@commercetools-uikit/icon-button@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/icons@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      '@types/dompurify': 2.4.0
-      dompurify: 3.2.7
-      react: 19.2.0
-      react-from-dom: 0.6.2(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/input-utils@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-textarea-autosize: 8.4.0(@types/react@19.2.14)(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/inputs@20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/async-creatable-select-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/async-select-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/checkbox-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/creatable-select-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/date-input': 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-range-input': 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/date-time-input': 20.5.0(@types/react@19.2.14)(moment-timezone@0.6.0)(moment@2.30.1)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-money-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-multiline-text-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-rich-text-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-text-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/money-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/multiline-text-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/number-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/password-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/radio-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/rich-text-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/search-select-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/search-text-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/selectable-search-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/text-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/time-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/toggle-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 5.3.4(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - moment
-      - moment-timezone
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/label@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/link-button@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 5.3.4(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/link@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      '@types/history': 4.7.11
-      '@types/react-router-dom': 5.3.3
-      history: 4.10.1
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 5.3.4(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/loading-spinner@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/localized-money-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-utils': 20.5.0(react@19.2.0)
-      '@commercetools-uikit/messages': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/money-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/localized-multiline-text-field@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-multiline-text-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/localized-multiline-text-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-utils': 20.5.0(react@19.2.0)
-      '@commercetools-uikit/messages': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      react-textarea-autosize: 8.4.0(@types/react@19.2.14)(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/localized-rich-text-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/collapsible-motion': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-utils': 20.5.0(react@19.2.0)
-      '@commercetools-uikit/messages': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/rich-text-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      downshift: 9.0.10(react@19.2.0)
-      immutable: 4.3.8
-      is-hotkey: 0.2.0
-      lodash: 4.18.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-textarea-autosize: 8.4.0(@types/react@19.2.14)(react@19.2.0)
-      slate: 0.75.0
-      slate-history: 0.113.1(slate@0.75.0)
-      slate-react: 0.75.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate@0.75.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/localized-text-field@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-text-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/localized-text-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/localized-utils': 20.5.0(react@19.2.0)
-      '@commercetools-uikit/messages': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/text-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/localized-utils@20.5.0(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      lodash: 4.18.1
-    transitivePeerDependencies:
-      - react
-
-  '@commercetools-uikit/messages@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/money-field@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/money-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/money-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/tooltip': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/multiline-text-field@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/multiline-text-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/multiline-text-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      downshift: 9.0.10(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-textarea-autosize: 8.4.0(@types/react@19.2.14)(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/notifications@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/number-field@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/number-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/number-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - react-intl
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/pagination@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/number-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      formik: 2.4.9(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/password-field@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/flat-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/password-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/password-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - react-intl
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/primary-action-dropdown@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/buttons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - react-router-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/primary-button@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/progress-bar@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/quick-filters@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tag': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - react-router-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/radio-field@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/radio-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/radio-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inset': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-is: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - react-intl
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/rich-text-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/collapsible-motion': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/flat-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/rich-text-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      downshift: 9.0.10(react@19.2.0)
-      immutable: 4.3.8
-      is-hotkey: 0.2.0
-      lodash: 4.18.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      slate: 0.75.0
-      slate-history: 0.113.1(slate@0.75.0)
-      slate-react: 0.75.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate@0.75.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/rich-text-utils@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/tooltip': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      '@types/dompurify': 2.4.0
-      '@types/escape-html': 1.0.4
-      dompurify: 3.2.7
-      downshift: 9.0.10(react@19.2.0)
-      escape-html: 1.0.3
-      is-hotkey: 0.2.0
-      is-url: 1.2.4
-      lodash: 4.18.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      slate: 0.75.0
-      slate-history: 0.113.1(slate@0.75.0)
-      slate-hyperscript: 0.100.0(slate@0.75.0)
-      slate-react: 0.75.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate@0.75.0)
-      style-to-object: 0.4.4
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/search-select-field@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/search-select-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/search-select-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/async-select-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/select-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/search-text-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - react-intl
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/secondary-button@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 5.3.4(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/secondary-icon-button@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/select-field@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/select-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/select-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-
-  '@commercetools-uikit/select-utils@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/checkbox-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/selectable-search-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icon-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/secondary-icon-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/select-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-select: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/spacings-inline@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/spacings-inset-squish@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/spacings-inset@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/spacings-stack@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/spacings@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inset': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inset-squish': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-stack': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/stamp@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - react-intl
-      - supports-color
-
-  '@commercetools-uikit/tag@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-router-dom@5.3.4(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/spacings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      react-router-dom: 5.3.4(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/text-field@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/messages': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/text-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/text-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - react-intl
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/text@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-      warning: 4.0.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/time-field@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/field-errors': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-label': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/field-warnings': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-stack': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/time-input': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/time-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/icons': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/spacings-inline': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-intl: 7.1.14(react@19.2.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/toggle-input@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/input-utils': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-intl@7.1.14(react@19.2.0)(typescript@5.9.3))(react@19.2.0)(typescript@5.9.3)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - react-intl
-      - supports-color
-      - typescript
-
-  '@commercetools-uikit/tooltip@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/constraints': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/hooks': 20.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-      react-is: 19.2.0
-      use-popper: 1.1.6(react@19.2.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
-  '@commercetools-uikit/utils@20.5.0(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@emotion/is-prop-valid': 1.4.0
-      react: 19.2.0
-
-  '@commercetools-uikit/view-switcher@20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@babel/runtime-corejs3': 7.29.2
-      '@commercetools-uikit/accessible-button': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/design-system': 20.5.0(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@commercetools-uikit/utils': 20.5.0(react@19.2.0)
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
-      lodash: 4.18.1
-      react: 19.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - react-dom
-      - supports-color
-
   '@commitlint/cli@20.1.0(@types/node@22.19.15)(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
     dependencies:
       '@commitlint/format': 20.5.0
@@ -26362,10 +23534,6 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
-
-  dompurify@3.2.7:
-    optionalDependencies:
-      '@types/trusted-types': 2.0.7
 
   dompurify@3.3.2:
     optionalDependencies:

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -23,8 +23,16 @@ function getAbsolutePath(value: string) {
 const config: StorybookConfig = {
   stories: [
     '../src/docs/**/**.mdx',
-    '../../packages/components/**/*.stories.@(js|jsx|mjs|ts|tsx)',
-    '../../packages/components/**/*.mdx',
+    // Anchored to a literal `src/` segment so the glob cannot descend into
+    // pnpm's nested <pkg>/node_modules/@commercetools-uikit/* workspace
+    // symlinks and re-discover the same stories under a different path.
+    // Without this, storybook 8 follows the symlinks and either chokes on
+    // duplicate story ids or hangs traversing the cyclic graph. Structural
+    // fix lives in the Storybook 9 upgrade tracked separately (FEC-935).
+    '../../packages/components/*/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+    '../../packages/components/*/*/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+    '../../packages/components/*/src/**/*.mdx',
+    '../../packages/components/*/*/src/**/*.mdx',
   ],
   // head = the manager-header.html file contents
   managerHead: (head) => `

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "pnpm install --frozen-lockfile",
-  "buildCommand": "pnpm --filter @commercetools-local/storybook run build"
+  "buildCommand": "pnpm build && pnpm --filter @commercetools-local/storybook run build"
 }


### PR DESCRIPTION
## TL;DR

Hotfix for the broken Release workflow on `main` after #3239 was merged. Three commits:

1. **`.npmrc`** — adds `link-workspace-packages=true` + `prefer-workspace-packages=true` so pnpm resolves internal `@commercetools-uikit/*` deps from the local workspace (matching yarn 3's default), instead of trying to fetch unpublished versions from npm during the release flow. Lockfile regenerated as a side-effect (~2.8k net deletion as 600+ redundant per-internal-package tarball trees collapse into `link:../packages/*` entries).
2. **`vercel.json`** — runs `pnpm build` before `storybook build` so workspace `dist/` exists when storybook resolves imports. Matches what CI has always done; pre-hotfix this only worked on Vercel by accident because the registry-fetched tarballs shipped pre-built `dist/`.
3. **`storybook/.storybook/main.ts`** — anchors the stories glob to a literal `src/` segment so it can't descend into workspace symlinks and re-discover the same stories under multiple paths. Storybook 8's `**`-glob otherwise chokes on duplicate story ids / cyclic traversal.

No published-package change. No source code change to any shipped package. CI/tooling only.

## What broke

Release workflow on the merge commit of #3239 ([run 26017897664](https://github.com/commercetools/ui-kit/actions/runs/26017897664)) failed at the `Create Release Pull Request or Publish to npm` step:

```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @commercetools-uikit/hooks@20.6.0 while fetching it from https://registry.npmjs.org/
The latest release of @commercetools-uikit/hooks is "20.5.0".
```

## Root cause (release flow)

Workspace-linking behavior difference between yarn 3 and pnpm 10:

- Internal deps in this repo are concrete version specifiers (e.g. `"@commercetools-uikit/hooks": "20.5.0"`), not `workspace:^`.
- Yarn 3 always links workspaces by name+version match → local workspace satisfies the dep, no registry call.
- pnpm 10 defaults `link-workspace-packages` to `false` → treats `"20.5.0"` as a registry semver and fetches the tarball from npm.

This is invisible during normal CI/dev (the workspace and the published `20.5.0` tarball have equivalent runtime behavior), but it breaks the release flow:

1. `changesets/action`'s version step (`pnpm changeset:version-and-format`) bumps every workspace AND every cross-workspace dep specifier from `20.5.0` → `20.6.0`.
2. The action then runs `pnpm install` to refresh `pnpm-lock.yaml`.
3. pnpm tries to fetch `@commercetools-uikit/hooks@20.6.0` from npm. That version doesn't exist yet — it's exactly what this release was about to publish. Install fails. Chicken-and-egg.

## Why pre-merge validation didn't catch it

Pre-merge validation exercised the **canary** publish path only: `pnpm changeset version --snapshot canary` → `pnpm changeset publish --tag canary`, with no install in between. The real-release path goes through `changesets/action`, which always reinstalls after `version`. That path was never run end-to-end before merge.

## Knock-on issues that fell out of the fix

Enabling workspace linking flushes out two further regressions that were also masked by the prior registry-fetch behavior. Both are fixed in this PR.

### Vercel previews stalled at `@storybook/core v8.6.18`

`vercel.json` ran `pnpm install --frozen-lockfile` then `storybook build` directly, with no intermediate `pnpm build`. Pre-hotfix this worked because pnpm installed registry tarballs of every internal `@commercetools-uikit/*` package — those tarballs ship pre-built `dist/`, so storybook's bundler resolved imports into `node_modules/.pnpm/.../dist/...`. Post-hotfix the same imports resolve through workspace symlinks to `packages/<pkg>/dist/`, which doesn't exist on a fresh runner (build output, not committed). Storybook stalls on the missing files.

Fixed in commit 2 by adding `pnpm build &&` to the `vercel.json` build command. CI was unaffected because `.github/workflows/main.yml` already builds packages before any downstream step — Vercel just lacked parity.

### Storybook 8 stories glob followed workspace symlinks

After enabling workspace linking, every workspace's nested `node_modules/@commercetools-uikit/*` is a symlink back to another workspace package:

```
packages/components/buttons/primary-button/node_modules/@commercetools-uikit/
  accessible-button -> ../../../accessible-button
  design-system     -> ../../../../../../design-system
  spacings-inline   -> ../../../../spacings/spacings-inline
  text              -> ../../../../text
  utils             -> ../../../../../utils
```

Storybook 8's glob `'../../packages/components/**/*.stories.@(js|jsx|mjs|ts|tsx)'` uses `**` and follows symlinks, so the same story file is reachable through many paths (its canonical location plus every consumer's nested node_modules). Storybook either chokes on duplicate story ids or hangs traversing the cyclic graph — same symptom as above, manifested in the Vercel build after `pnpm build` was added.

Fixed in commit 3 by anchoring the glob to a literal `src/` segment so it can only match `packages/components/<pkg>/src/...` (plus the two-level `<group>/<pkg>/src/...` variant for fields, inputs, etc.). The structural fix is the Storybook 8 → 9 upgrade tracked separately in #3242 (FEC-935); this is the minimal short-term workaround.

## Verification

- `pnpm install --frozen-lockfile` → ✓ (rerun against the regenerated lockfile)
- `node scripts/check-workspace-constraints.js` → ✓
- `pnpm build` → ✓
- `pnpm lint:publint` → exit 0
- `pnpm --filter @commercetools-local/storybook run build` → ✓ in ~11s (pre-fix: hung indefinitely under workspace linking)
- **Repro of the failing release scenario**: bump `packages/hooks` version to `20.6.0` AND `design-system`'s `@commercetools-uikit/hooks` specifier to `20.6.0`, then run `pnpm install --ignore-scripts`.
  - Pre-fix: fails with `ERR_PNPM_NO_MATCHING_VERSION` fetching from npm.
  - Post-fix: succeeds; `node_modules/@commercetools-uikit/hooks` symlinks to `../../packages/hooks`; lockfile records `version: link:../packages/hooks`.

## Side benefit (local dev)

This also fixes a silent local-dev regression introduced by #3239: under the previous setting, edits to `packages/hooks` (or any other internal package) were NOT picked up by sibling workspaces — they were using registry-fetched tarballs of the last published version. Post-fix, internal edits propagate via the workspace symlink, like they did under yarn.

## Out of scope

- The longer-term/idiomatic fix is to convert every internal `@commercetools-uikit/*` cross-dep from a concrete `"20.5.0"` specifier to `"workspace:^"`. That's ~100 packages and a much larger change; this hotfix unblocks releases now without touching package.json files.
- Storybook 8 → 9 upgrade (full structural fix for the symlink-traversal bug): tracked in #3242 (FEC-935).

## Test plan

- [ ] CI on this PR passes (`Main workflow` end-to-end)
- [ ] Vercel preview build completes (storybook deploy renders)
- [ ] After merge to `main`, the `Release` workflow on the merge commit successfully opens / updates the `Version Packages` PR (#3236) instead of erroring at install