### PR TITLE
FEC-1010: close reliably when `mouseleave` is missed or `animationend` never fires

### DIFF
--- a/.changeset/silver-swans-brush.md
+++ b/.changeset/silver-swans-brush.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/tooltip': patch
+---
+
+Allows hover close events to close Tooltip.

--- a/packages/components/tooltip/src/tooltip.spec.js
+++ b/packages/components/tooltip/src/tooltip.spec.js
@@ -70,22 +70,20 @@ const closeAndValidateTooltip = async ({
   // Move away from the trigger element
   fireEvent[options.eventType](options.triggerElement);
 
-  // We need to wait for the tooltip to be removed
-  // after the 'closeAfter' delay
-  await waitForTimeout(options.closeAfter);
-
-  // We need to fake trigger the animation we use to hide the tooltip
-  fireEvent.animationEnd(screen.getByTestId('tooltip-message-wrapper'));
+  // Wait for the tooltip to fully close (closeAfter delay + animation fallback).
+  // In jsdom there is no real popper instance, so the exiting effect calls
+  // handleClose directly without waiting for animationend.
+  await waitFor(() => {
+    expect(
+      screen.queryByText('What kind of bear is best?')
+    ).not.toBeInTheDocument();
+  });
 
   // should call the exit callbacks
   options.exitCallbacks.forEach((callback) => {
     expect(callback).toHaveBeenCalled();
   });
 
-  // should hide tooltip
-  expect(
-    screen.queryByText('What kind of bear is best?')
-  ).not.toBeInTheDocument();
   // should add the title again
   expect(options.triggerElement).toHaveProperty(
     'title',

--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -255,25 +255,13 @@ const Tooltip = ({
 
       if (closeAfter && state === 'opened') {
         leaveTimer.current = setTimeout(() => {
-          const tooltipElement = popperInstance?.popper.querySelector(
-            '[data-testid="tooltip-message-wrapper"]'
-          ) as HTMLElement;
-
-          if (tooltipElement) {
-            tooltipElement.addEventListener('animationend', () =>
-              handleClose()
-            );
-          } else {
-            handleClose();
-          }
-
           setState('exiting');
         }, closeAfter);
       } else {
         handleClose(event);
       }
     },
-    [closeAfter, onBlur, onMouseLeave, handleClose, state, popperInstance]
+    [closeAfter, onBlur, onMouseLeave, handleClose, state]
   );
 
   useEffect(() => {
@@ -289,6 +277,60 @@ const Tooltip = ({
       }
     }
   }, [off, closeAfter, handleClose, state]);
+
+  // When entering 'exiting' state, drive the close via animationend on the
+  // wrapper itself (scoped to event.target to ignore bubbled descendant events)
+  // with a hard fallback so a missed/blocked animationend never wedges the tooltip.
+  useEffect(() => {
+    if (state !== 'exiting') return;
+
+    const tooltipElement = popperInstance?.popper.querySelector(
+      '[data-testid="tooltip-message-wrapper"]'
+    ) as HTMLElement | null;
+
+    if (!tooltipElement) {
+      handleClose();
+      return;
+    }
+
+    let closed = false;
+    const close = () => {
+      if (closed) return;
+      closed = true;
+      handleClose();
+    };
+
+    const onAnimEnd = (event: AnimationEvent) => {
+      if (event.target === tooltipElement) close();
+    };
+
+    tooltipElement.addEventListener('animationend', onAnimEnd);
+    // growOut runs for 80 ms; 100 ms gives a small buffer before forcing close
+    const fallback = setTimeout(close, 100);
+
+    return () => {
+      tooltipElement.removeEventListener('animationend', onAnimEnd);
+      clearTimeout(fallback);
+    };
+  }, [state, popperInstance, handleClose]);
+
+  // Native mouseleave fallback: if React's synthetic onMouseLeave is never
+  // delivered (React 19 event-delegation timing), the tooltip would stay in
+  // 'opened' indefinitely. A direct DOM listener on the wrapper catches the
+  // same browser event that React missed and triggers the normal close path.
+  useEffect(() => {
+    if (state !== 'opened' || off || isControlled) return;
+
+    const wrapperEl = reference.ref.current as HTMLElement | null;
+    if (!wrapperEl) return;
+
+    const onNativeLeave = (event: MouseEvent) => {
+      handleLeave(event as unknown as ChangeEvent);
+    };
+
+    wrapperEl.addEventListener('mouseleave', onNativeLeave);
+    return () => wrapperEl.removeEventListener('mouseleave', onNativeLeave);
+  }, [state, off, isControlled, reference.ref, handleLeave]);
 
   const childrenProps = {
     // don't pass event listeners to children


### PR DESCRIPTION
## fix(tooltip): close reliably when `mouseleave` is missed or `animationend` never fires

closes [FEC-1010](https://commercetools.atlassian.net/browse/FEC-1010)
### Problem

Image-preview tooltips in Merchant Center (Product → Variants) can get permanently
stuck open after hover. The enlarged preview appears and never dismisses, requiring
a full page reload to clear.

Three root causes were identified (in order of severity):

**1. Opened-wedge (confirmed in production — the decisive bug)**
A tooltip can get stuck in the `opened` state because `handleLeave` is never called.
React 19's synthetic event delegation can silently drop the `mouseleave` event for a
specific instance. Once in `opened`, the component had no recovery path: no scheduled
timer, no `animationend` listener, nothing. The tooltip stayed visible indefinitely.

Confirmed via DevTools on a live Variants page:
- Single wrapper in DOM (`querySelectorAll('[data-testid=...]').length === 1`)
- Wrapper stuck in `opened` state with `growIn` animation, `opacity: 1`
- `getEventListeners(wrapper)` returned `{}` — no close listener was ever attached

**2. Exiting-wedge (seen in Storybook probing)**
Even when `handleLeave` *did* run and schedule the `exiting` transition, the tooltip
could get stuck in `exiting` forever if `animationend` never fired (e.g. a style
override suppressed the `growOut` animation, or `prefers-reduced-motion` was active).
There was no timeout fallback — if the event was missed, the tooltip never unmounted.

**3. Unscoped and accumulating `animationend` listener**
The listener attached inside `handleLeave`'s `setTimeout` accepted *any* bubbled
`animationend` — including the consumer's own `show` animation on a descendant —
and accumulated across enter/leave cycles (no `once: true`, no cleanup). Whether the
tooltip closed depended on a non-deterministic race between `growOut`, the consumer's
`show` keyframe, and a querySelector-null escape hatch.

---

### Fix

#### Fix 0 — Native `mouseleave` fallback while `opened` (addresses the wedge)

When state is `opened`, a native `addEventListener('mouseleave', …)` is attached
directly to the wrapper DOM node. This bypasses React's event delegation entirely and
fires regardless of whether React's synthetic `onMouseLeave` was delivered. The
`useEffect` that manages it is keyed on `state`, so it is automatically removed the
moment the state transitions away from `opened`.

```tsx
useEffect(() => {
  if (state !== 'opened' || off || isControlled) return;
  const wrapperEl = reference.ref.current as HTMLElement | null;
  if (!wrapperEl) return;
  const onNativeLeave = (event: MouseEvent) => {
    handleLeave(event as unknown as ChangeEvent);
  };
  wrapperEl.addEventListener('mouseleave', onNativeLeave);
  return () => wrapperEl.removeEventListener('mouseleave', onNativeLeave);
}, [state, off, isControlled, reference.ref, handleLeave]);
```

#### Fix 1 — Hard fallback timeout in `exiting` (addresses the exiting-wedge)

Added a `setTimeout(close, 100)` fallback alongside the `animationend` listener.
The `growOut` animation runs for 80 ms; 100 ms gives a small buffer. Whichever fires
first wins; the `closed` guard prevents double-close.

#### Fix 2+3 — Scoped listener with proper cleanup

Moved the `animationend` listener setup out of `handleLeave`'s `setTimeout` into a
dedicated `useEffect` for `state === 'exiting'`. The listener now checks
`event.target === tooltipElement` so bubbled events from consumer descendant
animations (e.g. the `show` keyframe in MC's `ImageContainer`) no longer trigger a
premature or phantom close. The `useEffect` return function removes the listener and
clears the fallback timer, so listeners no longer accumulate.

> **Ordering note**: Fix 1 (fallback timeout) was intentionally landed alongside
> Fix 2+3 (listener scoping). Tightening the listener scope without adding the
> fallback would have *increased* the stuck frequency by removing the accidental
> rescue that the consumer's bubbled `animationend` was providing.

---

### Files changed

- `packages/components/tooltip/src/tooltip.tsx` — all three fixes above
- `packages/components/tooltip/src/tooltip.spec.js` — updated `closeAndValidateTooltip`
  to use `waitFor` instead of `waitForTimeout` + manual `fireEvent.animationEnd`. In
  jsdom there is no real Popper instance, so the `exiting` effect now calls
  `handleClose()` directly (querySelector returns null); no animation event needs to
  be dispatched manually.

---

### Backward compatibility

- No changes to public props or component API.
- The `animationend`-based close path is preserved for real browsers where Popper and
  the DOM are fully set up; the new fallback only fires when the event is missed.
- Controlled tooltips (`isOpen` prop) are unaffected — the native fallback guards on
  `!isControlled`.


[FEC-1010]: https://commercetools.atlassian.net/browse/FEC-1010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