### PR TITLE
feat(FEC-944): always-visible scrollbars in MC dropdown menus

### DIFF
--- a/.changeset/fec-944-always-visible-dropdown-scrollbars.md
+++ b/.changeset/fec-944-always-visible-dropdown-scrollbars.md
@@ -1,0 +1,7 @@
+---
+'@commercetools-frontend/ui-kit': patch
+---
+
+Always render a visible scrollbar in overflowing `SelectInput` menus and `FilterMenu` bodies.
+
+Browsers — particularly macOS — hide scrollbars by default, which can mask the fact that more options exist below the fold in MC list-page action dropdowns and pre-filter dropdowns. The dropdowns now expose a persistent thin scrollbar whenever the menu content overflows its max-height, via `scrollbar-width` / `scrollbar-color` (Firefox) and `::-webkit-scrollbar` rules (Chrome, Safari, Edge). No API changes.

--- a/packages/components/filters/src/filter-menu/filter-menu.tsx
+++ b/packages/components/filters/src/filter-menu/filter-menu.tsx
@@ -125,6 +125,22 @@ export const menuBodyStyle = css`
 
   /** ensure that body scrolls with overflow now that there is a menu max-height */
   overflow: hidden auto;
+
+  /** force the scrollbar to render persistently — browsers (esp. macOS) hide
+      it by default, which masks the fact that more options exist below the fold */
+  scrollbar-width: thin;
+  scrollbar-color: ${designTokens.colorNeutral60} transparent;
+
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+  &::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: ${designTokens.colorNeutral60};
+    border-radius: 4px;
+  }
 `;
 
 function FilterMenu(props: TFilterMenuProps) {

--- a/packages/components/inputs/select-utils/src/create-select-styles.ts
+++ b/packages/components/inputs/select-utils/src/create-select-styles.ts
@@ -312,6 +312,18 @@ const menuListStyles = () => (base: TBase) => {
     padding: `${designTokens.spacing10} 0`,
     borderRadius: designTokens.borderRadiusForInput,
     backgroundColor: designTokens.backgroundColorForInput,
+    scrollbarWidth: 'thin',
+    scrollbarColor: `${designTokens.colorNeutral60} transparent`,
+    '&::-webkit-scrollbar': {
+      width: '8px',
+    },
+    '&::-webkit-scrollbar-track': {
+      backgroundColor: 'transparent',
+    },
+    '&::-webkit-scrollbar-thumb': {
+      backgroundColor: designTokens.colorNeutral60,
+      borderRadius: '4px',
+    },
   };
 };
 


### PR DESCRIPTION
## Summary

[FEC-944](https://commercetools.atlassian.net/browse/FEC-944) — make scrollbars persistently visible in Merchant Center action dropdowns and pre-filter dropdowns when their content overflows.

Browsers (especially macOS) hide scrollbars by default, which masks the fact that more options exist below the fold. The fix lives in the two shared primitives that back every list page the ticket enumerates (Products, Customers, Orders, Discounts):

- **`SelectInput`** — every `*-action-select-input` wrapper across `merchant-center-frontend` (Order, Customer, Business Unit, Category action selects + Discount/PIM bulk action dropdowns) renders its menu via this primitive. Styling change lives in `menuListStyles()` in `@commercetools-uikit/select-utils`.
- **`FilterMenu`** — used by `Filters` for every search-bar pre-filter dropdown. Styling change lives in `menuBodyStyle` in `@commercetools-uikit/filters`.

The new styling uses `scrollbar-width` / `scrollbar-color` (Firefox) and `::-webkit-scrollbar` rules (Chrome/Safari/Edge). No public API changes; ships as a patch under the `@commercetools-frontend/ui-kit` fixed group.

## Scope decision

Applied globally at the primitive level rather than behind an opt-in prop. Always-visible scrollbars on overflowing dropdown menus are a generally desirable UX rule, not action-menu-specific — smallest diff, no consumer churn.

## Test plan

- [ ] Storybook: `pnpm start` → open `FilterMenu` and `SelectInput` stories with overflowing option lists, confirm thin scrollbar visible at rest
- [ ] Cross-browser pass per ticket Notes: Chrome (WebKit path), Safari (macOS overlay-scrollbar nuances), Firefox (`scrollbar-width` path)
- [ ] End-to-end against MC list pages (after `@commercetools-frontend/ui-kit` release lands in `merchant-center-frontend`): Product List, Order List, Customer List, one Discount list — verify both an action dropdown and a filter dropdown
- [ ] Regression: confirm short, non-overflowing `SelectInput` menus look unchanged

[FEC-944]: https://commercetools.atlassian.net/browse/FEC-944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