### PR TITLE
Fix rich text editor typography rendering issues caused by global CSS resets in consuming applications.

### DIFF
--- a/.changeset/quiet-herons-collide.md
+++ b/.changeset/quiet-herons-collide.md
@@ -1,0 +1,5 @@
+---
+'@commercetools-uikit/rich-text-utils': patch
+---
+
+Fix rich text editor typography styles not applying correctly in applications with global CSS resets. The editor now explicitly defines font size, font weight, and line height for paragraph and heading elements (p, h1-h6) instead of relying on browser defaults. This ensures consistent typography rendering and preserves the intended visual hierarchy when embedded in applications such as Nimbus.

--- a/packages/components/inputs/rich-text-utils/src/rich-text-body/rich-text-body.styles.ts
+++ b/packages/components/inputs/rich-text-utils/src/rich-text-body/rich-text-body.styles.ts
@@ -134,15 +134,70 @@ const reset = (props: TRichTextBodyStylesProps) => [
       line-height: 22px;
     }
     /*
-     * Lists are rendered as bare <ul>/<ol>/<li> (see rich-text-utils
-     * slate-helpers), so they historically relied on the browser's
-     * user-agent default list styling for their markers and indentation.
-     * A host CSS reset (e.g. Nimbus / Chakra "preflight":
-     * "ol, ul { list-style: none }" plus "* { margin: 0; padding: 0 }")
-     * strips those defaults, hiding bullets/numbers in the preview.
-     * Declare the list styling explicitly so it survives any host reset.
-     * See SUPPORT-41503 / FEC-1126.
-     */
+ * Rich text content is rendered as bare semantic HTML elements (see
+ * rich-text-utils slate-helpers), so it historically relied on the
+ * browser's user-agent stylesheet for typography and default formatting.
+ * A host CSS reset (e.g. Nimbus / Chakra "preflight") can normalize or
+ * remove those defaults—flattening heading hierarchy, removing list
+ * markers and indentation, dropping italic and bold emphasis, clearing
+ * underline/strikethrough decorations, normalizing subscript/superscript
+ * alignment, removing blockquote indentation and borders, or overriding
+ * monospace fonts for preformatted text. Declare these styles explicitly
+ * so rich text rendering remains consistent regardless of host styles. 
+ * See SUPPORT-41503 / FEC-1126.
+  */
+    h1 {
+      font-size: ${designTokens.fontSize60};
+      font-weight: ${designTokens.fontWeight600};
+      line-height: ${designTokens.lineHeight60};
+    }
+    h2 {
+      font-size: ${designTokens.fontSize50};
+      font-weight: ${designTokens.fontWeight500};
+      line-height: ${designTokens.lineHeight50};
+    }
+    h3 {
+      font-size: ${designTokens.fontSize40};
+      font-weight: ${designTokens.fontWeight500};
+      line-height: ${designTokens.lineHeight30};
+    }
+    h4,
+    h5 {
+      font-size: ${designTokens.fontSize30};
+      font-weight: ${designTokens.fontWeight500};
+      line-height: ${designTokens.lineHeight20};
+    }
+    h6 {
+      font-size: ${designTokens.fontSize20};
+      font-weight: ${designTokens.fontWeight500};
+      line-height: ${designTokens.lineHeight20};
+    }
+    strong,
+    b {
+      font-weight: ${designTokens.fontWeight600};
+    }
+    u {
+      text-decoration: underline;
+    }
+    s,
+    del {
+      text-decoration: line-through;
+    }
+    sub {
+      vertical-align: sub;
+    }
+    sup {
+      vertical-align: super;
+    }
+
+    blockquote {
+      margin: 0;
+      padding-left: ${designTokens.spacing20};
+      border-left: 2px solid ${designTokens.colorNeutral};
+    }
+    pre {
+      font-family: monospace;
+    }
     ul,
     ol {
       margin: ${designTokens.spacing30} 0;
@@ -157,14 +212,6 @@ const reset = (props: TRichTextBodyStylesProps) => [
     li {
       line-height: 22px;
     }
-    /*
-     * Italic is rendered as bare <em> (see rich-text-utils slate-helpers),
-     * so it historically relied on the browser's user-agent default
-     * font-style for emphasis. A host CSS reset can normalize font-style
-     * on em/i (e.g. as part of a broader typography reset), silently
-     * dropping the italic preview. Declare it explicitly so it survives
-     * any host reset, mirroring the list-styling fix above.
-     */
     em,
     i {
       font-style: italic;


### PR DESCRIPTION


#### Summary

Rich text editor elements such as paragraphs, headings, quotes, preformatted text, and inline formatting were not consistently rendering their intended styles when embedded in applications that apply global CSS resets (for example, Nimbus-based applications).

The editor previously relied on browser default styles for some semantic HTML elements. These defaults can be removed or overridden by host application styles, causing typography elements to lose their expected visual hierarchy and formatting.

## Description

<img width="605" height="260" alt="Screenshot 2026-07-17 at 4 33 15 PM" src="https://github.com/user-attachments/assets/be97a0de-7c03-4755-a56a-bb5cbfb5161e" />

