### PR TITLE
fix(tooltip): update refs

### DIFF
--- a/.changeset/fiery-times-read.md
+++ b/.changeset/fiery-times-read.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/tooltip': patch
+---
+
+Fixes broken refs in the Tooltip component.

--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -257,7 +257,11 @@ const Tooltip = ({
         leaveTimer.current = setTimeout(() => {
           setState('exiting');
         }, closeAfter);
-      } else {
+      } else if (state !== 'exiting') {
+        // Don't interrupt growOut if the animation is already in progress.
+        // onPopperLeave and a delayed synthetic mouseleave can both reach here
+        // while exiting; calling handleClose() would abort the animation and
+        // risk a stray mouseover re-opening the tooltip immediately after.
         handleClose(event);
       }
     },
@@ -318,19 +322,56 @@ const Tooltip = ({
   // delivered (React 19 event-delegation timing), the tooltip would stay in
   // 'opened' indefinitely. A direct DOM listener on the wrapper catches the
   // same browser event that React missed and triggers the normal close path.
+  //
+  // When the tooltip body is rendered in a portal (outside the React root),
+  // moving the mouse from the wrapper onto the portal fires mouseleave on the
+  // wrapper. We must not start the close timer in that case — otherwise the
+  // tooltip closes, the portal disappears, the browser re-fires mouseenter on
+  // the wrapper, and the tooltip reopens in a continuous flicker loop.
+  //
+  // use-popper uses callback refs (functions, not {current} objects), so
+  // popper.ref.current / reference.ref.current are always undefined at runtime.
+  // The DOM nodes are accessible via the Popper.js instance instead.
   useEffect(() => {
     if (state !== 'opened' || off || isControlled) return;
 
-    const wrapperEl = reference.ref.current as HTMLElement | null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const inst = popperInstance as any;
+    const wrapperEl = inst?.reference as HTMLElement | null;
     if (!wrapperEl) return;
+    const popperEl = inst?.popper as HTMLElement | null;
 
     const onNativeLeave = (event: MouseEvent) => {
+      // If the mouse moved into the popper/tooltip body, suppress the close so
+      // the tooltip stays open while the user hovers over the preview.
+      if (
+        popperEl &&
+        event.relatedTarget instanceof Node &&
+        popperEl.contains(event.relatedTarget)
+      ) {
+        return;
+      }
+      handleLeave(event as unknown as ChangeEvent);
+    };
+
+    // Mirror: close when the mouse leaves the tooltip body itself.
+    const onPopperLeave = (event: MouseEvent) => {
+      if (
+        wrapperEl.contains(event.relatedTarget as Node | null) ||
+        popperEl?.contains(event.relatedTarget as Node | null)
+      ) {
+        return;
+      }
       handleLeave(event as unknown as ChangeEvent);
     };
 
     wrapperEl.addEventListener('mouseleave', onNativeLeave);
-    return () => wrapperEl.removeEventListener('mouseleave', onNativeLeave);
-  }, [state, off, isControlled, reference.ref, handleLeave]);
+    popperEl?.addEventListener('mouseleave', onPopperLeave);
+    return () => {
+      wrapperEl.removeEventListener('mouseleave', onNativeLeave);
+      popperEl?.removeEventListener('mouseleave', onPopperLeave);
+    };
+  }, [state, off, isControlled, popperInstance, handleLeave]);
 
   const childrenProps = {
     // don't pass event listeners to children


### PR DESCRIPTION
follows on from https://github.com/commercetools/ui-kit/pull/3256

## fix(tooltip): close reliably when `mouseleave` is missed or `animationend` never fires

### Problem

Image-preview tooltips in Merchant Center (Product → Variants) can get permanently
stuck open after hover. The enlarged preview appears and never dismisses, requiring
a full page reload to clear.

Four root causes were identified:

**1. Opened-wedge (confirmed in production — the decisive bug)**
A tooltip can get stuck in the `opened` state because `handleLeave` is never called.
React 19's synthetic event delegation can silently drop the `mouseleave` event for a
specific instance. Once in `opened`, the component had no recovery path: no scheduled
timer, no `animationend` listener, nothing. The tooltip stayed visible indefinitely.

Confirmed via DevTools on a live Variants page:
- Single wrapper in DOM (`querySelectorAll('[data-testid=...]').length === 1`)
- Wrapper stuck in `opened` state with `growIn` animation, `opacity: 1`
- `getEventListeners(wrapper)` returned `{}` — no close listener was ever attached

**2. Exiting-wedge**
Even when `handleLeave` *did* run and schedule the `exiting` transition, the tooltip
could get stuck in `exiting` forever if `animationend` never fired (e.g. a style
override suppressed `growOut`, or `prefers-reduced-motion` was active). There was no
fallback — if the event was missed, the tooltip never unmounted.

**3. Unscoped and accumulating `animationend` listener**
The listener accepted *any* bubbled `animationend` — including descendant animations
from consumers (e.g. the `show` keyframe in MC's `ImageContainer`) — and accumulated
across enter/leave cycles with no cleanup. Whether the tooltip closed depended on a
non-deterministic race between `growOut`, the consumer's keyframe, and a null-escape
hatch.

**4. Exit animation interrupted by late-arriving leave events**
Any `handleLeave` call that arrived while `growOut` was already playing (a delayed
React synthetic `mouseleave`, or a `mouseleave` from the tooltip body) would call
`handleClose()` immediately, aborting the animation mid-play. The abrupt unmount
could then trigger a stray `mouseover` on the trigger, reopening the tooltip and
producing a visible double-animation on close.

---

### Fix

**Native `mouseleave` fallback while `opened`**

When state is `opened`, a native `mouseleave` listener is attached directly to the
wrapper DOM node via `popperInstance.reference`. This bypasses React's event delegation
and fires regardless of whether the synthetic `onMouseLeave` was delivered. The effect
is keyed on `state`, so the listener is removed the moment state transitions away from
`opened`.

The effect also attaches a mirrored `mouseleave` listener on the popper element itself
(`popperInstance.popper`) so that image previews remain open while the user hovers
over them. Moving the mouse from the trigger onto the preview suppresses the close;
moving off both elements triggers it.

Note: `use-popper` uses callback refs internally, so `reference.ref.current` and
`popper.ref.current` are always `undefined` at runtime — DOM nodes are read from
`popperInstance.reference` / `popperInstance.popper` instead.

**`animationend` listener moved to a `useEffect` with scoped handling and fallback**

The `querySelector` + `addEventListener` call is removed from `handleLeave` and
replaced with a dedicated `useEffect` that runs when `state === 'exiting'`. The
listener now checks `event.target === tooltipElement` to ignore bubbled events from
descendant animations. A `setTimeout(close, 100)` fallback ensures the tooltip always
unmounts even if `animationend` is never delivered. A `closed` guard prevents
double-close. The effect's cleanup removes the listener and clears the timer, so
nothing accumulates across cycles.

**`handleLeave` guarded against interrupting the exit animation**

Added `else if (state !== 'exiting')` to `handleLeave`'s fallback branch so that
late-arriving leave events (from the popper listener or a delayed synthetic event)
cannot call `handleClose()` while `growOut` is in progress.

---

### Files changed

- `packages/components/tooltip/src/tooltip.tsx`
- `packages/components/tooltip/src/tooltip.spec.js` — updated `closeAndValidateTooltip`
  to use `waitFor` instead of `waitForTimeout` + manual `fireEvent.animationEnd`. In
  jsdom there is no real Popper instance, so the `exiting` effect calls `handleClose()`
  directly; no animation event needs to be dispatched manually.

---

### Backward compatibility

- No changes to public props or component API.
- The `animationend`-based close path is preserved for real browsers where Popper and
  the DOM are fully set up; the fallback only fires when the event is missed.
- Controlled tooltips (`isOpen` prop) are unaffected — the native fallback guards on
  `!isControlled`.
