### PR TITLE
debug: jest --detectOpenHandles to find CI leak

### DIFF
--- a/.changeset/housekeeping-deps-20260519-1250.md
+++ b/.changeset/housekeeping-deps-20260519-1250.md
@@ -1,0 +1,12 @@
+---
+'@commercetools-frontend/ui-kit': patch
+---
+
+Update workspace catalog dependencies (minor/patch only):
+
+- **react**: `react`, `react-dom`, `react-is` 19.2.0 → 19.2.6; `downshift` 9.0.10 → 9.3.3; `react-from-dom` 0.7.3 → 0.7.5; `react-textarea-autosize` 8.4.0 → 8.5.9; `@formatjs/cli` 6.7.4 → 6.16.0
+- **build**: `@babel/core` 7.28.4 → 7.29.0; `@vitejs/plugin-react` 5.0.4 → 5.2.0; `postcss` 8.5.6 → 8.5.15; `@preconstruct/cli` 2.8.12 → 2.8.13; `browserslist` 4.26.3 → 4.28.2
+- **default**: `dompurify` 3.3.2 → 3.4.5; `qs` 6.14.1 → 6.15.2; `moment-timezone` 0.6.0 → 0.6.2; `execa` 9.6.0 → 9.6.1; `glob` 13.0.0 → 13.0.6; `@types/listr` 0.14.9 → 0.14.10
+- **test**: `jest`, `jest-environment-jsdom`, `jest-validate`, `babel-jest` 30.3.0 → 30.4.x; `@percy/cli` 1.31.3 → 1.31.13
+- **lint**: `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser` 8.46.0 → 8.59.4; `stylelint` 16.25.0 → 16.26.1; `eslint-formatter-pretty` 7.0.0 → 7.1.0
+- **repo**: `@changesets/cli` 2.29.7 → 2.31.0; `@changesets/changelog-github` 0.5.1 → 0.5.2; `@commercetools-frontend/babel-preset-mc-app`, `@commercetools-frontend/eslint-config-mc-app` 27.0.0 → 27.6.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,9 @@ jobs:
         run: pnpm lint:publint
 
       - name: Running linters and tests
-        run: pnpm jest --projects jest.{eslint,test,ts-test,bundle}.config.js --reporters github-actions
+        # DEBUG: --detectOpenHandles to surface what's leaking on Linux CI.
+        # Default reporter so the leak stack traces show up in the log.
+        run: pnpm jest --projects jest.{eslint,test,ts-test,bundle}.config.js --detectOpenHandles
         env:
           CI: true
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ dist
 vendors
 .yarn
 .changeset
+pnpm-lock.yaml

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,14 +228,14 @@ catalogs:
       specifier: ^9.0.0
       version: 9.39.4
     eslint-formatter-pretty:
-      specifier: 7.0.0
-      version: 7.0.0
+      specifier: 7.1.0
+      version: 7.1.0
     prettier:
       specifier: 2.8.8
       version: 2.8.8
     stylelint:
-      specifier: 16.25.0
-      version: 16.25.0
+      specifier: 16.26.1
+      version: 16.26.1
     stylelint-config-standard:
       specifier: 36.0.1
       version: 36.0.1
@@ -477,8 +477,8 @@ overrides:
   '@types/react-dom': 19.2.1
   '@types/react-router': 5.1.20
   '@types/unist': 3.0.3
-  '@typescript-eslint/eslint-plugin': 8.46.0
-  '@typescript-eslint/parser': 8.46.0
+  '@typescript-eslint/eslint-plugin': 8.59.4
+  '@typescript-eslint/parser': 8.59.4
   '@conventional-changelog/git-client': ^2.0.0
   '@isaacs/brace-expansion': ^5.0.1
   axios: ^1.13.5
@@ -645,11 +645,11 @@ importers:
         specifier: 'catalog:'
         version: 0.8.17
       '@typescript-eslint/eslint-plugin':
-        specifier: 8.46.0
-        version: 8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        specifier: 8.59.4
+        version: 8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser':
-        specifier: 8.46.0
-        version: 8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        specifier: 8.59.4
+        version: 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       babel-jest:
         specifier: catalog:test
         version: 30.3.0(@babel/core@7.28.4)
@@ -679,7 +679,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-formatter-pretty:
         specifier: catalog:lint
-        version: 7.0.0
+        version: 7.1.0
       execa:
         specifier: 'catalog:'
         version: 9.6.0
@@ -724,7 +724,7 @@ importers:
         version: 2.3.0(eslint@9.39.4(jiti@2.6.1))(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))
       jest-runner-stylelint:
         specifier: catalog:test
-        version: 2.3.7(stylelint@16.25.0(typescript@5.9.3))
+        version: 2.3.7(stylelint@16.26.1(typescript@5.9.3))
       jest-silent-reporter:
         specifier: catalog:test
         version: 0.6.0
@@ -808,13 +808,13 @@ importers:
         version: 0.10.0
       stylelint:
         specifier: catalog:lint
-        version: 16.25.0(typescript@5.9.3)
+        version: 16.26.1(typescript@5.9.3)
       stylelint-config-standard:
         specifier: catalog:lint
-        version: 36.0.1(stylelint@16.25.0(typescript@5.9.3))
+        version: 36.0.1(stylelint@16.26.1(typescript@5.9.3))
       stylelint-order:
         specifier: catalog:lint
-        version: 5.0.0(stylelint@16.25.0(typescript@5.9.3))
+        version: 5.0.0(stylelint@16.26.1(typescript@5.9.3))
       ts-node:
         specifier: catalog:build
         version: 10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)
@@ -7115,6 +7115,17 @@ packages:
     peerDependencies:
       '@csstools/css-tokenizer': ^3.0.4
 
+  '@csstools/css-syntax-patches-for-csstree@1.1.4':
+    resolution:
+      {
+        integrity: sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==,
+      }
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
   '@csstools/css-tokenizer@3.0.4':
     resolution:
       {
@@ -9917,35 +9928,26 @@ packages:
         integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==,
       }
 
