### PR TITLE
ci: fix visual regression tests — provision a pinned Chrome for Puppeteer + Percy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,7 @@ permissions:
 
 jobs:
   build_lint_and_test:
-    # Pinned to 22.04: the current 24.04 runner image ships a partial
-    # ~/.cache/puppeteer that breaks `puppeteer browsers install`, and needs an
-    # AppArmor `aa-exec` workaround for Chrome's sandbox. 22.04 has neither, so
-    # the job runs without those workarounds.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -71,22 +67,27 @@ jobs:
       - name: Building Visual Regression Tests application for UI components
         run: pnpm visual-testing-app:build
 
-      # Both the visual-test browser (jest-puppeteer) and Percy's asset-discovery
-      # browser need a Chrome. Their pinned runtime downloads both fail in CI now
-      # — Puppeteer's Chrome-for-Testing 127.0.6533.88 and Percy's Chromium
-      # snapshot 1300309 (pruned from the public bucket) — which yielded 0
-      # snapshots. Use the runner's pre-installed Chrome for both instead of
-      # downloading. jest-puppeteer.config.js already reads
+      # The visual-test browser (jest-puppeteer) and Percy's asset-discovery
+      # browser both need a Chrome. Puppeteer's and Percy's own pinned downloads
+      # (Chrome-for-Testing 127.0.6533.88 / Percy Chromium snapshot 1300309) stopped
+      # working in CI and yielded 0 snapshots, so we provision Chrome explicitly
+      # here and point both tools at it. jest-puppeteer.config.js reads
       # PUPPETEER_EXECUTABLE_PATH and launches with --no-sandbox.
+      # TODO: pin `chrome-version` to a specific build for reproducible snapshots.
+      - name: Set up Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
+        with:
+          chrome-version: stable
+
       - name: Running Visual Regression Tests for UI components
         run: |
-          CHROME="$(command -v google-chrome google-chrome-stable chromium-browser 2>/dev/null | head -1)"
-          echo "Using Chrome for VRT + Percy: ${CHROME:?no Chrome found on runner}"
-          export PUPPETEER_EXECUTABLE_PATH="$CHROME"
-          export PERCY_BROWSER_EXECUTABLE="$CHROME"
+          echo "Using Chrome ${{ steps.setup-chrome.outputs.chrome-version }} at $PUPPETEER_EXECUTABLE_PATH"
           pnpm vrt:components
         timeout-minutes: 20
         env:
+          PUPPETEER_EXECUTABLE_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
+          PERCY_BROWSER_EXECUTABLE: ${{ steps.setup-chrome.outputs.chrome-path }}
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,10 @@ permissions:
 
 jobs:
   build_lint_and_test:
