### PR TITLE
FEC-1199: tighten supply chain settings in workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
   },
   "engines": {
     "node": ">=24",
-    "npm": ">=6"
+    "npm": ">=6",
+    "pnpm": ">=11"
   },
   "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72",
   "devDependencies": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,6 +36,10 @@ publicHoistPattern:
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - '@commercetools*'
+# minimumReleaseAge set explicitly flips this to hard-fail; false restores pnpm's soft fall-back so clean CI/Vercel installs don't break.
+minimumReleaseAgeStrict: false
+# Skip the age gate for packages whose registry metadata lacks a publish time (pnpm/pnpm#11616).
+minimumReleaseAgeIgnoreMissingTime: true
 blockExoticSubdeps: true
 # `prefer`, not `strict`: pnpm's strict mode requires the requested version to be
 # string-identical to the catalog specifier, even when the catalog entry is a range

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,15 +31,15 @@ packages:
 publicHoistPattern:
   - '@storybook/*'
 
-# Supply-chain hardening — values are pnpm v11 defaults made explicit so
-# behaviour is stable across toolchain upgrades and older local installs.
+# Supply-chain hardening — pnpm v11's effective behaviour made explicit,
+# with one deliberate tightening noted on minimumReleaseAgeIgnoreMissingTime.
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - '@commercetools*'
-# minimumReleaseAge set explicitly flips this to hard-fail; false restores pnpm's soft fall-back so clean CI/Vercel installs don't break.
-minimumReleaseAgeStrict: false
-# Skip the age gate for packages whose registry metadata lacks a publish time (pnpm/pnpm#11616).
-minimumReleaseAgeIgnoreMissingTime: true
+# Explicit minimumReleaseAge already makes pnpm hard-fail on a no-mature-match; true keeps that (no silent fall-back or auto-exclude).
+minimumReleaseAgeStrict: true
+# Deliberate tightening: enforce the gate even when registry metadata omits a publish time, so a time-less mirror can't waive the cooldown.
+minimumReleaseAgeIgnoreMissingTime: false
 blockExoticSubdeps: true
 # `prefer`, not `strict`: pnpm's strict mode requires the requested version to be
 # string-identical to the catalog specifier, even when the catalog entry is a range

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+# Vercel runs postinstall under its global pnpm (9.x), which trips this repo's engines.pnpm floor; skip dev-only setup there.
+if [ -n "$VERCEL" ]; then
+  echo "Skipping postinstall on Vercel."
+  exit 0
+fi
+
 if [ -n "$SKIP_POSTINSTALL_DEV_SETUP" ]; then
   echo "Skipping development setup."
 

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-# Vercel runs postinstall under its global pnpm (9.x), which trips this repo's engines.pnpm floor; skip dev-only setup there.
-if [ -n "$VERCEL" ]; then
-  echo "Skipping postinstall on Vercel."
-  exit 0
-fi
-
 if [ -n "$SKIP_POSTINSTALL_DEV_SETUP" ]; then
   echo "Skipping development setup."
 


### PR DESCRIPTION
Flip the pnpm age-gate from the soft fall-back to the strict posture, aligning with nimbus (#1859):

  - minimumReleaseAgeStrict: false -> true — no silent fall-back (or auto-generated
    exclude) when no version satisfies a range within the 24h gate
  - minimumReleaseAgeIgnoreMissingTime: true -> false — enforce the gate even when
    a package's registry metadata omits a publish time

  Refs: FEC-1199 (epic FEC-964 — Supply Chain Hardening)
