### PR TITLE
fix: Supply chain docs + explicit workspace settings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,12 @@ Some useful commands to work with the repository:
 - `pnpm build`
 - `pnpm lint`
 
+## Dependencies & supply chain security
+
+Dependency management in this repository follows the Merchant Center supply chain security baseline: a pnpm publish cooldown (`minimumReleaseAge`), build-script allowlists, SHA-pinned GitHub Actions, and centralized Renovate configuration. Before adding, updating, or overriding a dependency — or when a `minimumReleaseAge` cooldown or `pnpm audit --fix` blocks you — follow the baseline and override procedures:
+
+[Supply Chain Security — Baseline & Override Procedures](https://commercetools.atlassian.net/wiki/spaces/MCF/pages/3580231746/Supply+Chain+Security+-+Baseline+Override+Procedures)
+
 ## Developing locally
 
 When you develop UI components, it's recommended to start Storybook.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,14 @@ packages:
 publicHoistPattern:
   - '@storybook/*'
 
+# Supply-chain hardening — values are pnpm v11 defaults made explicit so
+# behaviour is stable across toolchain upgrades and older local installs.
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - '@commercetools*'
+blockExoticSubdeps: true
+catalogMode: strict
+
 # Postinstall scripts pnpm is allowed to run (strict allow-list).
 # strictDepBuilds causes pnpm to fail immediately if a dep not listed here
 # tries to run a lifecycle script — the pnpm v11 equivalent of onlyBuiltDependencies.


### PR DESCRIPTION
Closes FEC-972. Partially addresses FEC-1196 (see also: [app-kit PR](https://github.com/commercetools/merchant-center-application-kit/pull/4042)).

changes:

1. CONTRIBUTING.md — adds a "Dependencies & supply chain security" section pointing contributors to the Confluence baseline & override procedures page (FEC-972 acceptance criterion: at least one repo links to the doc from its contributing guide).

2. pnpm-workspace.yaml — makes four supply-chain settings explicit that were previously relying on pnpm v11 implicit defaults: minimumReleaseAge, minimumReleaseAgeExclude, blockExoticSubdeps, and catalogMode. No behavior change on CI (pinned toolchain already enforces these), but protects against silent drift across future pnpm upgrades and older local installs.
