### PR TITLE
fix(renovate): remove root config that shadowed .github/renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>commercetools/renovate-config"]
-}


### PR DESCRIPTION
## Problem

ui-kit has **two** Renovate config files on `main`:

- `renovate.json` (root) — added 2026-07-22 by #3272
- `.github/renovate.json` — the original

Renovate reads the **first** file it finds in a fixed search order, and root `renovate.json` sorts before `.github/renovate.json`. So since #3272 landed, `.github/renovate.json` has been dead — silently, with no warning or error in the run log.

The root file is only:

```json
{ "extends": ["github>commercetools/renovate-config"] }
```

which resolves to `default.json` **alone** — not `composite/component-library`. For the past two weeks ui-kit has therefore been running without:

- every `allowedVersions` guard — `html-loader <2.0.0`, `markdown-loader <8.0.0`, `@percy/puppeteer <=2.0.0`, `react-textarea-autosize <8.4.1`, `react-from-dom <=0.6.2`, `node-fetch <3.0.0`
- `ignoreDeps` for `slate`, `slate-html-serializer`, `slate-react`
- the svgr and stylelint `groupName` groupings
- `rebaseWhen: "never"`
- the storybook / emotion / react / typescript / testing presets from the composite

#3272 touched `renovate.json`, four workflows, `.npmrc`, `package.json` and `pnpm-workspace.yaml` — it never deleted `.github/renovate.json`, so this reads as an accident rather than a deliberate migration.

## Change

Delete the root `renovate.json`, keep `.github/renovate.json`. That matches where the rest of the org keeps it — 7 of the 11 commercetools repos that have a Renovate config use `.github/renovate.json`, including every merchant-center repo.

**The supply-chain hardening from #3272 is not affected.** `composite/component-library` extends `default.json`, which already pulls in `config:best-practices` (`:pinDevDependencies`, `docker:pinDigests`) and `helpers:pinGitHubActionDigests`. Pinning behaviour is identical either way.

## Not in scope

- **ui-kit is in Renovate's `silent` mode**, set on the Mend side, so every update — including the `dompurify`, `immutable` and `postcss` security patches — waits on a manual checkbox. This PR doesn't change that; it needs a Mend portal change. Worth doing, since patch/minor automerge from the shared config can't fire while silent mode is on.
- ui-kit doesn't extend `composite/auto-merging`, unlike merchant-center-frontend / -prices / -services. Probably should, but that's a policy call for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)