-  '@typescript-eslint/eslint-plugin@8.46.0':
+  '@typescript-eslint/eslint-plugin@8.59.4':
     resolution:
       {
-        integrity: sha512-hA8gxBq4ukonVXPy0OKhiaUh/68D0E88GSmtC1iAEnGaieuDi38LhS7jdCHRLi6ErJBNDGCzvh5EnzdPwUc0DA==,
+        integrity: sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      '@typescript-eslint/parser': 8.46.0
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      '@typescript-eslint/parser': 8.59.4
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.46.0':
+  '@typescript-eslint/parser@8.59.4':
     resolution:
       {
-        integrity: sha512-n1H6IcDhmmUEG7TNVSspGmiHHutt7iVKtZwRppD7e04wha5MrkV1h3pti9xQLcCMt6YWsncpoT0HMjkH1FNwWQ==,
+        integrity: sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/project-service@8.46.0':
-    resolution:
-      {
-        integrity: sha512-OEhec0mH+U5Je2NZOeK1AbVCdm0ChyapAyTeXVIYTPXDJ3F07+cu87PPXcGoYqZ7M9YJVvFnfpGg1UmCIqM+QQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/project-service@8.58.0':
     resolution:
@@ -9956,12 +9958,14 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/scope-manager@8.46.0':
+  '@typescript-eslint/project-service@8.59.4':
     resolution:
       {
-        integrity: sha512-lWETPa9XGcBes4jqAMYD9fW0j4n6hrPtTJwWDmtqgFO/4HF4jmdH/Q6wggTw5qIT5TXjKzbt7GsZUBnWoO3dqw==,
+        integrity: sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/scope-manager@8.58.0':
     resolution:
@@ -9970,14 +9974,12 @@ packages:
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@typescript-eslint/tsconfig-utils@8.46.0':
+  '@typescript-eslint/scope-manager@8.59.4':
     resolution:
       {
-        integrity: sha512-WrYXKGAHY836/N7zoK/kzi6p8tXFhasHh8ocFL9VZSAkvH956gfeRfcnhs3xzRy8qQ/dq3q44v1jvQieMFg2cw==,
+        integrity: sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/tsconfig-utils@8.58.0':
     resolution:
@@ -9988,22 +9990,24 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/type-utils@8.46.0':
+  '@typescript-eslint/tsconfig-utils@8.59.4':
     resolution:
       {
-        integrity: sha512-hy+lvYV1lZpVs2jRaEYvgCblZxUoJiPyCemwbQZ+NGulWkQRy0HRPYAoef/CNSzaLt+MLvMptZsHXHlkEilaeg==,
+        integrity: sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.46.0':
+  '@typescript-eslint/type-utils@8.59.4':
     resolution:
       {
-        integrity: sha512-bHGGJyVjSE4dJJIO5yyEWt/cHyNwga/zXGJbJJ8TiO01aVREK6gCTu3L+5wrkb1FbDkQ+TKjMNe9R/QQQP9+rA==,
+        integrity: sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/types@8.58.0':
     resolution:
@@ -10012,14 +10016,12 @@ packages:
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  '@typescript-eslint/typescript-estree@8.46.0':
+  '@typescript-eslint/types@8.59.4':
     resolution:
       {
-        integrity: sha512-ekDCUfVpAKWJbRfm8T1YRrCot1KFxZn21oV76v5Fj4tr7ELyk84OS+ouvYdcDAwZL89WpEkEj2DKQ+qg//+ucg==,
+        integrity: sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/typescript-estree@8.58.0':
     resolution:
@@ -10030,15 +10032,14 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.46.0':
+  '@typescript-eslint/typescript-estree@8.59.4':
     resolution:
       {
-        integrity: sha512-nD6yGWPj1xiOm4Gk0k6hLSZz2XkNXhuYmyIrOWcHoPuAhjT9i5bAG+xbWPgFeNR8HPHHtpNKdYUXJl/D3x7f5g==,
+        integrity: sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/utils@8.58.0':
     resolution:
@@ -10050,17 +10051,27 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.46.0':
+  '@typescript-eslint/utils@8.59.4':
     resolution:
       {
-        integrity: sha512-FrvMpAK+hTbFy7vH5j1+tMYHMSKLE6RzluFJlkFNKD0p9YsUT75JlBSmr5so3QRzvMwU5/bIEdeNrxm8du8l3Q==,
+        integrity: sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/visitor-keys@8.58.0':
     resolution:
       {
         integrity: sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    resolution:
+      {
+        integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
@@ -12475,10 +12486,10 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-formatter-pretty@7.0.0:
+  eslint-formatter-pretty@7.1.0:
     resolution:
       {
-        integrity: sha512-1CaE7Pnce8Csy+tlTEbFC2q5qgT5cJo2a0UkEOds+Y5+mI1nX3DApIhcBP8EPwV8TgTpLlzOfw8mcBJBAs3Y9Q==,
+        integrity: sha512-iyPrgpwKC3MMM75Wxn0VouD89HolpG+BL95NOxgwOWO0R+Omapo7gFX2xcGVsUDS7KiXLtDuynLbNbOARSE7YA==,
       }
     engines: { node: '>=18' }
 
@@ -12565,7 +12576,7 @@ packages:
       }
     engines: { node: ^16.10.0 || ^18.12.0 || >=20.0.0 }
     peerDependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.0
+      '@typescript-eslint/eslint-plugin': 8.59.4
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
       jest: '*'
     peerDependenciesMeta:
@@ -12958,10 +12969,10 @@ packages:
       }
     engines: { node: '>=18' }
 
-  file-entry-cache@10.1.4:
+  file-entry-cache@11.1.3:
     resolution:
       {
-        integrity: sha512-5XRUFc0WTtUbjfGzEwXc42tiGxQHBmtbUG1h9L2apu4SulCGN3Hqm//9D6FAolf8MYNL7f/YlJl9vy08pj5JuA==,
+        integrity: sha512-oMbq0PD6VIiIwMF6LIa7MEwd/l9huKwmqRKXqmrkqIZv8CvRbfowL+L0ryAl8h//HfAS0zS+4SbYoRyAoA6BJA==,
       }
 
   file-entry-cache@8.0.0:
@@ -13426,12 +13437,6 @@ packages:
     resolution:
       {
         integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
-      }
-
-  graphemer@1.4.0:
-    resolution:
-      {
-        integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==,
       }
 
   gzip-size@6.0.0:
@@ -17982,10 +17987,10 @@ packages:
     peerDependencies:
       stylelint: ^14.0.0
 
-  stylelint@16.25.0:
+  stylelint@16.26.1:
     resolution:
       {
-        integrity: sha512-Li0avYWV4nfv1zPbdnxLYBGq4z8DVZxbRgx4Kn6V+Uftz1rMoF1qiEI3oL4kgWqyYgCgs7gT5maHNZ82Gk03vQ==,
+        integrity: sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==,
       }
     engines: { node: '>=18.12.0' }
     hasBin: true
@@ -20443,15 +20448,15 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/eslint-parser': 7.28.6(@babel/core@7.28.4)(eslint@9.39.4(jiti@2.6.1))
       '@commercetools-frontend/babel-preset-mc-app': 27.6.2(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
-      '@typescript-eslint/eslint-plugin': 8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       confusing-browser-globals: 1.0.11
       eslint: 9.39.4(jiti@2.6.1)
       eslint-config-prettier: 8.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-cypress: 2.15.2(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-jest: 28.14.0(@typescript-eslint/eslint-plugin@8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-jest: 28.14.0(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       eslint-plugin-jest-dom: 4.0.3(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-prettier: 4.2.5(eslint-config-prettier@8.10.2(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@2.8.8)
@@ -20613,6 +20618,10 @@ snapshots:
   '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.4(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
 
   '@csstools/css-tokenizer@3.0.4': {}
 
@@ -22543,16 +22552,15 @@ snapshots:
       '@types/node': 22.19.15
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.46.0
-      '@typescript-eslint/type-utils': 8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.46.0
+      '@typescript-eslint/parser': 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/type-utils': 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.4
       eslint: 9.39.4(jiti@2.6.1)
-      graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -22560,23 +22568,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.46.0
-      '@typescript-eslint/types': 8.46.0
-      '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.46.0
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.4
       debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.39.4(jiti@2.6.1)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.46.0(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.46.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.46.0
-      debug: 4.4.3(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -22590,29 +22589,38 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.46.0':
+  '@typescript-eslint/project-service@8.59.4(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.46.0
-      '@typescript-eslint/visitor-keys': 8.46.0
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.4
+      debug: 4.4.3(supports-color@5.5.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@typescript-eslint/scope-manager@8.58.0':
     dependencies:
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/visitor-keys': 8.58.0
 
-  '@typescript-eslint/tsconfig-utils@8.46.0(typescript@5.9.3)':
+  '@typescript-eslint/scope-manager@8.59.4':
     dependencies:
-      typescript: 5.9.3
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
 
   '@typescript-eslint/tsconfig-utils@8.58.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.59.4(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.46.0
-      '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.39.4(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -22620,25 +22628,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.46.0': {}
-
   '@typescript-eslint/types@8.58.0': {}
 
-  '@typescript-eslint/typescript-estree@8.46.0(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.46.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.46.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.46.0
-      '@typescript-eslint/visitor-keys': 8.46.0
-      debug: 4.4.3(supports-color@5.5.0)
-      fast-glob: 3.3.3
-      is-glob: 4.0.3
-      minimatch: 10.2.5
-      semver: 7.7.4
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
+  '@typescript-eslint/types@8.59.4': {}
 
   '@typescript-eslint/typescript-estree@8.58.0(typescript@5.9.3)':
     dependencies:
@@ -22655,13 +22647,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.59.4(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.46.0
-      '@typescript-eslint/types': 8.46.0
-      '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.6.1)
+      '@typescript-eslint/project-service': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
+      debug: 4.4.3(supports-color@5.5.0)
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -22677,14 +22673,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.46.0':
+  '@typescript-eslint/utils@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.46.0
-      eslint-visitor-keys: 4.2.1
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@typescript-eslint/visitor-keys@8.58.0':
     dependencies:
       '@typescript-eslint/types': 8.58.0
+      eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.1': {}
@@ -24171,7 +24178,7 @@ snapshots:
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
 
-  eslint-formatter-pretty@7.0.0:
+  eslint-formatter-pretty@7.1.0:
     dependencies:
       '@types/eslint': 9.6.1
       ansi-escapes: 7.3.0
@@ -24201,15 +24208,15 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
@@ -24221,7 +24228,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       globals: 13.24.0
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -24232,7 +24239,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -24244,7 +24251,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -24257,12 +24264,12 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       requireindex: 1.2.0
 
-  eslint-plugin-jest@28.14.0(@typescript-eslint/eslint-plugin@8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
+  eslint-plugin-jest@28.14.0(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       jest: 30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
@@ -24566,7 +24573,7 @@ snapshots:
     dependencies:
       is-unicode-supported: 2.1.0
 
-  file-entry-cache@10.1.4:
+  file-entry-cache@11.1.3:
     dependencies:
       flat-cache: 6.1.22
 
@@ -24888,8 +24895,6 @@ snapshots:
   graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
-
-  graphemer@1.4.0: {}
 
   gzip-size@6.0.0:
     dependencies:
@@ -25653,11 +25658,11 @@ snapshots:
       - '@jest/test-result'
       - jest-runner
 
-  jest-runner-stylelint@2.3.7(stylelint@16.25.0(typescript@5.9.3)):
+  jest-runner-stylelint@2.3.7(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
       cosmiconfig: 7.1.0
       create-jest-runner: 0.7.1
-      stylelint: 16.25.0(typescript@5.9.3)
+      stylelint: 16.26.1(typescript@5.9.3)
 
   jest-runner@30.3.0:
     dependencies:
@@ -28122,24 +28127,25 @@ snapshots:
     dependencies:
       inline-style-parser: 0.1.1
 
-  stylelint-config-recommended@14.0.1(stylelint@16.25.0(typescript@5.9.3)):
+  stylelint-config-recommended@14.0.1(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.25.0(typescript@5.9.3)
+      stylelint: 16.26.1(typescript@5.9.3)
 
-  stylelint-config-standard@36.0.1(stylelint@16.25.0(typescript@5.9.3)):
+  stylelint-config-standard@36.0.1(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.25.0(typescript@5.9.3)
-      stylelint-config-recommended: 14.0.1(stylelint@16.25.0(typescript@5.9.3))
+      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint-config-recommended: 14.0.1(stylelint@16.26.1(typescript@5.9.3))
 
-  stylelint-order@5.0.0(stylelint@16.25.0(typescript@5.9.3)):
+  stylelint-order@5.0.0(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
       postcss: 8.5.6
       postcss-sorting: 7.0.1(postcss@8.5.6)
-      stylelint: 16.25.0(typescript@5.9.3)
+      stylelint: 16.26.1(typescript@5.9.3)
 
-  stylelint@16.25.0(typescript@5.9.3):
+  stylelint@16.26.1(typescript@5.9.3):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.4(css-tree@3.2.1)
       '@csstools/css-tokenizer': 3.0.4
       '@csstools/media-query-list-parser': 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.1)
@@ -28152,7 +28158,7 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       fast-glob: 3.3.3
       fastest-levenshtein: 1.0.16
-      file-entry-cache: 10.1.4
+      file-entry-cache: 11.1.3
       global-modules: 2.0.0
       globby: 11.1.0
       globjoin: 0.1.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,17 +308,17 @@ catalogs:
       version: 0.2.0
   repo:
     '@changesets/changelog-github':
-      specifier: 0.5.1
-      version: 0.5.1
+      specifier: 0.5.2
+      version: 0.5.2
     '@changesets/cli':
-      specifier: 2.29.7
-      version: 2.29.7
+      specifier: 2.31.0
+      version: 2.31.0
     '@commercetools-frontend/babel-preset-mc-app':
-      specifier: 27.0.0
-      version: 27.0.0
+      specifier: 27.6.2
+      version: 27.6.2
     '@commercetools-frontend/eslint-config-mc-app':
-      specifier: 27.0.0
-      version: 27.0.0
+      specifier: 27.6.2
+      version: 27.6.2
     '@commitlint/cli':
       specifier: 20.1.0
       version: 20.1.0
@@ -523,16 +523,16 @@ importers:
         version: 7.28.4
       '@changesets/changelog-github':
         specifier: catalog:repo
-        version: 0.5.1
+        version: 0.5.2
       '@changesets/cli':
         specifier: catalog:repo
-        version: 2.29.7(@types/node@22.19.15)
+        version: 2.31.0(@types/node@22.19.15)
       '@commercetools-frontend/babel-preset-mc-app':
         specifier: catalog:repo
-        version: 27.0.0(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
+        version: 27.6.2(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
       '@commercetools-frontend/eslint-config-mc-app':
         specifier: catalog:repo
-        version: 27.0.0(babel-plugin-istanbul@7.0.1)(eslint@9.39.4(jiti@2.6.1))(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
+        version: 27.6.2(babel-plugin-istanbul@7.0.1)(eslint@9.39.4(jiti@2.6.1))(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
       '@commercetools-frontend/ui-kit':
         specifier: workspace:^
         version: link:presets/ui-kit
@@ -6795,16 +6795,16 @@ packages:
         integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==,
       }
 
-  '@changesets/apply-release-plan@7.1.0':
+  '@changesets/apply-release-plan@7.1.1':
     resolution:
       {
-        integrity: sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ==,
+        integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==,
       }
 
-  '@changesets/assemble-release-plan@6.0.9':
+  '@changesets/assemble-release-plan@6.0.10':
     resolution:
       {
-        integrity: sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==,
+        integrity: sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==,
       }
 
   '@changesets/changelog-git@0.2.1':
@@ -6813,23 +6813,23 @@ packages:
         integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==,
       }
 
-  '@changesets/changelog-github@0.5.1':
+  '@changesets/changelog-github@0.5.2':
     resolution:
       {
-        integrity: sha512-BVuHtF+hrhUScSoHnJwTELB4/INQxVFc+P/Qdt20BLiBFIHFJDDUaGsZw+8fQeJTRP5hJZrzpt3oZWh0G19rAQ==,
+        integrity: sha512-HeGeDl8HaIGj9fQHo/tv5XKQ2SNEi9+9yl1Bss1jttPqeiASRXhfi0A2wv8yFKCp07kR1gpOI5ge6+CWNm1jPw==,
       }
 
-  '@changesets/cli@2.29.7':
+  '@changesets/cli@2.31.0':
     resolution:
       {
-        integrity: sha512-R7RqWoaksyyKXbKXBTbT4REdy22yH81mcFK6sWtqSanxUCbUi9Uf+6aqxZtDQouIqPdem2W56CdxXgsxdq7FLQ==,
+        integrity: sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==,
       }
     hasBin: true
 
-  '@changesets/config@3.1.3':
+  '@changesets/config@3.1.4':
     resolution:
       {
-        integrity: sha512-vnXjcey8YgBn2L1OPWd3ORs0bGC4LoYcK/ubpgvzNVr53JXV5GiTVj7fWdMRsoKUH7hhhMAQnsJUqLr21EncNw==,
+        integrity: sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==,
       }
 
   '@changesets/errors@0.2.0':
@@ -6838,22 +6838,22 @@ packages:
         integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==,
       }
 
-  '@changesets/get-dependents-graph@2.1.3':
+  '@changesets/get-dependents-graph@2.1.4':
     resolution:
       {
-        integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==,
+        integrity: sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==,
       }
 
-  '@changesets/get-github-info@0.6.0':
+  '@changesets/get-github-info@0.7.0':
     resolution:
       {
-        integrity: sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==,
+        integrity: sha512-+i67Bmhfj9V4KfDeS1+Tz3iF32btKZB2AAx+cYMqDSRFP7r3/ZdGbjCo+c6qkyViN9ygDuBjzageuPGJtKGe5A==,
       }
 
-  '@changesets/get-release-plan@4.0.15':
+  '@changesets/get-release-plan@4.0.16':
     resolution:
       {
-        integrity: sha512-Q04ZaRPuEVZtA+auOYgFaVQQSA98dXiVe/yFaZfY7hoSmQICHGvP0TF4u3EDNHWmmCS4ekA/XSpKlSM2PyTS2g==,
+        integrity: sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==,
       }
 
   '@changesets/get-version-range-type@0.4.0':
@@ -6916,10 +6916,10 @@ packages:
         integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==,
       }
 
-  '@commercetools-frontend/babel-preset-mc-app@27.0.0':
+  '@commercetools-frontend/babel-preset-mc-app@27.6.2':
     resolution:
       {
-        integrity: sha512-GASEM186y54+K6fj7rKGubWwtMWDe62U/usqV2MTuyFAuEIqp8eeX0+slzqio+bBp7N3HUFopMMTWseJk5a+MQ==,
+        integrity: sha512-19+48Go4DiapM7enu7IFC3usunBrjMb1aWnZUSmm2drqWPIkjxU0Y12EJr9L6TGadHbvM9Wo33VoTl7fE36UeA==,
       }
     engines: { node: 18.x || 20.x || >=22.0.0 }
     peerDependencies:
@@ -6928,10 +6928,10 @@ packages:
       babel-plugin-istanbul:
         optional: true
 
-  '@commercetools-frontend/eslint-config-mc-app@27.0.0':
+  '@commercetools-frontend/eslint-config-mc-app@27.6.2':
     resolution:
       {
-        integrity: sha512-m5bn3OX0a9XlEI7HzOLIG1moKoBzGDbhfR7YJnuFj3xqauw566x3nFLIxFMcff6mQKoWZoLZ6oHs28jydhgiGw==,
+        integrity: sha512-Xn+4o7EXuZD0nQyXjzstrh2/USBUTAyPBfWoVqu+JEyH/DDRWVw7DPgYRVewZUpMHkdEkkOyCBPWzZXI4MbRxw==,
       }
     engines: { node: 18.x || 20.x || >=22.0.0 }
     peerDependencies:
@@ -20247,9 +20247,9 @@ snapshots:
       hashery: 1.5.1
       keyv: 5.6.0
 
-  '@changesets/apply-release-plan@7.1.0':
+  '@changesets/apply-release-plan@7.1.1':
     dependencies:
-      '@changesets/config': 3.1.3
+      '@changesets/config': 3.1.4
       '@changesets/get-version-range-type': 0.4.0
       '@changesets/git': 3.0.4
       '@changesets/should-skip-package': 0.1.2
@@ -20263,10 +20263,10 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.7.4
 
-  '@changesets/assemble-release-plan@6.0.9':
+  '@changesets/assemble-release-plan@6.0.10':
     dependencies:
       '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.3
+      '@changesets/get-dependents-graph': 2.1.4
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
@@ -20276,23 +20276,23 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/changelog-github@0.5.1':
+  '@changesets/changelog-github@0.5.2':
     dependencies:
-      '@changesets/get-github-info': 0.6.0
+      '@changesets/get-github-info': 0.7.0
       '@changesets/types': 6.1.0
       dotenv: 8.6.0
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.29.7(@types/node@22.19.15)':
+  '@changesets/cli@2.31.0(@types/node@22.19.15)':
     dependencies:
-      '@changesets/apply-release-plan': 7.1.0
-      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/apply-release-plan': 7.1.1
+      '@changesets/assemble-release-plan': 6.0.10
       '@changesets/changelog-git': 0.2.1
-      '@changesets/config': 3.1.3
+      '@changesets/config': 3.1.4
       '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.3
-      '@changesets/get-release-plan': 4.0.15
+      '@changesets/get-dependents-graph': 2.1.4
+      '@changesets/get-release-plan': 4.0.16
       '@changesets/git': 3.0.4
       '@changesets/logger': 0.1.1
       '@changesets/pre': 2.0.2
@@ -20303,11 +20303,9 @@ snapshots:
       '@inquirer/external-editor': 1.0.3(@types/node@22.19.15)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
-      ci-info: 3.9.0
       enquirer: 2.4.1
       fs-extra: 7.0.1
       mri: 1.2.0
-      p-limit: 2.3.0
       package-manager-detector: 0.2.11
       picocolors: 1.1.1
       resolve-from: 5.0.0
@@ -20317,10 +20315,10 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@changesets/config@3.1.3':
+  '@changesets/config@3.1.4':
     dependencies:
       '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.3
+      '@changesets/get-dependents-graph': 2.1.4
       '@changesets/logger': 0.1.1
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
@@ -20332,24 +20330,24 @@ snapshots:
     dependencies:
       extendable-error: 0.1.7
 
-  '@changesets/get-dependents-graph@2.1.3':
+  '@changesets/get-dependents-graph@2.1.4':
     dependencies:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
       semver: 7.7.4
 
-  '@changesets/get-github-info@0.6.0':
+  '@changesets/get-github-info@0.7.0':
     dependencies:
       dataloader: 1.4.0
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/get-release-plan@4.0.15':
+  '@changesets/get-release-plan@4.0.16':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.9
-      '@changesets/config': 3.1.3
+      '@changesets/assemble-release-plan': 6.0.10
+      '@changesets/config': 3.1.4
       '@changesets/pre': 2.0.2
       '@changesets/read': 0.6.7
       '@changesets/types': 6.1.0
@@ -20407,7 +20405,7 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@commercetools-frontend/babel-preset-mc-app@27.0.0(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))':
+  '@commercetools-frontend/babel-preset-mc-app@27.6.2(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-proposal-do-expressions': 7.28.6(@babel/core@7.28.4)
@@ -20440,11 +20438,11 @@ snapshots:
       - supports-color
       - ts-jest
 
-  '@commercetools-frontend/eslint-config-mc-app@27.0.0(babel-plugin-istanbul@7.0.1)(eslint@9.39.4(jiti@2.6.1))(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))':
+  '@commercetools-frontend/eslint-config-mc-app@27.6.2(babel-plugin-istanbul@7.0.1)(eslint@9.39.4(jiti@2.6.1))(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/eslint-parser': 7.28.6(@babel/core@7.28.4)(eslint@9.39.4(jiti@2.6.1))
-      '@commercetools-frontend/babel-preset-mc-app': 27.0.0(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
+      '@commercetools-frontend/babel-preset-mc-app': 27.6.2(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
       '@typescript-eslint/eslint-plugin': 8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.46.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       confusing-browser-globals: 1.0.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,8 +244,8 @@ catalogs:
       version: 5.0.0
   react:
     '@formatjs/cli':
-      specifier: 6.7.4
-      version: 6.7.4
+      specifier: 6.16.0
+      version: 6.16.0
     '@formatjs/intl-relativetimeformat':
       specifier: 11.4.13
       version: 11.4.13
@@ -265,8 +265,8 @@ catalogs:
       specifier: ^10.0.0
       version: 10.5.41
     downshift:
-      specifier: 9.0.10
-      version: 9.0.10
+      specifier: 9.3.3
+      version: 9.3.3
     formik:
       specifier: ^2.4.6
       version: 2.4.9
@@ -277,20 +277,20 @@ catalogs:
       specifier: ^15.8.1
       version: 15.8.1
     react:
-      specifier: 19.2.0
-      version: 19.2.0
+      specifier: 19.2.6
+      version: 19.2.6
     react-docgen:
       specifier: 5.4.3
       version: 5.4.3
     react-dom:
-      specifier: 19.2.0
-      version: 19.2.0
+      specifier: 19.2.6
+      version: 19.2.6
     react-intl:
       specifier: ^7.1.4
       version: 7.1.14
     react-is:
-      specifier: 19.2.0
-      version: 19.2.0
+      specifier: 19.2.6
+      version: 19.2.6
     react-router:
       specifier: 5.3.4
       version: 5.3.4
@@ -301,8 +301,8 @@ catalogs:
       specifier: 5.10.2
       version: 5.10.2
     react-textarea-autosize:
-      specifier: 8.4.0
-      version: 8.4.0
+      specifier: 8.5.9
+      version: 8.5.9
     react-value:
       specifier: 0.2.0
       version: 0.2.0
@@ -562,13 +562,13 @@ importers:
         version: 20.0.0
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       '@formatjs/cli':
         specifier: catalog:react
-        version: 6.7.4
+        version: 6.16.0
       '@formatjs/intl-relativetimeformat':
         specifier: catalog:react
         version: 11.4.13
@@ -610,7 +610,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: catalog:test
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/history':
         specifier: 'catalog:'
         version: 4.7.11
@@ -685,7 +685,7 @@ importers:
         version: 9.6.1
       formik:
         specifier: catalog:react
-        version: 2.4.9(@types/react@19.2.14)(react@19.2.0)
+        version: 2.4.9(@types/react@19.2.14)(react@19.2.6)
       glob:
         specifier: 'catalog:'
         version: 13.0.6
@@ -784,19 +784,19 @@ importers:
         version: 1.0.3
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       react-router-dom:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
       react-value:
         specifier: catalog:react
-        version: 0.2.0(react@19.2.0)
+        version: 0.2.0(react@19.2.6)
       replace:
         specifier: 'catalog:'
         version: 1.2.2
@@ -838,7 +838,7 @@ importers:
         version: link:../packages/hooks
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -857,10 +857,10 @@ importers:
         version: 1.0.3
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-router:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
       yaml:
         specifier: 'catalog:'
         version: 2.8.3
@@ -1040,29 +1040,29 @@ importers:
         version: link:../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       moment:
         specifier: 'catalog:'
         version: 2.30.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/accessible-hidden:
     dependencies:
@@ -1074,11 +1074,11 @@ importers:
         version: 7.29.2
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/avatar:
     dependencies:
@@ -1096,10 +1096,10 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -1109,7 +1109,7 @@ importers:
         version: link:../icons
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/buttons/accessible-button:
     dependencies:
@@ -1127,10 +1127,10 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       '@types/react-is':
         specifier: catalog:react
         version: 19.2.0
@@ -1139,11 +1139,11 @@ importers:
         version: 4.18.1
       react-is:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/buttons/flat-button:
     dependencies:
@@ -1170,23 +1170,23 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       '@commercetools-uikit/icons':
         specifier: workspace:^
         version: link:../../icons
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/buttons/icon-button:
     dependencies:
@@ -1213,23 +1213,23 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       '@commercetools-uikit/icons':
         specifier: workspace:^
         version: link:../../icons
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/buttons/link-button:
     dependencies:
@@ -1256,10 +1256,10 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       history:
         specifier: 'catalog:'
         version: 4.10.1
@@ -1272,13 +1272,13 @@ importers:
         version: link:../../icons
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       react-router-dom:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
 
   packages/components/buttons/primary-button:
     dependencies:
@@ -1305,23 +1305,23 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       '@commercetools-uikit/icons':
         specifier: workspace:^
         version: link:../../icons
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/buttons/secondary-button:
     dependencies:
@@ -1348,10 +1348,10 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -1361,13 +1361,13 @@ importers:
         version: link:../../icons
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       react-router-dom:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
 
   packages/components/buttons/secondary-icon-button:
     dependencies:
@@ -1394,23 +1394,23 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       '@commercetools-uikit/icons':
         specifier: workspace:^
         version: link:../../icons
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/card:
     dependencies:
@@ -1431,10 +1431,10 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       '@types/react-router-dom':
         specifier: catalog:react
         version: 5.3.3
@@ -1447,10 +1447,10 @@ importers:
         version: link:../text
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-router-dom:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
 
   packages/components/collapsible:
     dependencies:
@@ -1468,17 +1468,17 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/collapsible-motion:
     dependencies:
@@ -1496,10 +1496,10 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -1509,7 +1509,7 @@ importers:
         version: link:../buttons/primary-button
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/collapsible-panel:
     dependencies:
@@ -1548,23 +1548,23 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/constraints:
     dependencies:
@@ -1582,14 +1582,14 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/data-table:
     dependencies:
@@ -1622,26 +1622,26 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       '@commercetools-uikit/spacings':
         specifier: workspace:^
         version: link:../../../presets/spacings
       formik:
         specifier: catalog:react
-        version: 2.4.9(@types/react@19.2.14)(react@19.2.0)
+        version: 2.4.9(@types/react@19.2.14)(react@19.2.6)
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/data-table-manager:
     dependencies:
@@ -1722,13 +1722,13 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       '@hello-pangea/dnd':
         specifier: catalog:react
-        version: 18.0.1(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 18.0.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/debounce-promise':
         specifier: 'catalog:'
         version: 3.1.9
@@ -1753,16 +1753,16 @@ importers:
         version: link:../inputs/toggle-input
       formik:
         specifier: catalog:react
-        version: 2.4.9(@types/react@19.2.14)(react@19.2.0)
+        version: 2.4.9(@types/react@19.2.14)(react@19.2.6)
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/dropdowns/dropdown-menu:
     dependencies:
@@ -1798,13 +1798,13 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       '@commercetools-uikit/buttons':
         specifier: workspace:^
@@ -1823,7 +1823,7 @@ importers:
         version: link:../../text
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/field-errors:
     dependencies:
@@ -1838,17 +1838,17 @@ importers:
         version: link:../messages
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/field-label:
     dependencies:
@@ -1890,20 +1890,20 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       '@commercetools-uikit/flat-button':
         specifier: workspace:^
         version: link:../buttons/flat-button
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/field-warnings:
     dependencies:
@@ -1918,17 +1918,17 @@ importers:
         version: link:../messages
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/fields/async-creatable-select-field:
     dependencies:
@@ -1964,26 +1964,26 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-router-dom:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
 
   packages/components/fields/async-select-field:
     dependencies:
@@ -2019,26 +2019,26 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-router-dom:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
 
   packages/components/fields/creatable-select-field:
     dependencies:
@@ -2074,23 +2074,23 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/fields/date-field:
     dependencies:
@@ -2126,13 +2126,13 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       '@commercetools-uikit/calendar-utils':
         specifier: workspace:^
@@ -2142,7 +2142,7 @@ importers:
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/fields/date-range-field:
     dependencies:
@@ -2178,20 +2178,20 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/fields/date-time-field:
     dependencies:
@@ -2227,20 +2227,20 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/fields/localized-multiline-text-field:
     dependencies:
@@ -2276,20 +2276,20 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/fields/localized-text-field:
     dependencies:
@@ -2325,20 +2325,20 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/fields/money-field:
     dependencies:
@@ -2374,26 +2374,26 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/fields/multiline-text-field:
     dependencies:
@@ -2429,20 +2429,20 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/fields/number-field:
     dependencies:
@@ -2478,20 +2478,20 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/fields/password-field:
     dependencies:
@@ -2539,20 +2539,20 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/fields/radio-field:
     dependencies:
@@ -2588,20 +2588,20 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/fields/search-select-field:
     dependencies:
@@ -2640,23 +2640,23 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/fields/select-field:
     dependencies:
@@ -2692,23 +2692,23 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/fields/text-field:
     dependencies:
@@ -2747,20 +2747,20 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/fields/time-field:
     dependencies:
@@ -2796,20 +2796,20 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/filters:
     dependencies:
@@ -2857,16 +2857,16 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-popover':
         specifier: catalog:react
-        version: 1.1.15(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 1.1.15(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       '@commercetools-uikit/buttons':
         specifier: workspace:^
@@ -2885,10 +2885,10 @@ importers:
         version: link:../inputs/text-input
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
 
   packages/components/grid:
     dependencies:
@@ -2900,17 +2900,17 @@ importers:
         version: 7.29.2
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       '@commercetools-uikit/design-system':
         specifier: workspace:^
         version: link:../../../design-system
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/icons:
     dependencies:
@@ -2928,10 +2928,10 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       '@types/dompurify':
         specifier: 'catalog:'
         version: 2.4.0
@@ -2940,7 +2940,7 @@ importers:
         version: 3.4.5
       react-from-dom:
         specifier: 0.6.2
-        version: 0.6.2(react@19.2.0)
+        version: 0.6.2(react@19.2.6)
     devDependencies:
       '@commercetools-uikit/spacings':
         specifier: workspace:^
@@ -2950,10 +2950,10 @@ importers:
         version: link:../text
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-router-dom:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
 
   packages/components/inputs/async-creatable-select-input:
     dependencies:
@@ -2992,29 +2992,29 @@ importers:
         version: 1.4.0
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/inputs/async-select-input:
     dependencies:
@@ -3050,29 +3050,29 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/inputs/checkbox-input:
     dependencies:
@@ -3096,17 +3096,17 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/inputs/creatable-select-input:
     dependencies:
@@ -3139,29 +3139,29 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/inputs/date-input:
     dependencies:
@@ -3212,16 +3212,16 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       downshift:
         specifier: catalog:react
-        version: 9.0.10(react@19.2.0)
+        version: 9.3.3(react@19.2.6)
       react-is:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       warning:
         specifier: 'catalog:'
         version: 4.0.3
@@ -3234,10 +3234,10 @@ importers:
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/inputs/date-range-input:
     dependencies:
@@ -3288,16 +3288,16 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       downshift:
         specifier: catalog:react
-        version: 9.0.10(react@19.2.0)
+        version: 9.3.3(react@19.2.6)
       react-is:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       warning:
         specifier: 'catalog:'
         version: 4.0.3
@@ -3310,10 +3310,10 @@ importers:
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/inputs/date-time-input:
     dependencies:
@@ -3364,16 +3364,16 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       downshift:
         specifier: catalog:react
-        version: 9.0.10(react@19.2.0)
+        version: 9.3.3(react@19.2.6)
       react-is:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       warning:
         specifier: 'catalog:'
         version: 4.0.3
@@ -3386,10 +3386,10 @@ importers:
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/inputs/input-utils:
     dependencies:
@@ -3413,17 +3413,17 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       react-textarea-autosize:
         specifier: catalog:react
-        version: 8.4.0(@types/react@19.2.14)(react@19.2.0)
+        version: 8.5.9(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/inputs/localized-money-input:
     dependencies:
@@ -3474,26 +3474,26 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/inputs/localized-multiline-text-input:
     dependencies:
@@ -3538,29 +3538,29 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-textarea-autosize:
         specifier: catalog:react
-        version: 8.4.0(@types/react@19.2.14)(react@19.2.0)
+        version: 8.5.9(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/inputs/localized-rich-text-input:
     dependencies:
@@ -3617,13 +3617,13 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       downshift:
         specifier: catalog:react
-        version: 9.0.10(react@19.2.0)
+        version: 9.3.3(react@19.2.6)
       immutable:
         specifier: ^4.3.8
         version: 4.3.8
@@ -3635,7 +3635,7 @@ importers:
         version: 4.18.1
       react-textarea-autosize:
         specifier: catalog:react
-        version: 8.4.0(@types/react@19.2.14)(react@19.2.0)
+        version: 8.5.9(@types/react@19.2.14)(react@19.2.6)
       slate:
         specifier: catalog:rich-text
         version: 0.75.0
@@ -3644,7 +3644,7 @@ importers:
         version: 0.113.1(slate@0.75.0)
       slate-react:
         specifier: catalog:rich-text
-        version: 0.75.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate@0.75.0)
+        version: 0.75.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(slate@0.75.0)
     devDependencies:
       '@commercetools-uikit/collapsible-panel':
         specifier: workspace:^
@@ -3657,16 +3657,16 @@ importers:
         version: link:../../../../presets/spacings
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       react-router-dom:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
 
   packages/components/inputs/localized-text-input:
     dependencies:
@@ -3714,20 +3714,20 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/inputs/money-input:
     dependencies:
@@ -3763,29 +3763,29 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/inputs/multiline-text-input:
     dependencies:
@@ -3830,26 +3830,26 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       downshift:
         specifier: catalog:react
-        version: 9.0.10(react@19.2.0)
+        version: 9.3.3(react@19.2.6)
       react-textarea-autosize:
         specifier: catalog:react
-        version: 8.4.0(@types/react@19.2.14)(react@19.2.0)
+        version: 8.5.9(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/inputs/number-input:
     dependencies:
@@ -3873,14 +3873,14 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/inputs/password-input:
     dependencies:
@@ -3904,14 +3904,14 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/inputs/radio-input:
     dependencies:
@@ -3947,17 +3947,17 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-is:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/inputs/rich-text-input:
     dependencies:
@@ -4005,13 +4005,13 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       downshift:
         specifier: catalog:react
-        version: 9.0.10(react@19.2.0)
+        version: 9.3.3(react@19.2.6)
       immutable:
         specifier: ^4.3.8
         version: 4.3.8
@@ -4029,7 +4029,7 @@ importers:
         version: 0.113.1(slate@0.75.0)
       slate-react:
         specifier: catalog:rich-text
-        version: 0.75.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate@0.75.0)
+        version: 0.75.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(slate@0.75.0)
     devDependencies:
       '@commercetools-uikit/collapsible-panel':
         specifier: workspace:^
@@ -4045,16 +4045,16 @@ importers:
         version: link:../../text
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       react-router:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
 
   packages/components/inputs/rich-text-utils:
     dependencies:
@@ -4084,10 +4084,10 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       '@types/dompurify':
         specifier: 'catalog:'
         version: 2.4.0
@@ -4099,7 +4099,7 @@ importers:
         version: 3.4.5
       downshift:
         specifier: catalog:react
-        version: 9.0.10(react@19.2.0)
+        version: 9.3.3(react@19.2.6)
       escape-html:
         specifier: 'catalog:'
         version: 1.0.3
@@ -4123,7 +4123,7 @@ importers:
         version: 0.100.0(slate@0.75.0)
       slate-react:
         specifier: catalog:rich-text
-        version: 0.75.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate@0.75.0)
+        version: 0.75.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(slate@0.75.0)
       style-to-object:
         specifier: 'catalog:'
         version: 0.4.4
@@ -4133,13 +4133,13 @@ importers:
         version: 26.1.0
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/inputs/search-select-input:
     dependencies:
@@ -4169,26 +4169,26 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/inputs/search-text-input:
     dependencies:
@@ -4218,14 +4218,14 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/inputs/select-input:
     dependencies:
@@ -4255,32 +4255,32 @@ importers:
         version: 1.4.0
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       prop-types:
         specifier: catalog:react
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       react-router-dom:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
 
   packages/components/inputs/select-utils:
     dependencies:
@@ -4313,26 +4313,26 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/inputs/selectable-search-input:
     dependencies:
@@ -4371,26 +4371,26 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
       react-select:
         specifier: catalog:react
-        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 5.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/inputs/text-input:
     dependencies:
@@ -4414,14 +4414,14 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/inputs/time-input:
     dependencies:
@@ -4460,17 +4460,17 @@ importers:
         version: 1.4.0
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/inputs/toggle-input:
     dependencies:
@@ -4494,14 +4494,14 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/label:
     dependencies:
@@ -4522,17 +4522,17 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/link:
     dependencies:
@@ -4556,10 +4556,10 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       '@types/history':
         specifier: 'catalog:'
         version: 4.7.11
@@ -4572,13 +4572,13 @@ importers:
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       react-router-dom:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
 
   packages/components/loading-spinner:
     dependencies:
@@ -4602,14 +4602,14 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/messages:
     dependencies:
@@ -4627,17 +4627,17 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/notifications:
     dependencies:
@@ -4661,14 +4661,14 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/pagination:
     dependencies:
@@ -4710,23 +4710,23 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       formik:
         specifier: catalog:react
-        version: 2.4.9(@types/react@19.2.14)(react@19.2.0)
+        version: 2.4.9(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/primary-action-dropdown:
     dependencies:
@@ -4759,23 +4759,23 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-router-dom:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
 
   packages/components/progress-bar:
     dependencies:
@@ -4805,20 +4805,20 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/quick-filters:
     dependencies:
@@ -4836,17 +4836,17 @@ importers:
         version: link:../tag
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/spacings/spacings-inline:
     dependencies:
@@ -4864,14 +4864,14 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/spacings/spacings-inset:
     dependencies:
@@ -4889,14 +4889,14 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/spacings/spacings-inset-squish:
     dependencies:
@@ -4914,14 +4914,14 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/spacings/spacings-stack:
     dependencies:
@@ -4939,14 +4939,14 @@ importers:
         version: link:../../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/stamp:
     dependencies:
@@ -4970,14 +4970,14 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       '@commercetools-uikit/icons':
         specifier: workspace:^
         version: link:../icons
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/tag:
     dependencies:
@@ -5010,23 +5010,23 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       history:
         specifier: 'catalog:'
         version: 4.10.1
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-router-dom:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
 
   packages/components/text:
     dependencies:
@@ -5044,7 +5044,7 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -5054,13 +5054,13 @@ importers:
     devDependencies:
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
 
   packages/components/tooltip:
     dependencies:
@@ -5084,10 +5084,10 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -5096,10 +5096,10 @@ importers:
         version: 1.15.0
       react-is:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       use-popper:
         specifier: 'catalog:'
-        version: 1.1.6(react@19.2.0)
+        version: 1.1.6(react@19.2.6)
     devDependencies:
       '@commercetools-uikit/primary-button':
         specifier: workspace:^
@@ -5112,7 +5112,7 @@ importers:
         version: 15.8.1
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/components/view-switcher:
     dependencies:
@@ -5133,10 +5133,10 @@ importers:
         version: link:../../utils
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -5146,7 +5146,7 @@ importers:
         version: link:../icons
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   packages/hooks:
     dependencies:
@@ -5174,13 +5174,13 @@ importers:
         version: 10.4.1
       '@testing-library/react':
         specifier: catalog:test
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
 
   packages/i18n:
     dependencies:
@@ -5220,7 +5220,7 @@ importers:
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   presets/buttons:
     dependencies:
@@ -5257,13 +5257,13 @@ importers:
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       react-router-dom:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
 
   presets/fields:
     dependencies:
@@ -5327,13 +5327,13 @@ importers:
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       react-router-dom:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
 
   presets/inputs:
     dependencies:
@@ -5418,13 +5418,13 @@ importers:
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       react-router-dom:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
 
   presets/spacings:
     dependencies:
@@ -5449,7 +5449,7 @@ importers:
     devDependencies:
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
 
   presets/ui-kit:
     dependencies:
@@ -5585,13 +5585,13 @@ importers:
         version: 0.6.2
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       react-router-dom:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
 
   storybook:
     devDependencies:
@@ -5615,10 +5615,10 @@ importers:
         version: 11.13.5
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       '@modyfi/vite-plugin-yaml':
         specifier: catalog:build
         version: 1.1.1(rollup@2.80.0)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
@@ -5630,10 +5630,10 @@ importers:
         version: 9.1.20(@types/react@19.2.14)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))
       '@storybook/addon-links':
         specifier: catalog:storybook
-        version: 9.1.20(react@19.2.0)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))
+        version: 9.1.20(react@19.2.6)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))
       '@storybook/react-vite':
         specifier: catalog:storybook
-        version: 9.1.20(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@2.80.0)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 9.1.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@2.80.0)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
       '@swc/plugin-emotion':
         specifier: catalog:build
         version: 14.7.0
@@ -5645,13 +5645,13 @@ importers:
         version: 9.1.20(eslint@9.39.4(jiti@2.6.1))(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))(typescript@5.9.3)
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       remark-gfm:
         specifier: catalog:rich-text
         version: 4.0.1
@@ -5672,10 +5672,10 @@ importers:
         version: link:../design-system
       '@emotion/react':
         specifier: catalog:build
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled':
         specifier: catalog:build
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       '@fontsource/inter':
         specifier: 'catalog:'
         version: 5.2.8
@@ -5690,19 +5690,19 @@ importers:
         version: 0.6.2
       react:
         specifier: catalog:react
-        version: 19.2.0
+        version: 19.2.6
       react-dom:
         specifier: catalog:react
-        version: 19.2.0(react@19.2.0)
+        version: 19.2.6(react@19.2.6)
       react-intl:
         specifier: catalog:react
-        version: 7.1.14(react@19.2.0)(typescript@5.9.3)
+        version: 7.1.14(react@19.2.6)(typescript@5.9.3)
       react-router:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
       react-router-dom:
         specifier: catalog:react
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.6)
     devDependencies:
       '@vitejs/plugin-react':
         specifier: catalog:build
@@ -7636,22 +7636,47 @@ packages:
         integrity: sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==,
       }
 
-  '@formatjs/cli@6.7.4':
+  '@formatjs/cli-native-darwin-arm64@1.1.0':
     resolution:
       {
-        integrity: sha512-k6uqdeZDAjDd7iKKQ8yFYizFpbi5Y9H9NkV+hoIhmxaMSGvWRnRusQJaIQ+2rI14MH6knW6fx7tnO15C+ijDiw==,
+        integrity: sha512-ygEpFpmRjbAKanWaeto/eUItyuK18667mdDzpDg3CTzc15WYzjZKnwJNFUuPFvFA4hiod1tnhXT1eiXmc1wWNg==,
       }
-    engines: { node: '>= 16' }
+    cpu: [arm64]
+    os: [darwin]
+
+  '@formatjs/cli-native-linux-arm64@1.2.0':
+    resolution:
+      {
+        integrity: sha512-G6YuIVD8D6hZjnsD/aYZQ2qMHSve7IadEiXgKiDfFQBbyrkjDAlt6LDSqq4qnuv3WJ7/jAOn/An6n/bGyt0rLg==,
+      }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@formatjs/cli-native-linux-x64@1.1.0':
+    resolution:
+      {
+        integrity: sha512-AxORf5LR14HvXU4ov9gnhLrNIS2DYKqKMkRkprUhuh+ljba1riF05msK8KzslEPYQoeYKc5A0OZp57poh4xz/g==,
+      }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@formatjs/cli@6.16.0':
+    resolution:
+      {
+        integrity: sha512-49VcOBTUkjAHkk6gLEXXtzeEAIEQem8DK11pCUCJ13ZCa/P2vf/uhQwvt3/yloJbQ7QqrBq+owO2XFmeWWZ2Eg==,
+      }
+    engines: { node: '>= 20.12.0' }
     hasBin: true
     peerDependencies:
       '@glimmer/env': '*'
       '@glimmer/reference': '*'
-      '@glimmer/syntax': ^0.95.0
+      '@glimmer/syntax': ^0.84.3 || ^0.95.0
       '@glimmer/validator': '*'
-      '@vue/compiler-core': ^3.5.12
-      content-tag: ^3.0.0
-      ember-template-recast: ^6.1.5
-      vue: ^3.5.12
+      '@vue/compiler-core': ^3.5.0
+      content-tag: ^4.1.0
+      vue: ^3.5.0
     peerDependenciesMeta:
       '@glimmer/env':
         optional: true
@@ -7664,8 +7689,6 @@ packages:
       '@vue/compiler-core':
         optional: true
       content-tag:
-        optional: true
-      ember-template-recast:
         optional: true
       vue:
         optional: true
@@ -12243,10 +12266,10 @@ packages:
       }
     engines: { node: '>=10' }
 
-  downshift@9.0.10:
+  downshift@9.3.3:
     resolution:
       {
-        integrity: sha512-TP/iqV6bBok6eGD5tZ8boM8Xt7/+DZvnVNr8cNIhbAm2oUBd79Tudiccs2hbcV9p7xAgS/ozE7Hxy3a9QqS6Mw==,
+        integrity: sha512-otjI/WtoFcIXwPOyIQYkbrAZJA2Gjz67F8ENOh1RvmJalOg6fk0KEx4ljJSFuJB54ryc6doymPkCM+GjAZ7zjA==,
       }
     peerDependencies:
       react: '>=16.12.0'
@@ -16767,13 +16790,13 @@ packages:
       }
     engines: { node: ^20.9.0 || >=22 }
 
-  react-dom@19.2.0:
+  react-dom@19.2.6:
     resolution:
       {
-        integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==,
+        integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==,
       }
     peerDependencies:
-      react: ^19.2.0
+      react: ^19.2.6
 
   react-fast-compare@2.0.4:
     resolution:
@@ -16813,22 +16836,10 @@ packages:
         integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==,
       }
 
-  react-is@18.2.0:
-    resolution:
-      {
-        integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==,
-      }
-
   react-is@18.3.1:
     resolution:
       {
         integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==,
-      }
-
-  react-is@19.2.0:
-    resolution:
-      {
-        integrity: sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==,
       }
 
   react-is@19.2.6:
@@ -16923,14 +16934,14 @@ packages:
       '@types/react':
         optional: true
 
-  react-textarea-autosize@8.4.0:
+  react-textarea-autosize@8.5.9:
     resolution:
       {
-        integrity: sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==,
+        integrity: sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==,
       }
     engines: { node: '>=10' }
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-transition-group@4.4.5:
     resolution:
@@ -16949,10 +16960,10 @@ packages:
     peerDependencies:
       react: ^15.0 || ^16.0
 
-  react@19.2.0:
+  react@19.2.6:
     resolution:
       {
-        integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==,
+        integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==,
       }
     engines: { node: '>=0.10.0' }
 
@@ -20737,17 +20748,17 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
-  '@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0)':
+  '@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.0)
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.6)
       '@emotion/utils': 1.4.2
       '@emotion/weak-memoize': 0.4.0
       hoist-non-react-statics: 3.3.2
-      react: 19.2.0
+      react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
     transitivePeerDependencies:
@@ -20763,16 +20774,16 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
-  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.0))(@types/react@19.2.14)(react@19.2.0)':
+  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@emotion/babel-plugin': 11.13.5
       '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.0)
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.6)
       '@emotion/utils': 1.4.2
-      react: 19.2.0
+      react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
     transitivePeerDependencies:
@@ -20780,9 +20791,9 @@ snapshots:
 
   '@emotion/unitless@0.10.0': {}
 
-  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.2.0)':
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.2.6)':
     dependencies:
-      react: 19.2.0
+      react: 19.2.6
 
   '@emotion/utils@1.4.2': {}
 
@@ -20923,17 +20934,30 @@ snapshots:
       '@floating-ui/core': 1.7.5
       '@floating-ui/utils': 0.2.11
 
-  '@floating-ui/react-dom@2.1.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@floating-ui/dom': 1.7.6
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
   '@floating-ui/utils@0.2.11': {}
 
   '@fontsource/inter@5.2.8': {}
 
-  '@formatjs/cli@6.7.4': {}
+  '@formatjs/cli-native-darwin-arm64@1.1.0':
+    optional: true
+
+  '@formatjs/cli-native-linux-arm64@1.2.0':
+    optional: true
+
+  '@formatjs/cli-native-linux-x64@1.1.0':
+    optional: true
+
+  '@formatjs/cli@6.16.0':
+    optionalDependencies:
+      '@formatjs/cli-native-darwin-arm64': 1.1.0
+      '@formatjs/cli-native-linux-arm64': 1.2.0
+      '@formatjs/cli-native-linux-x64': 1.1.0
 
   '@formatjs/ecma402-abstract@2.3.6':
     dependencies:
@@ -21004,14 +21028,14 @@ snapshots:
     dependencies:
       '@hapi/hoek': 11.0.7
 
-  '@hello-pangea/dnd@18.0.1(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@hello-pangea/dnd@18.0.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
       css-box-model: 1.2.1
       raf-schd: 4.0.3
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.0)(redux@5.0.1)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1)
       redux: 5.0.1
     transitivePeerDependencies:
       - '@types/react'
@@ -21409,11 +21433,11 @@ snapshots:
       js-yaml: 4.1.1
       tinyglobby: 0.2.15
 
-  '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.0)':
+  '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.14
-      react: 19.2.0
+      react: 19.2.6
 
   '@mdx-js/util@1.6.22': {}
 
@@ -21737,186 +21761,186 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.1(@types/react@19.2.14)
 
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.0)':
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
-      react: 19.2.0
+      react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.0)':
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
-      react: 19.2.0
+      react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.1(@types/react@19.2.14)
 
-  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.0)':
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
-      react: 19.2.0
+      react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.1(@types/react@19.2.14)
 
-  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.0)':
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
       aria-hidden: 1.2.6
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.0)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.1(@types/react@19.2.14)
 
-  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.0)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/rect': 1.1.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.1(@types/react@19.2.14)
 
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.1(@types/react@19.2.14)
 
-  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.1(@types/react@19.2.14)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.1(@types/react@19.2.14)
 
-  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.0)':
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.0)':
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
-      react: 19.2.0
+      react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.0)':
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.0)':
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.0)':
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.0)':
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
-      react: 19.2.0
+      react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.0)':
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       '@radix-ui/rect': 1.1.1
-      react: 19.2.0
+      react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.0)':
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.0)
-      react: 19.2.0
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -22107,23 +22131,23 @@ snapshots:
 
   '@storybook/addon-docs@9.1.20(@types/react@19.2.14)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))':
     dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.0)
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.6)
       '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))
