### PR TITLE
refactor(FEC-936): publint metadata cleanup (engines, type, repository.url)

### DIFF
--- a/.changeset/fec-936-engines-node.md
+++ b/.changeset/fec-936-engines-node.md
@@ -1,0 +1,13 @@
+---
+'@commercetools-frontend/ui-kit': patch
+---
+
+Declare `engines.node` on all published packages.
+
+Adds `"engines": { "node": ">=22" }` to every published `@commercetools-uikit/*`
+and `@commercetools-frontend/ui-kit` package. Closes one of the publint
+suggestions tracked in FEC-936. Pure metadata — no runtime, build, or
+consumer-API change.
+
+Consumers installing on Node <22 may see a non-fatal `npm install` engine
+warning. Node 22 is the current LTS line; pick a newer Node to silence it.

--- a/.changeset/fec-936-engines-node.md
+++ b/.changeset/fec-936-engines-node.md
@@ -2,12 +2,31 @@
 '@commercetools-frontend/ui-kit': patch
 ---
 
-Declare `engines.node` on all published packages.
+**FEC-936 — publint metadata cleanup across published packages.** Closes
+three of the four publint findings that every published package
+emitted. All changes are pure metadata — no build output, runtime, or
+consumer-API impact.
 
-Adds `"engines": { "node": ">=22" }` to every published `@commercetools-uikit/*`
-and `@commercetools-frontend/ui-kit` package. Closes one of the publint
-suggestions tracked in FEC-936. Pure metadata — no runtime, build, or
-consumer-API change.
+- `"engines": { "node": ">=22" }` declared on every published package.
+  Consumers installing on Node <22 will see a non-fatal `npm install`
+  engine warning.
+- `"type": "commonjs"` declared on every published package, matching
+  what Preconstruct's `.cjs.js` / `.esm.js` output already required Node
+  to assume.
+- `repository.url` rewritten from `https://…` to `git+https://…` so the
+  field is unambiguously parseable as a git remote.
 
-Consumers installing on Node <22 may see a non-fatal `npm install` engine
-warning. Node 22 is the current LTS line; pick a newer Node to silence it.
+The fourth finding (`pkg.exports` is missing) is deferred. Adding an
+`exports` field via Preconstruct's stable config silently degrades
+TypeScript types for consumers using `moduleResolution: "Bundler"` or
+`"NodeNext"` (TS resolves through the `module` condition, finds no
+`.esm.d.ts` sibling, and types drop to `any`). It will be revisited
+separately so the migration can be evaluated against downstream type
+resolution properly.
+
+Internal-only:
+
+- `scripts/check-workspace-constraints.js` enforces the new metadata
+  shape across the workspace.
+- `generators/package-json` template updated to preserve the new fields
+  across regenerations.

--- a/.changeset/fec-936-engines-node.md
+++ b/.changeset/fec-936-engines-node.md
@@ -2,31 +2,7 @@
 '@commercetools-frontend/ui-kit': patch
 ---
 
-**FEC-936 — publint metadata cleanup across published packages.** Closes
-three of the four publint findings that every published package
-emitted. All changes are pure metadata — no build output, runtime, or
-consumer-API impact.
-
-- `"engines": { "node": ">=22" }` declared on every published package.
-  Consumers installing on Node <22 will see a non-fatal `npm install`
-  engine warning.
-- `"type": "commonjs"` declared on every published package, matching
-  what Preconstruct's `.cjs.js` / `.esm.js` output already required Node
-  to assume.
-- `repository.url` rewritten from `https://…` to `git+https://…` so the
-  field is unambiguously parseable as a git remote.
-
-The fourth finding (`pkg.exports` is missing) is deferred. Adding an
-`exports` field via Preconstruct's stable config silently degrades
-TypeScript types for consumers using `moduleResolution: "Bundler"` or
-`"NodeNext"` (TS resolves through the `module` condition, finds no
-`.esm.d.ts` sibling, and types drop to `any`). It will be revisited
-separately so the migration can be evaluated against downstream type
-resolution properly.
-
-Internal-only:
-
-- `scripts/check-workspace-constraints.js` enforces the new metadata
-  shape across the workspace.
-- `generators/package-json` template updated to preserve the new fields
-  across regenerations.
+Every published `@commercetools-uikit/*` and `@commercetools-frontend/ui-kit`
+package now declares `engines.node: ">=22"`. Installing on Node 21 or older
+produces a non-fatal `npm install` engine warning; updating to a maintained
+LTS line silences it.

--- a/design-system/package.json
+++ b/design-system/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-design-system.cjs.js",
   "module": "dist/commercetools-uikit-design-system.esm.js",

--- a/design-system/package.json
+++ b/design-system/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-design-system.cjs.js",
   "module": "dist/commercetools-uikit-design-system.esm.js",
   "files": ["dist", "materials"],
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "build:tokens": "node ./scripts/generate-design-tokens.js",
     "build:tokens:watch": "nodemon -e yaml --quiet --watch materials/internals --exec 'pnpm build:tokens'"

