### PR TITLE
fix(supply-chain): pin deps and actions, extend shared renovate config

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
         with:
           any-of-labels: "⌛ Status: Waiting for Customer"
           start-date: "2022-04-06 00:00:00.000"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node (uses version in .nvmrc)
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: '.nvmrc'
 
@@ -34,7 +34,7 @@ jobs:
         id: pnpm-store
         run: echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ steps.pnpm-store.outputs.dir }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml', 'patches/*.patch') }}

--- a/.github/workflows/preview-release-on-comment.yml
+++ b/.github/workflows/preview-release-on-comment.yml
@@ -17,17 +17,17 @@ jobs:
       # Get GitHub token via the CT Changesets App
       - name: Generate GitHub token (via CT Changesets App)
         id: generate_github_token
-        uses: tibdex/github-app-token@v2.1.0
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
           private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
 
       - name: Get branch of PR
-        uses: xt0rted/pull-request-comment-branch@v1
+        uses: xt0rted/pull-request-comment-branch@653a7d5ca8bd91d3c5cb83286063314d0b063b8e # v1
         id: comment-branch
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # Pass a personal access token (using our `ct-release-bot` account) to be able to trigger
           # other workflows
@@ -37,10 +37,10 @@ jobs:
           token: ${{ steps.generate_github_token.outputs.token }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node (uses version in .nvmrc)
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -54,7 +54,7 @@ jobs:
         id: pnpm-store
         run: echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ steps.pnpm-store.outputs.dir }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml', 'patches/*.patch') }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,13 +15,13 @@ jobs:
       # Get GitHub token via the CT Changesets App
       - name: Generate GitHub token (via CT Changesets App)
         id: generate_github_token
-        uses: tibdex/github-app-token@v2.1.0
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.CT_CHANGESETS_APP_ID }}
           private_key: ${{ secrets.CT_CHANGESETS_APP_PEM }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # Pass a personal access token (using our `ct-release-bot` account) to be able to trigger
           # other workflows
@@ -30,10 +30,10 @@ jobs:
           token: ${{ steps.generate_github_token.outputs.token }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node (uses version in .nvmrc)
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -52,7 +52,7 @@ jobs:
           npm --version
           # Ensure latest npm is installed for trusted publishing (OIDC)
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ steps.pnpm-store.outputs.dir }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml', 'patches/*.patch') }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1.7.0
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           commit: 'ci(changesets): version packages'
           publish: pnpm changeset publish

--- a/.npmrc
+++ b/.npmrc
@@ -1,18 +1,2 @@
-# Strict pnpm — declared deps only, NO shamefully-hoist.
-#
-# One narrow carve-out: hoist the entire @storybook/* namespace. Leaf
-# component workspaces consume Storybook from a "framework-user"
-# perspective (matching the ESLint override for **/docs/**):
-#
-# - every *.stories.tsx imports `Meta` / `StoryObj` / `StoryFn` types
-#   from `@storybook/react-vite`, which re-exports from `@storybook/react`
-# - every *.readme.mdx imports `Meta` / `Markdown` from
-#   `@storybook/addon-docs/blocks`
-#
-# Adding ~15 @storybook/* packages as devDeps on 80+ leaf workspaces would
-# be pure noise — the storybook workspace is the rightful owner of these
-# deps. This pattern is dramatically narrower than `shamefully-hoist=true`
-# (which would hoist 1000+ packages), and avoids the v8-era bug where the
-# stories glob picked up `@storybook/react`'s bundled `template/cli/js/*`
-# (fixed structurally by the Storybook 9 upgrade in this branch).
-public-hoist-pattern[]=@storybook/*
+# pnpm v11: only auth and registry settings belong in .npmrc.
+# Non-auth settings (hoistPattern, publicHoistPattern, etc.) moved to pnpm-workspace.yaml.

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "node": ">=24",
     "npm": ">=6"
   },
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8",
   "devDependencies": {
     "@babel/core": "catalog:build",
     "@changesets/changelog-github": "catalog:repo",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,14 +13,17 @@ packages:
   - visual-testing-app
 
 # Postinstall scripts pnpm is allowed to run (strict allow-list).
-onlyBuiltDependencies:
-  - '@percy/core'
-  - '@swc/core'
-  - core-js
-  - core-js-pure
-  - esbuild
-  - puppeteer
-  - unrs-resolver
+# strictDepBuilds causes pnpm to fail immediately if a dep not listed here
+# tries to run a lifecycle script — the pnpm v11 equivalent of onlyBuiltDependencies.
+strictDepBuilds: true
+allowBuilds:
+  '@percy/core': true
+  '@swc/core': true
+  core-js: true
+  core-js-pure: true
+  esbuild: true
+  puppeteer: true
+  unrs-resolver: true
 
 # Transitive-dep pins for Dependabot security advisories and known-good
 # baselines. yarn-style `package@range` keys are preserved so the same

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,26 @@ packages:
   - presets/*
   - visual-testing-app
 
+# Strict pnpm — declared deps only, NO shamefully-hoist.
+#
+# One narrow carve-out: hoist the entire @storybook/* namespace. Leaf
+# component workspaces consume Storybook from a "framework-user"
+# perspective (matching the ESLint override for **/docs/**):
+#
+# - every *.stories.tsx imports `Meta` / `StoryObj` / `StoryFn` types
+#   from `@storybook/react-vite`, which re-exports from `@storybook/react`
+# - every *.readme.mdx imports `Meta` / `Markdown` from
+#   `@storybook/addon-docs/blocks`
+#
+# Adding ~15 @storybook/* packages as devDeps on 80+ leaf workspaces would
+# be pure noise — the storybook workspace is the rightful owner of these
+# deps. This pattern is dramatically narrower than `shamefully-hoist=true`
+# (which would hoist 1000+ packages), and avoids the v8-era bug where the
+# stories glob picked up `@storybook/react`'s bundled `template/cli/js/*`
+# (fixed structurally by the Storybook 9 upgrade in this branch).
+publicHoistPattern:
+  - '@storybook/*'
+
 # Postinstall scripts pnpm is allowed to run (strict allow-list).
 # strictDepBuilds causes pnpm to fail immediately if a dep not listed here
 # tries to run a lifecycle script — the pnpm v11 equivalent of onlyBuiltDependencies.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>commercetools/renovate-config"]
+}


### PR DESCRIPTION
## Summary

Implements the supply chain hardening items from [FEC-968](https://commercetools.atlassian.net/browse/FEC-968) across the ui-kit repo. No production code or published package APIs were changed — this is entirely tooling and CI infrastructure.

## Changes

**pnpm v11 upgrade**

Bumps the `packageManager` field in `package.json` from `pnpm@10.33.4` to `pnpm@11.10.0` (matching the version already adopted in nimbus). The sha512 integrity hash is included so Corepack can verify the binary before running it.

**`onlyBuiltDependencies` → `allowBuilds` migration**

pnpm v11 deprecates `onlyBuiltDependencies` in favour of a unified `allowBuilds` map. The existing 7-entry allowlist (`@percy/core`, `@swc/core`, `core-js`, `core-js-pure`, `esbuild`, `puppeteer`, `unrs-resolver`) is migrated to the new format with no entries added or removed.

Also adds `strictDepBuilds: true`, which causes `pnpm install` to fail immediately if any dependency not in the `allowBuilds` map attempts to run a lifecycle script — this is the strict enforcement mode the ticket calls for. Any new dep that needs a build script will surface as a hard install failure rather than silently succeeding, forcing an explicit review before it's added to the list.

**Renovate config**

Adds `renovate.json` extending the shared `github>commercetools/renovate-config` preset. This brings ui-kit into the standard commercetools Renovate setup (matching nimbus and other repos).

**GitHub Actions pinned to commit SHAs**

All third-party actions across the four affected workflow files are now pinned to their commit SHA with the version tag preserved as a comment. Pinning prevents a compromised or mutated tag from silently changing what runs in CI.

| Action | Tag | SHA |
|---|---|---|
| `actions/checkout` | v6 | `d23441a4` |
| `pnpm/action-setup` | v4 | `b906affc` |
| `actions/setup-node` | v6 | `24997072` |
| `actions/cache` | v5 | `caa29612` |
| `actions/stale` | v10 | `1e223db2` |
| `tibdex/github-app-token` | v2.1.0 | `3beb63f4` |
| `xt0rted/pull-request-comment-branch` | v1 | `653a7d5c` |
| `changesets/action` | v1.7.0 | `6a0a831f` |

`browser-actions/setup-chrome` was already pinned. `merge-blocking-labels.yml` uses a Docker image reference (`docker://agilepathway/pull-request-label-checker:latest`) which requires a digest pin rather than a git SHA — left as a follow-up.

## Testing

- [x] `pnpm install` passes with `strictDepBuilds: true` — no unexpected lifecycle script failures
- [x] `pnpm build && pnpm typecheck` pass
- [ ] CI green on this branch


[FEC-968]: https://commercetools.atlassian.net/browse/FEC-968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