### PR TITLE
fix(rich-text-utils): preview lists correctly under host CSS resets

### DIFF
--- a/.changeset/tender-lists-defend.md
+++ b/.changeset/tender-lists-defend.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/rich-text-utils': patch
+---
+
+Fix bulleted and numbered lists not displaying their bullets, numbers, and indentation in the rich text editor when it is used inside applications that apply a global CSS reset (for example, apps built on Nimbus). Lists now preview correctly in all environments.

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/rich-text-body.styles.ts
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/rich-text-body.styles.ts
@@ -133,6 +133,30 @@ const reset = (props: TRichTextBodyStylesProps) => [
       margin: 0;
       line-height: 22px;
     }
+    /*
+     * Lists are rendered as bare <ul>/<ol>/<li> (see rich-text-utils
+     * slate-helpers), so they historically relied on the browser's
+     * user-agent default list styling for their markers and indentation.
+     * A host CSS reset (e.g. Nimbus / Chakra "preflight":
+     * "ol, ul { list-style: none }" plus "* { margin: 0; padding: 0 }")
+     * strips those defaults, hiding bullets/numbers in the preview.
+     * Declare the list styling explicitly so it survives any host reset.
+     * See SUPPORT-41503 / FEC-1126.
+     */
+    ul,
+    ol {
+      margin: ${designTokens.spacing30} 0;
+      padding-left: ${designTokens.spacing40};
+    }
+    ul {
+      list-style: disc outside;
+    }
+    ol {
+      list-style: decimal outside;
+    }
+    li {
+      line-height: 22px;
+    }
   `,
   props.isReadOnly &&
     css`


### PR DESCRIPTION
## Summary

The rich text editor stopped previewing bulleted and numbered lists (no bullets, no numbers, no indentation) when embedded in an app that ships a global CSS reset. This declares the editor's list styling explicitly so lists render correctly regardless of any host reset.

## Root cause

The editor renders bare `<ul>`/`<ol>`/`<li>` elements (`rich-text-utils/src/slate-helpers.tsx`) and set no list styling of its own — it silently relied on the browser's user-agent default (`list-style`, padding). That default holds until a host app applies a global reset. `application-shell@27.7.0` introduces Nimbus, whose Chakra "preflight" applies, globally:

```css
* {
  margin: 0;
  padding: 0;
}
ol,
ul {
  list-style: none;
}
```

That strips the markers and indentation the editor depended on, so the list markup still serializes correctly but previews as flat, unformatted lines. (Italic is unaffected — the preflight has no `em`/`font-style` reset, so the "italic not previewing" note in SUPPORT-41503 is a separate perception, not caused here.)

## Fix

Declare list styling (`list-style`, `padding-left`, marker types) directly in the editor's own `reset` in `rich-text-body.styles.ts`. These emotion styles are unlayered, so they win over Chakra's layered (`@layer reset`) preflight regardless of specificity — the editor now owns its list appearance instead of depending on UA defaults a host can override.

### Before

<img width="954" height="717" alt="image" src="https://github.com/user-attachments/assets/405cac32-8f83-429d-9ea2-19a67342689e" />

### After

<img width="654" height="725" alt="image" src="https://github.com/user-attachments/assets/8cf18aa0-3a84-4494-846a-7d243ff7e6d4" />


## Regression test

No automated regression test added — the behavior depends on a host-supplied global CSS reset that the unit-test (jsdom) environment doesn't apply, so a meaningful assertion would need visual/browser testing this package doesn't currently have. Verified manually instead (below), and via a local repro Storybook story that reproduces the reset in an `@layer reset` and confirms the fix defends against it.

## Test plan

- [x] Repro story ("Form/Inputs/RichTextInput → List Style Reset") shows lists losing markers under a simulated host reset before the fix, and rendering correctly after.
- [x] All 58 tests across the `rich-text-input` / `rich-text-utils` / `localized-rich-text-input` suites pass.
- [x] Type-check and lint clean.

## Out of scope

FEC-1126's title also names a **build failure** — the `slate@0.75` (ui-kit) vs `slate@0.124` (Nimbus via application-shell) dependency conflict. That is a separate concern and is not addressed here; this PR fixes only the runtime list-preview regression (SUPPORT-41503).

Relates to FEC-1126, SUPPORT-41503
