### PR TITLE
chore(tooling): add Claude Code slash commands for housekeeping and security alerts

### DIFF
--- a/.claude/commands/github/fix-security-alerts.md
+++ b/.claude/commands/github/fix-security-alerts.md
@@ -1,0 +1,775 @@
+---
+description: Triage and fix Dependabot security alerts with optional PR creation
+---
+
+You are a **Security Engineer** tasked with resolving Dependabot security alerts
+in this pnpm monorepo. Your mission is to analyze alerts, propose a fix plan,
+apply auto-fixable updates after validation, and optionally push and create a
+PR.
+
+## Execution Flow
+
+```mermaid
+flowchart TD
+    Start([Start]) --> PreFlight[Phase 1: Pre-flight Checks]
+    PreFlight --> |Auth OK & Clean tree| Fetch[Phase 2: Fetch Alerts]
+    PreFlight --> |Failed| Abort1([Exit: Fix issues first])
+
+    Fetch --> |No alerts| Success1([🎉 No vulnerabilities!])
+    Fetch --> |Alerts found| Analyze[Phase 3: Analyze Alerts]
+
+    Analyze --> |All manual| Manual([Exit: Manual attention needed])
+    Analyze --> |Some auto-fixable| Present[Phase 4: Present Plan]
+
+    Present --> |User approves| Execute[Phase 5: Execute Fixes]
+    Present --> |User declines| Abort2([Exit: No changes])
+
+    Execute --> |Validation passes| Commit[Phase 6: Commit Changes]
+    Execute --> |Validation fails| Rollback([Exit: Rolled back])
+
+    Commit --> AskPublish{Ask: Push branch?}
+    AskPublish --> |Yes| Push[Push to remote]
+    AskPublish --> |No| LocalOnly([Exit: Branch ready locally])
+
+    Push --> AskPR{Ask: Create PR?}
+    AskPR --> |Yes| CreatePR[Create PR & Close old PRs]
+    AskPR --> |No| PushedNoPR([Exit: Branch pushed])
+
+    CreatePR --> Done([✅ PR Created!])
+```
+
+---
+
+## Phase 1: Pre-flight Checks
+
+### 1.1 Verify GitHub CLI Authentication
+
+```bash
+gh auth status
+```
+
+**If not authenticated**: Stop and instruct user to run `gh auth login` first.
+
+Also run `gh repo view --json viewerPermission --jq '.viewerPermission'`. **If
+the result is `READ`**: Note this upfront. All local work (analysis, fixes,
+commits) will proceed normally, but push and PR creation will be skipped — print
+the exact commands for the user to run manually instead.
+
+### 1.2 Check for Clean Working Tree
+
+```bash
+git status --porcelain
+```
+
+**If dirty**: Stop and instruct user: "You have uncommitted changes. Please
+commit or stash first."
+
+### 1.3 Check Current Branch
+
+```bash
+git branch --show-current
+```
+
+**If not on `main`**: Warn user: "You're on branch `[branch]`. This command
+works best from `main`. Continue anyway? (y/n)"
+
+---
+
+## Phase 2: Fetch Security Alerts
+
+### 2.1 Retrieve Dependabot Alerts
+
+```bash
+gh api repos/{owner}/{repo}/dependabot/alerts --jq '.[] | select(.state == "open")' 2>/dev/null
+```
+
+**Alternative if above fails** (permissions):
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "{owner}", name: "{repo}") {
+    vulnerabilityAlerts(first: 100, states: OPEN) {
+      nodes {
+        securityVulnerability {
+          package { name ecosystem }
+          vulnerableVersionRange
+          firstPatchedVersion { identifier }
+          severity
+          advisory { ghsaId summary cvss { score } }
+        }
+        vulnerableManifestPath
+        dismissReason
+      }
+    }
+  }
+}'
+```
+
+### 2.2 Handle No Alerts
+
+**If no open alerts found**: Output success message and exit:
+
+```
+🎉 No security alerts found!
+
+Your dependencies are clean. Run this command again after Dependabot detects new vulnerabilities.
+```
+
+---
+
+## Phase 3: Analyze Alerts
+
+For each alert, determine if it's **auto-fixable** or **needs manual
+attention**.
+
+### 3.1 Auto-Fixable Criteria (ALL must be true)
+
+- ✅ A patched version exists (`firstPatchedVersion` is not null)
+- ✅ Direct dependency — either listed in a workspace `package.json`, declared
+  in a `catalog:` / `catalogs.<name>:` block of `pnpm-workspace.yaml`, or
+  already pinned via `overrides:` in `pnpm-workspace.yaml`
+- ✅ Upgrade is patch or minor version (not major)
+- ✅ No conflicting peer dependency requirements
+- ✅ For named-catalog deps: the patch version is compatible with the rest of
+  the cohort (see 3.3 — named catalogs move in lockstep)
+
+### 3.2 Needs Manual Attention (ANY of these)
+
+| Condition                                   | Reason to Display                                         |
+| ------------------------------------------- | --------------------------------------------------------- |
+| Major version upgrade required              | "Major version bump (potential breaking changes)"         |
+| No patched version available                | "No fix available yet - monitor CVE"                      |
+| Peer dependency conflict                    | "Conflicts with peer requirement from `Z`"                |
+| Multiple versions in lockfile (complex)     | "Multiple versions present - complex resolution"          |
+| Transitive dep, but override would conflict | "Override target conflicts with peer/parent expectations" |
+
+**Transitive dependencies are NOT automatically manual.** This repo's
+`overrides:` block in `pnpm-workspace.yaml` is the established mechanism for
+patching vulnerable transitive deps until the parent upstream releases a fix.
+Adding a **new, minimal** override is auto-fixable when:
+
+- The transitive dep has a `firstPatchedVersion`
+- The patched version is in the same major (or otherwise SemVer-compatible
+  with all parents that consume it)
+- No peer-dep / engine conflict arises from the upgrade
+
+Treat every transitive override as a **temporary patch**, not a permanent
+fixture. Each one must be re-evaluated at the next run (see 3.4).
+
+### 3.3 Analyze Dependency Tree
+
+Parse `pnpm-lock.yaml` and `pnpm-workspace.yaml` to understand:
+
+- Which packages are direct vs transitive dependencies
+- Whether a direct dep is version-managed by `catalog:` / `catalogs.<name>:`
+  in `pnpm-workspace.yaml`, by a workspace `package.json`, or by `overrides:`
+- For catalog-managed deps: which catalog the dep lives in, and what other
+  deps share that catalog
+- Current installed versions
+- Peer dependency constraints
+
+```bash
+# Check if package is a direct dependency in any workspace package.json
+grep -l '"<package-name>"' package.json packages/*/package.json packages/**/package.json
+
+# Check if package is managed by a catalog or override in pnpm-workspace.yaml
+grep -n "<package-name>" pnpm-workspace.yaml
+
+# Check current resolved version(s) in the lockfile
+pnpm why <package-name>
+```
+
+**Catalogs as upgrade cohorts.** The default catalog (`catalog:` at the top
+level) holds singletons that can be bumped individually. Every **named**
+catalog (`catalogs.<name>:`) is treated as a cohort that should move together
+— bumping one entry without considering the rest can break compatibility
+across the cohort. When a vulnerable package is in a named catalog:
+
+1. List every other entry in that catalog.
+2. Check whether the proposed patch is internally consistent with the cohort
+   (e.g. matching majors, compatible peer ranges).
+3. If yes → bump the single entry in place inside the catalog.
+4. If no → classify as **manual attention** with reason "Named catalog cohort
+   bump required — coordinate with sibling entries `<list>`".
+
+Do not hard-code catalog names anywhere in this command — discover them at
+runtime by parsing `pnpm-workspace.yaml`.
+
+### 3.4 Audit Existing pnpm Overrides
+
+Read the `overrides:` block in `pnpm-workspace.yaml` (NOT `pnpm.overrides` in
+`package.json` — this repo declares overrides at the workspace level) and
+evaluate each entry using the appropriate checklist:
+
+**For non-security overrides (catalog pins, compatibility fixes):**
+
+1. Search `pnpm-lock.yaml` for the package name
+2. If no resolved version exists in the lockfile → Remove (stale)
+3. If versions found → Keep
+
+**For security overrides (version-range overrides that fix vulnerabilities):**
+
+Security overrides are **temporary patches**, not permanent fixtures. Each
+existing entry must be re-evaluated against current state and removed as soon
+as it is no longer doing useful work.
+
+1. Run `pnpm why <package-name>` to find which parent packages depend on it
+   and to confirm the override is actually resolving something in the tree.
+2. Check the **git history of the override entry** to recover the original
+   reason it was added — this is essential context for deciding whether the
+   override is still needed:
+   ```bash
+   git log -p --follow -- pnpm-workspace.yaml | grep -B 3 -A 1 "<package-name>" | head -40
+   git log --all --oneline -S "<package-name>" -- pnpm-workspace.yaml package.json
+   ```
+   Look at the commit message (CVE / GHSA / Dependabot reference) and any
+   linked PR/issue. If the override was added for a specific advisory, check
+   whether that advisory is now resolved upstream in every parent that pulls
+   the dep in.
+3. Inspect each parent's `package.json` in `node_modules` to see if it still
+   declares a dependency on the vulnerable range.
+4. Decide:
+   - Parent(s) still declare the vulnerable range → **Keep** (override is
+     actively protecting against it)
+   - Every parent has updated to a safe range upstream → **Remove** (the
+     temporary patch is no longer needed)
+   - Parent updated, but a newer safe version is available → **Update** the
+     target to the newer version (don't accidentally pin to an older safe
+     version)
+
+⚠️ **CRITICAL: A security override that blocks a vulnerable version from
+resolving will CAUSE that version to disappear from the lockfile. The absence
+of the vulnerable version does NOT mean the override is stale — it means the
+override is working. Always verify by checking the parent package and the
+override's git history before removing.**
+
+**For all overrides, also check:**
+
+- Whether the override target version should be bumped to a newer safe version
+
+Classify each override as:
+
+| Status     | Meaning                                                           |
+| ---------- | ----------------------------------------------------------------- |
+| **Keep**   | Override is actively resolving a version OR parent still needs it |
+| **Remove** | Package absent from lockfile AND parent updated to safe version   |
+| **Update** | Override target version should be bumped to newer safe version    |
+
+**Minimal-invasiveness rule.** When adding a NEW security override, choose
+the narrowest selector and the closest-to-current safe version that resolves
+the advisory. Prefer a bare `<pkg>: <range>` first; only use the
+yarn-style `<pkg>@<incoming-range>: <target>` selector when a bare override
+would force unrelated parents onto a riskier major. Don't bump further than
+necessary — every override is a maintenance liability until upstream
+releases a fix.
+
+### 3.5 Check for Existing Dependabot PRs
+
+```bash
+gh pr list --search "author:app/dependabot" --json number,title,url
+```
+
+Note any PRs that will be superseded by this fix.
+
+---
+
+## Phase 4: Present Plan
+
+### 4.1 Summary Header
+
+```
+Found X security alerts: Y auto-fixable, Z need manual attention
+```
+
+### 4.2 Auto-Fixable Table
+
+```markdown
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ AUTO-FIXABLE (will be included in PR) │
+├─────────────────┬──────────┬─────────────────┬───────────────┬───────────────┤
+│ Package │ Severity │ Version Change │ Affected │ CVE │
+├─────────────────┼──────────┼─────────────────┼───────────────┼───────────────┤
+│ <package> │ HIGH │ 1.2.3 → 1.2.4 │ root, nimbus │ CVE-XXXX-YYYY │
+└─────────────────┴──────────┴─────────────────┴───────────────┴───────────────┘
+```
+
+### 4.3 Manual Attention Table
+
+```markdown
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ NEEDS MANUAL ATTENTION │
+├─────────────────┬──────────┬─────────────────────────────────────────────────┤
+│ Package │ Severity │ Reason │
+├─────────────────┼──────────┼─────────────────────────────────────────────────┤
+│ <package> │ CRITICAL │ Major version bump (4.x → 5.x) │
+└─────────────────┴──────────┴─────────────────────────────────────────────────┘
+```
+
+### 4.4 Overrides Cleanup Table
+
+If any existing overrides were classified as **Remove** or **Update** in step
+3.4, present them:
+
+```markdown
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ OVERRIDES CLEANUP │
+├──────────────────────────────────┬──────────┬────────────────────────────────┤
+│ Override │ Status │ Reason │
+├──────────────────────────────────┼──────────┼────────────────────────────────┤
+│ tmp: ^0.2.5 │ Remove │ Not in dependency tree │ │ glob@>=10.2.0
+<10.5.0: >=10.5.0 │ Remove │ No matching versions in lock │
+└──────────────────────────────────┴──────────┴────────────────────────────────┘
+```
+
+If all overrides are still valid, note: "All existing overrides are still active
+— no cleanup needed."
+
+### 4.5 Existing Dependabot PRs Notice
+
+```markdown
+Note: X existing Dependabot PRs will be superseded:
+
+- #123: Bump lodash from 4.17.20 to 4.17.21
+- #124: Bump axios from 0.21.1 to 0.21.4
+```
+
+### 4.6 All Manual Case
+
+**If ALL alerts need manual attention**: Display the manual attention table,
+then exit with:
+
+```
+All X alerts require manual attention. See reasons above.
+
+No automatic fixes can be applied. Address each issue manually or wait for patches.
+```
+
+### 4.7 Request Approval
+
+```
+Proceed with auto-fixable updates? (y/n)
+```
+
+**If user declines**: Exit cleanly with no changes.
+
+---
+
+## Phase 5: Execute Fixes
+
+### 5.1 Create Feature Branch
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b security/fix-alerts-$(date +%Y-%m-%d)
+```
+
+**Immediately after branch creation, verify you are on the new branch:**
+
+```bash
+git branch --show-current
+```
+
+**If branch creation fails** (e.g., branch already exists, checkout error): Stop
+immediately and report:
+
+```
+❌ Branch creation failed
+
+Could not create branch: security/fix-alerts-YYYY-MM-DD
+
+Reason: [specific error message from git]
+
+No changes were made. Please investigate the issue before re-running this command.
+```
+
+Exit without making any changes. Do NOT proceed to update dependencies.
+
+### 5.2 Update Dependencies
+
+For each auto-fixable alert, pick the update site based on where the dep is
+declared (determined in 3.3):
+
+- **Catalog-managed dep (default or named catalog):** edit the entry in
+  `pnpm-workspace.yaml` in place. Do NOT run `pnpm update <pkg>@<ver>` for
+  these — it edits workspace `package.json` files and bypasses the catalog,
+  breaking `scripts/check-workspace-constraints.js`.
+- **Override-managed dep:** edit the entry in the `overrides:` block of
+  `pnpm-workspace.yaml`.
+- **Plain workspace dep (not in any catalog or override):**
+  ```bash
+  pnpm update <package-name>@<fixed-version>
+  ```
+
+### 5.3 Install and Verify Lockfile
+
+```bash
+pnpm install
+```
+
+### 5.4 Run Validation Suite
+
+```bash
+# Lint (JS/TS, CSS, publint)
+pnpm lint
+pnpm lint:css
+pnpm lint:publint
+
+# Type check
+pnpm typecheck
+
+# Build (preconstruct — catches dep regressions tests miss)
+pnpm build
+
+# Unit + integration tests
+pnpm test
+
+# Bundle size smoke (skip if it requires network credentials)
+pnpm test:bundle
+```
+
+If `pnpm test:bundle` requires a BundleWatch token that isn't configured
+locally, skip it and note that CI will run it on the PR.
+
+### 5.5 Handle Validation Failure
+
+**If ANY validation step fails**:
+
+1. Rollback all changes:
+
+   ```bash
+   git checkout . && git clean -fd
+   git checkout main
+   git branch -D security/fix-alerts-$(date +%Y-%m-%d)
+   ```
+
+2. Report failure:
+
+   ```
+   ❌ Fix validation failed
+
+   The following check failed: [lint|lint:css|lint:publint|typecheck|build|test|test:bundle]
+
+   Error output:
+   [Show relevant error output]
+
+   All changes have been rolled back. No PR was created.
+
+   Next steps:
+   - Review the failing check manually
+   - Address the issue before re-running this command
+   ```
+
+3. Exit (no PR created)
+
+---
+
+## Phase 6: Commit and Finalize
+
+### 6.1 Add Changesets for Affected Published Packages
+
+This repo uses [changesets](https://github.com/changesets/changesets) to
+version published workspace packages. If the dependency updates change the
+runtime behavior, types, or peer expectations of any **publishable**
+workspace package (i.e. a package whose `package.json` does not have
+`"private": true`), a changeset is required so the next release picks up
+the fix.
+
+For each publishable workspace package that consumes an updated dep
+(directly or via a catalog reference it depends on):
+
+1. Determine the affected packages — typically any `packages/**/package.json`
+   that lists the updated package as a dep, devDep, or peerDep, or that uses
+   a `catalog:` / `catalog:<name>` reference for it.
+2. Create a `patch` changeset at `.changeset/security-fix-alerts-YYYY-MM-DD.md`:
+
+   ```markdown
+   ---
+   '@commercetools-uikit/<affected-package-a>': patch
+   '@commercetools-uikit/<affected-package-b>': patch
+   ---
+
+   Security: bump <package-name> to <fixed-version> to address [CVE-IDs].
+   ```
+
+3. If only internal/private packages are affected, skip the changeset and
+   note "No publishable packages affected — no changeset needed" in the
+   final report.
+
+Ask the user to confirm the changeset content before continuing if the set
+of affected packages is large (>5) or if any of the bumps could plausibly
+warrant `minor` instead of `patch`.
+
+### 6.2 Commit Changes
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+fix(security): resolve dependabot alerts
+
+Addresses the following security vulnerabilities:
+[List CVE IDs]
+EOF
+)"
+```
+
+### 6.3 Report Local Success
+
+After committing, display the summary:
+
+```
+✅ Security fixes committed locally!
+
+Summary:
+- [X] vulnerabilities fixed in branch: security/fix-alerts-YYYY-MM-DD
+- [Y] alerts still need manual attention
+- [Changeset added | No publishable packages affected]
+
+All validation checks passed:
+- ✅ `pnpm lint` / `pnpm lint:css` / `pnpm lint:publint` - No linting errors
+- ✅ `pnpm typecheck` - No type errors
+- ✅ `pnpm build` - Build succeeded
+- ✅ `pnpm test` - All tests passing
+- ✅ `pnpm test:bundle` - Bundle within budget (or deferred to CI)
+```
+
+### 6.4 Ask: Push Branch to Remote?
+
+**Prompt the user:**
+
+```
+Would you like to push this branch to the remote repository? (y/n)
+```
+
+**If user declines**: Exit with:
+
+```
+Branch `security/fix-alerts-YYYY-MM-DD` is ready locally.
+
+To push later, run:
+  git push -u origin security/fix-alerts-YYYY-MM-DD
+```
+
+**If user accepts**: Proceed to push:
+
+```bash
+git push -u origin security/fix-alerts-$(date +%Y-%m-%d)
+```
+
+### 6.5 Ask: Create Pull Request?
+
+**After successful push, prompt the user:**
+
+```
+Would you like to create a Pull Request? (y/n)
+```
+
+**If user declines**: Exit with:
+
+```
+Branch pushed to remote.
+
+To create a PR later, run:
+  gh pr create --title "fix(security): resolve dependabot alerts"
+```
+
+**If user accepts**: Proceed to create PR.
+
+### 6.6 Create PR
+
+```bash
+gh pr create \
+  --title "fix(security): resolve dependabot alerts" \
+  --body "$(cat <<'EOF'
+## Summary
+
+This PR resolves [X] Dependabot security alerts by updating vulnerable dependencies to their patched versions.
+
+## 🔒 Vulnerabilities Fixed
+
+| Package | Severity | CVE | Version Change |
+|---------|----------|-----|----------------|
+| [package] | [severity] | [CVE-ID] | [old] → [new] |
+
+## ⚠️ Alerts Requiring Manual Attention
+
+The following alerts could not be automatically fixed:
+
+| Package | Severity | Reason |
+|---------|----------|--------|
+| [package] | [severity] | [reason] |
+
+## 🧹 Overrides Changes
+
+Summarize every change to the `overrides:` block in `pnpm-workspace.yaml`
+made by this PR. Group by action and omit empty sections. Include the
+specific selector key as it appears in the YAML (e.g. `picomatch@^2.2.1`,
+not just `picomatch`) so reviewers can see exactly which entry moved.
+
+**Added** (new override pinning a vulnerable transitive dep to a safe range):
+
+| Override | Pinned to | Reason |
+|----------|-----------|--------|
+| `<selector>` | `<version-range>` | Fixes [CVE-ID] in transitive dep |
+
+**Updated** (existing override bumped to a newer safe version):
+
+| Override | Old | New | Reason |
+|----------|-----|-----|--------|
+| `<selector>` | `<old-range>` | `<new-range>` | [CVE-ID] / parent advisory |
+
+**Removed** (override no longer needed — parent now declares a safe range):
+
+| Override | Was pinning to | Reason removed |
+|----------|----------------|----------------|
+| `<selector>` | `<old-range>` | Parent `<pkg>` updated to safe range |
+
+**Kept** (still actively protecting; verified parent still declares vulnerable range):
+
+| Override | Pinned to | Parent still on vulnerable range |
+|----------|-----------|----------------------------------|
+| `<selector>` | `<version-range>` | `<parent-pkg>` |
+
+If no override changes were made, write: "No changes to `overrides:` in
+`pnpm-workspace.yaml`."
+
+## 🔄 Superseded Dependabot PRs
+
+This PR supersedes the following Dependabot PRs:
+- #[number]: [title]
+
+## ✅ Validation
+
+All checks passed before PR creation:
+- ✅ `pnpm lint` / `pnpm lint:css` / `pnpm lint:publint` - No linting errors
+- ✅ `pnpm typecheck` - No type errors
+- ✅ `pnpm build` - Build succeeded
+- ✅ `pnpm test` - All tests passing
+- ✅ `pnpm test:bundle` - Bundle within budget (or deferred to CI)
+
+## 📋 Review Checklist
+
+- [ ] Verify no breaking changes in dependency updates
+- [ ] Confirm all CVEs are addressed
+- [ ] Review any alerts flagged for manual attention
+- [ ] Confirm changeset entries (if any) cover all affected publishable packages
+- [ ] Review the overrides summary — added entries are justified, removed entries are truly obsolete, kept entries are still load-bearing
+EOF
+)" \
+  --label "security" \
+  --label "dependencies"
+```
+
+### 6.7 Close Superseded Dependabot PRs
+
+For each existing Dependabot PR that was superseded:
+
+```bash
+gh pr close [PR_NUMBER] --comment "Superseded by #[NEW_PR_NUMBER] which addresses this along with other security alerts."
+```
+
+### 6.8 Report Final Success
+
+```
+✅ Security alerts fixed!
+
+PR created: [PR_URL]
+
+Summary:
+- [X] vulnerabilities fixed
+- [Y] alerts still need manual attention
+- [Z] Dependabot PRs closed
+
+The PR is ready for review.
+```
+
+---
+
+## Error Handling
+
+### GitHub API Errors
+
+| Error             | Response                                                      |
+| ----------------- | ------------------------------------------------------------- |
+| Not authenticated | "Run `gh auth login` first"                                   |
+| No repo access    | "Ensure you have access to this repository's security alerts" |
+| Rate limited      | "GitHub API rate limit hit - try again in X minutes"          |
+| Network failure   | "Could not reach GitHub - check your connection"              |
+
+### Dependency Resolution Errors
+
+| Error              | Response                                                     |
+| ------------------ | ------------------------------------------------------------ |
+| Version not found  | Move alert to "needs manual attention"                       |
+| Peer dep conflict  | Move alert to "needs manual attention" with conflict details |
+| pnpm install fails | Rollback, report error, exit                                 |
+
+### Git Errors
+
+| Error                  | Response                                          |
+| ---------------------- | ------------------------------------------------- |
+| Branch creation fails  | Stop immediately, report error, exit (no changes) |
+| Branch already exists  | Stop, report conflict, let user investigate       |
+| Not on expected branch | Stop immediately, do NOT proceed with any changes |
+| Push fails             | Report error, branch remains local                |
+
+---
+
+## Important Constraints
+
+- You MUST verify GitHub CLI authentication before proceeding
+- You MUST check for clean working tree before making changes
+- You MUST verify the feature branch was created successfully before making any
+  changes
+- You MUST stop immediately if branch creation fails - do NOT proceed on main
+- You MUST present the full plan and wait for user approval
+- You MUST run all validation (`lint`, `lint:css`, `lint:publint`, `typecheck`,
+  `build`, `test`, and `test:bundle` when available) before committing
+- You MUST rollback ALL changes if ANY validation fails (no partial fixes)
+- You MUST ask the user before pushing the branch to remote
+- You MUST ask the user before creating a Pull Request
+- You MUST close superseded Dependabot PRs when creating a new PR
+- You MUST NOT attempt to fix alerts that require major version upgrades
+- You MAY fix transitive dependency vulnerabilities by adding a **new,
+  minimal** entry to the `overrides:` block in `pnpm-workspace.yaml`, but you
+  MUST NOT run `pnpm update` directly against a transitive dep. Treat every
+  transitive override as a temporary patch that must be revisited (and ideally
+  removed) once upstream parents release a safe version
+- When auditing existing overrides, you SHOULD consult `git log` / `git blame`
+  on the `overrides:` block (and the equivalent location prior to its move
+  from `package.json`) to recover the original reason each override was added.
+  Reuse that context when deciding Keep / Remove / Update
+- You MUST audit existing `overrides:` entries in `pnpm-workspace.yaml` (not
+  `pnpm.overrides` in `package.json` — this repo declares overrides at the
+  workspace level) and remove stale entries that no longer resolve any
+  versions in the lockfile
+- You MUST NOT assume a security override is stale just because the vulnerable
+  version is absent from `pnpm-lock.yaml` — the override is why it's absent.
+  Always verify by checking if the parent package still declares a vulnerable
+  dependency range (use `pnpm why <package>` and inspect parent's
+  `package.json`)
+- You MUST detect whether each updated dep is managed by a catalog
+  (`catalog:` or `catalogs.<name>:` in `pnpm-workspace.yaml`), by an override,
+  or by a workspace `package.json`, and update it in the correct location.
+  Never edit a workspace `package.json` version for a catalog-managed dep —
+  it will be rejected by `scripts/check-workspace-constraints.js`
+- You MUST treat **named** catalogs as upgrade cohorts: bumping one entry
+  requires checking compatibility with the other entries in the same catalog;
+  if compatibility cannot be confirmed, classify the alert as manual
+- You MUST NOT hard-code catalog names — discover them at runtime by parsing
+  `pnpm-workspace.yaml`
+- You MUST add a changeset entry for any publishable workspace package whose
+  consumed dep was updated, unless no publishable packages are affected
+- You MUST include an "Overrides Changes" section in the PR body that lists
+  every Added, Updated, Removed, and Kept entry in the `overrides:` block of
+  `pnpm-workspace.yaml`. If no overrides changed, state so explicitly
+- You SHOULD sort alerts by severity (CRITICAL > HIGH > MEDIUM > LOW) in tables
+
+## RFC 2119 Key Words
+
+- **MUST** / **REQUIRED** / **SHALL** - Absolute requirement
+- **MUST NOT** / **SHALL NOT** - Absolute prohibition
+- **SHOULD** / **RECOMMENDED** - Should do unless valid reason not to
+- **SHOULD NOT** / **NOT RECOMMENDED** - Should not do unless valid reason
+- **MAY** / **OPTIONAL** - Truly optional

--- a/.claude/commands/housekeeping.md
+++ b/.claude/commands/housekeeping.md
@@ -1,0 +1,615 @@
+---
+description: Update workspace catalog dependencies to latest minor/patch versions, with risk-ordered cohorts and validation between checkpoints
+argument-hint: natural-language filter and/or "dry run" (e.g. "tooling only", "storybook dry run", "just the slate stack")
+---
+
+You are a **Senior DevOps Engineer** tasked with safely updating dependencies in
+the `ui-kit` pnpm monorepo. Your mission is to update entries in
+`pnpm-workspace.yaml` (`catalog:` and `catalogs.<name>:`) to their latest
+**minor and patch versions only** (no major bumps) while preserving build,
+type, lint, and test integrity for every publishable package.
+
+This repo publishes `@commercetools-uikit/*` and
+`@commercetools-frontend/ui-kit` to npm under a **single fixed version group**
+(see `.changeset/config.json` — every bump applies to all). Treat every
+runtime dependency change as semver-significant for the published surface.
+
+---
+
+## **Command Arguments**
+
+`$ARGUMENTS` is free-form natural language. Interpret it to decide:
+
+1. **Scope filter** (which catalogs / packages to touch). Examples:
+   - empty / `"all"` → update every catalog except `peer` (always frozen)
+   - `"tooling"` / `"toolchain"` → `build` + `lint` + `repo`
+   - `"storybook"` → only the `storybook` catalog
+   - `"jest"` / `"tests"` → only the `test` catalog
+   - `"slate"` / `"rich text"` → only the `rich-text` catalog
+   - `"react ecosystem"` → only the `react` catalog (peer remains frozen)
+   - `"singletons"` / `"default catalog"` → only the unnamed `catalog:` block
+   - `"just lodash and qs"` → only those specific deps within the default catalog
+2. **Dry run flag** — any occurrence of `"dry run"` / `"dry-run"` /
+   `"preview"` / `"don't apply"` activates dry-run mode.
+
+When the filter is ambiguous (e.g. `"react"` could mean the `react` catalog
+**or** anything React-bound), restate your interpretation in one line before
+proceeding and let the user correct it. Never invent a target — if you cannot
+map the request to a real catalog or set of deps in `pnpm-workspace.yaml`,
+stop and ask.
+
+**Target Filter:** $ARGUMENTS (defaults to all non-frozen catalogs)
+
+---
+
+## **Execution Strategy**
+
+### **Validation strategy (read this first)**
+
+The whole point of cohort-by-cohort processing is **fast, actionable triage
+when something breaks**. You MUST run the full validation suite (`pnpm lint`,
+`pnpm lint:css`, `pnpm lint:publint`, `pnpm typecheck`, `pnpm build`,
+`pnpm test`, `node scripts/check-workspace-constraints.js`) immediately
+after each catalog/cohort is bumped, and **before** moving to the next
+cohort. This makes any failure trivially attributable to the cohort that was
+just edited — no bisecting required. A failed cohort is rolled back locally
+and the run continues with the next one; the failure is recorded in the
+final report and PR body. Do NOT batch validation across cohorts.
+
+### **Phase 1: Git Setup & Pre-flight Checks**
+
+1. **Authentication / Permission Check:**
+
+   ```bash
+   gh auth status
+   gh repo view --json viewerPermission --jq '.viewerPermission'
+   ```
+
+   If `READ`, still do the local work but skip push and PR — print the exact
+   `git push` and `gh pr create` commands at the end for the user.
+
+2. **Working Tree Check:**
+
+   ```bash
+   git status --porcelain
+   ```
+
+   If dirty, halt and ask the user to commit or stash. Never proceed on a
+   dirty tree — rollbacks rely on a clean baseline.
+
+3. **Branch Creation:**
+
+   ```bash
+   git checkout main
+   git pull origin main
+   git checkout -b housekeeping-$(date +%Y%m%d-%H%M)
+   git branch --show-current   # verify
+   ```
+
+   Reuse the same timestamp for the changeset filename later. If branch
+   creation fails (e.g. duplicate), stop immediately and report — do NOT
+   continue on `main`.
+
+4. **Workspace Analysis:**
+
+   - Parse `pnpm-workspace.yaml`. Discover catalogs at runtime — do not
+     hard-code names. Today the file contains: the default `catalog:` plus
+     `catalogs.build`, `catalogs.lint`, `catalogs.peer`, `catalogs.react`,
+     `catalogs.repo`, `catalogs.rich-text`, `catalogs.storybook`,
+     `catalogs.test`. If new catalogs appear, treat them per the rules in
+     Phase 2.
+   - Preserve the **sub-cohort comment groupings** inside each named catalog
+     (e.g. `# Babel`, `# Emotion (CSS-in-JS)`, `# Storybook ecosystem`). When
+     editing, modify entries in place — never reorder or strip comments.
+   - The default `catalog:` is alphabetical. Keep it alphabetical.
+
+### **Phase 2: Dependency Categorization & Risk Ordering**
+
+Catalogs are **upgrade cohorts** — bumping one entry in a named catalog
+requires checking compatibility with its siblings. Risk-ordered (safest
+first):
+
+#### 🛠 `repo` (Lowest Risk — Update First)
+
+Monorepo plumbing & release tooling. All devDependency-only.
+
+- `@changesets/cli`, `@changesets/changelog-github`,
+  `conventional-changelog-cli`
+- `@manypkg/cli`, `@manypkg/find-root`, `@manypkg/get-packages`
+- `husky`, `lint-staged`, `@commitlint/cli`,
+  `@commitlint/config-conventional`
+- `@commercetools-frontend/babel-preset-mc-app`,
+  `@commercetools-frontend/eslint-config-mc-app` — external commercetools
+  shared configs; safe to bump within their major.
+
+#### 🧹 `lint` (Low Risk)
+
+Code-quality enforcers. All devDependency-only. **Bump prettier within `2.x`
+only** — the `peer` catalog pins `prettier: '2.x'` because consumers rely on
+prettier 2 output formatting; never break that contract from housekeeping.
+
+#### 🧪 `test` (Low Risk)
+
+Jest core (`30.x`), `jest-environment-jsdom`, `@testing-library/*`,
+`@percy/*`, `puppeteer`, `pptr-testing-library`. Jest runs through several
+specialized runners here (`jest-runner-eslint`, `jest-runner-stylelint`) so
+verify these still load after a bump.
+
+#### 📚 `storybook` (Low Risk, Strict Lockstep)
+
+**All `storybook` + `@storybook/*` entries MUST be the exact same version.**
+The catalog comment already states this. If `storybook@9.1.20 → 9.1.21`,
+every `@storybook/*` entry in the catalog moves to `9.1.21` together —
+no partial bumps. Includes `eslint-plugin-storybook` which is also pinned
+to the storybook version.
+
+#### 📦 default `catalog:` (Medium Risk)
+
+Singleton utilities (`lodash`, `qs`, `dompurify`, `glob`, `moment-timezone`,
+etc.). Members are independent and safe to bump individually. Keep
+alphabetical order intact. Note: `lodash: 4.18.1` already exceeds public
+`4.17.x` releases because of an internal override — don't try to "fix" the
+version downward.
+
+#### 🏗 `build` (Medium-High Risk — Affects Runtime)
+
+Compile/bundle/style toolchain consumed by published packages at build time
+**and** as peer/runtime deps in some cases:
+
+- **Babel** (`@babel/core`, `@babel/runtime`, `@babel/runtime-corejs3`) —
+  `@babel/runtime*` ships in published bundles via preconstruct; treat
+  bumps as runtime-affecting.
+- **Emotion** (`@emotion/react`, `@emotion/styled`, `@emotion/css`,
+  `@emotion/is-prop-valid`, `@swc/plugin-emotion`) — `@emotion/react` is a
+  **peer dep** of every published component. Bump only within the major
+  the consumer compatibility allows; if `@emotion/react: ^11.10.5` would
+  bump to `12.x`, halt and classify as manual.
+- **SVGR** (`@svgr/*`) — code-gen pipeline for icons.
+- **Vite** (`vite`, `@vitejs/plugin-react`, `@vitejs/plugin-react-swc`,
+  `@modyfi/vite-plugin-yaml`) — used by `storybook` and `visual-testing-app`.
+- **PostCSS** (`postcss`, `postcss-styled-syntax`, `postcss-syntax`,
+  `postcss-value-parser`).
+- **TypeScript** (`typescript`, `ts-node`, `tsc-files`) — TS major moves
+  are breaking for consumers (peer is `'5.x'`); bump only within `5.x`.
+- **Output / bundling** (`@preconstruct/cli`, `browserslist`,
+  `bundlewatch`).
+
+#### ✍️ `rich-text` (High Risk — Tight Cohort)
+
+The Slate + remark + unified stack is **deeply interlinked**. Even minor
+version drift between `slate`, `slate-history`, `slate-react`,
+`slate-hyperscript` will break the editor. Move the four `slate*` entries
+together. Move the `remark-*` entries together. Move the `unified` /
+`vfile` family together. If any sibling lacks a compatible minor bump,
+classify the whole sub-cohort as manual rather than partial-bumping.
+
+`remark-gfm-v1: 'npm:remark-gfm@1.0.0'` is intentionally pinned to an old
+version under an alias — **do not bump it**.
+
+#### ⚛️ `react` (Highest Risk — Consumer-Facing)
+
+Runtime React stack, formatjs, React-bound utilities.
+
+- **React core** (`react`, `react-dom`, `react-is`, `@types/react*`):
+  bumping within `19.x` is allowed because the `peer` catalog declares
+  `react: '19.x'` / `react-dom: '19.x'`. **Never** bump out of `19.x` from
+  housekeeping — that's a coordinated major release.
+- **React Router 5.x** (`react-router`, `react-router-dom`,
+  `@types/react-router-dom`): the `peer` catalog pins
+  `react-router-dom: '5.x'`. Legacy. Do not bump to 6.x. Treat as frozen
+  at major.
+- **formatjs** (`@formatjs/cli`, `@formatjs/intl-relativetimeformat`,
+  `babel-plugin-formatjs`, `intl-pluralrules`, `react-intl`): the `peer`
+  catalog pins `react-intl: '7.x'`. Move within major only.
+- **React-bound utilities** (`@hello-pangea/dnd`,
+  `@radix-ui/react-popover`, `downshift`, `formik`, `prop-types`,
+  `react-docgen`, `react-from-dom`, `react-select`,
+  `react-textarea-autosize`, `react-value`): safe to bump within major.
+  Note `react-from-dom: 0.7.3` in catalog vs `react-from-dom: 0.6.2`
+  override — leave the override alone.
+
+#### 🔒 `peer` (FROZEN — NEVER UPDATE)
+
+`catalogs.peer` declares consumer compatibility ranges (`react: '19.x'`,
+`react-intl: '7.x'`, `react-router-dom: '5.x'`, `prettier: '2.x'`,
+`typescript: '5.x'`, `moment: '2.x'`, `moment-timezone: '0.6.x'`). These
+are deliberate consumer-facing decisions. Bumping them changes who can
+install our packages. **Housekeeping MUST NOT touch any entry in the
+`peer` catalog.** If a non-peer catalog bump would require widening a peer
+range, halt and classify as manual.
+
+### **Phase 3: Progressive Updates with Safety Checks**
+
+For each catalog in the filter, in the risk order above:
+
+1. **Fetch Latest Versions** (skip catalogs the filter excluded):
+
+   ```bash
+   pnpm view <package-name> versions --json
+   ```
+
+   Use `versions` (plural) so you can pick the latest minor/patch within the
+   current major rather than blindly taking `latest` (which may have crossed
+   a major).
+
+2. **Version Comparison Rules:**
+
+   - You MUST only update to the latest minor/patch within the **current
+     major**. No major bumps.
+   - You MUST respect any `peer` catalog range for the same dep (e.g.
+     `react: '19.x'` in peer means `react` in the `react` catalog stays
+     in `19.x`).
+   - You MUST NOT bump entries in the `peer` catalog.
+   - You MUST NOT bump `remark-gfm-v1` (intentionally aliased to `1.0.0`).
+   - For named catalogs marked as cohorts (`storybook`, `rich-text`),
+     either move every required sibling together or skip the cohort.
+   - If a bump would require widening a peer range, classify as **manual**
+     and skip.
+
+3. **Update Workspace Catalog:**
+
+   - Edit `pnpm-workspace.yaml` in place. **Never** edit a workspace
+     `package.json` for a catalog-managed dep — `scripts/check-workspace-constraints.js`
+     will reject it, and our CI runs that check.
+   - Preserve sub-cohort comments and blank-line groupings. Don't
+     reorder named-catalog entries. Keep the default catalog alphabetical.
+
+4. **Install & Validate (run after EVERY cohort, before moving on):**
+
+   This is the single atomic gate per cohort. Run all of these in order
+   immediately after the cohort's edits — never carry a cohort forward
+   without a green validation run. If anything fails, you know exactly
+   which cohort caused it.
+
+   ```bash
+   pnpm install
+   node scripts/check-workspace-constraints.js   # catalog references intact
+   pnpm lint              # jest-runner-eslint
+   pnpm lint:css          # jest-runner-stylelint
+   pnpm lint:publint      # scripts/check-publint.js
+   pnpm typecheck         # tsc --noEmit --skipLibCheck
+   pnpm build             # codegen + preconstruct build
+   pnpm test              # jest --projects jest.{ts-test,test}.config.js
+   ```
+
+   `pnpm test:bundle` (bundlewatch) needs a token — skip locally if absent
+   and rely on CI; mention this in the PR body.
+
+   If any step fails, **rollback this cohort** (see Phase 6 below), log
+   which step failed plus the relevant error excerpt, and continue with
+   the next cohort. Do not abandon the whole run for one cohort's failure
+   unless the rollback itself fails. The whole reason for the per-cohort
+   gate is that any failure is unambiguously attributable to the cohort
+   that just changed — preserve that property.
+
+5. **Safety Checkpoint:**
+
+   After a cohort's full validation passes, create a checkpoint commit:
+
+   ```bash
+   git add pnpm-workspace.yaml pnpm-lock.yaml
+   git commit -m "chore(deps): update <catalog-name> catalog"
+   ```
+
+   Use the exact catalog name as the scope (`chore(deps): update build`,
+   `chore(deps): update storybook`, etc.). If multiple unrelated default-
+   catalog singletons were bumped in one cohort, `chore(deps): update
+default catalog` is fine.
+
+### **Phase 4: Final Verification**
+
+After all cohorts in the filter are processed:
+
+```bash
+pnpm install                  # confirm lockfile is consistent
+pnpm build                    # full build including codegen
+pnpm test                     # complete suite
+node scripts/check-workspace-constraints.js
+```
+
+If any final step fails despite per-cohort validation having passed, fall
+back to the last good checkpoint commit and stop. Investigate the
+interaction between cohorts before retrying.
+
+### **Phase 5: Changeset (Required When Published Packages Are Affected)**
+
+This repo uses [changesets](https://github.com/changesets/changesets) with
+a **fixed version group**: `@commercetools-frontend/*` and
+`@commercetools-uikit/*` always release in lockstep.
+
+**When to create a changeset:**
+
+- If any updated dep is consumed (as `dependencies` or `peerDependencies`,
+  **not** just `devDependencies`) by a publishable workspace package
+  (anything in `packages/**` that lacks `"private": true` in its
+  `package.json`), you MUST create a changeset.
+- Catalogs that almost always require changesets: `react`, `build` (via
+  `@babel/runtime*` and Emotion), `rich-text`, and any default-catalog
+  entry that's a runtime dep.
+- Catalogs that typically do NOT require changesets: `repo`, `lint`,
+  `test`, `storybook` — devDeps only. Verify by checking whether any
+  publishable package lists the updated dep outside `devDependencies`.
+
+**How to create the changeset:**
+
+Reuse the branch timestamp so branch and changeset always correspond:
+
+```bash
+# Branch: housekeeping-20260519-1430  →  Changeset:
+.changeset/housekeeping-deps-20260519-1430.md
+```
+
+Because of the fixed-version group, you only need to list **one** member;
+the rest follow. Pick `@commercetools-frontend/ui-kit` (the all-in-one
+preset) as the canonical listing:
+
+```markdown
+---
+'@commercetools-frontend/ui-kit': patch
+---
+
+Update <catalog> dependencies: <key packages and version bumps>
+```
+
+Always use `patch` — minor/patch dependency bumps are backward compatible
+by definition for this command. If a bump genuinely warrants `minor`
+(e.g. it surfaces a new public API), the user should escalate it out of
+housekeeping into a feature PR.
+
+Commit the changeset together with the final cohort:
+
+```bash
+git add .changeset/housekeeping-deps-*.md
+git commit -m "chore(deps): add housekeeping changeset"
+```
+
+### **Phase 6: Per-Cohort Rollback Procedure**
+
+If a cohort's validation fails:
+
+1. Restore the catalog block from git:
+
+   ```bash
+   git checkout HEAD -- pnpm-workspace.yaml pnpm-lock.yaml
+   pnpm install
+   ```
+
+2. If a mid-cohort commit was already made (rare — should not happen with
+   the per-cohort flow), reset to the previous checkpoint:
+
+   ```bash
+   git reset --hard HEAD~1
+   ```
+
+3. Record the cohort as **failed** in the final report — do NOT silently
+   skip it.
+
+4. Continue to the next cohort. A failed cohort does not abort the run.
+
+### **Phase 7: Push & Pull Request**
+
+1. **Confirm with user before pushing:**
+
+   ```
+   Cohorts processed: <list>
+   Updated: <N> packages
+   Failed cohorts: <list or "none">
+   Push branch and open PR? (y/n)
+   ```
+
+2. **Push:**
+
+   ```bash
+   git push -u origin housekeeping-$(date +%Y%m%d-%H%M)
+   ```
+
+3. **PR (use the timestamp from the branch, not `date` recomputed):**
+
+   Replace all bracketed placeholders before creating the PR.
+
+   ```bash
+   gh pr create \
+     --title "chore(deps): housekeeping — update workspace catalog dependencies" \
+     --body "$(cat <<'EOF'
+   ## Summary
+
+   This PR bumps workspace catalog dependencies in `pnpm-workspace.yaml` to their latest minor and patch versions, processed in risk-ordered cohorts with per-cohort validation.
+
+   ## 📦 Updates by Catalog
+
+   ### 🛠 `repo`
+   - [package]: [old] → [new]
+
+   ### 🧹 `lint`
+   - [package]: [old] → [new]
+
+   ### 🧪 `test`
+   - [package]: [old] → [new]
+
+   ### 📚 `storybook` (moved in lockstep)
+   - storybook + @storybook/*: [old] → [new]
+
+   ### 📦 default `catalog:`
+   - [package]: [old] → [new]
+
+   ### 🏗 `build`
+   - [package]: [old] → [new]
+
+   ### ✍️ `rich-text`
+   - [package]: [old] → [new]
+
+   ### ⚛️ `react`
+   - [package]: [old] → [new]
+
+   ## 🔒 Frozen / Skipped
+
+   - `catalogs.peer` — consumer compatibility ranges, never bumped from housekeeping
+   - `remark-gfm-v1` — intentionally pinned to aliased 1.0.0
+   - Cross-major bumps available but not applied: [list, or "none"]
+
+   ## ⚠️ Failed Cohorts
+
+   [List any cohorts whose validation failed and were rolled back. Include the failing step (lint / typecheck / build / test) and the relevant error excerpt. Omit this section if all cohorts passed.]
+
+   ## 🧪 Validation
+
+   - ✅ `pnpm lint`
+   - ✅ `pnpm lint:css`
+   - ✅ `pnpm lint:publint`
+   - ✅ `pnpm typecheck`
+   - ✅ `pnpm build`
+   - ✅ `pnpm test`
+   - ✅ `node scripts/check-workspace-constraints.js`
+   - ⏭ `pnpm test:bundle` — deferred to CI (requires BundleWatch token)
+
+   ## 📝 Changeset
+
+   [`@commercetools-frontend/ui-kit: patch` — included] / [No publishable packages affected — no changeset needed]
+
+   ## 🔍 Review Notes
+
+   1. Bumps are patch/minor only — no major version changes.
+   2. `peer` catalog untouched: consumer compatibility ranges remain stable.
+   3. Storybook and rich-text cohorts moved in lockstep where bumped.
+   4. Fixed version group means a single changeset covers every publishable package.
+   EOF
+   )"
+   ```
+
+4. **If `viewerPermission` was `READ` (Phase 1)**, skip the push and PR.
+   Print the exact `git push` and `gh pr create` commands for the user to
+   run manually and stop.
+
+---
+
+## **Dry Run Mode**
+
+Activated by any of `"dry run"`, `"dry-run"`, `"preview"`, or
+`"don't apply"` in `$ARGUMENTS`. When active:
+
+- Run all of Phase 1 (branch is still useful as a planning artifact — but
+  you MAY skip branch creation if the user prefers; ask).
+- Run Phase 2 analysis and Phase 3 step 1 (version fetching) fully.
+- For each catalog, print the proposed bump list (current → target) and
+  the predicted classification (auto / manual / frozen).
+- Do **not** edit `pnpm-workspace.yaml`, do not run `pnpm install`, do not
+  commit, do not push, do not create a PR.
+
+---
+
+## **Example Output**
+
+```
+🧹 HOUSEKEEPING — ui-kit catalog updates
+
+✅ Pre-flight: clean tree, branch housekeeping-20260519-1430 created
+📦 Analyzing catalogs in pnpm-workspace.yaml
+   default     → 12 singletons
+   build       → 24 entries
+   lint        → 8 entries
+   peer        → 7 entries (FROZEN, skipped)
+   react       → 18 entries
+   repo        → 11 entries
+   rich-text   → 13 entries
+   storybook   → 5 entries (lockstep)
+   test        → 17 entries
+
+🛠 repo (11 pkgs, 3 bumps):
+   @changesets/cli: 2.29.7 → 2.29.8
+   husky: 9.1.7 → 9.2.0
+   @manypkg/cli: 0.25.1 → 0.25.2
+   ✅ lint / typecheck / build / test passed
+   ✅ checkpoint commit: chore(deps): update repo
+
+🧹 lint (8 pkgs, 1 bump):
+   eslint: 9.18.0 → 9.20.1
+   ✅ checkpoint commit: chore(deps): update lint
+
+🧪 test (17 pkgs, 4 bumps):
+   jest: 30.3.0 → 30.4.1
+   @testing-library/dom: 10.4.0 → 10.5.0
+   …
+   ✅ checkpoint commit: chore(deps): update test
+
+📚 storybook (5 pkgs, lockstep): 9.1.20 → 9.1.21
+   ✅ checkpoint commit: chore(deps): update storybook
+
+📦 default catalog (12 pkgs, 2 bumps):
+   lodash: 4.18.1 → 4.18.2
+   yaml: 2.8.3 → 2.8.4
+   ✅ checkpoint commit: chore(deps): update default catalog
+
+🏗 build (24 pkgs, 5 bumps): typescript 5.9.3 → 5.9.4, vite 6.4.2 → 6.4.3, …
+   ✅ checkpoint commit: chore(deps): update build
+
+✍️ rich-text (13 pkgs): no internally-consistent bumps available — skipped
+
+⚛️ react (18 pkgs, 3 bumps):
+   react-intl: 7.1.4 → 7.1.10
+   downshift: 9.0.10 → 9.0.11
+   formik: 2.4.6 → 2.4.7
+   ⏸ react / react-dom — already at 19.2.0, latest in 19.x
+   ✅ checkpoint commit: chore(deps): update react
+
+📝 Changeset: .changeset/housekeeping-deps-20260519-1430.md
+   '@commercetools-frontend/ui-kit': patch (fixed group propagates)
+
+✅ Final verification: build, test, workspace constraints all pass
+
+📊 SUMMARY
+   - 15 packages updated across 7 cohorts
+   - 1 cohort skipped (rich-text — no consistent cohort bump)
+   - 0 cohorts failed
+   - peer catalog frozen as designed
+   - PR ready for review
+```
+
+---
+
+## **RFC 2119 Key Words**
+
+- **MUST** / **REQUIRED** / **SHALL** — Absolute requirement
+- **MUST NOT** / **SHALL NOT** — Absolute prohibition
+- **SHOULD** / **RECOMMENDED** — Default unless valid reason not to
+- **SHOULD NOT** / **NOT RECOMMENDED** — Avoid unless valid reason
+- **MAY** / **OPTIONAL** — Truly optional
+
+---
+
+## **Important Constraints**
+
+- You MUST verify GitHub CLI auth and viewer permission before pushing.
+- You MUST start from a clean working tree on `main`.
+- You MUST create the `housekeeping-YYYYMMDD-HHMM` branch successfully
+  before any edits — abort if branch creation fails.
+- You MUST NOT update any entry in `catalogs.peer` from this command.
+- You MUST NOT bump `remark-gfm-v1` (aliased pin).
+- You MUST NOT bump beyond the current major for any dep.
+- You MUST move `storybook` + `@storybook/*` entries together as one
+  version, and you MUST move `rich-text` sub-cohorts (slate, remark,
+  unified/vfile) together or not at all.
+- You MUST edit catalog entries in `pnpm-workspace.yaml` directly — never
+  bump a catalog-managed dep via `pnpm update` against a workspace
+  `package.json`. `scripts/check-workspace-constraints.js` will reject it.
+- You MUST run `pnpm lint`, `pnpm lint:css`, `pnpm lint:publint`,
+  `pnpm typecheck`, `pnpm build`, `pnpm test`, and
+  `node scripts/check-workspace-constraints.js` per cohort and again at
+  the end.
+- You MUST rollback a cohort's edits if its validation fails, then
+  continue with the next cohort. A single failed cohort MUST NOT abort
+  the whole run.
+- You MUST add a `patch` changeset listing
+  `@commercetools-frontend/ui-kit` whenever any runtime / peer dep of a
+  publishable package is bumped. The fixed version group propagates.
+- You MUST ask the user before pushing and before creating the PR.
+- You SHOULD preserve sub-cohort comment groupings and blank lines inside
+  named catalogs. The default `catalog:` SHOULD remain alphabetical.
+- You SHOULD interpret `$ARGUMENTS` as natural language and restate your
+  scope interpretation in one line before proceeding when the request is
+  ambiguous.
+
+---
+
+**Remember:** Safety first. Validate after every cohort. Roll back early
+and locally rather than carrying a broken cohort into a later one. The
+fixed version group means one bad bump can affect every published package.


### PR DESCRIPTION
## Summary

Ports two Claude Code slash commands from the nimbus repo, tailored to this `ui-kit` monorepo:

- **`/housekeeping`** — updates `pnpm-workspace.yaml` catalog entries (`catalog:` and `catalogs.<name>:`) to their latest **minor/patch** versions only, in risk-ordered cohorts, with build/lint/type/test validation between checkpoints. Accepts free-form scope filters (e.g. `"tooling only"`, `"storybook dry run"`, `"just the slate stack"`). The `peer` catalog stays frozen.
- **`/github/fix-security-alerts`** — triages Dependabot alerts in this repo, proposes a fix plan, applies auto-fixable updates after validation, and optionally pushes and opens a PR.

Both files are pure tooling — they only land in `.claude/commands/` and don't affect published packages, so no changeset is required.

## Test plan

- [ ] In a Claude Code session at the repo root, run `/housekeeping dry run` and confirm it enumerates catalogs without applying changes.
- [ ] Run `/github/fix-security-alerts` and confirm it reaches the "present plan" phase against current Dependabot alerts before any commits are made.
- [ ] Verify both commands appear in the `/` command palette.