--- a/design-system/package.json
+++ b/design-system/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "design-system"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/generators/package-json/src/index.ts
+++ b/generators/package-json/src/index.ts
@@ -73,6 +73,11 @@ export const transformDocument = (
     publishConfig: {
       access: 'public',
     },
+    // Matches the de facto behavior of Preconstruct's output: every .js
+    // file under main/module resolution is CJS. Pinning this silences
+    // publint's "missing type field" suggestion without changing how
+    // bundlers or Node interpret the package.
+    type: 'commonjs',
     sideEffects: false,
     // Managed by `preconstruct`
     main: originalPackageJson.main,

--- a/generators/package-json/src/index.ts
+++ b/generators/package-json/src/index.ts
@@ -80,6 +80,9 @@ export const transformDocument = (
     module: originalPackageJson.module,
     preconstruct: originalPackageJson.preconstruct,
     files: originalPackageJson.files,
+    engines: {
+      node: '>=22',
+    },
     scripts: originalPackageJson.scripts,
     dependencies: originalPackageJson.dependencies,
     devDependencies: originalPackageJson.devDependencies,

--- a/generators/package-json/src/index.ts
+++ b/generators/package-json/src/index.ts
@@ -64,7 +64,7 @@ export const transformDocument = (
     bugs: 'https://github.com/commercetools/ui-kit/issues',
     repository: {
       type: 'git',
-      url: 'https://github.com/commercetools/ui-kit.git',
+      url: 'git+https://github.com/commercetools/ui-kit.git',
       directory: relativePackageFolderPath,
     },
     homepage: 'https://uikit.commercetools.com',

--- a/generators/package-json/test/generate-package-json.spec.ts
+++ b/generators/package-json/test/generate-package-json.spec.ts
@@ -75,6 +75,7 @@ describe('when package.json is NOT private', () => {
           "url": "git+https://github.com/commercetools/ui-kit.git",
         },
         "sideEffects": false,
+        "type": "commonjs",
         "version": "1.0.0",
       }
     `);

--- a/generators/package-json/test/generate-package-json.spec.ts
+++ b/generators/package-json/test/generate-package-json.spec.ts
@@ -43,6 +43,9 @@ describe('when package.json is NOT private', () => {
       {
         "bugs": "https://github.com/commercetools/ui-kit/issues",
         "description": "Render an Avenger",
+        "engines": {
+          "node": ">=22",
+        },
         "homepage": "https://uikit.commercetools.com",
         "keywords": [
           "javascript",

--- a/generators/package-json/test/generate-package-json.spec.ts
+++ b/generators/package-json/test/generate-package-json.spec.ts
@@ -72,7 +72,7 @@ describe('when package.json is NOT private', () => {
         "repository": {
           "directory": "packages/avenger",
           "type": "git",
-          "url": "https://github.com/commercetools/ui-kit.git",
+          "url": "git+https://github.com/commercetools/ui-kit.git",
         },
         "sideEffects": false,
         "version": "1.0.0",

--- a/packages/calendar-time-utils/package.json
+++ b/packages/calendar-time-utils/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/calendar-time-utils"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/calendar-time-utils/package.json
+++ b/packages/calendar-time-utils/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-calendar-time-utils.cjs.js",
   "module": "dist/commercetools-uikit-calendar-time-utils.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/calendar-time-utils/package.json
+++ b/packages/calendar-time-utils/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-calendar-time-utils.cjs.js",
   "module": "dist/commercetools-uikit-calendar-time-utils.esm.js",

--- a/packages/calendar-utils/package.json
+++ b/packages/calendar-utils/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/calendar-utils"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/calendar-utils/package.json
+++ b/packages/calendar-utils/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-calendar-utils.cjs.js",
   "module": "dist/commercetools-uikit-calendar-utils.esm.js",

--- a/packages/calendar-utils/package.json
+++ b/packages/calendar-utils/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-calendar-utils.cjs.js",
   "module": "dist/commercetools-uikit-calendar-utils.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/accessible-hidden/package.json
+++ b/packages/components/accessible-hidden/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-accessible-hidden.cjs.js",
   "module": "dist/commercetools-uikit-accessible-hidden.esm.js",

--- a/packages/components/accessible-hidden/package.json
+++ b/packages/components/accessible-hidden/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/accessible-hidden"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/accessible-hidden/package.json
+++ b/packages/components/accessible-hidden/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-accessible-hidden.cjs.js",
   "module": "dist/commercetools-uikit-accessible-hidden.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/avatar/package.json
+++ b/packages/components/avatar/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/avatar"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/avatar/package.json
+++ b/packages/components/avatar/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-avatar.cjs.js",
   "module": "dist/commercetools-uikit-avatar.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/avatar/package.json
+++ b/packages/components/avatar/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-avatar.cjs.js",
   "module": "dist/commercetools-uikit-avatar.esm.js",

--- a/packages/components/buttons/accessible-button/package.json
+++ b/packages/components/buttons/accessible-button/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-accessible-button.cjs.js",
   "module": "dist/commercetools-uikit-accessible-button.esm.js",

--- a/packages/components/buttons/accessible-button/package.json
+++ b/packages/components/buttons/accessible-button/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/buttons/accessible-button"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/buttons/accessible-button/package.json
+++ b/packages/components/buttons/accessible-button/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-accessible-button.cjs.js",
   "module": "dist/commercetools-uikit-accessible-button.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/buttons/flat-button/package.json
+++ b/packages/components/buttons/flat-button/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/buttons/flat-button"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/buttons/flat-button/package.json
+++ b/packages/components/buttons/flat-button/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-flat-button.cjs.js",
   "module": "dist/commercetools-uikit-flat-button.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/buttons/flat-button/package.json
+++ b/packages/components/buttons/flat-button/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-flat-button.cjs.js",
   "module": "dist/commercetools-uikit-flat-button.esm.js",

--- a/packages/components/buttons/icon-button/package.json
+++ b/packages/components/buttons/icon-button/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-icon-button.cjs.js",
   "module": "dist/commercetools-uikit-icon-button.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/buttons/icon-button/package.json
+++ b/packages/components/buttons/icon-button/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/buttons/icon-button"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/buttons/icon-button/package.json
+++ b/packages/components/buttons/icon-button/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-icon-button.cjs.js",
   "module": "dist/commercetools-uikit-icon-button.esm.js",

--- a/packages/components/buttons/link-button/package.json
+++ b/packages/components/buttons/link-button/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/buttons/link-button"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/buttons/link-button/package.json
+++ b/packages/components/buttons/link-button/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-link-button.cjs.js",
   "module": "dist/commercetools-uikit-link-button.esm.js",

--- a/packages/components/buttons/link-button/package.json
+++ b/packages/components/buttons/link-button/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-link-button.cjs.js",
   "module": "dist/commercetools-uikit-link-button.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/buttons/primary-button/package.json
+++ b/packages/components/buttons/primary-button/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-primary-button.cjs.js",
   "module": "dist/commercetools-uikit-primary-button.esm.js",

--- a/packages/components/buttons/primary-button/package.json
+++ b/packages/components/buttons/primary-button/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/buttons/primary-button"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/buttons/primary-button/package.json
+++ b/packages/components/buttons/primary-button/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-primary-button.cjs.js",
   "module": "dist/commercetools-uikit-primary-button.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/buttons/secondary-button/package.json
+++ b/packages/components/buttons/secondary-button/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-secondary-button.cjs.js",
   "module": "dist/commercetools-uikit-secondary-button.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/buttons/secondary-button/package.json
+++ b/packages/components/buttons/secondary-button/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/buttons/secondary-button"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/buttons/secondary-button/package.json
+++ b/packages/components/buttons/secondary-button/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-secondary-button.cjs.js",
   "module": "dist/commercetools-uikit-secondary-button.esm.js",

--- a/packages/components/buttons/secondary-icon-button/package.json
+++ b/packages/components/buttons/secondary-icon-button/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/buttons/secondary-icon-button"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/buttons/secondary-icon-button/package.json
+++ b/packages/components/buttons/secondary-icon-button/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-secondary-icon-button.cjs.js",
   "module": "dist/commercetools-uikit-secondary-icon-button.esm.js",

--- a/packages/components/buttons/secondary-icon-button/package.json
+++ b/packages/components/buttons/secondary-icon-button/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-secondary-icon-button.cjs.js",
   "module": "dist/commercetools-uikit-secondary-icon-button.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-card.cjs.js",
   "module": "dist/commercetools-uikit-card.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/card"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-card.cjs.js",
   "module": "dist/commercetools-uikit-card.esm.js",

--- a/packages/components/collapsible-motion/package.json
+++ b/packages/components/collapsible-motion/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-collapsible-motion.cjs.js",
   "module": "dist/commercetools-uikit-collapsible-motion.esm.js",

--- a/packages/components/collapsible-motion/package.json
+++ b/packages/components/collapsible-motion/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-collapsible-motion.cjs.js",
   "module": "dist/commercetools-uikit-collapsible-motion.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/collapsible-motion/package.json
+++ b/packages/components/collapsible-motion/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/collapsible-motion"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/collapsible-panel/package.json
+++ b/packages/components/collapsible-panel/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/collapsible-panel"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/collapsible-panel/package.json
+++ b/packages/components/collapsible-panel/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-collapsible-panel.cjs.js",
   "module": "dist/commercetools-uikit-collapsible-panel.esm.js",

--- a/packages/components/collapsible-panel/package.json
+++ b/packages/components/collapsible-panel/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-collapsible-panel.cjs.js",
   "module": "dist/commercetools-uikit-collapsible-panel.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/collapsible/package.json
+++ b/packages/components/collapsible/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-collapsible.cjs.js",
   "module": "dist/commercetools-uikit-collapsible.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/collapsible/package.json
+++ b/packages/components/collapsible/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/collapsible"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/collapsible/package.json
+++ b/packages/components/collapsible/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-collapsible.cjs.js",
   "module": "dist/commercetools-uikit-collapsible.esm.js",

--- a/packages/components/constraints/package.json
+++ b/packages/components/constraints/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/constraints"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/constraints/package.json
+++ b/packages/components/constraints/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-constraints.cjs.js",
   "module": "dist/commercetools-uikit-constraints.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/constraints/package.json
+++ b/packages/components/constraints/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-constraints.cjs.js",
   "module": "dist/commercetools-uikit-constraints.esm.js",

--- a/packages/components/data-table-manager/package.json
+++ b/packages/components/data-table-manager/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-data-table-manager.cjs.js",
   "module": "dist/commercetools-uikit-data-table-manager.esm.js",

--- a/packages/components/data-table-manager/package.json
+++ b/packages/components/data-table-manager/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/data-table-manager"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/data-table-manager/package.json
+++ b/packages/components/data-table-manager/package.json
@@ -25,6 +25,9 @@
     ]
   },
   "files": ["dist", "data-table-manager-provider", "column-settings-manager"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/data-table/package.json
+++ b/packages/components/data-table/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-data-table.cjs.js",
   "module": "dist/commercetools-uikit-data-table.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/data-table/package.json
+++ b/packages/components/data-table/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/data-table"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/data-table/package.json
+++ b/packages/components/data-table/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-data-table.cjs.js",
   "module": "dist/commercetools-uikit-data-table.esm.js",

--- a/packages/components/dropdowns/dropdown-menu/package.json
+++ b/packages/components/dropdowns/dropdown-menu/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-dropdown-menu.cjs.js",
   "module": "dist/commercetools-uikit-dropdown-menu.esm.js",

--- a/packages/components/dropdowns/dropdown-menu/package.json
+++ b/packages/components/dropdowns/dropdown-menu/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-dropdown-menu.cjs.js",
   "module": "dist/commercetools-uikit-dropdown-menu.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/dropdowns/dropdown-menu/package.json
+++ b/packages/components/dropdowns/dropdown-menu/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/dropdowns/dropdown-menu"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/field-errors/package.json
+++ b/packages/components/field-errors/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-field-errors.cjs.js",
   "module": "dist/commercetools-uikit-field-errors.esm.js",

--- a/packages/components/field-errors/package.json
+++ b/packages/components/field-errors/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-field-errors.cjs.js",
   "module": "dist/commercetools-uikit-field-errors.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/field-errors/package.json
+++ b/packages/components/field-errors/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/field-errors"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/field-label/package.json
+++ b/packages/components/field-label/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/field-label"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/field-label/package.json
+++ b/packages/components/field-label/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-field-label.cjs.js",
   "module": "dist/commercetools-uikit-field-label.esm.js",

--- a/packages/components/field-label/package.json
+++ b/packages/components/field-label/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-field-label.cjs.js",
   "module": "dist/commercetools-uikit-field-label.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/field-warnings/package.json
+++ b/packages/components/field-warnings/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/field-warnings"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/field-warnings/package.json
+++ b/packages/components/field-warnings/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-field-warnings.cjs.js",
   "module": "dist/commercetools-uikit-field-warnings.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/field-warnings/package.json
+++ b/packages/components/field-warnings/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-field-warnings.cjs.js",
   "module": "dist/commercetools-uikit-field-warnings.esm.js",

--- a/packages/components/fields/async-creatable-select-field/package.json
+++ b/packages/components/fields/async-creatable-select-field/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-async-creatable-select-field.cjs.js",
   "module": "dist/commercetools-uikit-async-creatable-select-field.esm.js",

--- a/packages/components/fields/async-creatable-select-field/package.json
+++ b/packages/components/fields/async-creatable-select-field/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/fields/async-creatable-select-field"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/fields/async-creatable-select-field/package.json
+++ b/packages/components/fields/async-creatable-select-field/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-async-creatable-select-field.cjs.js",
   "module": "dist/commercetools-uikit-async-creatable-select-field.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/fields/async-select-field/package.json
+++ b/packages/components/fields/async-select-field/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-async-select-field.cjs.js",
   "module": "dist/commercetools-uikit-async-select-field.esm.js",

--- a/packages/components/fields/async-select-field/package.json
+++ b/packages/components/fields/async-select-field/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/fields/async-select-field"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/fields/async-select-field/package.json
+++ b/packages/components/fields/async-select-field/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-async-select-field.cjs.js",
   "module": "dist/commercetools-uikit-async-select-field.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/fields/creatable-select-field/package.json
+++ b/packages/components/fields/creatable-select-field/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/fields/creatable-select-field"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/fields/creatable-select-field/package.json
+++ b/packages/components/fields/creatable-select-field/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-creatable-select-field.cjs.js",
   "module": "dist/commercetools-uikit-creatable-select-field.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/fields/creatable-select-field/package.json
+++ b/packages/components/fields/creatable-select-field/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-creatable-select-field.cjs.js",
   "module": "dist/commercetools-uikit-creatable-select-field.esm.js",

--- a/packages/components/fields/date-field/package.json
+++ b/packages/components/fields/date-field/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-date-field.cjs.js",
   "module": "dist/commercetools-uikit-date-field.esm.js",

--- a/packages/components/fields/date-field/package.json
+++ b/packages/components/fields/date-field/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/fields/date-field"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/fields/date-field/package.json
+++ b/packages/components/fields/date-field/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-date-field.cjs.js",
   "module": "dist/commercetools-uikit-date-field.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/fields/date-range-field/package.json
+++ b/packages/components/fields/date-range-field/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-date-range-field.cjs.js",
   "module": "dist/commercetools-uikit-date-range-field.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/fields/date-range-field/package.json
+++ b/packages/components/fields/date-range-field/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/fields/date-range-field"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/fields/date-range-field/package.json
+++ b/packages/components/fields/date-range-field/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-date-range-field.cjs.js",
   "module": "dist/commercetools-uikit-date-range-field.esm.js",

--- a/packages/components/fields/date-time-field/package.json
+++ b/packages/components/fields/date-time-field/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-date-time-field.cjs.js",
   "module": "dist/commercetools-uikit-date-time-field.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/fields/date-time-field/package.json
+++ b/packages/components/fields/date-time-field/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-date-time-field.cjs.js",
   "module": "dist/commercetools-uikit-date-time-field.esm.js",

--- a/packages/components/fields/date-time-field/package.json
+++ b/packages/components/fields/date-time-field/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/fields/date-time-field"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/fields/localized-multiline-text-field/package.json
+++ b/packages/components/fields/localized-multiline-text-field/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/fields/localized-multiline-text-field"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/fields/localized-multiline-text-field/package.json
+++ b/packages/components/fields/localized-multiline-text-field/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-localized-multiline-text-field.cjs.js",
   "module": "dist/commercetools-uikit-localized-multiline-text-field.esm.js",

--- a/packages/components/fields/localized-multiline-text-field/package.json
+++ b/packages/components/fields/localized-multiline-text-field/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-localized-multiline-text-field.cjs.js",
   "module": "dist/commercetools-uikit-localized-multiline-text-field.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/fields/localized-text-field/package.json
+++ b/packages/components/fields/localized-text-field/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/fields/localized-text-field"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/fields/localized-text-field/package.json
+++ b/packages/components/fields/localized-text-field/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-localized-text-field.cjs.js",
   "module": "dist/commercetools-uikit-localized-text-field.esm.js",

--- a/packages/components/fields/localized-text-field/package.json
+++ b/packages/components/fields/localized-text-field/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-localized-text-field.cjs.js",
   "module": "dist/commercetools-uikit-localized-text-field.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/fields/money-field/package.json
+++ b/packages/components/fields/money-field/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-money-field.cjs.js",
   "module": "dist/commercetools-uikit-money-field.esm.js",

--- a/packages/components/fields/money-field/package.json
+++ b/packages/components/fields/money-field/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/fields/money-field"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/fields/money-field/package.json
+++ b/packages/components/fields/money-field/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-money-field.cjs.js",
   "module": "dist/commercetools-uikit-money-field.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/fields/multiline-text-field/package.json
+++ b/packages/components/fields/multiline-text-field/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-multiline-text-field.cjs.js",
   "module": "dist/commercetools-uikit-multiline-text-field.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/fields/multiline-text-field/package.json
+++ b/packages/components/fields/multiline-text-field/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/fields/multiline-text-field"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/fields/multiline-text-field/package.json
+++ b/packages/components/fields/multiline-text-field/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-multiline-text-field.cjs.js",
   "module": "dist/commercetools-uikit-multiline-text-field.esm.js",

--- a/packages/components/fields/number-field/package.json
+++ b/packages/components/fields/number-field/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/fields/number-field"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/fields/number-field/package.json
+++ b/packages/components/fields/number-field/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-number-field.cjs.js",
   "module": "dist/commercetools-uikit-number-field.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/fields/number-field/package.json
+++ b/packages/components/fields/number-field/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-number-field.cjs.js",
   "module": "dist/commercetools-uikit-number-field.esm.js",

--- a/packages/components/fields/password-field/package.json
+++ b/packages/components/fields/password-field/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-password-field.cjs.js",
   "module": "dist/commercetools-uikit-password-field.esm.js",

--- a/packages/components/fields/password-field/package.json
+++ b/packages/components/fields/password-field/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/fields/password-field"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/fields/password-field/package.json
+++ b/packages/components/fields/password-field/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-password-field.cjs.js",
   "module": "dist/commercetools-uikit-password-field.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/fields/radio-field/package.json
+++ b/packages/components/fields/radio-field/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-radio-field.cjs.js",
   "module": "dist/commercetools-uikit-radio-field.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/fields/radio-field/package.json
+++ b/packages/components/fields/radio-field/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-radio-field.cjs.js",
   "module": "dist/commercetools-uikit-radio-field.esm.js",

--- a/packages/components/fields/radio-field/package.json
+++ b/packages/components/fields/radio-field/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/fields/radio-field"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/fields/search-select-field/package.json
+++ b/packages/components/fields/search-select-field/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-search-select-field.cjs.js",
   "module": "dist/commercetools-uikit-search-select-field.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/fields/search-select-field/package.json
+++ b/packages/components/fields/search-select-field/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/fields/search-select-field"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/fields/search-select-field/package.json
+++ b/packages/components/fields/search-select-field/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-search-select-field.cjs.js",
   "module": "dist/commercetools-uikit-search-select-field.esm.js",

--- a/packages/components/fields/select-field/package.json
+++ b/packages/components/fields/select-field/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/fields/select-field"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/fields/select-field/package.json
+++ b/packages/components/fields/select-field/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-select-field.cjs.js",
   "module": "dist/commercetools-uikit-select-field.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/fields/select-field/package.json
+++ b/packages/components/fields/select-field/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-select-field.cjs.js",
   "module": "dist/commercetools-uikit-select-field.esm.js",

--- a/packages/components/fields/text-field/package.json
+++ b/packages/components/fields/text-field/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-text-field.cjs.js",
   "module": "dist/commercetools-uikit-text-field.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/fields/text-field/package.json
+++ b/packages/components/fields/text-field/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/fields/text-field"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/fields/text-field/package.json
+++ b/packages/components/fields/text-field/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-text-field.cjs.js",
   "module": "dist/commercetools-uikit-text-field.esm.js",

--- a/packages/components/fields/time-field/package.json
+++ b/packages/components/fields/time-field/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-time-field.cjs.js",
   "module": "dist/commercetools-uikit-time-field.esm.js",

--- a/packages/components/fields/time-field/package.json
+++ b/packages/components/fields/time-field/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/fields/time-field"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/fields/time-field/package.json
+++ b/packages/components/fields/time-field/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-time-field.cjs.js",
   "module": "dist/commercetools-uikit-time-field.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/filters/package.json
+++ b/packages/components/filters/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/filters"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/filters/package.json
+++ b/packages/components/filters/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-filters.cjs.js",
   "module": "dist/commercetools-uikit-filters.esm.js",

--- a/packages/components/filters/package.json
+++ b/packages/components/filters/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-filters.cjs.js",
   "module": "dist/commercetools-uikit-filters.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/grid/package.json
+++ b/packages/components/grid/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-grid.cjs.js",
   "module": "dist/commercetools-uikit-grid.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/grid/package.json
+++ b/packages/components/grid/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/grid"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/grid/package.json
+++ b/packages/components/grid/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-grid.cjs.js",
   "module": "dist/commercetools-uikit-grid.esm.js",

--- a/packages/components/icons/package.json
+++ b/packages/components/icons/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-icons.cjs.js",
   "module": "dist/commercetools-uikit-icons.esm.js",

--- a/packages/components/icons/package.json
+++ b/packages/components/icons/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/icons"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/icons/package.json
+++ b/packages/components/icons/package.json
@@ -33,6 +33,9 @@
     "leading-icon",
     "generated/**"
   ],
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "generate-icons": "svgr -d src/generated -- src/svg"
   },

--- a/packages/components/inputs/async-creatable-select-input/package.json
+++ b/packages/components/inputs/async-creatable-select-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-async-creatable-select-input.cjs.js",
   "module": "dist/commercetools-uikit-async-creatable-select-input.esm.js",

--- a/packages/components/inputs/async-creatable-select-input/package.json
+++ b/packages/components/inputs/async-creatable-select-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/async-creatable-select-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/async-creatable-select-input/package.json
+++ b/packages/components/inputs/async-creatable-select-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-async-creatable-select-input.cjs.js",
   "module": "dist/commercetools-uikit-async-creatable-select-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/async-select-input/package.json
+++ b/packages/components/inputs/async-select-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/async-select-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/async-select-input/package.json
+++ b/packages/components/inputs/async-select-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-async-select-input.cjs.js",
   "module": "dist/commercetools-uikit-async-select-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/async-select-input/package.json
+++ b/packages/components/inputs/async-select-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-async-select-input.cjs.js",
   "module": "dist/commercetools-uikit-async-select-input.esm.js",

--- a/packages/components/inputs/checkbox-input/package.json
+++ b/packages/components/inputs/checkbox-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/checkbox-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/checkbox-input/package.json
+++ b/packages/components/inputs/checkbox-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-checkbox-input.cjs.js",
   "module": "dist/commercetools-uikit-checkbox-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "generate-icons": "svgr -d src/icons/generated --typescript -- src/icons/svg"
   },

--- a/packages/components/inputs/checkbox-input/package.json
+++ b/packages/components/inputs/checkbox-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-checkbox-input.cjs.js",
   "module": "dist/commercetools-uikit-checkbox-input.esm.js",

--- a/packages/components/inputs/creatable-select-input/package.json
+++ b/packages/components/inputs/creatable-select-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-creatable-select-input.cjs.js",
   "module": "dist/commercetools-uikit-creatable-select-input.esm.js",

--- a/packages/components/inputs/creatable-select-input/package.json
+++ b/packages/components/inputs/creatable-select-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/creatable-select-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/creatable-select-input/package.json
+++ b/packages/components/inputs/creatable-select-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-creatable-select-input.cjs.js",
   "module": "dist/commercetools-uikit-creatable-select-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/date-input/package.json
+++ b/packages/components/inputs/date-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/date-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/date-input/package.json
+++ b/packages/components/inputs/date-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-date-input.cjs.js",
   "module": "dist/commercetools-uikit-date-input.esm.js",

--- a/packages/components/inputs/date-input/package.json
+++ b/packages/components/inputs/date-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-date-input.cjs.js",
   "module": "dist/commercetools-uikit-date-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/date-range-input/package.json
+++ b/packages/components/inputs/date-range-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-date-range-input.cjs.js",
   "module": "dist/commercetools-uikit-date-range-input.esm.js",

--- a/packages/components/inputs/date-range-input/package.json
+++ b/packages/components/inputs/date-range-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/date-range-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/date-range-input/package.json
+++ b/packages/components/inputs/date-range-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-date-range-input.cjs.js",
   "module": "dist/commercetools-uikit-date-range-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/date-time-input/package.json
+++ b/packages/components/inputs/date-time-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/date-time-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/date-time-input/package.json
+++ b/packages/components/inputs/date-time-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-date-time-input.cjs.js",
   "module": "dist/commercetools-uikit-date-time-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/date-time-input/package.json
+++ b/packages/components/inputs/date-time-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-date-time-input.cjs.js",
   "module": "dist/commercetools-uikit-date-time-input.esm.js",

--- a/packages/components/inputs/input-utils/package.json
+++ b/packages/components/inputs/input-utils/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-input-utils.cjs.js",
   "module": "dist/commercetools-uikit-input-utils.esm.js",

--- a/packages/components/inputs/input-utils/package.json
+++ b/packages/components/inputs/input-utils/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-input-utils.cjs.js",
   "module": "dist/commercetools-uikit-input-utils.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/input-utils/package.json
+++ b/packages/components/inputs/input-utils/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/input-utils"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/localized-money-input/package.json
+++ b/packages/components/inputs/localized-money-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/localized-money-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/localized-money-input/package.json
+++ b/packages/components/inputs/localized-money-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-localized-money-input.cjs.js",
   "module": "dist/commercetools-uikit-localized-money-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/localized-money-input/package.json
+++ b/packages/components/inputs/localized-money-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-localized-money-input.cjs.js",
   "module": "dist/commercetools-uikit-localized-money-input.esm.js",

--- a/packages/components/inputs/localized-multiline-text-input/package.json
+++ b/packages/components/inputs/localized-multiline-text-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-localized-multiline-text-input.cjs.js",
   "module": "dist/commercetools-uikit-localized-multiline-text-input.esm.js",

--- a/packages/components/inputs/localized-multiline-text-input/package.json
+++ b/packages/components/inputs/localized-multiline-text-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/localized-multiline-text-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/localized-multiline-text-input/package.json
+++ b/packages/components/inputs/localized-multiline-text-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-localized-multiline-text-input.cjs.js",
   "module": "dist/commercetools-uikit-localized-multiline-text-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/localized-rich-text-input/package.json
+++ b/packages/components/inputs/localized-rich-text-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/localized-rich-text-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/localized-rich-text-input/package.json
+++ b/packages/components/inputs/localized-rich-text-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-localized-rich-text-input.cjs.js",
   "module": "dist/commercetools-uikit-localized-rich-text-input.esm.js",

--- a/packages/components/inputs/localized-rich-text-input/package.json
+++ b/packages/components/inputs/localized-rich-text-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-localized-rich-text-input.cjs.js",
   "module": "dist/commercetools-uikit-localized-rich-text-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/localized-text-input/package.json
+++ b/packages/components/inputs/localized-text-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-localized-text-input.cjs.js",
   "module": "dist/commercetools-uikit-localized-text-input.esm.js",

--- a/packages/components/inputs/localized-text-input/package.json
+++ b/packages/components/inputs/localized-text-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-localized-text-input.cjs.js",
   "module": "dist/commercetools-uikit-localized-text-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/localized-text-input/package.json
+++ b/packages/components/inputs/localized-text-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/localized-text-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/money-input/package.json
+++ b/packages/components/inputs/money-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-money-input.cjs.js",
   "module": "dist/commercetools-uikit-money-input.esm.js",

--- a/packages/components/inputs/money-input/package.json
+++ b/packages/components/inputs/money-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-money-input.cjs.js",
   "module": "dist/commercetools-uikit-money-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/money-input/package.json
+++ b/packages/components/inputs/money-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/money-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/multiline-text-input/package.json
+++ b/packages/components/inputs/multiline-text-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-multiline-text-input.cjs.js",
   "module": "dist/commercetools-uikit-multiline-text-input.esm.js",

--- a/packages/components/inputs/multiline-text-input/package.json
+++ b/packages/components/inputs/multiline-text-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/multiline-text-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/multiline-text-input/package.json
+++ b/packages/components/inputs/multiline-text-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-multiline-text-input.cjs.js",
   "module": "dist/commercetools-uikit-multiline-text-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/number-input/package.json
+++ b/packages/components/inputs/number-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-number-input.cjs.js",
   "module": "dist/commercetools-uikit-number-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/number-input/package.json
+++ b/packages/components/inputs/number-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/number-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/number-input/package.json
+++ b/packages/components/inputs/number-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-number-input.cjs.js",
   "module": "dist/commercetools-uikit-number-input.esm.js",

--- a/packages/components/inputs/password-input/package.json
+++ b/packages/components/inputs/password-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/password-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/password-input/package.json
+++ b/packages/components/inputs/password-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-password-input.cjs.js",
   "module": "dist/commercetools-uikit-password-input.esm.js",

--- a/packages/components/inputs/password-input/package.json
+++ b/packages/components/inputs/password-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-password-input.cjs.js",
   "module": "dist/commercetools-uikit-password-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/radio-input/package.json
+++ b/packages/components/inputs/radio-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-radio-input.cjs.js",
   "module": "dist/commercetools-uikit-radio-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/radio-input/package.json
+++ b/packages/components/inputs/radio-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/radio-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/radio-input/package.json
+++ b/packages/components/inputs/radio-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-radio-input.cjs.js",
   "module": "dist/commercetools-uikit-radio-input.esm.js",

--- a/packages/components/inputs/rich-text-input/package.json
+++ b/packages/components/inputs/rich-text-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-rich-text-input.cjs.js",
   "module": "dist/commercetools-uikit-rich-text-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/rich-text-input/package.json
+++ b/packages/components/inputs/rich-text-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-rich-text-input.cjs.js",
   "module": "dist/commercetools-uikit-rich-text-input.esm.js",

--- a/packages/components/inputs/rich-text-input/package.json
+++ b/packages/components/inputs/rich-text-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/rich-text-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/rich-text-utils/package.json
+++ b/packages/components/inputs/rich-text-utils/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-rich-text-utils.cjs.js",
   "module": "dist/commercetools-uikit-rich-text-utils.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "generate-icons": "svgr -d src/rich-text-body/icons/generated --typescript -- src/rich-text-body/icons/svg"
   },

--- a/packages/components/inputs/rich-text-utils/package.json
+++ b/packages/components/inputs/rich-text-utils/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/rich-text-utils"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/rich-text-utils/package.json
+++ b/packages/components/inputs/rich-text-utils/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-rich-text-utils.cjs.js",
   "module": "dist/commercetools-uikit-rich-text-utils.esm.js",

--- a/packages/components/inputs/search-select-input/package.json
+++ b/packages/components/inputs/search-select-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/search-select-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/search-select-input/package.json
+++ b/packages/components/inputs/search-select-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-search-select-input.cjs.js",
   "module": "dist/commercetools-uikit-search-select-input.esm.js",

--- a/packages/components/inputs/search-select-input/package.json
+++ b/packages/components/inputs/search-select-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-search-select-input.cjs.js",
   "module": "dist/commercetools-uikit-search-select-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/search-text-input/package.json
+++ b/packages/components/inputs/search-text-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/search-text-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/search-text-input/package.json
+++ b/packages/components/inputs/search-text-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-search-text-input.cjs.js",
   "module": "dist/commercetools-uikit-search-text-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/search-text-input/package.json
+++ b/packages/components/inputs/search-text-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-search-text-input.cjs.js",
   "module": "dist/commercetools-uikit-search-text-input.esm.js",

--- a/packages/components/inputs/select-input/package.json
+++ b/packages/components/inputs/select-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/select-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/select-input/package.json
+++ b/packages/components/inputs/select-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-select-input.cjs.js",
   "module": "dist/commercetools-uikit-select-input.esm.js",

--- a/packages/components/inputs/select-input/package.json
+++ b/packages/components/inputs/select-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-select-input.cjs.js",
   "module": "dist/commercetools-uikit-select-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/select-utils/package.json
+++ b/packages/components/inputs/select-utils/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-select-utils.cjs.js",
   "module": "dist/commercetools-uikit-select-utils.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/select-utils/package.json
+++ b/packages/components/inputs/select-utils/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-select-utils.cjs.js",
   "module": "dist/commercetools-uikit-select-utils.esm.js",

--- a/packages/components/inputs/select-utils/package.json
+++ b/packages/components/inputs/select-utils/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/select-utils"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/selectable-search-input/package.json
+++ b/packages/components/inputs/selectable-search-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-selectable-search-input.cjs.js",
   "module": "dist/commercetools-uikit-selectable-search-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/selectable-search-input/package.json
+++ b/packages/components/inputs/selectable-search-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/selectable-search-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/selectable-search-input/package.json
+++ b/packages/components/inputs/selectable-search-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-selectable-search-input.cjs.js",
   "module": "dist/commercetools-uikit-selectable-search-input.esm.js",

--- a/packages/components/inputs/text-input/package.json
+++ b/packages/components/inputs/text-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-text-input.cjs.js",
   "module": "dist/commercetools-uikit-text-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/text-input/package.json
+++ b/packages/components/inputs/text-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/text-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/text-input/package.json
+++ b/packages/components/inputs/text-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-text-input.cjs.js",
   "module": "dist/commercetools-uikit-text-input.esm.js",

--- a/packages/components/inputs/time-input/package.json
+++ b/packages/components/inputs/time-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-time-input.cjs.js",
   "module": "dist/commercetools-uikit-time-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/time-input/package.json
+++ b/packages/components/inputs/time-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/time-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/inputs/time-input/package.json
+++ b/packages/components/inputs/time-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-time-input.cjs.js",
   "module": "dist/commercetools-uikit-time-input.esm.js",

--- a/packages/components/inputs/toggle-input/package.json
+++ b/packages/components/inputs/toggle-input/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-toggle-input.cjs.js",
   "module": "dist/commercetools-uikit-toggle-input.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/inputs/toggle-input/package.json
+++ b/packages/components/inputs/toggle-input/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-toggle-input.cjs.js",
   "module": "dist/commercetools-uikit-toggle-input.esm.js",

--- a/packages/components/inputs/toggle-input/package.json
+++ b/packages/components/inputs/toggle-input/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/inputs/toggle-input"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/label/package.json
+++ b/packages/components/label/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-label.cjs.js",
   "module": "dist/commercetools-uikit-label.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/label/package.json
+++ b/packages/components/label/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-label.cjs.js",
   "module": "dist/commercetools-uikit-label.esm.js",

--- a/packages/components/label/package.json
+++ b/packages/components/label/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/label"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/link/package.json
+++ b/packages/components/link/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-link.cjs.js",
   "module": "dist/commercetools-uikit-link.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/link/package.json
+++ b/packages/components/link/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/link"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/link/package.json
+++ b/packages/components/link/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-link.cjs.js",
   "module": "dist/commercetools-uikit-link.esm.js",

--- a/packages/components/loading-spinner/package.json
+++ b/packages/components/loading-spinner/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/loading-spinner"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/loading-spinner/package.json
+++ b/packages/components/loading-spinner/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-loading-spinner.cjs.js",
   "module": "dist/commercetools-uikit-loading-spinner.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/loading-spinner/package.json
+++ b/packages/components/loading-spinner/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-loading-spinner.cjs.js",
   "module": "dist/commercetools-uikit-loading-spinner.esm.js",

--- a/packages/components/messages/package.json
+++ b/packages/components/messages/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/messages"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/messages/package.json
+++ b/packages/components/messages/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-messages.cjs.js",
   "module": "dist/commercetools-uikit-messages.esm.js",

--- a/packages/components/messages/package.json
+++ b/packages/components/messages/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-messages.cjs.js",
   "module": "dist/commercetools-uikit-messages.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/notifications/package.json
+++ b/packages/components/notifications/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-notifications.cjs.js",
   "module": "dist/commercetools-uikit-notifications.esm.js",

--- a/packages/components/notifications/package.json
+++ b/packages/components/notifications/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/notifications"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/notifications/package.json
+++ b/packages/components/notifications/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-notifications.cjs.js",
   "module": "dist/commercetools-uikit-notifications.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/pagination/package.json
+++ b/packages/components/pagination/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-pagination.cjs.js",
   "module": "dist/commercetools-uikit-pagination.esm.js",

--- a/packages/components/pagination/package.json
+++ b/packages/components/pagination/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/pagination"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/pagination/package.json
+++ b/packages/components/pagination/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-pagination.cjs.js",
   "module": "dist/commercetools-uikit-pagination.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/primary-action-dropdown/package.json
+++ b/packages/components/primary-action-dropdown/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-primary-action-dropdown.cjs.js",
   "module": "dist/commercetools-uikit-primary-action-dropdown.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/primary-action-dropdown/package.json
+++ b/packages/components/primary-action-dropdown/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-primary-action-dropdown.cjs.js",
   "module": "dist/commercetools-uikit-primary-action-dropdown.esm.js",

--- a/packages/components/primary-action-dropdown/package.json
+++ b/packages/components/primary-action-dropdown/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/primary-action-dropdown"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/progress-bar/package.json
+++ b/packages/components/progress-bar/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-progress-bar.cjs.js",
   "module": "dist/commercetools-uikit-progress-bar.esm.js",

--- a/packages/components/progress-bar/package.json
+++ b/packages/components/progress-bar/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-progress-bar.cjs.js",
   "module": "dist/commercetools-uikit-progress-bar.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/progress-bar/package.json
+++ b/packages/components/progress-bar/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/progress-bar"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/quick-filters/package.json
+++ b/packages/components/quick-filters/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-quick-filters.cjs.js",
   "module": "dist/commercetools-uikit-quick-filters.esm.js",

--- a/packages/components/quick-filters/package.json
+++ b/packages/components/quick-filters/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/quick-filters"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/quick-filters/package.json
+++ b/packages/components/quick-filters/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-quick-filters.cjs.js",
   "module": "dist/commercetools-uikit-quick-filters.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/spacings/spacings-inline/package.json
+++ b/packages/components/spacings/spacings-inline/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/spacings/spacings-inline"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/spacings/spacings-inline/package.json
+++ b/packages/components/spacings/spacings-inline/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-spacings-inline.cjs.js",
   "module": "dist/commercetools-uikit-spacings-inline.esm.js",

--- a/packages/components/spacings/spacings-inline/package.json
+++ b/packages/components/spacings/spacings-inline/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-spacings-inline.cjs.js",
   "module": "dist/commercetools-uikit-spacings-inline.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/spacings/spacings-inset-squish/package.json
+++ b/packages/components/spacings/spacings-inset-squish/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-spacings-inset-squish.cjs.js",
   "module": "dist/commercetools-uikit-spacings-inset-squish.esm.js",

--- a/packages/components/spacings/spacings-inset-squish/package.json
+++ b/packages/components/spacings/spacings-inset-squish/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/spacings/spacings-inset-squish"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/spacings/spacings-inset-squish/package.json
+++ b/packages/components/spacings/spacings-inset-squish/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-spacings-inset-squish.cjs.js",
   "module": "dist/commercetools-uikit-spacings-inset-squish.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/spacings/spacings-inset/package.json
+++ b/packages/components/spacings/spacings-inset/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/spacings/spacings-inset"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/spacings/spacings-inset/package.json
+++ b/packages/components/spacings/spacings-inset/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-spacings-inset.cjs.js",
   "module": "dist/commercetools-uikit-spacings-inset.esm.js",

--- a/packages/components/spacings/spacings-inset/package.json
+++ b/packages/components/spacings/spacings-inset/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-spacings-inset.cjs.js",
   "module": "dist/commercetools-uikit-spacings-inset.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/spacings/spacings-stack/package.json
+++ b/packages/components/spacings/spacings-stack/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/spacings/spacings-stack"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/spacings/spacings-stack/package.json
+++ b/packages/components/spacings/spacings-stack/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-spacings-stack.cjs.js",
   "module": "dist/commercetools-uikit-spacings-stack.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/spacings/spacings-stack/package.json
+++ b/packages/components/spacings/spacings-stack/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-spacings-stack.cjs.js",
   "module": "dist/commercetools-uikit-spacings-stack.esm.js",

--- a/packages/components/stamp/package.json
+++ b/packages/components/stamp/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/stamp"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/stamp/package.json
+++ b/packages/components/stamp/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-stamp.cjs.js",
   "module": "dist/commercetools-uikit-stamp.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/stamp/package.json
+++ b/packages/components/stamp/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-stamp.cjs.js",
   "module": "dist/commercetools-uikit-stamp.esm.js",

--- a/packages/components/tag/package.json
+++ b/packages/components/tag/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-tag.cjs.js",
   "module": "dist/commercetools-uikit-tag.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/tag/package.json
+++ b/packages/components/tag/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/tag"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/tag/package.json
+++ b/packages/components/tag/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-tag.cjs.js",
   "module": "dist/commercetools-uikit-tag.esm.js",

--- a/packages/components/text/package.json
+++ b/packages/components/text/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/text"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/text/package.json
+++ b/packages/components/text/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-text.cjs.js",
   "module": "dist/commercetools-uikit-text.esm.js",

--- a/packages/components/text/package.json
+++ b/packages/components/text/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-text.cjs.js",
   "module": "dist/commercetools-uikit-text.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/tooltip"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-tooltip.cjs.js",
   "module": "dist/commercetools-uikit-tooltip.esm.js",

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-tooltip.cjs.js",
   "module": "dist/commercetools-uikit-tooltip.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/view-switcher/package.json
+++ b/packages/components/view-switcher/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/components/view-switcher"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/components/view-switcher/package.json
+++ b/packages/components/view-switcher/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-view-switcher.cjs.js",
   "module": "dist/commercetools-uikit-view-switcher.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/components/view-switcher/package.json
+++ b/packages/components/view-switcher/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-view-switcher.cjs.js",
   "module": "dist/commercetools-uikit-view-switcher.esm.js",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -21,6 +21,9 @@
     "entrypoints": ["./index.ts", "./polyfills.ts"]
   },
   "files": ["dist", "polyfills"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/hooks"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-hooks.cjs.js",
   "module": "dist/commercetools-uikit-hooks.esm.js",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-i18n.cjs.js",
   "module": "dist/commercetools-uikit-i18n.esm.js",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/i18n"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-i18n.cjs.js",
   "module": "dist/commercetools-uikit-i18n.esm.js",
   "files": ["dist", "data", "compiled-data"],
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "compile-data": "formatjs compile-folder --format=transifex --ast data compiled-data"
   },

--- a/packages/localized-utils/package.json
+++ b/packages/localized-utils/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-localized-utils.cjs.js",
   "module": "dist/commercetools-uikit-localized-utils.esm.js",

--- a/packages/localized-utils/package.json
+++ b/packages/localized-utils/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/localized-utils"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/localized-utils/package.json
+++ b/packages/localized-utils/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-localized-utils.cjs.js",
   "module": "dist/commercetools-uikit-localized-utils.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-utils.cjs.js",
   "module": "dist/commercetools-uikit-utils.esm.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "packages/utils"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-utils.cjs.js",
   "module": "dist/commercetools-uikit-utils.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/presets/buttons/package.json
+++ b/presets/buttons/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "presets/buttons"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/presets/buttons/package.json
+++ b/presets/buttons/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-buttons.cjs.js",
   "module": "dist/commercetools-uikit-buttons.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/presets/buttons/package.json
+++ b/presets/buttons/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-buttons.cjs.js",
   "module": "dist/commercetools-uikit-buttons.esm.js",

--- a/presets/fields/package.json
+++ b/presets/fields/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-fields.cjs.js",
   "module": "dist/commercetools-uikit-fields.esm.js",

--- a/presets/fields/package.json
+++ b/presets/fields/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-fields.cjs.js",
   "module": "dist/commercetools-uikit-fields.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/presets/fields/package.json
+++ b/presets/fields/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "presets/fields"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/presets/inputs/package.json
+++ b/presets/inputs/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "presets/inputs"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/presets/inputs/package.json
+++ b/presets/inputs/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-inputs.cjs.js",
   "module": "dist/commercetools-uikit-inputs.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/presets/inputs/package.json
+++ b/presets/inputs/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-inputs.cjs.js",
   "module": "dist/commercetools-uikit-inputs.esm.js",

--- a/presets/spacings/package.json
+++ b/presets/spacings/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-uikit-spacings.cjs.js",
   "module": "dist/commercetools-uikit-spacings.esm.js",

--- a/presets/spacings/package.json
+++ b/presets/spacings/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-uikit-spacings.cjs.js",
   "module": "dist/commercetools-uikit-spacings.esm.js",
   "files": ["dist"],
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@babel/runtime": "catalog:build",
     "@babel/runtime-corejs3": "catalog:build",

--- a/presets/spacings/package.json
+++ b/presets/spacings/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "presets/spacings"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/presets/ui-kit/package.json
+++ b/presets/ui-kit/package.json
@@ -18,6 +18,9 @@
   "main": "dist/commercetools-frontend-ui-kit.cjs.js",
   "module": "dist/commercetools-frontend-ui-kit.esm.js",
   "files": ["dist", "materials", "i18n"],
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "copy-assets": "rm -rf i18n materials && mkdir -p i18n/data && cp -R ../../design-system/materials materials && cp -R ../../packages/i18n/data i18n/"
   },

--- a/presets/ui-kit/package.json
+++ b/presets/ui-kit/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/commercetools/ui-kit/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/commercetools/ui-kit.git",
+    "url": "git+https://github.com/commercetools/ui-kit.git",
     "directory": "presets/ui-kit"
   },
   "homepage": "https://uikit.commercetools.com",

--- a/presets/ui-kit/package.json
+++ b/presets/ui-kit/package.json
@@ -14,6 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "commonjs",
   "sideEffects": false,
   "main": "dist/commercetools-frontend-ui-kit.cjs.js",
   "module": "dist/commercetools-frontend-ui-kit.esm.js",

--- a/scripts/check-workspace-constraints.js
+++ b/scripts/check-workspace-constraints.js
@@ -29,7 +29,7 @@ const fs = require('fs');
 const path = require('path');
 
 const ROOT = path.resolve(__dirname, '..');
-const REPO_URL = 'https://github.com/commercetools/ui-kit.git';
+const REPO_URL = 'git+https://github.com/commercetools/ui-kit.git';
 // Runtime Node floor for *published* artifacts — independent of the build
 // env (root engines.node). Decoupled because the build env may be stricter
 // than what consumers need to use the published bundles.

--- a/scripts/check-workspace-constraints.js
+++ b/scripts/check-workspace-constraints.js
@@ -8,17 +8,18 @@
  * 2. Public packages must have correct repository fields; private packages must not.
  * 3. Public packages must have publishConfig.access = "public"; private packages must not.
  * 4. A dependency must not appear in both "dependencies" and "devDependencies".
+ * 5. Public packages must declare `engines.node` matching PUBLISHED_NODE_FLOOR.
  *
  * Cross-workspace rules (Pass 2):
- * 5. Every dep listed under `catalog:` (default) in pnpm-workspace.yaml must
+ * 6. Every dep listed under `catalog:` (default) in pnpm-workspace.yaml must
  *    be consumed via `catalog:` in workspace `dependencies` / `devDependencies`.
- * 6. Every dep listed under a named catalog `catalogs.<name>:` must be
+ * 7. Every dep listed under a named catalog `catalogs.<name>:` must be
  *    consumed via `catalog:<name>` in workspace `dependencies` /
  *    `devDependencies`.
- * 7. Every dep listed under `catalogs.peer:` must be consumed via
+ * 8. Every dep listed under `catalogs.peer:` must be consumed via
  *    `catalog:peer` in workspace `peerDependencies`.
  *    Literal versions on a cataloged dep are an error in all three cases.
- * 8. Drift: an uncataloged external dep used at two or more distinct
+ * 9. Drift: an uncataloged external dep used at two or more distinct
  *    specifiers across workspaces is an error — add it to a catalog so
  *    the version is centrally controlled. Install (deps + devDeps) and
  *    peer drift are checked separately.
@@ -29,6 +30,10 @@ const path = require('path');
 
 const ROOT = path.resolve(__dirname, '..');
 const REPO_URL = 'https://github.com/commercetools/ui-kit.git';
+// Runtime Node floor for *published* artifacts — independent of the build
+// env (root engines.node). Decoupled because the build env may be stricter
+// than what consumers need to use the published bundles.
+const PUBLISHED_NODE_FLOOR = '>=22';
 
 // Parse the `catalog:` (default) and `catalogs.<name>:` (named) blocks from
 // pnpm-workspace.yaml. Minimal parser scoped to the shape we use — key:value
@@ -204,6 +209,20 @@ for (const ws of workspaces) {
       errors.push(
         `${label}: publishConfig.access must be "public" (got ${JSON.stringify(
           pc.access
+        )})`
+      );
+    }
+
+    // Public packages must declare an engines.node floor for consumers
+    const eng = pkg.engines;
+    if (!eng || typeof eng !== 'object') {
+      errors.push(
+        `${label}: public package must have "engines": { "node": "${PUBLISHED_NODE_FLOOR}" }`
+      );
+    } else if (eng.node !== PUBLISHED_NODE_FLOOR) {
+      errors.push(
+        `${label}: engines.node must be "${PUBLISHED_NODE_FLOOR}" (got ${JSON.stringify(
+          eng.node
         )})`
       );
     }

--- a/scripts/check-workspace-constraints.js
+++ b/scripts/check-workspace-constraints.js
@@ -9,20 +9,21 @@
  * 3. Public packages must have publishConfig.access = "public"; private packages must not.
  * 4. A dependency must not appear in both "dependencies" and "devDependencies".
  * 5. Public packages must declare `engines.node` matching PUBLISHED_NODE_FLOOR.
+ * 6. Public packages must declare `type: "commonjs"` (matches dist output).
  *
  * Cross-workspace rules (Pass 2):
- * 6. Every dep listed under `catalog:` (default) in pnpm-workspace.yaml must
+ * 7. Every dep listed under `catalog:` (default) in pnpm-workspace.yaml must
  *    be consumed via `catalog:` in workspace `dependencies` / `devDependencies`.
- * 7. Every dep listed under a named catalog `catalogs.<name>:` must be
+ * 8. Every dep listed under a named catalog `catalogs.<name>:` must be
  *    consumed via `catalog:<name>` in workspace `dependencies` /
  *    `devDependencies`.
- * 8. Every dep listed under `catalogs.peer:` must be consumed via
+ * 9. Every dep listed under `catalogs.peer:` must be consumed via
  *    `catalog:peer` in workspace `peerDependencies`.
  *    Literal versions on a cataloged dep are an error in all three cases.
- * 9. Drift: an uncataloged external dep used at two or more distinct
- *    specifiers across workspaces is an error — add it to a catalog so
- *    the version is centrally controlled. Install (deps + devDeps) and
- *    peer drift are checked separately.
+ * 10. Drift: an uncataloged external dep used at two or more distinct
+ *     specifiers across workspaces is an error — add it to a catalog so
+ *     the version is centrally controlled. Install (deps + devDeps) and
+ *     peer drift are checked separately.
  */
 const { execSync } = require('child_process');
 const fs = require('fs');
@@ -223,6 +224,17 @@ for (const ws of workspaces) {
       errors.push(
         `${label}: engines.node must be "${PUBLISHED_NODE_FLOOR}" (got ${JSON.stringify(
           eng.node
+        )})`
+      );
+    }
+
+    // Public packages must declare type = "commonjs" — matches the
+    // .cjs.js / .esm.js layout Preconstruct emits and silences publint's
+    // "missing type field" suggestion.
+    if (pkg.type !== 'commonjs') {
+      errors.push(
+        `${label}: public package must have "type": "commonjs" (got ${JSON.stringify(
+          pkg.type
         )})`
       );
     }


### PR DESCRIPTION
## TL;DR

Closes 3 of the 4 publint findings on all 97 published packages — pure metadata, no consumer-API or build-output change. The 4th finding (`pkg.exports`) is not being tackled here because the only working paths to fix it carry real breaking-change risk for downstream consumers (subpath imports, TypeScript type resolution, module resolution), and ui-kit is approaching EOL — consumers asked to spend cycles fixing breakage on a deprecated package would reasonably resent that instead of investing in the Nimbus migration.

## Summary

Closes [FEC-936](https://commercetools.atlassian.net/browse/FEC-936) (partial). Four commits, one per finding for review, plus a `docs:` commit that rewrites the changeset to follow the Nimbus changeset conventions (consumer-facing, not internal):

1. **`engines.node` floor `>=22`** declared on every published package. Runtime floor decoupled from the build env (`>=24` at root).
2. **`fix: preserve engines.node` in the package-json generator template** — the pre-commit hook regenerates package.json from a hardcoded template; without this fix the engines field would have been stripped back out on the next unrelated commit.
3. **`repository.url` normalization** — `git+https://…` everywhere; `REPO_URL` constant in the constraints script flipped in lockstep.
4. **`type: "commonjs"`** declared on every published package, matching what Preconstruct's `.cjs.js` / `.esm.js` output already required Node to assume.

`scripts/check-workspace-constraints.js` gains rules for both `engines.node = PUBLISHED_NODE_FLOOR` and `type = "commonjs"` so future packages can't drop them silently.

## Why `pkg.exports` is not in this PR

The cost isn't engineering effort — with AI in the loop the work itself is cheap. The cost is **risk to consumers we can't fully survey**:

- Adding an `exports` field via Preconstruct's stable config silently degrades TypeScript types for any consumer using `moduleResolution: "Bundler"` or `"NodeNext"`. TS walks the conditions, picks `module → .esm.js`, finds no sibling `.esm.d.ts`, and drops types to `any`. Preconstruct's experimental `importsConditions` flag emits a `types` condition but the `.d.ts` re-export chain still breaks under a real `pnpm build`.
- Deep-import surveys across the maintained/* repos already turned up consumer patterns we had to preserve (`@commercetools-uikit/i18n/compiled-data/*.json`, `@commercetools-uikit/design-system/materials/*.css`, plus a trailing-slash typo in mc-frontend). There are almost certainly more we haven't seen.
- ui-kit is approaching EOL — Nimbus is the successor. Shipping a non-trivial breaking-change risk on a sunsetting package is a bad trade: consumers reasonably expect a stable runway through migration, not new breakage to absorb.

If this surfaces again post-EOL or via a Nimbus migration tool, it's worth revisiting with a proper consumer-impact analysis.

## Test plan

- [x] `node scripts/check-workspace-constraints.js` — green
- [x] `pnpm generate-package-json --all-workspace-packages` — round-trip stable
- [x] `pnpm typecheck` — clean (no regressions from this PR)
- [x] `pnpm lint:publint` — 3 findings closed at source, 1 remaining (the deferred exports suggestion) does not fail the gate
- [ ] CI green

[FEC-936]: https://commercetools.atlassian.net/browse/FEC-936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