-      '@storybook/icons': 1.6.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      '@storybook/icons': 1.6.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
       storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-links@9.1.20(react@19.2.0)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))':
+  '@storybook/addon-links@9.1.20(react@19.2.6)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))':
     dependencies:
       '@storybook/global': 5.0.0
       storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
     optionalDependencies:
-      react: 19.2.0
+      react: 19.2.6
 
   '@storybook/builder-vite@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))':
     dependencies:
@@ -22139,28 +22163,28 @@ snapshots:
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/icons@1.6.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@storybook/icons@1.6.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
-  '@storybook/react-dom-shim@9.1.20(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))':
+  '@storybook/react-dom-shim@9.1.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))':
     dependencies:
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
       storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
-  '@storybook/react-vite@9.1.20(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@2.80.0)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))':
+  '@storybook/react-vite@9.1.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@2.80.0)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@2.80.0)
       '@storybook/builder-vite': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
-      '@storybook/react': 9.1.20(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))(typescript@5.9.3)
+      '@storybook/react': 9.1.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))(typescript@5.9.3)
       find-up: 7.0.0
       magic-string: 0.30.21
-      react: 19.2.0
+      react: 19.2.6
       react-docgen: 8.0.3
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.6(react@19.2.6)
       resolve: 1.22.11
       storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
       tsconfig-paths: 4.2.0
@@ -22170,12 +22194,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@storybook/react@9.1.20(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))(typescript@5.9.3)':
+  '@storybook/react@9.1.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
       storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
     optionalDependencies:
       typescript: 5.9.3
@@ -22387,12 +22411,12 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.1(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@testing-library/dom': 10.4.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.1(@types/react@19.2.14)
@@ -24003,13 +24027,13 @@ snapshots:
 
   dotenv@8.6.0: {}
 
-  downshift@9.0.10(react@19.2.0):
+  downshift@9.3.3(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.29.2
       compute-scroll-into-view: 3.1.1
       prop-types: 15.8.1
-      react: 19.2.0
-      react-is: 18.2.0
+      react: 19.2.6
+      react-is: 18.3.1
       tslib: 2.8.1
 
   dunder-proto@1.0.1:
@@ -24699,14 +24723,14 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
-  formik@2.4.9(@types/react@19.2.14)(react@19.2.0):
+  formik@2.4.9(@types/react@19.2.14)(react@19.2.6):
     dependencies:
       '@types/hoist-non-react-statics': 3.3.7(@types/react@19.2.14)
       deepmerge: 2.2.1
       hoist-non-react-statics: 3.3.2
       lodash: 4.18.1
       lodash-es: 4.18.1
-      react: 19.2.0
+      react: 19.2.6
       react-fast-compare: 2.0.4
       tiny-warning: 1.0.3
       tslib: 2.8.1
@@ -27277,18 +27301,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-dom@19.2.0(react@19.2.0):
+  react-dom@19.2.6(react@19.2.6):
     dependencies:
-      react: 19.2.0
+      react: 19.2.6
       scheduler: 0.27.0
 
   react-fast-compare@2.0.4: {}
 
-  react-from-dom@0.6.2(react@19.2.0):
+  react-from-dom@0.6.2(react@19.2.6):
     dependencies:
-      react: 19.2.0
+      react: 19.2.6
 
-  react-intl@7.1.14(react@19.2.0)(typescript@5.9.3):
+  react-intl@7.1.14(react@19.2.6)(typescript@5.9.3):
     dependencies:
       '@formatjs/ecma402-abstract': 2.3.6
       '@formatjs/icu-messageformat-parser': 2.11.4
@@ -27297,7 +27321,7 @@ snapshots:
       '@types/react': 19.2.14
       hoist-non-react-statics: 3.3.2
       intl-messageformat: 10.7.18
-      react: 19.2.0
+      react: 19.2.6
       tslib: 2.8.1
     optionalDependencies:
       typescript: 5.9.3
@@ -27306,56 +27330,52 @@ snapshots:
 
   react-is@17.0.2: {}
 
-  react-is@18.2.0: {}
-
   react-is@18.3.1: {}
-
-  react-is@19.2.0: {}
 
   react-is@19.2.6: {}
 
-  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.0)(redux@5.0.1):
+  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1):
     dependencies:
       '@types/use-sync-external-store': 0.0.6
-      react: 19.2.0
-      use-sync-external-store: 1.6.0(react@19.2.0)
+      react: 19.2.6
+      use-sync-external-store: 1.6.0(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
       redux: 5.0.1
 
   react-refresh@0.18.0: {}
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.0):
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.6):
     dependencies:
-      react: 19.2.0
-      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.0)
+      react: 19.2.6
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.6)
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.0):
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.6):
     dependencies:
-      react: 19.2.0
-      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.0)
-      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.0)
+      react: 19.2.6
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.6)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.6)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.0)
-      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.0)
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.6)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-router-dom@5.3.4(react@19.2.0):
+  react-router-dom@5.3.4(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.29.2
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
-      react: 19.2.0
-      react-router: 5.3.4(react@19.2.0)
+      react: 19.2.6
+      react-router: 5.3.4(react@19.2.6)
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  react-router@5.3.4(react@19.2.0):
+  react-router@5.3.4(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.29.2
       history: 4.10.1
@@ -27363,59 +27383,59 @@ snapshots:
       loose-envify: 1.4.0
       path-to-regexp: 3.3.0
       prop-types: 15.8.1
-      react: 19.2.0
+      react: 19.2.6
       react-is: 16.13.1
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  react-select@5.10.2(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-select@5.10.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.29.2
       '@emotion/cache': 11.14.0
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@floating-ui/dom': 1.7.6
       '@types/react-transition-group': 4.4.12(@types/react@19.2.14)
       memoize-one: 6.0.0
       prop-types: 15.8.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-transition-group: 4.4.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.14)(react@19.2.0)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-transition-group: 4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.14)(react@19.2.6)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
 
-  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.0):
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.6):
     dependencies:
       get-nonce: 1.0.1
-      react: 19.2.0
+      react: 19.2.6
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-textarea-autosize@8.4.0(@types/react@19.2.14)(react@19.2.0):
+  react-textarea-autosize@8.5.9(@types/react@19.2.14)(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.29.2
-      react: 19.2.0
-      use-composed-ref: 1.4.0(@types/react@19.2.14)(react@19.2.0)
-      use-latest: 1.3.0(@types/react@19.2.14)(react@19.2.0)
+      react: 19.2.6
+      use-composed-ref: 1.4.0(@types/react@19.2.14)(react@19.2.6)
+      use-latest: 1.3.0(@types/react@19.2.14)(react@19.2.6)
     transitivePeerDependencies:
       - '@types/react'
 
-  react-transition-group@4.4.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-transition-group@4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.29.2
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
-  react-value@0.2.0(react@19.2.0):
+  react-value@0.2.0(react@19.2.6):
     dependencies:
-      react: 19.2.0
+      react: 19.2.6
 
-  react@19.2.0: {}
+  react@19.2.6: {}
 
   read-package-up@11.0.0:
     dependencies:
@@ -27887,7 +27907,7 @@ snapshots:
       is-plain-object: 5.0.0
       slate: 0.75.0
 
-  slate-react@0.75.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(slate@0.75.0):
+  slate-react@0.75.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(slate@0.75.0):
     dependencies:
       '@types/is-hotkey': 0.1.10
       '@types/lodash': 4.17.24
@@ -27895,8 +27915,8 @@ snapshots:
       is-hotkey: 0.1.8
       is-plain-object: 5.0.0
       lodash: 4.18.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
       scroll-into-view-if-needed: 2.2.31
       slate: 0.75.0
       tiny-invariant: 1.0.6
@@ -28697,54 +28717,54 @@ snapshots:
 
   urlpattern-polyfill@10.0.0: {}
 
-  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.0):
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.6):
     dependencies:
-      react: 19.2.0
+      react: 19.2.6
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
 
-  use-composed-ref@1.4.0(@types/react@19.2.14)(react@19.2.0):
+  use-composed-ref@1.4.0(@types/react@19.2.14)(react@19.2.6):
     dependencies:
-      react: 19.2.0
+      react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
 
-  use-deep-compare@0.1.0(react@19.2.0):
+  use-deep-compare@0.1.0(react@19.2.6):
     dependencies:
       dequal: 1.0.0
-      react: 19.2.0
+      react: 19.2.6
 
-  use-isomorphic-layout-effect@1.2.1(@types/react@19.2.14)(react@19.2.0):
+  use-isomorphic-layout-effect@1.2.1(@types/react@19.2.14)(react@19.2.6):
     dependencies:
-      react: 19.2.0
+      react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
 
-  use-latest@1.3.0(@types/react@19.2.14)(react@19.2.0):
+  use-latest@1.3.0(@types/react@19.2.14)(react@19.2.6):
     dependencies:
-      react: 19.2.0
-      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.14)(react@19.2.0)
+      react: 19.2.6
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.14)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
 
-  use-popper@1.1.6(react@19.2.0):
+  use-popper@1.1.6(react@19.2.6):
     dependencies:
       popper.js: 1.15.0
-      react: 19.2.0
-      use-deep-compare: 0.1.0(react@19.2.0)
+      react: 19.2.6
+      use-deep-compare: 0.1.0(react@19.2.6)
 
-  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.0):
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.6):
     dependencies:
       detect-node-es: 1.1.0
-      react: 19.2.0
+      react: 19.2.6
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
 
-  use-sync-external-store@1.6.0(react@19.2.0):
+  use-sync-external-store@1.6.0(react@19.2.6):
     dependencies:
-      react: 19.2.0
+      react: 19.2.6
 
   util-deprecate@1.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   build:
     '@babel/core':
-      specifier: 7.28.4
-      version: 7.28.4
+      specifier: 7.29.0
+      version: 7.29.0
     '@babel/runtime':
       specifier: ^7.20.13
       version: 7.29.2
@@ -31,8 +31,8 @@ catalogs:
       specifier: ^1.1.0
       version: 1.1.1
     '@preconstruct/cli':
-      specifier: 2.8.12
-      version: 2.8.12
+      specifier: 2.8.13
+      version: 2.8.13
     '@svgr/babel-plugin-svg-dynamic-title':
       specifier: ^8.0.0
       version: 8.0.0
@@ -52,20 +52,20 @@ catalogs:
       specifier: ^14.3.0
       version: 14.7.0
     '@vitejs/plugin-react':
-      specifier: 5.0.4
-      version: 5.0.4
+      specifier: 5.2.0
+      version: 5.2.0
     '@vitejs/plugin-react-swc':
       specifier: ^4.2.2
       version: 4.3.0
     browserslist:
-      specifier: 4.26.3
-      version: 4.26.3
+      specifier: 4.28.2
+      version: 4.28.2
     bundlewatch:
       specifier: ^0.4.1
       version: 0.4.1
     postcss:
-      specifier: 8.5.6
-      version: 8.5.6
+      specifier: 8.5.15
+      version: 8.5.15
     postcss-styled-syntax:
       specifier: ^0.7.0
       version: 0.7.1
@@ -520,7 +520,7 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: catalog:build
-        version: 7.28.4
+        version: 7.29.0
       '@changesets/changelog-github':
         specifier: catalog:repo
         version: 0.5.2
@@ -529,10 +529,10 @@ importers:
         version: 2.31.0(@types/node@22.19.15)
       '@commercetools-frontend/babel-preset-mc-app':
         specifier: catalog:repo
-        version: 27.6.2(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
+        version: 27.6.2(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
       '@commercetools-frontend/eslint-config-mc-app':
         specifier: catalog:repo
-        version: 27.6.2(babel-plugin-istanbul@7.0.1)(eslint@9.39.4(jiti@2.6.1))(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
+        version: 27.6.2(babel-plugin-istanbul@7.0.1)(eslint@9.39.4(jiti@2.6.1))(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(ts-jest@29.4.5(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
       '@commercetools-frontend/ui-kit':
         specifier: workspace:^
         version: link:presets/ui-kit
@@ -586,10 +586,10 @@ importers:
         version: 2.0.2(puppeteer@22.15.0(typescript@5.9.3))
       '@preconstruct/cli':
         specifier: catalog:build
-        version: 2.8.12
+        version: 2.8.13
       '@svgr/babel-plugin-svg-dynamic-title':
         specifier: catalog:build
-        version: 8.0.0(@babel/core@7.28.4)
+        version: 8.0.0(@babel/core@7.29.0)
       '@svgr/cli':
         specifier: catalog:build
         version: 8.1.0(typescript@5.9.3)
@@ -652,13 +652,13 @@ importers:
         version: 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       babel-jest:
         specifier: catalog:test
-        version: 30.4.1(@babel/core@7.28.4)
+        version: 30.4.1(@babel/core@7.29.0)
       babel-plugin-formatjs:
         specifier: catalog:react
-        version: 10.5.41(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
+        version: 10.5.41(ts-jest@29.4.5(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
       browserslist:
         specifier: catalog:build
-        version: 4.26.3
+        version: 4.28.2
       bundlewatch:
         specifier: catalog:build
         version: 0.4.1
@@ -751,13 +751,13 @@ importers:
         version: 1.2.0
       postcss:
         specifier: catalog:build
-        version: 8.5.6
+        version: 8.5.15
       postcss-styled-syntax:
         specifier: catalog:build
-        version: 0.7.1(postcss@8.5.6)
+        version: 0.7.1(postcss@8.5.15)
       postcss-syntax:
         specifier: catalog:build
-        version: 0.36.2(postcss@8.5.6)
+        version: 0.36.2(postcss@8.5.15)
       postcss-value-parser:
         specifier: catalog:build
         version: 4.2.0
@@ -5706,7 +5706,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-react':
         specifier: catalog:build
-        version: 5.0.4(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 5.2.0(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
       vite:
         specifier: catalog:build
         version: 6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
@@ -5749,6 +5749,13 @@ packages:
     resolution:
       {
         integrity: sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/core@7.29.0':
+    resolution:
+      {
+        integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==,
       }
     engines: { node: '>=6.9.0' }
 
@@ -8414,10 +8421,10 @@ packages:
       }
     engines: { node: '>=12' }
 
-  '@preconstruct/cli@2.8.12':
+  '@preconstruct/cli@2.8.13':
     resolution:
       {
-        integrity: sha512-SMsMICUWROmu/vb4cmrk7EJUiWhgNjB3U3tM654K9bu9yECXqrPN473vliO7KPV3CSLhmtl3S4nfcMirEJmyZg==,
+        integrity: sha512-+1I98YKqXy3nNQQBTvwzgjFujcDndX4Q7G0QHBCCRCxGRA5LIyUvK9XN92pyWPbbmUPPg2amlTGxWThGgn1DRQ==,
       }
     hasBin: true
 
@@ -8726,10 +8733,10 @@ packages:
         integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==,
       }
 
-  '@rolldown/pluginutils@1.0.0-beta.38':
+  '@rolldown/pluginutils@1.0.0-rc.3':
     resolution:
       {
-        integrity: sha512-N/ICGKleNhA5nc9XXQG/kkKHJ7S55u0x0XUJbbkmdCnFuoRkM1Il12q9q0eX19+M7KKUEPw/daUPIRnxhcxAIw==,
+        integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==,
       }
 
   '@rolldown/pluginutils@1.0.0-rc.7':
@@ -10257,14 +10264,14 @@ packages:
     peerDependencies:
       vite: ^4 || ^5 || ^6 || ^7 || ^8
 
-  '@vitejs/plugin-react@5.0.4':
+  '@vitejs/plugin-react@5.2.0':
     resolution:
       {
-        integrity: sha512-La0KD0vGkVkSk6K+piWDKRUyg8Rl5iAIKRMH0vMJI0Eg47bq1eOxmoObAaQG37WMW9MSyk7Cs8EIWwJC1PtzKA==,
+        integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@vitest/expect@3.2.4':
     resolution:
@@ -10967,14 +10974,6 @@ packages:
         integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
       }
     engines: { node: '>=8' }
-
-  browserslist@4.26.3:
-    resolution:
-      {
-        integrity: sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==,
-      }
-    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
-    hasBin: true
 
   browserslist@4.28.2:
     resolution:
@@ -15749,6 +15748,14 @@ packages:
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
+  nanoid@3.3.12:
+    resolution:
+      {
+        integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==,
+      }
+    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+    hasBin: true
+
   napi-postinstall@0.3.4:
     resolution:
       {
@@ -16475,6 +16482,13 @@ packages:
         integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==,
       }
 
+  postcss@8.5.15:
+    resolution:
+      {
+        integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
+
   postcss@8.5.6:
     resolution:
       {
@@ -16838,10 +16852,10 @@ packages:
       redux:
         optional: true
 
-  react-refresh@0.17.0:
+  react-refresh@0.18.0:
     resolution:
       {
-        integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==,
+        integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==,
       }
     engines: { node: '>=0.10.0' }
 
@@ -19377,9 +19391,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.28.6(@babel/core@7.28.4)(eslint@9.39.4(jiti@2.6.1))':
+  '@babel/core@7.29.0':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3(supports-color@5.5.0)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@2.6.1))':
+    dependencies:
+      '@babel/core': 7.29.0
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
       eslint: 9.39.4(jiti@2.6.1)
       eslint-visitor-keys: 2.1.0
@@ -19405,29 +19439,29 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.28.4)':
+  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.28.4)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/traverse': 7.29.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.28.4)':
+  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.28.4)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3(supports-color@5.5.0)
@@ -19470,6 +19504,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
       '@babel/types': 7.29.0
@@ -19478,18 +19521,18 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.28.4)':
+  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.28.6(@babel/core@7.28.4)':
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/traverse': 7.29.0
@@ -19526,49 +19569,49 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.28.4)':
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.28.4)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-do-expressions@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-proposal-do-expressions@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-proposal-export-default-from@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-proposal-export-default-from@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-proposal-object-rest-spread@7.12.1(@babel/core@7.12.9)':
@@ -19578,48 +19621,48 @@ snapshots:
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.9)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.12.9)
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.4)':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-jsx@7.12.1(@babel/core@7.12.9)':
@@ -19627,24 +19670,24 @@ snapshots:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.12.9)':
@@ -19652,276 +19695,276 @@ snapshots:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.28.4)':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.28.4)':
+  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.4)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.4)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.4)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.28.4)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/template': 7.28.6
 
-  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.28.4)':
+  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.28.4)':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.4)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.4)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.28.4)':
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.28.4)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.4)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.4)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.28.4)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
@@ -19932,265 +19975,265 @@ snapshots:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.4)':
+  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.4)
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.28.4)':
+  '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.4)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.28.4)':
+  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-runtime@7.29.0(@babel/core@7.28.4)':
+  '@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.28.4)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.4)
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.28.4)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.0)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.4)
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.28.4)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.28.4)':
+  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.28.4)':
+  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/preset-env@7.29.2(@babel/core@7.28.4)':
+  '@babel/preset-env@7.29.2(@babel/core@7.29.0)':
     dependencies:
       '@babel/compat-data': 7.29.0
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.28.4)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.4)
-      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.28.4)
-      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.4)
-      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.28.4)
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.28.4)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.28.4)
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.4)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.28.4)
-      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.28.4)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.28.4)
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.28.4)
-      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.28.4)
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.28.4)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.0)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0)
+      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.0)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.0)
       core-js-compat: 3.49.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.4)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/types': 7.29.0
       esutils: 2.0.3
 
-  '@babel/preset-react@7.28.5(@babel/core@7.28.4)':
+  '@babel/preset-react@7.28.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.28.4)
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-typescript@7.28.5(@babel/core@7.28.4)':
+  '@babel/preset-typescript@7.28.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.28.4)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -20395,29 +20438,29 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@commercetools-frontend/babel-preset-mc-app@27.6.2(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))':
+  '@commercetools-frontend/babel-preset-mc-app@27.6.2(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/plugin-proposal-do-expressions': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.4)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.28.4)
-      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.28.4)
-      '@babel/preset-env': 7.29.2(@babel/core@7.28.4)
-      '@babel/preset-react': 7.28.5(@babel/core@7.28.4)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-do-expressions': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.0)
+      '@babel/preset-env': 7.29.2(@babel/core@7.29.0)
+      '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/runtime': 7.29.2
       '@babel/runtime-corejs3': 7.29.2
       '@emotion/babel-plugin': 11.13.5
