### PR TITLE
FEC-1010: add `positionFixed` prop and resize-based reflow to prevent viewport clipping

### DIFF
--- a/.changeset/tiny-bananas-beam.md
+++ b/.changeset/tiny-bananas-beam.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/tooltip': patch
+---
+
+Prevents image clipping when Tooltip component is hovered.

--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -107,6 +107,12 @@ export type TTooltipProps = {
    */
   modifiers?: Modifiers;
   /**
+   * Use CSS `position: fixed` for the popper element instead of `position: absolute`.
+   * Recommended when the tooltip body is rendered in a portal (e.g. via `TooltipWrapperComponent`)
+   * to prevent clipping caused by scrolled ancestors.
+   */
+  positionFixed?: boolean;
+  /**
    * Customize the appearance of certain elements of the tooltip.
    */
   components?: TComponents;
@@ -185,6 +191,7 @@ const Tooltip = ({
   const { reference, popper, popperInstance } = usePopper({
     placement: placement,
     modifiers: props.modifiers,
+    positionFixed: props.positionFixed,
   });
   const [state, setState] = useState<TTooltipState>('closed');
 
@@ -372,6 +379,21 @@ const Tooltip = ({
       popperEl?.removeEventListener('mouseleave', onPopperLeave);
     };
   }, [state, off, isControlled, popperInstance, handleLeave]);
+
+  // Recompute position when the tooltip body resizes (e.g. an image that loads
+  // after the initial position was calculated from a 0-height container).
+  useEffect(() => {
+    if (!tooltipIsOpen) return;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const inst = popperInstance as any;
+    const popperEl = inst?.popper as HTMLElement | null;
+    if (!popperEl) return;
+    const ro = new ResizeObserver(() => {
+      inst.scheduleUpdate?.();
+    });
+    ro.observe(popperEl);
+    return () => ro.disconnect();
+  }, [tooltipIsOpen, popperInstance]);
 
   const childrenProps = {
     // don't pass event listeners to children

--- a/test/setup-tests.js
+++ b/test/setup-tests.js
@@ -29,6 +29,11 @@ Object.defineProperty(window, 'TextDecoder', {
   writable: true,
   value: TextDecoder,
 });
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
 
 const silenceConsoleWarnings = [];
 const notThrowWarnings = [


### PR DESCRIPTION
### Problem

When a `TooltipWrapperComponent` renders the tooltip body into a React portal
(e.g. `ReactDOM.createPortal(..., document.body)`), tooltips near the bottom of the
page render partially outside the visible viewport.

Two root causes were identified:

**1. `position: absolute` coordinate drift**
Popper.js defaults to `position: absolute`. When the scroll container is not
`<body>` (e.g. the MC app scrolls an inner div), the absolute coordinates Popper
computes diverge from the viewport, causing the portal tooltip to paint at the
wrong location.

**2. Position computed before content has loaded**
Popper.js calculates the tooltip's position when the popper node is first mounted.
If the body contains an `<img>` that has not yet loaded, the container reports 0
height at that moment. Once the image loads and the container grows, Popper.js never
recomputes — the tooltip extends below the visible area.

---

### Fix

**`positionFixed` prop**

A new optional `positionFixed?: boolean` prop is threaded through to `usePopper`.
When `true`, Popper.js uses `position: fixed` for the popper element instead of
`position: absolute`. Fixed positioning is always viewport-relative and bypasses any
scrolled ancestor that would otherwise shift absolute coordinates.

Consumers should pair this with:
```tsx
modifiers={{
  flip: { enabled: false },
  preventOverflow: { boundariesElement: 'viewport' },
}}
```
`flip` disabled prevents Popper from switching placement (e.g. `"top"` → `"bottom"`)
near the page edge. `preventOverflow` with `boundariesElement: 'viewport'` aligns the
boundary with the fixed-position coordinate system so the tooltip is clamped correctly.

**`ResizeObserver` reflow**

A `ResizeObserver` is attached to the popper element whenever the tooltip is open.
If the element's dimensions change after the initial position was computed (the common
case when an `<img>` loads lazily inside the body), `scheduleUpdate()` is called so
Popper.js recomputes with the correct height and `preventOverflow` can clamp it within
the viewport. The observer is disconnected when the tooltip closes.

---

### Files changed

- `packages/components/tooltip/src/tooltip.tsx`

---

### Backward compatibility

- `positionFixed` is optional and defaults to `false`, preserving existing behavior
  for all current consumers.
- No other public props or the component API are changed.
