### PR TITLE
fix(build): stop dts emit leaking @commercetools-frontend/ui-kit into published types

### DIFF
--- a/.changeset/dts-emit-meta-package-leak.md
+++ b/.changeset/dts-emit-meta-package-leak.md
@@ -4,16 +4,11 @@
 "@commercetools-uikit/view-switcher": patch
 ---
 
-fix: stop declaration emit from leaking `@commercetools-frontend/ui-kit` into published types
+fix: correct leaked type references in `Constraints`, `RadioInput`, and `ViewSwitcher` declarations
 
-The compound components (`Constraints`, `RadioInput`, `ViewSwitcher`) emitted
-`import("@commercetools-frontend/ui-kit").T...Props` in their published `.d.ts`.
-Strict consumers that install only the granular `@commercetools-uikit/*`
-packages don't have the aggregate preset, so the reference resolved to `any` —
-collapsing event-handler prop types and producing `TS7006` on a minor upgrade.
-
-The leak was triggered by `@commercetools-frontend/ui-kit` becoming a root
-`devDependency` (so the `.visualroute`/`bundlespec` fixtures resolve under
-strict pnpm), which made the bare specifier resolvable during preconstruct's
-declaration emit. The build now hides that symlink for the emit step only, so
-the correct in-package relative specifier is used. No component API changed.
+Their published `.d.ts` referenced the aggregate `@commercetools-frontend/ui-kit`
+package, which isn't installed when you depend only on the granular
+`@commercetools-uikit/*` packages. That unresolved reference collapsed the
+affected prop types to `any`, surfacing as `TS7006` errors in strict
+TypeScript setups. The declarations now use in-package relative references, so
+the prop types resolve correctly. No component API or runtime behavior changed.

--- a/.changeset/dts-emit-meta-package-leak.md
+++ b/.changeset/dts-emit-meta-package-leak.md
@@ -1,0 +1,19 @@
+---
+"@commercetools-uikit/constraints": patch
+"@commercetools-uikit/radio-input": patch
+"@commercetools-uikit/view-switcher": patch
+---
+
+fix: stop declaration emit from leaking `@commercetools-frontend/ui-kit` into published types
+
+The compound components (`Constraints`, `RadioInput`, `ViewSwitcher`) emitted
+`import("@commercetools-frontend/ui-kit").T...Props` in their published `.d.ts`.
+Strict consumers that install only the granular `@commercetools-uikit/*`
+packages don't have the aggregate preset, so the reference resolved to `any` —
+collapsing event-handler prop types and producing `TS7006` on a minor upgrade.
+
+The leak was triggered by `@commercetools-frontend/ui-kit` becoming a root
+`devDependency` (so the `.visualroute`/`bundlespec` fixtures resolve under
+strict pnpm), which made the bare specifier resolvable during preconstruct's
+declaration emit. The build now hides that symlink for the emit step only, so
+the correct in-package relative specifier is used. No component API changed.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,6 +36,19 @@ pnpm preconstruct build
 
 restore_meta_symlink
 trap - EXIT
+
+# Regression guard: assert the leak stays gone. No granular package's emitted
+# declarations should reference the aggregate `@commercetools-frontend/ui-kit`
+# preset by its bare specifier — strict consumers can't resolve it (see above).
+# Catches a future reintroduction (workaround dropped, preconstruct resolution
+# change, a new compound component). Excludes the preset's own dist.
+leaks="$(find packages -type d -name declarations -path '*/dist/*' -prune -exec grep -rl 'import("@commercetools-frontend/ui-kit")' {} + 2>/dev/null || true)"
+if [ -n "$leaks" ]; then
+  echo "ERROR: published declarations leak the @commercetools-frontend/ui-kit aggregate preset:" >&2
+  echo "$leaks" | sed 's/^/  - /' >&2
+  echo "See the FEC-938 declaration-emit workaround above in scripts/build.sh." >&2
+  exit 1
+fi
 # --- end workaround ---
 
 pnpm --filter @commercetools-frontend/ui-kit run copy-assets

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,6 +6,36 @@ pnpm generate-icons
 pnpm design-tokens:build
 pnpm compile-intl
 
+# --- declaration-emit leak workaround (FEC-938) ---
+# `@commercetools-frontend/ui-kit` (the aggregate preset) is a root
+# devDependency because the .visualroute/bundlespec fixtures import it. Under
+# strict pnpm that puts a `node_modules/@commercetools-frontend/ui-kit` symlink
+# in place, and preconstruct's declaration emit then prefers that resolvable
+# bare specifier over the in-package relative path — leaking
+# `import("@commercetools-frontend/ui-kit").T...Props` into the published .d.ts
+# of the compound components (constraints, radio-input, view-switcher). Strict
+# consumers can't resolve it, so those prop types collapse to `any`.
+#
+# preconstruct does not need that symlink (the fixtures aren't part of the dts
+# program), so we hide it during the build to force the correct relative
+# specifier, and restore it afterwards (and on any exit).
+META_SYMLINK="node_modules/@commercetools-frontend/ui-kit"
+META_SYMLINK_TARGET=""
+restore_meta_symlink() {
+  if [ -n "$META_SYMLINK_TARGET" ] && [ ! -e "$META_SYMLINK" ]; then
+    ln -s "$META_SYMLINK_TARGET" "$META_SYMLINK"
+  fi
+}
+if [ -L "$META_SYMLINK" ]; then
+  META_SYMLINK_TARGET="$(readlink "$META_SYMLINK")"
+  trap restore_meta_symlink EXIT
+  rm "$META_SYMLINK"
+fi
+
 pnpm preconstruct build
