### PR TITLE
fix(security): resolve 22 dependabot alerts via workspace overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,6 @@ catalogs:
     bundlewatch:
       specifier: ^0.4.1
       version: 0.4.1
-    postcss:
-      specifier: 8.5.15
-      version: 8.5.15
     postcss-styled-syntax:
       specifier: ^0.7.0
       version: 0.7.1
@@ -472,6 +469,7 @@ catalogs:
 
 overrides:
   '@babel/preset-env': ^7.18.6
+  '@babel/plugin-transform-modules-systemjs': ^7.29.4
   '@types/eslint': ^9.0.0
   '@types/react': ^19.0.3
   '@types/react-dom': 19.2.1
@@ -480,16 +478,18 @@ overrides:
   '@typescript-eslint/eslint-plugin': 8.59.4
   '@typescript-eslint/parser': 8.59.4
   '@conventional-changelog/git-client': ^2.0.0
-  '@isaacs/brace-expansion': ^5.0.1
-  axios: ^1.13.5
-  basic-ftp: ^5.2.0
+  axios: ^1.15.2
+  basic-ftp: ^5.2.2
   core-js-compat: ^3.23.4
+  fast-uri: ^3.1.2
   flatted: ^3.4.2
+  follow-redirects: ^1.16.0
   glob-parent: ^6.0.0
-  got: 14.5.0
   handlebars: ^4.7.9
   immutable: ^4.3.8
+  ip-address: ^10.1.1
   jest-environment-node: ^30.4.1
+  js-yaml@^4.0.0: ^4.1.1
   json5: ^2.0.0
   lodash: ^4.18.1
   lodash-es: ^4.18.0
@@ -501,12 +501,12 @@ overrides:
   picomatch@^2.2.2: ^2.3.2
   picomatch@^2.2.3: ^2.3.2
   picomatch@^2.3.1: ^2.3.2
+  postcss: ^8.5.10
   react-from-dom: 0.6.2
   rollup@^2.79.1: ^2.80.0
   rollup@^4.34.9: ^4.59.0
   svgo: ^3.3.3
-  systeminformation: ^5.31.0
-  tar: ^7.5.11
+  systeminformation: ^5.31.6
   tar-fs@^2.0.0: ^2.1.4
   tar-fs@^3.0.6: ^3.1.1
   trim@0.0.1: ^0.0.3
@@ -752,7 +752,7 @@ importers:
         specifier: 'catalog:'
         version: 1.2.0
       postcss:
-        specifier: catalog:build
+        specifier: ^8.5.10
         version: 8.5.15
       postcss-styled-syntax:
         specifier: catalog:build