-      '@emotion/babel-preset-css-prop': 11.12.0(@babel/core@7.28.4)
-      babel-plugin-dev-expression: 0.2.3(@babel/core@7.28.4)
-      babel-plugin-formatjs: 10.5.41(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
+      '@emotion/babel-preset-css-prop': 11.12.0(@babel/core@7.29.0)
+      babel-plugin-dev-expression: 0.2.3(@babel/core@7.29.0)
+      babel-plugin-formatjs: 10.5.41(ts-jest@29.4.5(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
       babel-plugin-macros: 3.1.0
       babel-plugin-preval: 5.1.0
       babel-plugin-transform-react-remove-prop-types: 0.4.24
@@ -20428,11 +20471,11 @@ snapshots:
       - supports-color
       - ts-jest
 
-  '@commercetools-frontend/eslint-config-mc-app@27.6.2(babel-plugin-istanbul@7.0.1)(eslint@9.39.4(jiti@2.6.1))(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))':
+  '@commercetools-frontend/eslint-config-mc-app@27.6.2(babel-plugin-istanbul@7.0.1)(eslint@9.39.4(jiti@2.6.1))(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(ts-jest@29.4.5(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/eslint-parser': 7.28.6(@babel/core@7.28.4)(eslint@9.39.4(jiti@2.6.1))
-      '@commercetools-frontend/babel-preset-mc-app': 27.6.2(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
+      '@babel/core': 7.29.0
+      '@babel/eslint-parser': 7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@2.6.1))
+      '@commercetools-frontend/babel-preset-mc-app': 27.6.2(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
       '@typescript-eslint/eslint-plugin': 8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       confusing-browser-globals: 1.0.11
@@ -20637,10 +20680,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emotion/babel-plugin-jsx-pragmatic@0.3.0(@babel/core@7.28.4)':
+  '@emotion/babel-plugin-jsx-pragmatic@0.3.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
@@ -20658,13 +20701,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@emotion/babel-preset-css-prop@11.12.0(@babel/core@7.28.4)':
+  '@emotion/babel-preset-css-prop@11.12.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/runtime': 7.29.2
       '@emotion/babel-plugin': 11.13.5
-      '@emotion/babel-plugin-jsx-pragmatic': 0.3.0(@babel/core@7.28.4)
+      '@emotion/babel-plugin-jsx-pragmatic': 0.3.0(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -20934,7 +20977,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@formatjs/ts-transformer@3.14.2(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))':
+  '@formatjs/ts-transformer@3.14.2(ts-jest@29.4.5(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))':
     dependencies:
       '@formatjs/icu-messageformat-parser': 2.11.4
       '@types/node': 22.19.15
@@ -20943,7 +20986,7 @@ snapshots:
       tslib: 2.8.1
       typescript: 5.9.3
     optionalDependencies:
-      ts-jest: 29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+      ts-jest: 29.4.5(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
 
   '@hapi/address@5.1.1':
     dependencies:
@@ -21221,7 +21264,7 @@ snapshots:
 
   '@jest/transform@30.4.1':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.31
       babel-plugin-istanbul: 7.0.1
@@ -21624,10 +21667,10 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@preconstruct/cli@2.8.12':
+  '@preconstruct/cli@2.8.13':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
       '@babel/runtime': 7.29.2
       '@preconstruct/hook': 0.4.0
@@ -21667,8 +21710,8 @@ snapshots:
 
   '@preconstruct/hook@0.4.0':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
       pirates: 4.0.7
       source-map-support: 0.5.21
     transitivePeerDependencies:
@@ -21879,7 +21922,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@rolldown/pluginutils@1.0.0-beta.38': {}
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
@@ -22137,49 +22180,49 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.4)':
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.28.4)':
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.28.4)':
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.28.4)':
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.28.4)':
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.28.4)':
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.28.4)':
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.28.4)':
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-preset@8.1.0(@babel/core@7.28.4)':
+  '@svgr/babel-preset@8.1.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.4
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.28.4)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.28.4)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.28.4)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.28.4)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.28.4)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.28.4)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.28.4)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
 
   '@svgr/cli@8.1.0(typescript@5.9.3)':
     dependencies:
@@ -22199,8 +22242,8 @@ snapshots:
 
   '@svgr/core@8.1.0(typescript@5.9.3)':
     dependencies:
-      '@babel/core': 7.28.4
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@5.9.3)
       snake-case: 3.0.4
@@ -22215,8 +22258,8 @@ snapshots:
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
     dependencies:
-      '@babel/core': 7.28.4
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
       '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
@@ -22779,14 +22822,14 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@5.0.4(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))':
+  '@vitejs/plugin-react@5.2.0(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))':
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.4)
-      '@rolldown/pluginutils': 1.0.0-beta.38
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
-      react-refresh: 0.17.0
+      react-refresh: 0.18.0
       vite: 6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
@@ -23042,32 +23085,32 @@ snapshots:
 
   b4a@1.8.0: {}
 
-  babel-jest@30.4.1(@babel/core@7.28.4):
+  babel-jest@30.4.1(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@jest/transform': 30.4.1
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 7.0.1
-      babel-preset-jest: 30.4.0(@babel/core@7.28.4)
+      babel-preset-jest: 30.4.0(@babel/core@7.29.0)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-dev-expression@0.2.3(@babel/core@7.28.4):
+  babel-plugin-dev-expression@0.2.3(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
 
-  babel-plugin-formatjs@10.5.41(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)):
+  babel-plugin-formatjs@10.5.41(ts-jest@29.4.5(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)):
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.4)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       '@formatjs/icu-messageformat-parser': 2.11.4
-      '@formatjs/ts-transformer': 3.14.2(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
+      '@formatjs/ts-transformer': 3.14.2(ts-jest@29.4.5(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
       '@types/babel__core': 7.20.5
       '@types/babel__helper-plugin-utils': 7.10.3
       '@types/babel__traverse': 7.28.0
@@ -23096,35 +23139,35 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.11
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.28.4):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
     dependencies:
       '@babel/compat-data': 7.29.0
-      '@babel/core': 7.28.4
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.28.4):
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.28.4):
+  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.28.4):
+  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -23137,30 +23180,30 @@ snapshots:
 
   babel-plugin-transform-react-remove-prop-types@0.4.24: {}
 
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.4):
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.4)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.4)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.4)
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.4)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.4)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.4)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.4)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.0)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
 
-  babel-preset-jest@30.4.0(@babel/core@7.28.4):
+  babel-preset-jest@30.4.0(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       babel-plugin-jest-hoist: 30.4.0
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.4)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
 
   bail@1.0.5: {}
 
@@ -23238,14 +23281,6 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
-
-  browserslist@4.26.3:
-    dependencies:
-      baseline-browser-mapping: 2.10.13
-      caniuse-lite: 1.0.30001784
-      electron-to-chromium: 1.5.330
-      node-releases: 2.0.36
-      update-browserslist-db: 1.2.3(browserslist@4.26.3)
 
   browserslist@4.28.2:
     dependencies:
@@ -25319,7 +25354,7 @@ snapshots:
 
   istanbul-lib-instrument@6.0.3:
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -25418,12 +25453,12 @@ snapshots:
 
   jest-config@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)):
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
       '@jest/pattern': 30.4.0
       '@jest/test-sequencer': 30.4.1
       '@jest/types': 30.4.1
-      babel-jest: 30.4.1(@babel/core@7.28.4)
+      babel-jest: 30.4.1(@babel/core@7.29.0)
       chalk: 4.1.2
       ci-info: 4.4.0
       deepmerge: 4.3.1
@@ -25712,17 +25747,17 @@ snapshots:
 
   jest-snapshot@30.4.1:
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.28.4)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/types': 7.29.0
       '@jest/expect-utils': 30.4.1
       '@jest/get-type': 30.1.0
       '@jest/snapshot-utils': 30.4.1
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.4)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
       chalk: 4.1.2
       expect: 30.4.1
       graceful-fs: 4.2.11
@@ -26623,6 +26658,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.12: {}
+
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
@@ -26994,29 +27031,35 @@ snapshots:
 
   postcss-resolve-nested-selector@0.1.6: {}
 
