### PR TITLE
fix(rich-text-utils): preserve italic rendering under host CSS resets

### DIFF
--- a/.changeset/tame-italics-glow.md
+++ b/.changeset/tame-italics-glow.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/rich-text-utils': patch
+---
+
+Fix italic text not rendering correctly in the rich text editor when it is used inside applications that apply a global CSS reset (for example, apps built on Nimbus). The editor now explicitly applies font-style: italic to <em> and <i> elements instead of relying on browser default styling, ensuring italic formatting previews correctly in all embedding environments.

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/rich-text-body.styles.ts
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/rich-text-body.styles.ts
@@ -157,6 +157,18 @@ const reset = (props: TRichTextBodyStylesProps) => [
     li {
       line-height: 22px;
     }
+    /*
+     * Italic is rendered as bare <em> (see rich-text-utils slate-helpers),
+     * so it historically relied on the browser's user-agent default
+     * font-style for emphasis. A host CSS reset can normalize font-style
+     * on em/i (e.g. as part of a broader typography reset), silently
+     * dropping the italic preview. Declare it explicitly so it survives
+     * any host reset, mirroring the list-styling fix above.
+     */
+    em,
+    i {
+      font-style: italic;
+    }
   `,
   props.isReadOnly &&
     css`


### PR DESCRIPTION

#### Summary

Fix italic formatting in the rich text editor when embedded in applications that apply a global CSS reset. The editor now explicitly applies font-style: italic to <em> and <i> elements, ensuring italic text renders correctly regardless of host styles.

## Description

Previously, italic formatting relied on the browser's default styling for <em> and <i> elements. In embedding environments where the host application applied a global CSS or typography reset, these default styles could be overridden, causing italic text to render as normal text in the editor preview.

This change explicitly defines font-style: italic for <em> and <i> within the editor's stylesheet, making italic rendering self-contained and resilient to host CSS overrides. The approach mirrors the existing fix for list styling, where explicit CSS is used instead of relying on browser defaults.

Changes
Explicitly apply font-style: italic to <em> and <i> elements.
Ensure italic formatting renders consistently across embedding environments.
Prevent host CSS resets from overriding the editor's italic styling.

<img width="585" height="227" alt="Screenshot 2026-07-16 at 5 27 40 PM" src="https://github.com/user-attachments/assets/8ad80779-97da-459d-bf9b-b9c42d114cf1" />