@@ -6159,8 +6159,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0':
-    resolution: {integrity: sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==}
+  '@babel/plugin-transform-modules-systemjs@7.29.4':
+    resolution: {integrity: sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -8604,6 +8604,10 @@ packages:
   add-stream@1.0.0:
     resolution: {integrity: sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==}
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -8799,8 +8803,8 @@ packages:
     resolution: {integrity: sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==}
     engines: {node: '>=4'}
 
-  axios@1.14.0:
-    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+  axios@1.16.1:
+    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -8940,10 +8944,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  basic-ftp@5.2.0:
-    resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   better-opn@3.0.2:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
@@ -10090,8 +10093,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -10179,8 +10182,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -10489,6 +10492,10 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -10605,8 +10612,8 @@ packages:
   intl-pluralrules@2.0.1:
     resolution: {integrity: sha512-astxTLzIdXPeN0K9Rumi6LfMpm3rvNO0iJE+h/k8Kr/is+wPbRe4ikyDjlLr6VTh/mEfNv8RjN+gu3KwDiuhqg==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   irregular-plurals@3.5.0:
@@ -11124,10 +11131,6 @@ packages:
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
-
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
   js-yaml@4.1.1:
@@ -11657,11 +11660,6 @@ packages:
     resolution: {integrity: sha512-yTW+2okrElHiH4fsiz/+/zc0EDo9BDDoC3iKk8dpv1GeRc9nUWzUZHx6TofMWErchhUQR8hY9/Eu1Uja9x1nqA==}
     engines: {node: '>=20.17'}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -12043,7 +12041,7 @@ packages:
     resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
     engines: {node: '>=18.0'}
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: ^8.5.10
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -12052,18 +12050,18 @@ packages:
   postcss-sorting@7.0.1:
     resolution: {integrity: sha512-iLBFYz6VRYyLJEJsBJ8M3TCqNcckVzz4wFounSc5Oez35ogE/X+aoC5fFu103Ot7NyvjU3/xqIXn93Gp3kJk4g==}
     peerDependencies:
-      postcss: ^8.3.9
+      postcss: ^8.5.10
 
   postcss-styled-syntax@0.7.1:
     resolution: {integrity: sha512-V5Iy8JztqXOKnTojdytF8IJ3zDXyVR927XftBPinJa3TnKdChGvGzUNEYlNuDtR+iqpuFkwJMgZdaJarYfGFCg==}
     engines: {node: '>=14.17'}
     peerDependencies:
-      postcss: ^8.5.1
+      postcss: ^8.5.10
 
   postcss-syntax@0.36.2:
     resolution: {integrity: sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==}
     peerDependencies:
-      postcss: '>=5.0.0'
+      postcss: ^8.5.10
       postcss-html: '*'
       postcss-jsx: '*'
       postcss-less: '*'
@@ -12086,10 +12084,6 @@ packages:
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   pptr-testing-library@0.8.0:
@@ -13005,8 +12999,8 @@ packages:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  systeminformation@5.31.5:
-    resolution: {integrity: sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==}
+  systeminformation@5.31.6:
+    resolution: {integrity: sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==}
     engines: {node: '>=8.0.0'}
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
@@ -14298,7 +14292,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
@@ -14571,7 +14565,7 @@ snapshots:
       '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
@@ -15803,7 +15797,7 @@ snapshots:
   '@modyfi/vite-plugin-yaml@1.1.1(rollup@2.80.0)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@2.80.0)
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       tosource: 2.0.0-alpha.3
       vite: 6.4.2(@types/node@22.19.15)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
     transitivePeerDependencies:
@@ -15839,19 +15833,13 @@ snapshots:
       '@percy/cli-command': 1.31.13(typescript@5.9.3)
       '@percy/cli-exec': 1.31.13(typescript@5.9.3)
     transitivePeerDependencies:
-      - bufferutil
-      - supports-color
       - typescript
-      - utf-8-validate
 
   '@percy/cli-build@1.31.13(typescript@5.9.3)':
     dependencies:
       '@percy/cli-command': 1.31.13(typescript@5.9.3)
     transitivePeerDependencies:
-      - bufferutil
-      - supports-color
       - typescript
-      - utf-8-validate
 
   '@percy/cli-command@1.31.13(typescript@5.9.3)':
     dependencies:
@@ -15868,10 +15856,7 @@ snapshots:
     dependencies:
       '@percy/cli-command': 1.31.13(typescript@5.9.3)
     transitivePeerDependencies:
-      - bufferutil
-      - supports-color
       - typescript
-      - utf-8-validate
 
   '@percy/cli-doctor@1.31.13(typescript@5.9.3)':
     dependencies:
@@ -15897,20 +15882,14 @@ snapshots:
       cross-spawn: 7.0.6
       which: 2.0.2
     transitivePeerDependencies:
-      - bufferutil
-      - supports-color
       - typescript
-      - utf-8-validate
 
   '@percy/cli-snapshot@1.31.13(typescript@5.9.3)':
     dependencies:
       '@percy/cli-command': 1.31.13(typescript@5.9.3)
       yaml: 2.8.3
     transitivePeerDependencies:
-      - bufferutil
-      - supports-color
       - typescript
-      - utf-8-validate
 
   '@percy/cli-upload@1.31.13(typescript@5.9.3)':
     dependencies:
@@ -15918,10 +15897,7 @@ snapshots:
       fast-glob: 3.3.3
       image-size: 1.2.1
     transitivePeerDependencies:
-      - bufferutil
-      - supports-color
       - typescript
-      - utf-8-validate
 
   '@percy/cli@1.31.13(typescript@5.9.3)':
     dependencies:
@@ -16001,7 +15977,7 @@ snapshots:
       '@percy/config': 1.31.13(typescript@5.9.3)
       '@percy/logger': 1.31.13
       '@percy/sdk-utils': 1.31.13
-      systeminformation: 5.31.5
+      systeminformation: 5.31.6
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -17255,6 +17231,12 @@ snapshots:
 
   add-stream@1.0.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   ajv@6.14.0:
@@ -17267,7 +17249,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -17450,13 +17432,15 @@ snapshots:
 
   axe-core@4.11.2: {}
 
-  axios@1.14.0:
+  axios@1.16.1:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
@@ -17626,7 +17610,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.13: {}
 
-  basic-ftp@5.2.0: {}
+  basic-ftp@5.3.1: {}
 
   better-opn@3.0.2:
     dependencies:
@@ -17689,7 +17673,7 @@ snapshots:
 
   bundlewatch@0.4.1:
     dependencies:
-      axios: 1.14.0
+      axios: 1.16.1
       bytes: 3.1.2
       chalk: 4.1.2
       ci-env: 1.17.0
@@ -17701,6 +17685,7 @@ snapshots:
       read-pkg-up: 7.0.1
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   bytes@3.0.0: {}
 
@@ -18959,7 +18944,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastest-levenshtein@1.0.16: {}
 
@@ -19052,7 +19037,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -19182,7 +19167,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.2.0
+      basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
@@ -19406,6 +19391,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -19501,7 +19493,7 @@ snapshots:
 
   intl-pluralrules@2.0.1: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   irregular-plurals@3.5.0: {}
 
@@ -19872,6 +19864,7 @@ snapshots:
       wait-on: 8.0.5
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   jest-diff@30.4.1:
     dependencies:
@@ -19921,6 +19914,7 @@ snapshots:
       jest-environment-node: 30.4.1
     transitivePeerDependencies:
       - debug
+      - supports-color
       - typescript
 
   jest-haste-map@30.4.1:
@@ -19994,6 +19988,7 @@ snapshots:
       puppeteer: 22.15.0(typescript@5.9.3)
     transitivePeerDependencies:
       - debug
+      - supports-color
       - typescript
 
   jest-regex-util@30.0.1: {}
@@ -20243,10 +20238,6 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
-
-  js-yaml@4.1.0:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.1.1:
     dependencies:
@@ -20997,8 +20988,6 @@ snapshots:
 
   nano-spawn@2.1.0: {}
 
-  nanoid@3.3.11: {}
-
   nanoid@3.3.12: {}
 
   napi-postinstall@0.3.4: {}
@@ -21399,12 +21388,6 @@ snapshots:
   postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.6:
-    dependencies:
-      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -22273,7 +22256,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.1.0
+      ip-address: 10.2.0
       smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}
@@ -22615,7 +22598,7 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.9
 
-  systeminformation@5.31.5: {}
+  systeminformation@5.31.6: {}
 
   table@6.9.0:
     dependencies:
@@ -23141,7 +23124,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.6
+      postcss: 8.5.15
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -23159,13 +23142,14 @@ snapshots:
 
   wait-on@8.0.5:
     dependencies:
-      axios: 1.14.0
+      axios: 1.16.1
       joi: 18.1.2
       lodash: 4.18.1
       minimist: 1.2.8
       rxjs: 7.8.2
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   walker@1.0.8:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,6 +27,7 @@ onlyBuiltDependencies:
 # entry can target multiple incoming ranges.
 overrides:
   '@babel/preset-env': ^7.18.6
+  '@babel/plugin-transform-modules-systemjs': ^7.29.4
   '@types/eslint': ^9.0.0
   '@types/react': ^19.0.3
   '@types/react-dom': 19.2.1
@@ -35,21 +36,23 @@ overrides:
   '@typescript-eslint/eslint-plugin': 8.59.4
   '@typescript-eslint/parser': 8.59.4
   '@conventional-changelog/git-client': ^2.0.0
-  '@isaacs/brace-expansion': ^5.0.1
-  axios: ^1.13.5
-  basic-ftp: ^5.2.0
+  axios: ^1.15.2
+  basic-ftp: ^5.2.2
   core-js-compat: ^3.23.4
+  fast-uri: ^3.1.2
   flatted: ^3.4.2
+  follow-redirects: ^1.16.0
   glob-parent: ^6.0.0
-  got: 14.5.0
   handlebars: ^4.7.9
   immutable: ^4.3.8
+  ip-address: ^10.1.1
   # jest-environment-puppeteer pulls jest-environment-node@29.7.0 (which
   # bundles jest-mock@29.7.0, missing `clearMocksOnScope`). pnpm hoists 29.7.0
   # into .pnpm/node_modules/, which is what Jest's `testEnvironment: 'node'`
   # resolver finds. Jest 30 then crashes in Runtime.resetModules. Forcing the
   # whole tree to a jest-mock@30.4.x-compatible version fixes the resolution.
   jest-environment-node: ^30.4.1
+  'js-yaml@^4.0.0': ^4.1.1
   json5: ^2.0.0
   lodash: ^4.18.1
   lodash-es: ^4.18.0
@@ -61,12 +64,12 @@ overrides:
   'picomatch@^2.2.2': ^2.3.2
   'picomatch@^2.2.3': ^2.3.2
   'picomatch@^2.3.1': ^2.3.2
+  postcss: ^8.5.10
   react-from-dom: 0.6.2
   'rollup@^2.79.1': ^2.80.0
   'rollup@^4.34.9': ^4.59.0
   svgo: ^3.3.3
-  systeminformation: ^5.31.0
-  tar: ^7.5.11
+  systeminformation: ^5.31.6
   'tar-fs@^2.0.0': ^2.1.4
   'tar-fs@^3.0.6': ^3.1.1
   'trim@0.0.1': ^0.0.3


### PR DESCRIPTION
## Summary

Resolves all 22 open Dependabot security alerts by lifting transitive dependency floors in `pnpm-workspace.yaml` `overrides:`. Every affected package is **dev-scoped** (build/test/visual-regression tooling — axios via Bundlewatch & Puppeteer, basic-ftp/ip-address via Percy, postcss via Vite, etc.), so there is **no runtime impact on publishable `@commercetools-uikit/*` packages** and no changeset is required.

## 🔒 Vulnerabilities Fixed

| Package | Severity | Advisories | Version Change |
|---|---|---|---|
| `axios` | HIGH×5, MED×6, LOW×1 | CVE-2025-62718, CVE-2026-40175, CVE-2026-42033, CVE-2026-42035, CVE-2026-42037, CVE-2026-42038, CVE-2026-42040, CVE-2026-42041, CVE-2026-42042, CVE-2026-42043, CVE-2026-42044, CVE-2026-42264 | resolves 1.14.0 → 1.16.1 |
| `basic-ftp` | HIGH×2 | CVE-2026-39983, GHSA-6v7q-wjvx-w8wg | resolves 5.2.0 → 5.3.1 |
| `systeminformation` | HIGH | CVE-2026-44724 | resolves 5.31.5 → 5.31.6 |
| `@babel/plugin-transform-modules-systemjs` | HIGH | CVE-2026-44728 | resolves 7.29.0 → 7.29.4 |
| `fast-uri` | HIGH×2 | CVE-2026-6321, CVE-2026-6322 | resolves 3.1.0 → 3.1.2 |
| `follow-redirects` | MED | GHSA-r4q5-vmmm-2653 | resolves 1.15.11 → 1.16.0 |
| `ip-address` | MED | CVE-2026-42338 | resolves 10.1.0 → 10.2.0 |
| `js-yaml` | MED | CVE-2025-64718 | resolves 4.1.0 → 4.1.1 (3.14.2 untouched) |
| `postcss` | MED | CVE-2026-41305 | resolves transitive 8.5.6 → 8.5.15 (already-safe catalog version) |

## ⚠️ Alerts Requiring Manual Attention

None — all 22 alerts had a SemVer-compatible patched version and were auto-fixable via overrides.

## 🧹 Overrides Changes

**Added**

| Override | Pinned to | Reason |
|---|---|---|
| `@babel/plugin-transform-modules-systemjs` | `^7.29.4` | Fixes CVE-2026-44728 in transitive of `@babel/preset-env@7.29.2` |
| `fast-uri` | `^3.1.2` | Fixes CVE-2026-6321 & CVE-2026-6322 in transitive of `ajv@8.18.0` |
| `follow-redirects` | `^1.16.0` | Fixes GHSA-r4q5-vmmm-2653 in transitive of axios |
| `ip-address` | `^10.1.1` | Fixes CVE-2026-42338 in transitive of `socks@2.8.7` |
| `js-yaml@^4.0.0` | `^4.1.1` | Fixes CVE-2025-64718 in transitive of `@modyfi/vite-plugin-yaml`. Scoped to 4.x line — js-yaml@3.14.2 (istanbul tooling) is unaffected and stays |
| `postcss` | `^8.5.10` | Fixes CVE-2026-41305 in stale vite transitive (8.5.6). Workspace consumers already use catalog `postcss: 8.5.15` |

**Updated**

| Override | Old | New | Reason |
|---|---|---|---|
| `axios` | `^1.13.5` | `^1.15.2` | 12 CVEs (5 high / 6 medium / 1 low) — `1.14.0` was resolving inside the old range |
| `basic-ftp` | `^5.2.0` | `^5.2.2` | CVE-2026-39983 + GHSA-6v7q-wjvx-w8wg — `5.2.0` was resolving inside the old range |
| `systeminformation` | `^5.31.0` | `^5.31.6` | CVE-2026-44724 — `5.31.5` was resolving inside the old range |

**Removed** (no parent in the current tree declares these; not blocking any vulnerable version — verified via `pnpm why` + `node_modules/.pnpm/` inventory)

| Override | Was pinning to | Reason removed |
|---|---|---|
| `@isaacs/brace-expansion` | `^5.0.1` | Absent from lockfile and from `node_modules/.pnpm/`; no parent declares it |
| `got` | `14.5.0` | Absent from lockfile and from `node_modules/.pnpm/`; no parent declares it |
| `tar` | `^7.5.11` | Absent from lockfile and from `node_modules/.pnpm/`; no parent declares it |

**Kept** — all other existing overrides remain (`@babel/preset-env`, `core-js-compat`, `flatted`, `glob-parent`, `handlebars`, `immutable`, `jest-environment-node`, `json5`, `lodash`, `lodash-es`, `minimatch`, `path-to-regexp@*`, `picomatch@*`, `react-from-dom`, `rollup@*`, `svgo`, `tar-fs@*`, `trim@0.0.1`, plus the `@types/*` and `@typescript-eslint/*` compatibility pins). Each was verified still active by `pnpm why` resolving against a parent in the current tree.

## 🔄 Superseded Dependabot PRs

None — Dependabot did not have any open PRs for these alerts (`gh pr list --search "author:app/dependabot"` returned an empty list).

## ✅ Validation

| Check | Status | Notes |
|---|---|---|
| `pnpm lint` | ✅ Pass | 1308/1308 |
| `pnpm lint:publint` | ✅ Pass | EXIT=0 after fresh build (this is what CI runs after the build step) |
| `pnpm typecheck` | ✅ Pass | clean |
| `pnpm build` | ✅ Pass | bundles built |
| `pnpm test` | ✅ Pass | 1402/1402 |
| `pnpm test:bundle` | ✅ Pass | 3/3 |
| `pnpm lint:css` | ⚠️ 19 pre-existing failures | **Not** caused by this PR. `lint:css` was removed from CI in March 2023 (commit `cb0a75647`, "ci: disable stylelint"); the same 19 stylelint failures exist on `main`. Out of scope for this PR. |

## 📋 Review Checklist

- [ ] All 22 CVEs in the table above are covered
- [ ] No catalog or workspace `package.json` edits required (overrides are the right knob)
- [ ] Removed overrides really are unused — spot-check `git log -S "<override>"` if curious about original intent
- [ ] No changeset needed — confirm no `@commercetools-uikit/*` package gains a vulnerable dep at runtime