-    runs-on: ubuntu-24.04
+    # Pinned to 22.04: the 24.04 runner image (since ~20260525) tightened
+    # AppArmor unprivileged-userns restrictions that prevent Percy/Chromium from
+    # launching, so VRT produced 0 snapshots. 22.04 has no such restriction.
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
@@ -40,13 +43,6 @@ jobs:
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml', 'patches/*.patch') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-
-
-      # GitHub's runner image can ship a partial ~/.cache/puppeteer (a browser
-      # folder without the executable). @puppeteer/browsers refuses to repair an
-      # incomplete install and fails the "Install Puppeteer's Chrome" step below.
-      # Clear it so Puppeteer's postinstall downloads a clean Chrome.
-      - name: Clear stale Puppeteer browser cache
-        run: rm -rf ~/.cache/puppeteer
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -84,13 +80,7 @@ jobs:
         run: pnpm exec puppeteer browsers install chrome
 
       - name: Running Visual Regression Tests for UI components
-      # aa-exec:
-      # ubuntu-24.04, the image used for `ubuntu-latest` as of Oct 14 2024(https://github.com/actions/runner-images/issues/10636),
-      # introduced security measures in its app-armor security  (https://github.com/puppeteer/puppeteer/issues/12818#issuecomment-2247844464)
-      # that made it so that puppeteers chromium installation is not whitelisted,
-      # which made it so that the chromium sandbox is not available and puppeteer errors out,
-      # so we need to specify that we are using app armor's chrome profile when running puppeteer (https://github.com/mermaid-js/mermaid-cli/issues/730#issuecomment-2408615110)
-        run: aa-exec --profile=chrome -- pnpm vrt:components
+        run: pnpm vrt:components
         timeout-minutes: 20
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,14 +18,6 @@ jobs:
   build_lint_and_test:
     runs-on: ubuntu-24.04
 
-    # Install Puppeteer's Chrome into a workspace-local, cacheable directory
-    # instead of the default ~/.cache/puppeteer. This keeps the browser binary
-    # out of any stale/partial system cache the runner image may ship (which
-    # made `puppeteer browsers install` fail with "the browser folder exists but
-    # the executable is missing") and lets us cache the binary ourselves.
-    env:
-      PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
-
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -49,14 +41,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-
 
-      # Skip Puppeteer's postinstall Chrome download. Under the restored pnpm
-      # store it leaves a partial browser folder (directory without the
-      # executable) in PUPPETEER_CACHE_DIR, which @puppeteer/browsers then
-      # refuses to repair ("the browser folder exists but the executable is
-      # missing"). Chrome is installed explicitly, into a cached dir, further down.
+      # GitHub's runner image can ship a partial ~/.cache/puppeteer (a browser
+      # folder without the executable). @puppeteer/browsers refuses to repair an
+      # incomplete install and fails the "Install Puppeteer's Chrome" step below.
+      # Clear it so Puppeteer's postinstall downloads a clean Chrome.
+      - name: Clear stale Puppeteer browser cache
+        run: rm -rf ~/.cache/puppeteer
+
       - name: Install dependencies
-        env:
-          PUPPETEER_SKIP_DOWNLOAD: 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Check for unmet constraints
@@ -82,27 +74,12 @@ jobs:
       - name: Building Visual Regression Tests application for UI components
         run: pnpm visual-testing-app:build
 
-      # Puppeteer downloads Chrome outside node_modules / the pnpm store, so the
-      # pnpm-store cache (which records that the postinstall "ran") leaves the
-      # binary missing on a cache hit. Cache the browser directory itself so it's
-      # preserved across runs: the explicit install below is a no-op on a hit,
-      # and a clean download into an empty workspace-local dir on a miss (never a
-      # partially-populated one).
-      #
-      # The Chrome build is pinned transitively by the `puppeteer` dependency, so
-      # key the cache on that version: a Puppeteer bump changes the key and forces
-      # a clean re-download; same-version runs reuse the cached binary. (No
-      # restore-keys — a stale-version fallback is exactly what we want to avoid.)
-      - name: Resolve Puppeteer version (for cache key)
-        id: puppeteer
-        run: echo "version=$(node -p "require('./node_modules/puppeteer/package.json').version")" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Puppeteer browser
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/.cache/puppeteer
-          key: ${{ runner.os }}-puppeteer-${{ steps.puppeteer.outputs.version }}
-
+      # Puppeteer's postinstall hook downloads Chrome to ~/.cache/puppeteer.
+      # Under pnpm, the postinstall script's side-effects are cached in the pnpm
+      # store (which is restored from the GitHub Actions cache), so pnpm skips
+      # re-running it. But Chrome lives outside node_modules / the pnpm store,
+      # so the binary is missing on the runner. Install it explicitly here so
+      # the visual regression tests can find it.
       - name: Install Puppeteer's Chrome
         run: pnpm exec puppeteer browsers install chrome
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,14 @@ jobs:
   build_lint_and_test:
     runs-on: ubuntu-24.04
 
+    # Install Puppeteer's Chrome into a workspace-local, cacheable directory
+    # instead of the default ~/.cache/puppeteer. This keeps the browser binary
+    # out of any stale/partial system cache the runner image may ship (which
+    # made `puppeteer browsers install` fail with "the browser folder exists but
+    # the executable is missing") and lets us cache the binary ourselves.
+    env:
+      PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -67,12 +75,20 @@ jobs:
       - name: Building Visual Regression Tests application for UI components
         run: pnpm visual-testing-app:build
 
-      # Puppeteer's postinstall hook downloads Chrome to ~/.cache/puppeteer.
-      # Under pnpm, the postinstall script's side-effects are cached in the pnpm
-      # store (which is restored from the GitHub Actions cache), so pnpm skips
-      # re-running it. But Chrome lives outside node_modules / the pnpm store,
-      # so the binary is missing on the runner. Install it explicitly here so
-      # the visual regression tests can find it.
+      # Puppeteer downloads Chrome outside node_modules / the pnpm store, so the
+      # pnpm-store cache (which records that the postinstall "ran") leaves the
+      # binary missing on a cache hit. Cache the browser directory itself, keyed
+      # on the lockfile, so it's preserved across runs: the explicit install
+      # below is a no-op on a hit, and a clean download into an empty
+      # workspace-local dir on a miss (never a partially-populated one).
+      - name: Cache Puppeteer browser
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/.cache/puppeteer
+          key: ${{ runner.os }}-puppeteer-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-puppeteer-
+
       - name: Install Puppeteer's Chrome
         run: pnpm exec puppeteer browsers install chrome
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,12 +73,16 @@ jobs:
       # working in CI and yielded 0 snapshots, so we provision Chrome explicitly
       # here and point both tools at it. jest-puppeteer.config.js reads
       # PUPPETEER_EXECUTABLE_PATH and launches with --no-sandbox.
-      # TODO: pin `chrome-version` to a specific build for reproducible snapshots.
+      #
+      # Pinned to 127.0.6533.88 — the Chrome build puppeteer 22.15.0 targets and
+      # the one the Percy baseline was captured with. `chrome-version: stable`
+      # pulled Chrome 149 (~22 majors newer), which broke 2 visual test suites
+      # via CDP/runtime drift. Bump this in lockstep with puppeteer.
       - name: Set up Chrome
         id: setup-chrome
         uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
         with:
-          chrome-version: stable
+          chrome-version: 127.0.6533.88
 
       - name: Running Visual Regression Tests for UI components
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,10 @@ permissions:
 
 jobs:
   build_lint_and_test:
-    # Pinned to 22.04: the 24.04 runner image (since ~20260525) tightened
-    # AppArmor unprivileged-userns restrictions that prevent Percy/Chromium from
-    # launching, so VRT produced 0 snapshots. 22.04 has no such restriction.
+    # Pinned to 22.04: the current 24.04 runner image ships a partial
+    # ~/.cache/puppeteer that breaks `puppeteer browsers install`, and needs an
+    # AppArmor `aa-exec` workaround for Chrome's sandbox. 22.04 has neither, so
+    # the job runs without those workarounds.
     runs-on: ubuntu-22.04
 
     steps:
@@ -79,8 +80,16 @@ jobs:
       - name: Install Puppeteer's Chrome
         run: pnpm exec puppeteer browsers install chrome
 
+      # @percy/core pins a Chromium snapshot revision (1300309) for asset
+      # discovery and auto-downloads it; that revision was pruned from the public
+      # bucket, so the download now hangs and VRT captures 0 snapshots. Point
+      # Percy at the runner's pre-installed Chrome so it skips the download
+      # entirely (it falls back to the broken download if this path is empty).
       - name: Running Visual Regression Tests for UI components
-        run: pnpm vrt:components
+        run: |
+          export PERCY_BROWSER_EXECUTABLE="$(command -v google-chrome google-chrome-stable chromium-browser 2>/dev/null | head -1)"
+          echo "Percy discovery browser: ${PERCY_BROWSER_EXECUTABLE:-<none found; Percy will download>}"
+          pnpm vrt:components
         timeout-minutes: 20
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,24 +71,19 @@ jobs:
       - name: Building Visual Regression Tests application for UI components
         run: pnpm visual-testing-app:build
 
-      # Puppeteer's postinstall hook downloads Chrome to ~/.cache/puppeteer.
-      # Under pnpm, the postinstall script's side-effects are cached in the pnpm
-      # store (which is restored from the GitHub Actions cache), so pnpm skips
-      # re-running it. But Chrome lives outside node_modules / the pnpm store,
-      # so the binary is missing on the runner. Install it explicitly here so
-      # the visual regression tests can find it.
-      - name: Install Puppeteer's Chrome
-        run: pnpm exec puppeteer browsers install chrome
-
-      # @percy/core pins a Chromium snapshot revision (1300309) for asset
-      # discovery and auto-downloads it; that revision was pruned from the public
-      # bucket, so the download now hangs and VRT captures 0 snapshots. Point
-      # Percy at the runner's pre-installed Chrome so it skips the download
-      # entirely (it falls back to the broken download if this path is empty).
+      # Both the visual-test browser (jest-puppeteer) and Percy's asset-discovery
+      # browser need a Chrome. Their pinned runtime downloads both fail in CI now
+      # — Puppeteer's Chrome-for-Testing 127.0.6533.88 and Percy's Chromium
+      # snapshot 1300309 (pruned from the public bucket) — which yielded 0
+      # snapshots. Use the runner's pre-installed Chrome for both instead of
+      # downloading. jest-puppeteer.config.js already reads
+      # PUPPETEER_EXECUTABLE_PATH and launches with --no-sandbox.
       - name: Running Visual Regression Tests for UI components
         run: |
-          export PERCY_BROWSER_EXECUTABLE="$(command -v google-chrome google-chrome-stable chromium-browser 2>/dev/null | head -1)"
-          echo "Percy discovery browser: ${PERCY_BROWSER_EXECUTABLE:-<none found; Percy will download>}"
+          CHROME="$(command -v google-chrome google-chrome-stable chromium-browser 2>/dev/null | head -1)"
+          echo "Using Chrome for VRT + Percy: ${CHROME:?no Chrome found on runner}"
+          export PUPPETEER_EXECUTABLE_PATH="$CHROME"
+          export PERCY_BROWSER_EXECUTABLE="$CHROME"
           pnpm vrt:components
         timeout-minutes: 20
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,17 +77,24 @@ jobs:
 
       # Puppeteer downloads Chrome outside node_modules / the pnpm store, so the
       # pnpm-store cache (which records that the postinstall "ran") leaves the
-      # binary missing on a cache hit. Cache the browser directory itself, keyed
-      # on the lockfile, so it's preserved across runs: the explicit install
-      # below is a no-op on a hit, and a clean download into an empty
-      # workspace-local dir on a miss (never a partially-populated one).
+      # binary missing on a cache hit. Cache the browser directory itself so it's
+      # preserved across runs: the explicit install below is a no-op on a hit,
+      # and a clean download into an empty workspace-local dir on a miss (never a
+      # partially-populated one).
+      #
+      # The Chrome build is pinned transitively by the `puppeteer` dependency, so
+      # key the cache on that version: a Puppeteer bump changes the key and forces
+      # a clean re-download; same-version runs reuse the cached binary. (No
+      # restore-keys — a stale-version fallback is exactly what we want to avoid.)
+      - name: Resolve Puppeteer version (for cache key)
+        id: puppeteer
+        run: echo "version=$(node -p "require('./node_modules/puppeteer/package.json').version")" >> "$GITHUB_OUTPUT"
+
       - name: Cache Puppeteer browser
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.cache/puppeteer
-          key: ${{ runner.os }}-puppeteer-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-puppeteer-
+          key: ${{ runner.os }}-puppeteer-${{ steps.puppeteer.outputs.version }}
 
       - name: Install Puppeteer's Chrome
         run: pnpm exec puppeteer browsers install chrome

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-
 
+      # Skip Puppeteer's postinstall Chrome download. Under the restored pnpm
+      # store it leaves a partial browser folder (directory without the
+      # executable) in PUPPETEER_CACHE_DIR, which @puppeteer/browsers then
+      # refuses to repair ("the browser folder exists but the executable is
+      # missing"). Chrome is installed explicitly, into a cached dir, further down.
       - name: Install dependencies
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Check for unmet constraints

--- a/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.visualspec.js
+++ b/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.visualspec.js
@@ -9,6 +9,11 @@ jest.setTimeout(20000);
 beforeEach(async () => {
   browser = await puppeteer.launch({
     headless: 'new',
+    // This spec launches its own browser (not the jest-puppeteer global one), so
+    // it must opt out of the Chrome sandbox itself. CI runners (Ubuntu 24.04+)
+    // restrict unprivileged user namespaces via AppArmor, so the sandbox can't
+    // start otherwise. Matches jest-puppeteer.config.js used by other specs.
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
     slowMo: 10, // Launching the browser in slow motion is necessary due to race conditions. Otherwise browser closes prematurely and tests fail.
   });
   page = await browser.newPage();

--- a/packages/components/inputs/rich-text-input/src/rich-text-input.visualspec.js
+++ b/packages/components/inputs/rich-text-input/src/rich-text-input.visualspec.js
@@ -9,6 +9,11 @@ jest.setTimeout(20000);
 beforeEach(async () => {
   browser = await puppeteer.launch({
     headless: 'new',
+    // This spec launches its own browser (not the jest-puppeteer global one), so
+    // it must opt out of the Chrome sandbox itself. CI runners (Ubuntu 24.04+)
+    // restrict unprivileged user namespaces via AppArmor, so the sandbox can't
+    // start otherwise. Matches jest-puppeteer.config.js used by other specs.
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
     slowMo: 10, // Launching the browser in slow motion is necessary due to race conditions. Otherwise browser closes prematurely and tests fail.
   });
   page = await browser.newPage();


### PR DESCRIPTION
## Problem

The `build_lint_and_test` job's visual-regression step started capturing **0 snapshots**, so Percy builds came back "manually failed" / *"no snapshots uploaded."* The last healthy run was **build 13795 (May 27, 81 snapshots)**; every run after that captured nothing — with no relevant change in this repo.

## Causes

Three independent things broke, all external to our source (the first two surfaced first; the third only became visible once the browsers were available again):

1. **Puppeteer's Chrome no longer installed.** `puppeteer browsers install chrome` (Chrome-for-Testing `127.0.6533.88`, via `@puppeteer/browsers@2.3.0`) silently stopped installing, so `jest-puppeteer`'s `globalSetup` failed with `Could not find Chrome (ver. 127.0.6533.88)`.
2. **Percy's discovery Chromium download hung.** `@percy/core@1.31.13` pins Chromium snapshot revision `1300309` and auto-downloads it; that revision was pruned from the public Chromium snapshots bucket, so the download went from ~4s (May 27) to a permanent hang (`this.executable = executable || (await install.chromium())`).
3. **Two visual specs crash Chrome's sandbox on `ubuntu-24.04`.** `rich-text-input` and `localized-rich-text-input` launch their **own** Puppeteer browser (not the jest-puppeteer global one) without `--no-sandbox`. On `ubuntu-24.04`, AppArmor restricts unprivileged user namespaces, so those launches die with *"No usable sandbox"*. They had only ever passed because of a now-removed `aa-exec --profile=chrome` wrapper.

## Solution

**Provision one explicit, pinned Chrome and use it for everything; stop relying on the tools' own (now-broken) downloads.**

- **`browser-actions/setup-chrome`** (SHA-pinned) installs **`127.0.6533.88`** — the build `puppeteer@22.15.0` targets and the one the Percy baseline was captured with. `chrome-version: stable` was rejected: it pulled Chrome 149 (~22 majors newer).
- Point both tools at it: `PUPPETEER_EXECUTABLE_PATH` (read by `jest-puppeteer.config.js`) and `PERCY_BROWSER_EXECUTABLE`. This removes both failing downloads (#1, #2).
- Add `--no-sandbox`/`--disable-setuid-sandbox` to the two self-launching rich-text specs, matching `jest-puppeteer.config.js` used by the other 68 specs. Fixes #3 without a privileged runner sysctl, on any OS.
- Drop the now-redundant **Install Puppeteer's Chrome** step and the **`aa-exec`** wrapper. Stay on **`ubuntu-24.04`** (no longer needs either, and avoids the `ubuntu-22.04` deprecation track).

## Verification

Green run on this branch → Percy **build 13802**:
- `Test Suites: 71 passed, 71 total` (the two rich-text suites pass again)
- Provisioned **Chrome 127.0.6533.88**, **81 snapshots** (matches the May-27 baseline count)
- `Finalized build #13802` → `exited with status: 0`
- `percy/ui-kit`: **pass** — *"automatically approved, no visual changes found"* (Chrome 127 renders identically to the baseline — no baseline shift)

## Notes / follow-ups

- The commit history records the full investigation (a since-abandoned cache/skip-download approach, the `~/.cache/puppeteer` husk, a `ubuntu-22.04` pin, a brief unpinned-Chrome attempt). The *net* change is only the items under Solution.
- Reproducibility now hinges on the pinned `chrome-version` — **bump it in lockstep with `puppeteer`**.