+
+restore_meta_symlink
+trap - EXIT
+# --- end workaround ---
 
 pnpm --filter @commercetools-frontend/ui-kit run copy-assets


### PR DESCRIPTION
## Summary

The published `.d.ts` of three compound components — `@commercetools-uikit/constraints`, `@commercetools-uikit/radio-input`, and `@commercetools-uikit/view-switcher` — leak a reference to the aggregate preset package:

```ts
// before (20.6.0 / 20.6.1)
Group: { (props: import("@commercetools-frontend/ui-kit").TGroupProps): JSX.Element; … }
```

Strict-TS consumers that install only the granular `@commercetools-uikit/*` packages don't have `@commercetools-frontend/ui-kit`, so the reference resolves to `any`, contextual handler typing is lost, and `noImplicitAny` flags it as **`TS7006`** — on what looks like a routine minor bump. This was discovered downstream in **commercetools/identity#757** (`RadioInput.Group` `onChange` handlers).

## Root cause

Not an API change — source is byte-identical and `tsc` alone emits the correct relative specifier. With `preserveSymlinks: false` (set in FEC-935 so typecheck resolves `@storybook/*` subpaths), TypeScript's declaration emit follows pnpm's symlinks, discovers that the leaf type is _also_ reachable through the node_modules package `@commercetools-frontend/ui-kit` (which re-exports it), and **prefers the bare node_modules specifier over the relative path** — a deliberate, long-standing TypeScript behavior.

That package is only present in `node_modules` because it became a root `devDependency` (added in FEC-938 so the `.visualroute`/`bundlespec` fixtures resolve under strict pnpm). Verified by toggling the single variable — with the symlink present the emit leaks; with it removed (everything else held constant, including `preserveSymlinks: false`) the emit is correct:

| condition                                     | emitted specifier                                         |
| --------------------------------------------- | --------------------------------------------------------- |
| meta-package symlink present (current `main`) | `import("@commercetools-frontend/ui-kit").TGroupProps` ❌ |
| meta-package symlink hidden during emit       | `import("./radio-group.js").TGroupProps` ✅               |

## Fix (minimally invasive)

Belt and suspenders:

- **The belt** — `scripts/build.sh` hides the meta-package symlink for the `preconstruct build` step only (preconstruct doesn't need it — the fixtures aren't part of the dts program), then restores it (trap-guarded so it's restored even if the build fails). No source, component API, or `preserveSymlinks` change; the `.visualroute`/`bundlespec` fixtures are untouched.
- **The suspenders** — after emit, the build asserts that no granular package's published declarations reference the aggregate preset by its bare specifier, and fails the build if one does. This future-proofs the workaround against being dropped, preconstruct changing its resolution, or a new compound component reintroducing the pattern. The check uses `find` (not a `**` glob) so it covers packages at every nesting depth.

This is the smallest change that produces correct published types, and it's the right trade-off for a legacy codebase: it touches one build script and leaves every TypeScript config, dependency, and source file exactly as it is.

## Alternatives considered (and why not)

`paths` cannot fix this — TypeScript's `paths` changes module _resolution_, never declaration _emit_. The two structural options were both heavier and were rejected:

- **Flip `preserveSymlinks: true`** (globally, or via a dedicated emit tsconfig). It does fix the specifier, but it reintroduces the full FEC-935 typecheck breakage (~270 errors, including in published component source, not just stories), so it breaks `pnpm typecheck` and the IDE. Decoupling it for emit-only isn't clean either: preconstruct requires a custom-named tsconfig to exist in **every package directory** (it doesn't walk up to the root), and VS Code can't be pointed at a non-default tsconfig — so the editor would still surface the ~270 errors.
- **Remove the root `@commercetools-frontend/ui-kit` devDependency** and repoint the **71** `.visualroute`/`bundlespec` fixtures off the aggregate onto granular packages. This is the most structurally "correct" fix (the symlink would never exist), but it's 71 mechanical edits plus a Percy visual-regression re-run — disproportionate to a one-line build-step problem.

The chosen fix implements the same underlying strategy as the structural option — _keep the aggregate package out of the leaf packages' declaration-emit graph_ — but does it at build time with no churn.

## Known limitation

A bare `pnpm preconstruct build` run _outside_ `scripts/build.sh` would still leak, and the regression guard only runs as part of `scripts/build.sh`. The release path goes through `pnpm build`, so published artifacts are both fixed and guarded.

## Verification

Full `pnpm build` run on this branch:

- ✅ build green; meta-package symlink restored afterward
- ✅ leaked specifiers across the whole published cohort: **0** (was 3)
- ✅ the 3 packages now emit relative specifiers:
  - `radio-input` → `import("./radio-group.js").TGroupProps`, `import("./radio-option.js").TOptionProps`
  - `constraints` → `import("./horizontal/index.js").THorizontalProps`
  - `view-switcher` → `import("./view-switcher.js").TViewSwitcherProps`
- ✅ regression guard tested both ways: passes on the fixed dist, and fails the build (naming the offending file) when a leak is injected

## Release

Patch changeset included. The cohort is a `fixed` changeset group, so the whole `20.6.x` line republishes together — every package is rebuilt with the fixed build, so the fix propagates cohort-wide.

Refs: commercetools/identity#757