-  postcss-safe-parser@7.0.1(postcss@8.5.6):
+  postcss-safe-parser@7.0.1(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.15
 
   postcss-selector-parser@7.1.1:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-sorting@7.0.1(postcss@8.5.6):
+  postcss-sorting@7.0.1(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.15
 
-  postcss-styled-syntax@0.7.1(postcss@8.5.6):
+  postcss-styled-syntax@0.7.1(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.15
       typescript: 5.9.3
 
-  postcss-syntax@0.36.2(postcss@8.5.6):
+  postcss-syntax@0.36.2(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.15
 
   postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.6:
     dependencies:
@@ -27280,7 +27323,7 @@ snapshots:
       '@types/react': 19.2.14
       redux: 5.0.1
 
-  react-refresh@0.17.0: {}
+  react-refresh@0.18.0: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.0):
     dependencies:
@@ -28136,8 +28179,8 @@ snapshots:
 
   stylelint-order@5.0.0(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
-      postcss: 8.5.6
-      postcss-sorting: 7.0.1(postcss@8.5.6)
+      postcss: 8.5.15
+      postcss-sorting: 7.0.1(postcss@8.5.15)
       stylelint: 16.26.1(typescript@5.9.3)
 
   stylelint@16.26.1(typescript@5.9.3):
@@ -28170,9 +28213,9 @@ snapshots:
       micromatch: 4.0.8
       normalize-path: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.15
       postcss-resolve-nested-selector: 0.1.6
-      postcss-safe-parser: 7.0.1(postcss@8.5.6)
+      postcss-safe-parser: 7.0.1(postcss@8.5.15)
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
@@ -28376,7 +28419,7 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.5(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -28390,10 +28433,10 @@ snapshots:
       typescript: 5.9.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
-      babel-jest: 30.4.1(@babel/core@7.28.4)
+      babel-jest: 30.4.1(@babel/core@7.29.0)
       esbuild: 0.25.12
       jest-util: 30.4.1
     optional: true
@@ -28636,12 +28679,6 @@ snapshots:
       '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
-
-  update-browserslist-db@1.2.3(browserslist@4.26.3):
-    dependencies:
-      browserslist: 4.26.3
-      escalade: 3.2.0
-      picocolors: 1.1.1
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,8 +410,8 @@ catalogs:
       version: 9.1.20
   test:
     '@percy/cli':
-      specifier: 1.31.3
-      version: 1.31.3
+      specifier: 1.31.13
+      version: 1.31.13
     '@percy/puppeteer':
       specifier: 2.0.2
       version: 2.0.2
@@ -428,17 +428,17 @@ catalogs:
       specifier: ^30.0.0
       version: 30.0.0
     babel-jest:
-      specifier: 30.3.0
-      version: 30.3.0
+      specifier: 30.4.1
+      version: 30.4.1
     identity-obj-proxy:
       specifier: 3.0.0
       version: 3.0.0
     jest:
-      specifier: 30.3.0
-      version: 30.3.0
+      specifier: 30.4.2
+      version: 30.4.2
     jest-environment-jsdom:
-      specifier: 30.3.0
-      version: 30.3.0
+      specifier: 30.4.1
+      version: 30.4.1
     jest-localstorage-mock:
       specifier: 2.4.26
       version: 2.4.26
@@ -455,8 +455,8 @@ catalogs:
       specifier: 0.6.0
       version: 0.6.0
     jest-validate:
-      specifier: 30.3.0
-      version: 30.3.0
+      specifier: 30.4.1
+      version: 30.4.1
     jest-watch-typeahead:
       specifier: 3.0.1
       version: 3.0.1
@@ -529,10 +529,10 @@ importers:
         version: 2.31.0(@types/node@22.19.15)
       '@commercetools-frontend/babel-preset-mc-app':
         specifier: catalog:repo
-        version: 27.6.2(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
+        version: 27.6.2(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
       '@commercetools-frontend/eslint-config-mc-app':
         specifier: catalog:repo
-        version: 27.6.2(babel-plugin-istanbul@7.0.1)(eslint@9.39.4(jiti@2.6.1))(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
+        version: 27.6.2(babel-plugin-istanbul@7.0.1)(eslint@9.39.4(jiti@2.6.1))(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
       '@commercetools-frontend/ui-kit':
         specifier: workspace:^
         version: link:presets/ui-kit
@@ -580,7 +580,7 @@ importers:
         version: 1.1.3
       '@percy/cli':
         specifier: catalog:test
-        version: 1.31.3(typescript@5.9.3)
+        version: 1.31.13(typescript@5.9.3)
       '@percy/puppeteer':
         specifier: catalog:test
         version: 2.0.2(puppeteer@22.15.0(typescript@5.9.3))
@@ -652,10 +652,10 @@ importers:
         version: 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       babel-jest:
         specifier: catalog:test
-        version: 30.3.0(@babel/core@7.28.4)
+        version: 30.4.1(@babel/core@7.28.4)
       babel-plugin-formatjs:
         specifier: catalog:react
-        version: 10.5.41(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
+        version: 10.5.41(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
       browserslist:
         specifier: catalog:build
         version: 4.26.3
@@ -709,10 +709,10 @@ importers:
         version: 1.2.4
       jest:
         specifier: catalog:test
-        version: 30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: catalog:test
-        version: 30.3.0
+        version: 30.4.1
       jest-localstorage-mock:
         specifier: catalog:test
         version: 2.4.26
@@ -721,7 +721,7 @@ importers:
         version: 11.0.0(puppeteer@22.15.0(typescript@5.9.3))(typescript@5.9.3)
       jest-runner-eslint:
         specifier: catalog:test
-        version: 2.3.0(eslint@9.39.4(jiti@2.6.1))(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))
+        version: 2.3.0(eslint@9.39.4(jiti@2.6.1))(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))
       jest-runner-stylelint:
         specifier: catalog:test
         version: 2.3.7(stylelint@16.26.1(typescript@5.9.3))
@@ -730,10 +730,10 @@ importers:
         version: 0.6.0
       jest-validate:
         specifier: catalog:test
-        version: 30.3.0
+        version: 30.4.1
       jest-watch-typeahead:
         specifier: catalog:test
-        version: 3.0.1(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))
+        version: 3.0.1(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))
       lint-staged:
         specifier: catalog:repo
         version: 16.2.4
@@ -7850,10 +7850,17 @@ packages:
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  '@jest/core@30.3.0':
+  '@jest/console@30.4.1':
     resolution:
       {
-        integrity: sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==,
+        integrity: sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==,
+      }
+    engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
+
+  '@jest/core@30.4.2':
+    resolution:
+      {
+        integrity: sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
     peerDependencies:
@@ -7862,13 +7869,6 @@ packages:
       node-notifier:
         optional: true
 
-  '@jest/diff-sequences@30.3.0':
-    resolution:
-      {
-        integrity: sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==,
-      }
-    engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
-
   '@jest/diff-sequences@30.4.0':
     resolution:
       {
@@ -7876,10 +7876,10 @@ packages:
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  '@jest/environment-jsdom-abstract@30.3.0':
+  '@jest/environment-jsdom-abstract@30.4.1':
     resolution:
       {
-        integrity: sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==,
+        integrity: sha512-dSlKrqug3siYNHVnjwIldShY12wAH3spwRltO/+8VOjg0X+xEq7vOs3DbBs4LRKsu7OH+NUb9kuZUNBF9Ho3TA==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
     peerDependencies:
@@ -7896,17 +7896,10 @@ packages:
       }
     engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
 
-  '@jest/environment@30.3.0':
+  '@jest/environment@30.4.1':
     resolution:
       {
-        integrity: sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==,
-      }
-    engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
-
-  '@jest/expect-utils@30.3.0':
-    resolution:
-      {
-        integrity: sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==,
+        integrity: sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
@@ -7917,10 +7910,10 @@ packages:
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  '@jest/expect@30.3.0':
+  '@jest/expect@30.4.1':
     resolution:
       {
-        integrity: sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==,
+        integrity: sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
@@ -7931,10 +7924,10 @@ packages:
       }
     engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
 
-  '@jest/fake-timers@30.3.0':
+  '@jest/fake-timers@30.4.1':
     resolution:
       {
-        integrity: sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==,
+        integrity: sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
@@ -7945,10 +7938,10 @@ packages:
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  '@jest/globals@30.3.0':
+  '@jest/globals@30.4.1':
     resolution:
       {
-        integrity: sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==,
+        integrity: sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
@@ -7966,10 +7959,10 @@ packages:
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  '@jest/reporters@30.3.0':
+  '@jest/reporters@30.4.1':
     resolution:
       {
-        integrity: sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==,
+        integrity: sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
     peerDependencies:
@@ -7999,10 +7992,10 @@ packages:
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  '@jest/snapshot-utils@30.3.0':
+  '@jest/snapshot-utils@30.4.1':
     resolution:
       {
-        integrity: sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==,
+        integrity: sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
@@ -8020,17 +8013,24 @@ packages:
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  '@jest/test-sequencer@30.3.0':
+  '@jest/test-result@30.4.1':
     resolution:
       {
-        integrity: sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==,
+        integrity: sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  '@jest/transform@30.3.0':
+  '@jest/test-sequencer@30.4.1':
     resolution:
       {
-        integrity: sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==,
+        integrity: sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==,
+      }
+    engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
+
+  '@jest/transform@30.4.1':
+    resolution:
+      {
+        integrity: sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
@@ -8236,109 +8236,116 @@ packages:
       }
     engines: { node: '>=12.4.0' }
 
-  '@percy/cli-app@1.31.3':
+  '@percy/cli-app@1.31.13':
     resolution:
       {
-        integrity: sha512-g9NnYQgVVugGQZhUnpd4bJY9zfZnSOM4jJVPrdA2cOO+JxKJr7079JCkcNdrOqmtSbZ01XugSKz5UgQN+SUgMg==,
+        integrity: sha512-onVbiQkG2FaAnP9rw1OtCR/8OkD0lo/S8Cz56Qe3sln/kJtfEC1VAsTq9x/e3caeNFPh7aObF78o8BVvIexcNQ==,
       }
     engines: { node: '>=14' }
 
-  '@percy/cli-build@1.31.3':
+  '@percy/cli-build@1.31.13':
     resolution:
       {
-        integrity: sha512-VNybZILAj9GoEf2lB/DueO+KibEhgV2Gbh1kCUsUwmINOrZy2vD6Izy+asCPgdLWY5xe09K2QuLPOfgq5JfZWw==,
+        integrity: sha512-tsAr+pzGe5LqRNJiB4CBo7YDBXqH/uXm/89iovwor8wkqDgHR3DfC8u5+GgNNbfazEG2nDx4l3QmmOvN+APARw==,
       }
     engines: { node: '>=14' }
 
-  '@percy/cli-command@1.31.3':
+  '@percy/cli-command@1.31.13':
     resolution:
       {
-        integrity: sha512-NLF4HoLkz3vlgIIfgweQgwFowyOG5PYD67DCzzwK34picoeOa6u1zlx1mhaZA9L1kDwJcfTSNSbht7CpBiL6JQ==,
-      }
-    engines: { node: '>=14' }
-    hasBin: true
-
-  '@percy/cli-config@1.31.3':
-    resolution:
-      {
-        integrity: sha512-hELWI27R9RyRGC59f30+Ob9Zy07OuGPqrm9SccGsybpj31qZkV0WK8H3vTWkLzPBPoHMnXbshPFYr5VkEsUBTA==,
-      }
-    engines: { node: '>=14' }
-
-  '@percy/cli-exec@1.31.3':
-    resolution:
-      {
-        integrity: sha512-TZiCFoDyNmsw8ZB3dmz2ciVVoApHYkaK4plCBBRY1BI7d6jRBJifct0rNvklnTjHYsCsTGVGthnenAih33kFaA==,
-      }
-    engines: { node: '>=14' }
-
-  '@percy/cli-snapshot@1.31.3':
-    resolution:
-      {
-        integrity: sha512-amurMrPpj3AmoHopdr3utA/iv0Oj6d+BPqbRLvh7OhutPMPOc0zrDKVDKiocfRKTkGVxkBgnt8NTl+rvx450Vg==,
-      }
-    engines: { node: '>=14' }
-
-  '@percy/cli-upload@1.31.3':
-    resolution:
-      {
-        integrity: sha512-rP+iDQBFguuG2wWN+OwbclM+3Vj01dkxNUcBBEeQ16pZQ0zSbOq5Qt/2Mw93SMoNpa0il4vk4zmcXPgApA+Qgg==,
-      }
-    engines: { node: '>=14' }
-
-  '@percy/cli@1.31.3':
-    resolution:
-      {
-        integrity: sha512-BhxNjwTWuN1xxin1bc1qGCqe2suusFUDKYot7e90UGRa6wUSZsyjmzC9kGfb3IhEmpM0EswQSePp7RR2d6saww==,
+        integrity: sha512-pGcs0yPocP3bXqpkzS1UThoQ+8ayVDXLBtpSU+/7N0Rnj6R0eUD1xWggobPT7pY1EOrWqKMEzb67scEvrSIq7Q==,
       }
     engines: { node: '>=14' }
     hasBin: true
 
-  '@percy/client@1.31.3':
+  '@percy/cli-config@1.31.13':
     resolution:
       {
-        integrity: sha512-XzXHNco39qqzclL8y7t/k/VTR+9nhXkyfCqvbxFUS9DDG+Jd2Tv6dpRc5qv7phhp2VoKBdVVu46gMBG+qSl7yg==,
+        integrity: sha512-t0K7SYCeWp+UrRMqrTmzZiidBTxWkAvNqCyrExa5yQy3GJXyYqhygqymfP8Y5+8e2SbIGBoXZQW0fIzoSc83ww==,
       }
     engines: { node: '>=14' }
 
-  '@percy/config@1.31.3':
+  '@percy/cli-doctor@1.31.13':
     resolution:
       {
-        integrity: sha512-yTl+MUGNxMv+xQbMXR3g/tISRohE39b+s7216Z3ILtqJejIzxB0jbBfkvGqLAmlBbC63hTjg6s2JECoH7x131w==,
+        integrity: sha512-sX+VNyyTZ3viFW75NPFYMTjD+CHraD43VJ7K5Mpt4hq2IR8LS1J0C37kAiMJnTwFHeeXpaaIsCxVrKiS+jHvOQ==,
       }
     engines: { node: '>=14' }
 
-  '@percy/core@1.31.3':
+  '@percy/cli-exec@1.31.13':
     resolution:
       {
-        integrity: sha512-RuYNMDpnybYpE8bcB9ymmBH67gZkL04gtqt5MljYwOvhdtBhG6B/Tn0j7j9wSwA+ob70jzJ+/YHDQkMVOQA+TA==,
+        integrity: sha512-93w98Mejp2V7vuXgvEdwbJ4odHa3KHHJ6yrWkvydhKe0FmjoEnH20fYpZ1661Rh6YPTm61a/VvspoWEMD7E+5g==,
       }
     engines: { node: '>=14' }
 
-  '@percy/dom@1.31.3':
+  '@percy/cli-snapshot@1.31.13':
     resolution:
       {
-        integrity: sha512-Sj52zexDmEvDlASrPyf0HFQ8qQOw/X8GjAgdvfCMOiwqxRfEwYGxOYO0L7x69+BVNqaZj4rlvaNdJJ9RekQLnA==,
-      }
-
-  '@percy/env@1.31.3':
-    resolution:
-      {
-        integrity: sha512-luUfJq4gN1PgbvQQGx+cytqxmp/pOThCze/cts2PZx1vxGyRjOzBmMQYlrx99rnKeJ3vw6DVdnAyk1y55nVz6g==,
+        integrity: sha512-k9gG8ImwbcLZPeLtanBETdT8qWvAIKPcZXJ0P8OnoL+onyqEbT/BuYNTY7tlezWDg5utJFwT4LczOqAnHdS0AA==,
       }
     engines: { node: '>=14' }
 
-  '@percy/logger@1.31.3':
+  '@percy/cli-upload@1.31.13':
     resolution:
       {
-        integrity: sha512-msfmqpthOblDfsnLzRKTeJeV/qHYMZ1dPDP2mZJmN7BmgADw81imPylrbzCWmvv4ljoQ7vYu4QuAM9qHV3dzFw==,
+        integrity: sha512-+/HkIGWqHH/EJmbxATXO0N8XnwtXrhnePDKFZtWx7JrpaZXxRXI96NGL7/mjKQ2sAQKPSGvbbUAB++UoFZSnYg==,
       }
     engines: { node: '>=14' }
 
-  '@percy/monitoring@1.31.3':
+  '@percy/cli@1.31.13':
     resolution:
       {
-        integrity: sha512-+QERs2QMkG27nh2a9feQ1+WEUxS7m2qqt0FzO0TReUbQLH1hNa4qREWhLqeYAzbYI+FKZjtcE6ghVSu8+PZDYA==,
+        integrity: sha512-QpNpqt4rpmQMOixvWzds2bMKaNT64cUNsELokM0jAP8wSbKZLAsvWddM24fZTqsKXpm4peBpzO73S3bwV0Ep5w==,
+      }
+    engines: { node: '>=14' }
+    hasBin: true
+
+  '@percy/client@1.31.13':
+    resolution:
+      {
+        integrity: sha512-eFoUacW2GolCm3rL8oS1QyWD6b4UWds9HrMbtp6OJWUr6sQ8bcOemjr3M1YpkDsV2wGC0ikLISQxU8XrTxKDhA==,
+      }
+    engines: { node: '>=14' }
+
+  '@percy/config@1.31.13':
+    resolution:
+      {
+        integrity: sha512-gxd292C8+v/psxYJNfId2gwhlIGjvRGGOTCw9gBTb/eBT8cZirVLHq+d/j2nqPxCDC7JzZqChWH4TkVkTr/Xwg==,
+      }
+    engines: { node: '>=14' }
+
+  '@percy/core@1.31.13':
+    resolution:
+      {
+        integrity: sha512-SFVw/skIpcFecn8V3emAhmqqOgsX3K9toamMhhVay9FtAoy/NmsV+WuvP3IsAvujepY8ApZe2Zi5CuzZbmDy0w==,
+      }
+    engines: { node: '>=14' }
+
+  '@percy/dom@1.31.13':
+    resolution:
+      {
+        integrity: sha512-5v/ybb2f4aQLUdsbQzTuHzQNAP5zcqn/aO18k2AjvnNdxNmtLC3XwMaSMznImQAXCGsSqsmrJTGtrYP3pbTPYw==,
+      }
+
+  '@percy/env@1.31.13':
+    resolution:
+      {
+        integrity: sha512-oYEPbZwEtRFfuso+V1lnAZkZZC1gSk+H+//AdLU5De1+h2jxYW14qc1bpW707ZSina5DY5C2tcbsHNV4lcYI/A==,
+      }
+    engines: { node: '>=14' }
+
+  '@percy/logger@1.31.13':
+    resolution:
+      {
+        integrity: sha512-ym8Viw3mAGv00afk4NwaODBXLcS7/pPtpa/RSPS0knToPbCvN4/aE9PoZ99M8UbKY02ZFqGAbBNL+uPgS1nKbA==,
+      }
+    engines: { node: '>=14' }
+
+  '@percy/monitoring@1.31.13':
+    resolution:
+      {
+        integrity: sha512-TNHrEA8juyvSM2Egnub9gEDi3p1yYXwGfa4F+H3Ub+zNWFZ/11vxFRQuryzN9aQha/hvcBnXFQJk8JR73I+T4g==,
       }
     engines: { node: '>=14' }
 
@@ -8358,17 +8365,17 @@ packages:
       }
     engines: { node: '>=14' }
 
-  '@percy/sdk-utils@1.31.3':
+  '@percy/sdk-utils@1.31.13':
     resolution:
       {
-        integrity: sha512-iEnhc+x5lVmH6va5FuljAWfSFcjjqcPJ+GgoFvuvvYv39nMgXgsw4qGT+sr2ET+FpBB4f0MNs/Bn7QEkk1TlvA==,
+        integrity: sha512-0JW+ngBKLjkhbsI6ZD8wnWDV1U/S66X4vBrJqHLSi8t8BygQrulAwKLrtSV27DHCxz3a+zptTMBQufwFbal5gg==,
       }
     engines: { node: '>=14' }
 
-  '@percy/webdriver-utils@1.31.3':
+  '@percy/webdriver-utils@1.31.13':
     resolution:
       {
-        integrity: sha512-+MzTmpcmuLCX9jYmtJxNV9yE8748DSk0NZfu56Jp4HuOf/LBRnh/ShpHHo4tuEg3qaM3yqNP7KvR99/HpECQRg==,
+        integrity: sha512-wiCPRI42Vg6+qL/wiDMPkpauBHbpPJoiaMZB0gDyzrjHJx8cPwG85+oUOgvtMDNdvy55jAtcSdqzA5kXcvMsOw==,
       }
     engines: { node: '>=14' }
 
@@ -10701,10 +10708,10 @@ packages:
       react-native-b4a:
         optional: true
 
-  babel-jest@30.3.0:
+  babel-jest@30.4.1:
     resolution:
       {
-        integrity: sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==,
+        integrity: sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
     peerDependencies:
@@ -10731,10 +10738,10 @@ packages:
       }
     engines: { node: '>=12' }
 
-  babel-plugin-jest-hoist@30.3.0:
+  babel-plugin-jest-hoist@30.4.0:
     resolution:
       {
-        integrity: sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==,
+        integrity: sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
@@ -10798,10 +10805,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0 || ^8.0.0-0
 
-  babel-preset-jest@30.3.0:
+  babel-preset-jest@30.4.0:
     resolution:
       {
-        integrity: sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==,
+        integrity: sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
     peerDependencies:
@@ -12828,13 +12835,6 @@ packages:
       }
     engines: { node: '>=18' }
 
-  expect@30.3.0:
-    resolution:
-      {
-        integrity: sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==,
-      }
-    engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
-
   expect@30.4.1:
     resolution:
       {
@@ -14352,24 +14352,24 @@ packages:
       }
     engines: { node: 20 || >=22 }
 
-  jest-changed-files@30.3.0:
+  jest-changed-files@30.4.1:
     resolution:
       {
-        integrity: sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==,
+        integrity: sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  jest-circus@30.3.0:
+  jest-circus@30.4.2:
     resolution:
       {
-        integrity: sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==,
+        integrity: sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  jest-cli@30.3.0:
+  jest-cli@30.4.2:
     resolution:
       {
-        integrity: sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==,
+        integrity: sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
     hasBin: true
@@ -14379,10 +14379,10 @@ packages:
       node-notifier:
         optional: true
 
-  jest-config@30.3.0:
+  jest-config@30.4.2:
     resolution:
       {
-        integrity: sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==,
+        integrity: sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
     peerDependencies:
@@ -14404,13 +14404,6 @@ packages:
       }
     engines: { node: '>=18' }
 
-  jest-diff@30.3.0:
-    resolution:
-      {
-        integrity: sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==,
-      }
-    engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
-
   jest-diff@30.4.1:
     resolution:
       {
@@ -14418,24 +14411,24 @@ packages:
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  jest-docblock@30.2.0:
+  jest-docblock@30.4.0:
     resolution:
       {
-        integrity: sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==,
+        integrity: sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  jest-each@30.3.0:
+  jest-each@30.4.1:
     resolution:
       {
-        integrity: sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==,
+        integrity: sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  jest-environment-jsdom@30.3.0:
+  jest-environment-jsdom@30.4.1:
     resolution:
       {
-        integrity: sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==,
+        integrity: sha512-o3nfaN4zej7qgk2X0j8Jhq/S9nAVKs2xK3QeQxeHVvpkEPxaA1yxDGydR+iVI7zPy7Cp62Aq2h3Ja46QvfWHGA==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
     peerDependencies:
@@ -14451,10 +14444,10 @@ packages:
       }
     engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
 
-  jest-environment-node@30.3.0:
+  jest-environment-node@30.4.1:
     resolution:
       {
-        integrity: sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==,
+        integrity: sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
@@ -14465,17 +14458,17 @@ packages:
       }
     engines: { node: '>=18' }
 
-  jest-haste-map@30.3.0:
+  jest-haste-map@30.4.1:
     resolution:
       {
-        integrity: sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==,
+        integrity: sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  jest-leak-detector@30.3.0:
+  jest-leak-detector@30.4.1:
     resolution:
       {
-        integrity: sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==,
+        integrity: sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
@@ -14485,13 +14478,6 @@ packages:
         integrity: sha512-owAJrYnjulVlMIXOYQIPRCCn3MmqI3GzgfZCXdD3/pmwrIvFMXcKVWZ+aMc44IzaASapg0Z4SEFxR+v5qxDA2w==,
       }
     engines: { node: '>=6.16.0' }
-
-  jest-matcher-utils@30.3.0:
-    resolution:
-      {
-        integrity: sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==,
-      }
-    engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
   jest-matcher-utils@30.4.1:
     resolution:
@@ -14527,13 +14513,6 @@ packages:
         integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==,
       }
     engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
-
-  jest-mock@30.3.0:
-    resolution:
-      {
-        integrity: sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==,
-      }
-    engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
   jest-mock@30.4.1:
     resolution:
@@ -14577,17 +14556,17 @@ packages:
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  jest-resolve-dependencies@30.3.0:
+  jest-resolve-dependencies@30.4.2:
     resolution:
       {
-        integrity: sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==,
+        integrity: sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  jest-resolve@30.3.0:
+  jest-resolve@30.4.1:
     resolution:
       {
-        integrity: sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==,
+        integrity: sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
@@ -14609,17 +14588,17 @@ packages:
     peerDependencies:
       stylelint: '*'
 
-  jest-runner@30.3.0:
+  jest-runner@30.4.2:
     resolution:
       {
-        integrity: sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==,
+        integrity: sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  jest-runtime@30.3.0:
+  jest-runtime@30.4.2:
     resolution:
       {
-        integrity: sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==,
+        integrity: sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
@@ -14629,10 +14608,10 @@ packages:
         integrity: sha512-4nmS+5o7ycVlvbQOTx7CnGdbBtP2646hnDgQpQLaVhjHcQNHD+gqBAetyjRDlgpZ8+8N82MWI59K+EX2LsVk7g==,
       }
 
-  jest-snapshot@30.3.0:
+  jest-snapshot@30.4.1:
     resolution:
       {
-        integrity: sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==,
+        integrity: sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
@@ -14664,10 +14643,10 @@ packages:
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  jest-validate@30.3.0:
+  jest-validate@30.4.1:
     resolution:
       {
-        integrity: sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==,
+        integrity: sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
@@ -14687,6 +14666,13 @@ packages:
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
+  jest-watcher@30.4.1:
+    resolution:
+      {
+        integrity: sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==,
+      }
+    engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
+
   jest-worker@26.6.2:
     resolution:
       {
@@ -14701,17 +14687,17 @@ packages:
       }
     engines: { node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0 }
 
-  jest-worker@30.3.0:
+  jest-worker@30.4.1:
     resolution:
       {
-        integrity: sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==,
+        integrity: sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
 
-  jest@30.3.0:
+  jest@30.4.2:
     resolution:
       {
-        integrity: sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==,
+        integrity: sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==,
       }
     engines: { node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0 }
     hasBin: true
@@ -20410,7 +20396,7 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@commercetools-frontend/babel-preset-mc-app@27.6.2(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))':
+  '@commercetools-frontend/babel-preset-mc-app@27.6.2(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-proposal-do-expressions': 7.28.6(@babel/core@7.28.4)
@@ -20432,7 +20418,7 @@ snapshots:
       '@emotion/babel-plugin': 11.13.5
       '@emotion/babel-preset-css-prop': 11.12.0(@babel/core@7.28.4)
       babel-plugin-dev-expression: 0.2.3(@babel/core@7.28.4)
-      babel-plugin-formatjs: 10.5.41(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
+      babel-plugin-formatjs: 10.5.41(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
       babel-plugin-macros: 3.1.0
       babel-plugin-preval: 5.1.0
       babel-plugin-transform-react-remove-prop-types: 0.4.24
@@ -20443,11 +20429,11 @@ snapshots:
       - supports-color
       - ts-jest
 
-  '@commercetools-frontend/eslint-config-mc-app@27.6.2(babel-plugin-istanbul@7.0.1)(eslint@9.39.4(jiti@2.6.1))(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))':
+  '@commercetools-frontend/eslint-config-mc-app@27.6.2(babel-plugin-istanbul@7.0.1)(eslint@9.39.4(jiti@2.6.1))(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/eslint-parser': 7.28.6(@babel/core@7.28.4)(eslint@9.39.4(jiti@2.6.1))
-      '@commercetools-frontend/babel-preset-mc-app': 27.6.2(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
+      '@commercetools-frontend/babel-preset-mc-app': 27.6.2(babel-plugin-istanbul@7.0.1)(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
       '@typescript-eslint/eslint-plugin': 8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       confusing-browser-globals: 1.0.11
@@ -20456,7 +20442,7 @@ snapshots:
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-cypress: 2.15.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-jest: 28.14.0(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+      eslint-plugin-jest: 28.14.0(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       eslint-plugin-jest-dom: 4.0.3(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-prettier: 4.2.5(eslint-config-prettier@8.10.2(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@2.8.8)
@@ -20949,7 +20935,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@formatjs/ts-transformer@3.14.2(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))':
+  '@formatjs/ts-transformer@3.14.2(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))':
     dependencies:
       '@formatjs/icu-messageformat-parser': 2.11.4
       '@types/node': 22.19.15
@@ -20958,7 +20944,7 @@ snapshots:
       tslib: 2.8.1
       typescript: 5.9.3
     optionalDependencies:
-      ts-jest: 29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+      ts-jest: 29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
 
   '@hapi/address@5.1.1':
     dependencies:
@@ -21038,34 +21024,44 @@ snapshots:
       jest-util: 30.3.0
       slash: 3.0.0
 
-  '@jest/core@30.3.0(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))':
+  '@jest/console@30.4.1':
     dependencies:
-      '@jest/console': 30.3.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
+      '@types/node': 22.19.15
+      chalk: 4.1.2
+      jest-message-util: 30.4.1
+      jest-util: 30.4.1
+      slash: 3.0.0
+
+  '@jest/core@30.4.2(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 30.4.1
+      '@jest/pattern': 30.4.0
+      '@jest/reporters': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 22.19.15
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
+      fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
-      jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-resolve-dependencies: 30.3.0
-      jest-runner: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      jest-watcher: 30.3.0
-      pretty-format: 30.3.0
+      jest-changed-files: 30.4.1
+      jest-config: 30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
+      jest-haste-map: 30.4.1
+      jest-message-util: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-resolve-dependencies: 30.4.2
+      jest-runner: 30.4.2
+      jest-runtime: 30.4.2
+      jest-snapshot: 30.4.1
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      jest-watcher: 30.4.1
+      pretty-format: 30.4.1
       slash: 3.0.0
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -21073,19 +21069,17 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/diff-sequences@30.3.0': {}
-
   '@jest/diff-sequences@30.4.0': {}
 
-  '@jest/environment-jsdom-abstract@30.3.0(jsdom@26.1.0)':
+  '@jest/environment-jsdom-abstract@30.4.1(jsdom@26.1.0)':
     dependencies:
-      '@jest/environment': 30.3.0
-      '@jest/fake-timers': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/environment': 30.4.1
+      '@jest/fake-timers': 30.4.1
+      '@jest/types': 30.4.1
       '@types/jsdom': 21.1.7
       '@types/node': 22.19.15
-      jest-mock: 30.3.0
-      jest-util: 30.3.0
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
       jsdom: 26.1.0
 
   '@jest/environment@29.7.0':
@@ -21095,25 +21089,21 @@ snapshots:
       '@types/node': 22.19.15
       jest-mock: 29.7.0
 
-  '@jest/environment@30.3.0':
+  '@jest/environment@30.4.1':
     dependencies:
-      '@jest/fake-timers': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/fake-timers': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 22.19.15
-      jest-mock: 30.3.0
-
-  '@jest/expect-utils@30.3.0':
-    dependencies:
-      '@jest/get-type': 30.1.0
+      jest-mock: 30.4.1
 
   '@jest/expect-utils@30.4.1':
     dependencies:
       '@jest/get-type': 30.1.0
 
-  '@jest/expect@30.3.0':
+  '@jest/expect@30.4.1':
     dependencies:
-      expect: 30.3.0
-      jest-snapshot: 30.3.0
+      expect: 30.4.1
+      jest-snapshot: 30.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -21126,23 +21116,23 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  '@jest/fake-timers@30.3.0':
+  '@jest/fake-timers@30.4.1':
     dependencies:
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       '@sinonjs/fake-timers': 15.4.0
       '@types/node': 22.19.15
-      jest-message-util: 30.3.0
-      jest-mock: 30.3.0
-      jest-util: 30.3.0
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
 
   '@jest/get-type@30.1.0': {}
 
-  '@jest/globals@30.3.0':
+  '@jest/globals@30.4.1':
     dependencies:
-      '@jest/environment': 30.3.0
-      '@jest/expect': 30.3.0
-      '@jest/types': 30.3.0
-      jest-mock: 30.3.0
+      '@jest/environment': 30.4.1
+      '@jest/expect': 30.4.1
+      '@jest/types': 30.4.1
+      jest-mock: 30.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -21156,13 +21146,13 @@ snapshots:
       '@types/node': 22.19.15
       jest-regex-util: 30.4.0
 
-  '@jest/reporters@30.3.0':
+  '@jest/reporters@30.4.1':
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
-      '@jest/console': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/console': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.31
       '@types/node': 22.19.15
       chalk: 4.1.2
@@ -21175,9 +21165,9 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.2.0
-      jest-message-util: 30.3.0
-      jest-util: 30.3.0
-      jest-worker: 30.3.0
+      jest-message-util: 30.4.1
+      jest-util: 30.4.1
+      jest-worker: 30.4.1
       slash: 3.0.0
       string-length: 4.0.2
       v8-to-istanbul: 9.3.0
@@ -21196,9 +21186,9 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.34.49
 
-  '@jest/snapshot-utils@30.3.0':
+  '@jest/snapshot-utils@30.4.1':
     dependencies:
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       chalk: 4.1.2
       graceful-fs: 4.2.11
       natural-compare: 1.4.0
@@ -21216,26 +21206,33 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       collect-v8-coverage: 1.0.3
 
-  '@jest/test-sequencer@30.3.0':
+  '@jest/test-result@30.4.1':
     dependencies:
-      '@jest/test-result': 30.3.0
+      '@jest/console': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/istanbul-lib-coverage': 2.0.6
+      collect-v8-coverage: 1.0.3
+
+  '@jest/test-sequencer@30.4.1':
+    dependencies:
+      '@jest/test-result': 30.4.1
       graceful-fs: 4.2.11
-      jest-haste-map: 30.3.0
+      jest-haste-map: 30.4.1
       slash: 3.0.0
 
-  '@jest/transform@30.3.0':
+  '@jest/transform@30.4.1':
     dependencies:
       '@babel/core': 7.28.4
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.31
       babel-plugin-istanbul: 7.0.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
-      jest-haste-map: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-util: 30.3.0
+      jest-haste-map: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-util: 30.4.1
       pirates: 4.0.7
       slash: 3.0.0
       write-file-atomic: 5.0.1
@@ -21412,49 +21409,60 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@percy/cli-app@1.31.3(typescript@5.9.3)':
+  '@percy/cli-app@1.31.13(typescript@5.9.3)':
     dependencies:
-      '@percy/cli-command': 1.31.3(typescript@5.9.3)
-      '@percy/cli-exec': 1.31.3(typescript@5.9.3)
+      '@percy/cli-command': 1.31.13(typescript@5.9.3)
+      '@percy/cli-exec': 1.31.13(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@percy/cli-build@1.31.3(typescript@5.9.3)':
+  '@percy/cli-build@1.31.13(typescript@5.9.3)':
     dependencies:
-      '@percy/cli-command': 1.31.3(typescript@5.9.3)
+      '@percy/cli-command': 1.31.13(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@percy/cli-command@1.31.13(typescript@5.9.3)':
+    dependencies:
+      '@percy/config': 1.31.13(typescript@5.9.3)
+      '@percy/core': 1.31.13(typescript@5.9.3)
+      '@percy/logger': 1.31.13
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@percy/cli-command@1.31.3(typescript@5.9.3)':
+  '@percy/cli-config@1.31.13(typescript@5.9.3)':
     dependencies:
-      '@percy/config': 1.31.3(typescript@5.9.3)
-      '@percy/core': 1.31.3(typescript@5.9.3)
-      '@percy/logger': 1.31.3
+      '@percy/cli-command': 1.31.13(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@percy/cli-doctor@1.31.13(typescript@5.9.3)':
+    dependencies:
+      '@percy/cli-command': 1.31.13(typescript@5.9.3)
+      '@percy/client': 1.31.13(typescript@5.9.3)
+      '@percy/config': 1.31.13(typescript@5.9.3)
+      '@percy/core': 1.31.13(typescript@5.9.3)
+      '@percy/env': 1.31.13
+      '@percy/logger': 1.31.13
+      '@percy/monitoring': 1.31.13(typescript@5.9.3)
+      minimatch: 10.2.5
+      ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@percy/cli-config@1.31.3(typescript@5.9.3)':
+  '@percy/cli-exec@1.31.13(typescript@5.9.3)':
     dependencies:
-      '@percy/cli-command': 1.31.3(typescript@5.9.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - typescript
-      - utf-8-validate
-
-  '@percy/cli-exec@1.31.3(typescript@5.9.3)':
-    dependencies:
-      '@percy/cli-command': 1.31.3(typescript@5.9.3)
-      '@percy/logger': 1.31.3
+      '@percy/cli-command': 1.31.13(typescript@5.9.3)
+      '@percy/logger': 1.31.13
       cross-spawn: 7.0.6
       which: 2.0.2
     transitivePeerDependencies:
@@ -21463,72 +21471,67 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percy/cli-snapshot@1.31.3(typescript@5.9.3)':
+  '@percy/cli-snapshot@1.31.13(typescript@5.9.3)':
     dependencies:
-      '@percy/cli-command': 1.31.3(typescript@5.9.3)
+      '@percy/cli-command': 1.31.13(typescript@5.9.3)
       yaml: 2.8.3
     transitivePeerDependencies:
-      - bufferutil
-      - supports-color
       - typescript
-      - utf-8-validate
 
-  '@percy/cli-upload@1.31.3(typescript@5.9.3)':
+  '@percy/cli-upload@1.31.13(typescript@5.9.3)':
     dependencies:
-      '@percy/cli-command': 1.31.3(typescript@5.9.3)
+      '@percy/cli-command': 1.31.13(typescript@5.9.3)
       fast-glob: 3.3.3
       image-size: 1.2.1
     transitivePeerDependencies:
-      - bufferutil
-      - supports-color
       - typescript
-      - utf-8-validate
 
-  '@percy/cli@1.31.3(typescript@5.9.3)':
+  '@percy/cli@1.31.13(typescript@5.9.3)':
     dependencies:
-      '@percy/cli-app': 1.31.3(typescript@5.9.3)
-      '@percy/cli-build': 1.31.3(typescript@5.9.3)
-      '@percy/cli-command': 1.31.3(typescript@5.9.3)
-      '@percy/cli-config': 1.31.3(typescript@5.9.3)
-      '@percy/cli-exec': 1.31.3(typescript@5.9.3)
-      '@percy/cli-snapshot': 1.31.3(typescript@5.9.3)
-      '@percy/cli-upload': 1.31.3(typescript@5.9.3)
-      '@percy/client': 1.31.3(typescript@5.9.3)
-      '@percy/logger': 1.31.3
+      '@percy/cli-app': 1.31.13(typescript@5.9.3)
+      '@percy/cli-build': 1.31.13(typescript@5.9.3)
+      '@percy/cli-command': 1.31.13(typescript@5.9.3)
+      '@percy/cli-config': 1.31.13(typescript@5.9.3)
+      '@percy/cli-doctor': 1.31.13(typescript@5.9.3)
+      '@percy/cli-exec': 1.31.13(typescript@5.9.3)
+      '@percy/cli-snapshot': 1.31.13(typescript@5.9.3)
+      '@percy/cli-upload': 1.31.13(typescript@5.9.3)
+      '@percy/client': 1.31.13(typescript@5.9.3)
+      '@percy/logger': 1.31.13
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@percy/client@1.31.3(typescript@5.9.3)':
+  '@percy/client@1.31.13(typescript@5.9.3)':
     dependencies:
-      '@percy/config': 1.31.3(typescript@5.9.3)
-      '@percy/env': 1.31.3
-      '@percy/logger': 1.31.3
+      '@percy/config': 1.31.13(typescript@5.9.3)
+      '@percy/env': 1.31.13
+      '@percy/logger': 1.31.13
       pac-proxy-agent: 7.2.0
       pako: 2.1.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@percy/config@1.31.3(typescript@5.9.3)':
+  '@percy/config@1.31.13(typescript@5.9.3)':
     dependencies:
-      '@percy/logger': 1.31.3
+      '@percy/logger': 1.31.13
       ajv: 8.18.0
       cosmiconfig: 8.3.6(typescript@5.9.3)
       yaml: 2.8.3
     transitivePeerDependencies:
       - typescript
 
-  '@percy/core@1.31.3(typescript@5.9.3)':
+  '@percy/core@1.31.13(typescript@5.9.3)':
     dependencies:
-      '@percy/client': 1.31.3(typescript@5.9.3)
-      '@percy/config': 1.31.3(typescript@5.9.3)
-      '@percy/dom': 1.31.3
-      '@percy/logger': 1.31.3
-      '@percy/monitoring': 1.31.3(typescript@5.9.3)
-      '@percy/webdriver-utils': 1.31.3(typescript@5.9.3)
+      '@percy/client': 1.31.13(typescript@5.9.3)
+      '@percy/config': 1.31.13(typescript@5.9.3)
+      '@percy/dom': 1.31.13
+      '@percy/logger': 1.31.13
+      '@percy/monitoring': 1.31.13(typescript@5.9.3)
+      '@percy/webdriver-utils': 1.31.13(typescript@5.9.3)
       content-disposition: 0.5.4
       cross-spawn: 7.0.6
       extract-zip: 2.0.1
@@ -21540,25 +21543,27 @@ snapshots:
       rimraf: 3.0.2
       ws: 8.20.0
       yaml: 2.8.3
+    optionalDependencies:
+      '@percy/cli-doctor': 1.31.13(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@percy/dom@1.31.3': {}
+  '@percy/dom@1.31.13': {}
 
-  '@percy/env@1.31.3':
+  '@percy/env@1.31.13':
     dependencies:
-      '@percy/logger': 1.31.3
+      '@percy/logger': 1.31.13
 
-  '@percy/logger@1.31.3': {}
+  '@percy/logger@1.31.13': {}
 
-  '@percy/monitoring@1.31.3(typescript@5.9.3)':
+  '@percy/monitoring@1.31.13(typescript@5.9.3)':
     dependencies:
-      '@percy/config': 1.31.3(typescript@5.9.3)
-      '@percy/logger': 1.31.3
-      '@percy/sdk-utils': 1.31.3
+      '@percy/config': 1.31.13(typescript@5.9.3)
+      '@percy/logger': 1.31.13
+      '@percy/sdk-utils': 1.31.13
       systeminformation: 5.31.5
     transitivePeerDependencies:
       - supports-color
@@ -21577,16 +21582,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@percy/sdk-utils@1.31.3':
+  '@percy/sdk-utils@1.31.13':
     dependencies:
       pac-proxy-agent: 7.2.0
     transitivePeerDependencies:
       - supports-color
 
-  '@percy/webdriver-utils@1.31.3(typescript@5.9.3)':
+  '@percy/webdriver-utils@1.31.13(typescript@5.9.3)':
     dependencies:
-      '@percy/config': 1.31.3(typescript@5.9.3)
-      '@percy/sdk-utils': 1.31.3
+      '@percy/config': 1.31.13(typescript@5.9.3)
+      '@percy/sdk-utils': 1.31.13
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -23026,13 +23031,13 @@ snapshots:
 
   b4a@1.8.0: {}
 
-  babel-jest@30.3.0(@babel/core@7.28.4):
+  babel-jest@30.4.1(@babel/core@7.28.4):
     dependencies:
       '@babel/core': 7.28.4
-      '@jest/transform': 30.3.0
+      '@jest/transform': 30.4.1
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 7.0.1
-      babel-preset-jest: 30.3.0(@babel/core@7.28.4)
+      babel-preset-jest: 30.4.0(@babel/core@7.28.4)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -23043,7 +23048,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.4
 
-  babel-plugin-formatjs@10.5.41(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)):
+  babel-plugin-formatjs@10.5.41(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.28.6
@@ -23051,7 +23056,7 @@ snapshots:
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       '@formatjs/icu-messageformat-parser': 2.11.4
-      '@formatjs/ts-transformer': 3.14.2(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
+      '@formatjs/ts-transformer': 3.14.2(ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3))
       '@types/babel__core': 7.20.5
       '@types/babel__helper-plugin-utils': 7.10.3
       '@types/babel__traverse': 7.28.0
@@ -23070,7 +23075,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-jest-hoist@30.3.0:
+  babel-plugin-jest-hoist@30.4.0:
     dependencies:
       '@types/babel__core': 7.20.5
 
@@ -23140,10 +23145,10 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.4)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.4)
 
-  babel-preset-jest@30.3.0(@babel/core@7.28.4):
+  babel-preset-jest@30.4.0(@babel/core@7.28.4):
     dependencies:
       '@babel/core': 7.28.4
-      babel-plugin-jest-hoist: 30.3.0
+      babel-plugin-jest-hoist: 30.4.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.4)
 
   bail@1.0.5: {}
@@ -24264,13 +24269,13 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       requireindex: 1.2.0
 
-  eslint-plugin-jest@28.14.0(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
+  eslint-plugin-jest@28.14.0(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      jest: 30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
+      jest: 30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -24487,15 +24492,6 @@ snapshots:
       os-homedir: 1.0.2
 
   expect-puppeteer@11.0.0: {}
-
-  expect@30.3.0:
-    dependencies:
-      '@jest/expect-utils': 30.3.0
-      '@jest/get-type': 30.1.0
-      jest-matcher-utils: 30.3.0
-      jest-message-util: 30.3.0
-      jest-mock: 30.3.0
-      jest-util: 30.3.0
 
   expect@30.4.1:
     dependencies:
@@ -25358,31 +25354,31 @@ snapshots:
     dependencies:
       '@isaacs/cliui': 9.0.0
 
-  jest-changed-files@30.3.0:
+  jest-changed-files@30.4.1:
     dependencies:
       execa: 5.1.1
-      jest-util: 30.3.0
+      jest-util: 30.4.1
       p-limit: 3.1.0
 
-  jest-circus@30.3.0(babel-plugin-macros@3.1.0):
+  jest-circus@30.4.2(babel-plugin-macros@3.1.0):
     dependencies:
-      '@jest/environment': 30.3.0
-      '@jest/expect': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/environment': 30.4.1
+      '@jest/expect': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 22.19.15
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2(babel-plugin-macros@3.1.0)
       is-generator-fn: 2.1.0
-      jest-each: 30.3.0
-      jest-matcher-utils: 30.3.0
-      jest-message-util: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
+      jest-each: 30.4.1
+      jest-matcher-utils: 30.4.1
+      jest-message-util: 30.4.1
+      jest-runtime: 30.4.2
+      jest-snapshot: 30.4.1
+      jest-util: 30.4.1
       p-limit: 3.1.0
-      pretty-format: 30.3.0
+      pretty-format: 30.4.1
       pure-rand: 7.0.1
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -25390,17 +25386,17 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)):
+  jest-cli@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/core': 30.4.2(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
+      jest-config: 30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
       yargs: 17.7.2
     transitivePeerDependencies:
       - '@types/node'
@@ -25409,29 +25405,29 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)):
+  jest-config@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.28.4
       '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.28.4)
+      '@jest/pattern': 30.4.0
+      '@jest/test-sequencer': 30.4.1
+      '@jest/types': 30.4.1
+      babel-jest: 30.4.1(@babel/core@7.28.4)
       chalk: 4.1.2
       ci-info: 4.4.0
       deepmerge: 4.3.1
       glob: 10.5.0
       graceful-fs: 4.2.11
-      jest-circus: 30.3.0(babel-plugin-macros@3.1.0)
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
+      jest-circus: 30.4.2(babel-plugin-macros@3.1.0)
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-runner: 30.4.2
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
       parse-json: 5.2.0
-      pretty-format: 30.3.0
+      pretty-format: 30.4.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
@@ -25454,13 +25450,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  jest-diff@30.3.0:
-    dependencies:
-      '@jest/diff-sequences': 30.3.0
-      '@jest/get-type': 30.1.0
-      chalk: 4.1.2
-      pretty-format: 30.3.0
-
   jest-diff@30.4.1:
     dependencies:
       '@jest/diff-sequences': 30.4.0
@@ -25468,22 +25457,22 @@ snapshots:
       chalk: 4.1.2
       pretty-format: 30.4.1
 
-  jest-docblock@30.2.0:
+  jest-docblock@30.4.0:
     dependencies:
       detect-newline: 3.1.0
 
-  jest-each@30.3.0:
+  jest-each@30.4.1:
     dependencies:
       '@jest/get-type': 30.1.0
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       chalk: 4.1.2
-      jest-util: 30.3.0
-      pretty-format: 30.3.0
+      jest-util: 30.4.1
+      pretty-format: 30.4.1
 
-  jest-environment-jsdom@30.3.0:
+  jest-environment-jsdom@30.4.1:
     dependencies:
-      '@jest/environment': 30.3.0
-      '@jest/environment-jsdom-abstract': 30.3.0(jsdom@26.1.0)
+      '@jest/environment': 30.4.1
+      '@jest/environment-jsdom-abstract': 30.4.1(jsdom@26.1.0)
       jsdom: 26.1.0
     transitivePeerDependencies:
       - bufferutil
@@ -25499,15 +25488,15 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-environment-node@30.3.0:
+  jest-environment-node@30.4.1:
     dependencies:
-      '@jest/environment': 30.3.0
-      '@jest/fake-timers': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/environment': 30.4.1
+      '@jest/fake-timers': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 22.19.15
-      jest-mock: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
 
   jest-environment-puppeteer@11.0.0(typescript@5.9.3):
     dependencies:
@@ -25520,34 +25509,27 @@ snapshots:
       - debug
       - typescript
 
-  jest-haste-map@30.3.0:
+  jest-haste-map@30.4.1:
     dependencies:
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       '@types/node': 22.19.15
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
-      jest-regex-util: 30.0.1
-      jest-util: 30.3.0
-      jest-worker: 30.3.0
+      jest-regex-util: 30.4.0
+      jest-util: 30.4.1
+      jest-worker: 30.4.1
       picomatch: 4.0.4
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
 
-  jest-leak-detector@30.3.0:
+  jest-leak-detector@30.4.1:
     dependencies:
       '@jest/get-type': 30.1.0
-      pretty-format: 30.3.0
+      pretty-format: 30.4.1
 
   jest-localstorage-mock@2.4.26: {}
-
-  jest-matcher-utils@30.3.0:
-    dependencies:
-      '@jest/get-type': 30.1.0
-      chalk: 4.1.2
-      jest-diff: 30.3.0
-      pretty-format: 30.3.0
 
   jest-matcher-utils@30.4.1:
     dependencies:
@@ -25599,21 +25581,15 @@ snapshots:
       '@types/node': 22.19.15
       jest-util: 29.7.0
 
-  jest-mock@30.3.0:
-    dependencies:
-      '@jest/types': 30.3.0
-      '@types/node': 22.19.15
-      jest-util: 30.3.0
-
   jest-mock@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
       '@types/node': 22.19.15
       jest-util: 30.4.1
 
-  jest-pnp-resolver@1.2.3(jest-resolve@30.3.0):
+  jest-pnp-resolver@1.2.3(jest-resolve@30.4.1):
     optionalDependencies:
-      jest-resolve: 30.3.0
+      jest-resolve: 30.4.1
 
   jest-puppeteer@11.0.0(puppeteer@22.15.0(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
@@ -25628,32 +25604,32 @@ snapshots:
 
   jest-regex-util@30.4.0: {}
 
-  jest-resolve-dependencies@30.3.0:
+  jest-resolve-dependencies@30.4.2:
     dependencies:
-      jest-regex-util: 30.0.1
-      jest-snapshot: 30.3.0
+      jest-regex-util: 30.4.0
+      jest-snapshot: 30.4.1
     transitivePeerDependencies:
       - supports-color
 
-  jest-resolve@30.3.0:
+  jest-resolve@30.4.1:
     dependencies:
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      jest-haste-map: 30.3.0
-      jest-pnp-resolver: 1.2.3(jest-resolve@30.3.0)
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
+      jest-haste-map: 30.4.1
+      jest-pnp-resolver: 1.2.3(jest-resolve@30.4.1)
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
       slash: 3.0.0
       unrs-resolver: 1.11.1
 
-  jest-runner-eslint@2.3.0(eslint@9.39.4(jiti@2.6.1))(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))):
+  jest-runner-eslint@2.3.0(eslint@9.39.4(jiti@2.6.1))(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))):
     dependencies:
       chalk: 4.1.2
       cosmiconfig: 7.1.0
       create-jest-runner: 0.11.2
       dot-prop: 6.0.1
       eslint: 9.39.4(jiti@2.6.1)
-      jest: 30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
+      jest: 30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@jest/test-result'
       - jest-runner
@@ -25664,55 +25640,55 @@ snapshots:
       create-jest-runner: 0.7.1
       stylelint: 16.26.1(typescript@5.9.3)
 
-  jest-runner@30.3.0:
+  jest-runner@30.4.2:
     dependencies:
-      '@jest/console': 30.3.0
-      '@jest/environment': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/console': 30.4.1
+      '@jest/environment': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 22.19.15
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
       graceful-fs: 4.2.11
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-haste-map: 30.3.0
-      jest-leak-detector: 30.3.0
-      jest-message-util: 30.3.0
-      jest-resolve: 30.3.0
-      jest-runtime: 30.3.0
-      jest-util: 30.3.0
-      jest-watcher: 30.3.0
-      jest-worker: 30.3.0
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-haste-map: 30.4.1
+      jest-leak-detector: 30.4.1
+      jest-message-util: 30.4.1
+      jest-resolve: 30.4.1
+      jest-runtime: 30.4.2
+      jest-util: 30.4.1
+      jest-watcher: 30.4.1
+      jest-worker: 30.4.1
       p-limit: 3.1.0
       source-map-support: 0.5.13
     transitivePeerDependencies:
       - supports-color
 
-  jest-runtime@30.3.0:
+  jest-runtime@30.4.2:
     dependencies:
-      '@jest/environment': 30.3.0
-      '@jest/fake-timers': 30.3.0
-      '@jest/globals': 30.3.0
+      '@jest/environment': 30.4.1
+      '@jest/fake-timers': 30.4.1
+      '@jest/globals': 30.4.1
       '@jest/source-map': 30.0.1
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
       '@types/node': 22.19.15
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
       glob: 10.5.0
       graceful-fs: 4.2.11
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-mock: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
+      jest-haste-map: 30.4.1
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-snapshot: 30.4.1
+      jest-util: 30.4.1
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
@@ -25723,27 +25699,27 @@ snapshots:
       chalk: 4.1.2
       jest-util: 26.6.2
 
-  jest-snapshot@30.3.0:
+  jest-snapshot@30.4.1:
     dependencies:
       '@babel/core': 7.28.4
       '@babel/generator': 7.29.1
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.4)
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.28.4)
       '@babel/types': 7.29.0
-      '@jest/expect-utils': 30.3.0
+      '@jest/expect-utils': 30.4.1
       '@jest/get-type': 30.1.0
-      '@jest/snapshot-utils': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
+      '@jest/snapshot-utils': 30.4.1
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.4)
       chalk: 4.1.2
-      expect: 30.3.0
+      expect: 30.4.1
       graceful-fs: 4.2.11
-      jest-diff: 30.3.0
-      jest-matcher-utils: 30.3.0
-      jest-message-util: 30.3.0
-      jest-util: 30.3.0
-      pretty-format: 30.3.0
+      jest-diff: 30.4.1
+      jest-matcher-utils: 30.4.1
+      jest-message-util: 30.4.1
+      jest-util: 30.4.1
+      pretty-format: 30.4.1
       semver: 7.7.4
       synckit: 0.11.12
     transitivePeerDependencies:
@@ -25785,20 +25761,20 @@ snapshots:
       graceful-fs: 4.2.11
       picomatch: 4.0.4
 
-  jest-validate@30.3.0:
+  jest-validate@30.4.1:
     dependencies:
       '@jest/get-type': 30.1.0
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       camelcase: 6.3.0
       chalk: 4.1.2
       leven: 3.1.0
-      pretty-format: 30.3.0
+      pretty-format: 30.4.1
 
-  jest-watch-typeahead@3.0.1(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))):
+  jest-watch-typeahead@3.0.1(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))):
     dependencies:
       ansi-escapes: 7.3.0
       chalk: 5.6.2
-      jest: 30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
+      jest: 30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
       jest-regex-util: 30.4.0
       jest-watcher: 30.3.0
       slash: 5.1.0
@@ -25816,6 +25792,17 @@ snapshots:
       jest-util: 30.3.0
       string-length: 4.0.2
 
+  jest-watcher@30.4.1:
+    dependencies:
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 22.19.15
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.13.1
+      jest-util: 30.4.1
+      string-length: 4.0.2
+
   jest-worker@26.6.2:
     dependencies:
       '@types/node': 22.19.15
@@ -25828,20 +25815,20 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest-worker@30.3.0:
+  jest-worker@30.4.1:
     dependencies:
       '@types/node': 22.19.15
       '@ungap/structured-clone': 1.3.1
-      jest-util: 30.3.0
+      jest-util: 30.4.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)):
+  jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
-      '@jest/types': 30.3.0
+      '@jest/core': 30.4.2(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
+      '@jest/types': 30.4.1
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
+      jest-cli: 30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -28378,12 +28365,12 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.5(@babel/core@7.28.4)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
+      jest: 30.4.2(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.21)(@types/node@22.19.15)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -28393,9 +28380,9 @@ snapshots:
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.28.4
-      '@jest/transform': 30.3.0
+      '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
-      babel-jest: 30.3.0(@babel/core@7.28.4)
+      babel-jest: 30.4.1(@babel/core@7.28.4)
       esbuild: 0.25.12
       jest-util: 30.4.1
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,8 +110,8 @@ catalogs:
       specifier: ^1.2.32
       version: 1.2.32
     '@types/listr':
-      specifier: 0.14.9
-      version: 0.14.9
+      specifier: 0.14.10
+      version: 0.14.10
     '@types/lodash':
       specifier: ^4.17.24
       version: 4.17.24
@@ -140,17 +140,17 @@ catalogs:
       specifier: ^3.1.2
       version: 3.1.2
     dompurify:
-      specifier: 3.3.2
-      version: 3.3.2
+      specifier: 3.4.5
+      version: 3.4.5
     escape-html:
       specifier: 1.0.3
       version: 1.0.3
     execa:
-      specifier: 9.6.0
-      version: 9.6.0
+      specifier: 9.6.1
+      version: 9.6.1
     glob:
-      specifier: 13.0.0
-      version: 13.0.0
+      specifier: 13.0.6
+      version: 13.0.6
     global:
       specifier: 4.4.0
       version: 4.4.0
@@ -173,8 +173,8 @@ catalogs:
       specifier: 2.30.1
       version: 2.30.1
     moment-timezone:
-      specifier: 0.6.0
-      version: 0.6.0
+      specifier: 0.6.2
+      version: 0.6.2
     nodemon:
       specifier: ^3.0.0
       version: 3.1.14
@@ -188,8 +188,8 @@ catalogs:
       specifier: ^0.3.21
       version: 0.3.21
     qs:
-      specifier: 6.14.1
-      version: 6.14.1
+      specifier: 6.15.2
+      version: 6.15.2
     raf-schd:
       specifier: ^4.0.3
       version: 4.0.3
@@ -682,13 +682,13 @@ importers:
         version: 7.1.0
       execa:
         specifier: 'catalog:'
-        version: 9.6.0
+        version: 9.6.1
       formik:
         specifier: catalog:react
         version: 2.4.9(@types/react@19.2.14)(react@19.2.0)
       glob:
         specifier: 'catalog:'
-        version: 13.0.0
+        version: 13.0.6
       global:
         specifier: 'catalog:'
         version: 4.4.0
@@ -745,7 +745,7 @@ importers:
         version: 2.30.1
       moment-timezone:
         specifier: 'catalog:'
-        version: 0.6.0
+        version: 0.6.2
       omit-empty-es:
         specifier: 'catalog:'
         version: 1.2.0
@@ -778,7 +778,7 @@ importers:
         version: 22.15.0(typescript@5.9.3)
       qs:
         specifier: 'catalog:'
-        version: 6.14.1
+        version: 6.15.2
       rcfile:
         specifier: 'catalog:'
         version: 1.0.3
@@ -906,7 +906,7 @@ importers:
         version: 1.1.3
       '@types/listr':
         specifier: 'catalog:'
-        version: 0.14.9
+        version: 0.14.10
       '@types/lodash':
         specifier: 'catalog:'
         version: 4.17.24
@@ -998,7 +998,7 @@ importers:
     devDependencies:
       moment-timezone:
         specifier: 'catalog:'
-        version: 0.6.0
+        version: 0.6.2
 
   packages/calendar-utils:
     dependencies:
@@ -2937,7 +2937,7 @@ importers:
         version: 2.4.0
       dompurify:
         specifier: 'catalog:'
-        version: 3.3.2
+        version: 3.4.5
       react-from-dom:
         specifier: 0.6.2
         version: 0.6.2(react@19.2.0)
@@ -4096,7 +4096,7 @@ importers:
         version: 1.0.4
       dompurify:
         specifier: 'catalog:'
-        version: 3.3.2
+        version: 3.4.5
       downshift:
         specifier: catalog:react
         version: 9.0.10(react@19.2.0)
@@ -5582,7 +5582,7 @@ importers:
         version: 2.30.1
       moment-timezone:
         specifier: 'catalog:'
-        version: 0.6.0
+        version: 0.6.2
       react:
         specifier: catalog:react
         version: 19.2.0
@@ -5687,7 +5687,7 @@ importers:
         version: 2.30.1
       moment-timezone:
         specifier: 'catalog:'
-        version: 0.6.0
+        version: 0.6.2
       react:
         specifier: catalog:react
         version: 19.2.0
@@ -9744,10 +9744,10 @@ packages:
         integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==,
       }
 
-  '@types/listr@0.14.9':
+  '@types/listr@0.14.10':
     resolution:
       {
-        integrity: sha512-Ncsy/jtO/HZYrupLGcnp1BOswZVsNvggjIjnf2EZ1xECfU4hxcQ3FWvFEyR+/DXssz0HDm74Op/tEsyrB3eV5w==,
+        integrity: sha512-g5/EazbMACM1JrM/oGtW28vXo4Bv0E03/FIsqqIXbR/CztuHEgR8QAJDrB1Y5bQH7/ISQh0jNV3v65NM29HgAQ==,
       }
 
   '@types/lodash@4.17.24':
@@ -12205,12 +12205,11 @@ packages:
       }
     engines: { node: '>= 4' }
 
-  dompurify@3.3.2:
+  dompurify@3.4.5:
     resolution:
       {
-        integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==,
+        integrity: sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==,
       }
-    engines: { node: '>=20' }
 
   domutils@3.2.2:
     resolution:
@@ -12807,10 +12806,10 @@ packages:
       }
     engines: { node: '>=10' }
 
-  execa@9.6.0:
+  execa@9.6.1:
     resolution:
       {
-        integrity: sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==,
+        integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==,
       }
     engines: { node: ^18.19.0 || >=20.5.0 }
 
@@ -13316,12 +13315,12 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
-  glob@13.0.0:
+  glob@13.0.6:
     resolution:
       {
-        integrity: sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==,
+        integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==,
       }
-    engines: { node: 20 || >=22 }
+    engines: { node: 18 || 20 || >=22 }
 
   glob@7.2.3:
     resolution:
@@ -15704,10 +15703,10 @@ packages:
         integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==,
       }
 
-  moment-timezone@0.6.0:
+  moment-timezone@0.6.2:
     resolution:
       {
-        integrity: sha512-ldA5lRNm3iJCWZcBCab4pnNL3HSZYXVb/3TYr75/1WCTWYuTqYUb5f/S384pncYjJ88lbO8Z4uPDvmoluHJc8Q==,
+        integrity: sha512-lDsQv8FoGdBUdf0+TjGsq2orxKuXdwFlQ6Zw6TX3xIcTwTfEpCLyKqvEauvCHJ8iu3KBV8+uPhlv70YsNGdUBQ==,
       }
 
   moment@2.30.1:
@@ -16672,10 +16671,10 @@ packages:
       }
     engines: { node: '>=20' }
 
-  qs@6.14.1:
+  qs@6.15.2:
     resolution:
       {
-        integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==,
+        integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==,
       }
     engines: { node: '>=0.6' }
 
@@ -21423,7 +21422,10 @@ snapshots:
     dependencies:
       '@percy/cli-command': 1.31.13(typescript@5.9.3)
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-command@1.31.13(typescript@5.9.3)':
     dependencies:
@@ -21440,7 +21442,10 @@ snapshots:
     dependencies:
       '@percy/cli-command': 1.31.13(typescript@5.9.3)
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-doctor@1.31.13(typescript@5.9.3)':
     dependencies:
@@ -21476,7 +21481,10 @@ snapshots:
       '@percy/cli-command': 1.31.13(typescript@5.9.3)
       yaml: 2.8.3
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-upload@1.31.13(typescript@5.9.3)':
     dependencies:
@@ -21484,7 +21492,10 @@ snapshots:
       fast-glob: 3.3.3
       image-size: 1.2.1
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli@1.31.13(typescript@5.9.3)':
     dependencies:
@@ -22457,7 +22468,7 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
-  '@types/listr@0.14.9':
+  '@types/listr@0.14.10':
     dependencies:
       '@types/node': 22.19.15
       rxjs: 6.6.7
@@ -23932,7 +23943,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.3.2:
+  dompurify@3.4.5:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -24470,7 +24481,7 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
-  execa@9.6.0:
+  execa@9.6.1:
     dependencies:
       '@sindresorhus/merge-streams': 4.0.0
       cross-spawn: 7.0.6
@@ -24808,7 +24819,7 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
 
-  glob@13.0.0:
+  glob@13.0.6:
     dependencies:
       minimatch: 10.2.5
       minipass: 7.1.3
@@ -26596,7 +26607,7 @@ snapshots:
 
   mitt@3.0.1: {}
 
-  moment-timezone@0.6.0:
+  moment-timezone@0.6.2:
     dependencies:
       moment: 2.30.1
 
@@ -27152,7 +27163,7 @@ snapshots:
     dependencies:
       hookified: 2.1.1
 
-  qs@6.14.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -316,10 +316,10 @@ catalogs:
 
   test:
     # Jest core
-    jest: 30.3.0
-    jest-environment-jsdom: 30.3.0
-    jest-validate: 30.3.0
-    babel-jest: 30.3.0
+    jest: 30.4.2
+    jest-environment-jsdom: 30.4.1
+    jest-validate: 30.4.1
+    babel-jest: 30.4.1
     '@types/jest': ^30.0.0
 
     # Jest plugins / runners
@@ -340,7 +340,7 @@ catalogs:
     '@testing-library/react': ^16.2.0
 
     # Visual regression / Puppeteer
-    '@percy/cli': 1.31.3
+    '@percy/cli': 1.31.13
     '@percy/puppeteer': 2.0.2
     puppeteer: 22.15.0
     pptr-testing-library: 0.8.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -257,8 +257,8 @@ catalogs:
 
   repo:
     # Versioning / release
-    '@changesets/cli': 2.29.7
-    '@changesets/changelog-github': 0.5.1
+    '@changesets/cli': 2.31.0
+    '@changesets/changelog-github': 0.5.2
     conventional-changelog-cli: 5.0.0
 
     # Monorepo tooling
@@ -273,8 +273,8 @@ catalogs:
     '@commitlint/config-conventional': 20.0.0
 
     # Shared commercetools configs
-    '@commercetools-frontend/babel-preset-mc-app': 27.0.0
-    '@commercetools-frontend/eslint-config-mc-app': 27.0.0
+    '@commercetools-frontend/babel-preset-mc-app': 27.6.2
+    '@commercetools-frontend/eslint-config-mc-app': 27.6.2
 
   rich-text:
     # Slate (editor core)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -104,7 +104,7 @@ catalog:
   '@types/history': ^4.7.11
   '@types/is-hotkey': ^0.1.7
   '@types/is-url': ^1.2.32
-  '@types/listr': 0.14.9
+  '@types/listr': 0.14.10
   '@types/lodash': ^4.17.24
   '@types/node': ^22.13.1
   '@types/prettier': ^2.7.3
@@ -114,10 +114,10 @@ catalog:
   commander: ^13.1.0
   cross-env: 10.1.0
   debounce-promise: ^3.1.2
-  dompurify: 3.3.2
+  dompurify: 3.4.5
   escape-html: 1.0.3
-  execa: 9.6.0
-  glob: 13.0.0
+  execa: 9.6.1
+  glob: 13.0.6
   global: 4.4.0
   history: 4.10.1
   immutable: 4.3.8
@@ -127,12 +127,12 @@ catalog:
   listr-verbose-renderer: 0.6.0
   lodash: 4.18.1
   moment: 2.30.1
-  moment-timezone: 0.6.0
+  moment-timezone: 0.6.2
   nodemon: ^3.0.0
   omit-empty-es: 1.2.0
   'popper.js': ^1.15.0
   publint: ^0.3.21
-  qs: 6.14.1
+  qs: 6.15.2
   raf-schd: ^4.0.3
   rcfile: 1.0.3
   replace: 1.2.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,8 +32,8 @@ overrides:
   '@types/react-dom': 19.2.1
   '@types/react-router': 5.1.20
   '@types/unist': 3.0.3
-  '@typescript-eslint/eslint-plugin': 8.46.0
-  '@typescript-eslint/parser': 8.46.0
+  '@typescript-eslint/eslint-plugin': 8.59.4
+  '@typescript-eslint/parser': 8.59.4
   '@conventional-changelog/git-client': ^2.0.0
   '@isaacs/brace-expansion': ^5.0.1
   axios: ^1.13.5
@@ -191,14 +191,14 @@ catalogs:
   lint:
     # ESLint
     eslint: ^9.0.0
-    eslint-formatter-pretty: 7.0.0
+    eslint-formatter-pretty: 7.1.0
 
     # typescript-eslint
     '@typescript-eslint/eslint-plugin': 8.46.0
     '@typescript-eslint/parser': 8.46.0
 
     # Stylelint
-    stylelint: 16.25.0
+    stylelint: 16.26.1
     stylelint-config-standard: 36.0.1
     stylelint-order: 5.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -222,9 +222,9 @@ catalogs:
 
   react:
     # React core
-    react: 19.2.0
-    react-dom: 19.2.0
-    react-is: 19.2.0
+    react: 19.2.6
+    react-dom: 19.2.6
+    react-is: 19.2.6
 
     # @types (must match runtime major)
     '@types/react': ^19.0.7
@@ -237,7 +237,7 @@ catalogs:
     '@types/react-router-dom': ^5.3.3
 
     # i18n (formatjs)
-    '@formatjs/cli': 6.7.4
+    '@formatjs/cli': 6.16.0
     '@formatjs/intl-relativetimeformat': 11.4.13
     babel-plugin-formatjs: ^10.0.0
     intl-pluralrules: 2.0.1
@@ -246,13 +246,13 @@ catalogs:
     # React-bound utilities
     '@hello-pangea/dnd': ^18.0.0
     '@radix-ui/react-popover': ^1.1.4
-    downshift: 9.0.10
+    downshift: 9.3.3
     formik: ^2.4.6
     prop-types: ^15.8.1
     react-docgen: 5.4.3
-    react-from-dom: 0.7.3
+    react-from-dom: 0.7.5
     react-select: 5.10.2
-    react-textarea-autosize: 8.4.0
+    react-textarea-autosize: 8.5.9
     react-value: 0.2.0
 
   repo:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -148,7 +148,7 @@ catalog:
 catalogs:
   build:
     # Babel
-    '@babel/core': 7.28.4
+    '@babel/core': 7.29.0
     '@babel/runtime': ^7.20.13
     '@babel/runtime-corejs3': ^7.20.13
 
@@ -168,12 +168,12 @@ catalogs:
 
     # Vite
     '@modyfi/vite-plugin-yaml': ^1.1.0
-    '@vitejs/plugin-react': 5.0.4
+    '@vitejs/plugin-react': 5.2.0
     '@vitejs/plugin-react-swc': ^4.2.2
     vite: 6.4.2
 
     # PostCSS
-    postcss: 8.5.6
+    postcss: 8.5.15
     postcss-styled-syntax: ^0.7.0
     postcss-syntax: ^0.36.2
     postcss-value-parser: 4.2.0
@@ -184,8 +184,8 @@ catalogs:
     typescript: 5.9.3
 
     # Output / bundling
-    '@preconstruct/cli': 2.8.12
-    browserslist: 4.26.3
+    '@preconstruct/cli': 2.8.13
+    browserslist: 4.28.2
     bundlewatch: ^0.4.1
 
   lint:


### PR DESCRIPTION
Throwaway debug PR. Adds `--detectOpenHandles` to the test step so the Linux CI runner reveals what handles are leaking (not reproducible on macOS). Once we know the culprit, this PR gets closed and the real fix goes into #3246.