### PR TITLE
fix(supply chain): add minimumReleaseAgeStrict + minimumReleaseAgeIgn…

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
   },
   "engines": {
     "node": ">=24",
-    "npm": ">=6"
+    "npm": ">=6",
+    "pnpm": ">=11"
   },
   "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8",
   "devDependencies": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,6 +37,10 @@ publicHoistPattern:
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - '@commercetools*'
+# minimumReleaseAge set explicitly flips this to hard-fail; false restores pnpm's soft fall-back so clean CI/Vercel installs don't break.
+minimumReleaseAgeStrict: false
+# Skip the age gate for packages whose registry metadata lacks a publish time (pnpm/pnpm#11616).
+minimumReleaseAgeIgnoreMissingTime: true
 blockExoticSubdeps: true
 catalogMode: strict
 


### PR DESCRIPTION
This pull request updates the project’s Node.js package management configuration to improve compatibility and reliability, particularly when using pnpm. The most important changes are:

**Package Manager Requirements:**

* Updated the `package.json` to require `pnpm` version 11 or higher in the `engines` field, ensuring that contributors use a compatible version of pnpm.

**pnpm Workspace Configuration:**

* Added `minimumReleaseAgeStrict: false` in `pnpm-workspace.yaml` to restore pnpm’s soft fallback behavior, preventing hard failures during clean installs on CI or Vercel.
* Added `minimumReleaseAgeIgnoreMissingTime: true` to skip the age gate for packages missing publish time metadata, improving compatibility with certain registries.