### PR TITLE
fix(deps): switch pnpm catalogMode from strict to prefer

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,7 +38,21 @@ minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - '@commercetools*'
 blockExoticSubdeps: true
-catalogMode: strict
+# `prefer`, not `strict`: pnpm's strict mode requires the requested version to be
+# string-identical to the catalog specifier, even when the catalog entry is a range
+# (e.g. `^7.20.13`) that the requested version already satisfies. This breaks
+# Renovate's artifact-update flow, since `pnpm update <pkg>@<version> --recursive
+# --lockfile-only` against any range-pinned catalog entry always fails with
+# ERR_PNPM_CATALOG_VERSION_MISMATCH, even for in-range versions. pnpm/pnpm#11706
+# preserved this behavior deliberately rather than fixing it, so it is not
+# transient. `prefer` warns on drift instead of hard-failing; scripts/check-
+# workspace-constraints.js still enforces "must be in a catalog" in CI, so that
+# guarantee is unaffected.
+#
+# Filed upstream: https://github.com/pnpm/pnpm/issues/13715, proposing
+# `semver.satisfies` for a range catalog entry under strict mode. When that
+# lands and ships, revisit switching this back to `strict`.
+catalogMode: prefer
 
 # Postinstall scripts pnpm is allowed to run (strict allow-list).
 # strictDepBuilds causes pnpm to fail immediately if a dep not listed here


### PR DESCRIPTION
## Problem

Renovate PRs against this repo fail whenever the artifact updater needs to force a lockfile resolution bump for a catalog-referenced dependency whose catalog entry is a semver range (most entries in the named catalogs, e.g. `@babel/runtime-corejs3: ^7.20.13`). The updater runs `pnpm update <pkg>@<version> --recursive --lockfile-only`, and with `catalogMode: strict` that command fails with `ERR_PNPM_CATALOG_VERSION_MISMATCH`, even when the requested version already satisfies the catalog range. This is the same failure pattern already seen and fixed in `commercetools/merchant-center-application-kit` (PRs #4047, #4049, #4050).

## Root cause

`catalogMode: strict` requires exact version-string equality against the catalog specifier, rather than checking whether the requested version satisfies that specifier when it is a range. This is confirmed upstream pnpm behaviour: pnpm/pnpm#11570 reported it, and pnpm/pnpm#11706 closed it without changing the underlying comparison, so it is not expected to be fixed by a future pnpm release on its own.

There is also a separate, more recent upstream report, pnpm/pnpm#13715, filed against this exact combination of `catalogMode: strict` and range-based catalog entries. Worth tracking: when that issue is fixed and ships in a pnpm release, this repo can revisit switching `catalogMode` back to `strict`.

## Fix

Switch `catalogMode` from `strict` to `prefer` in `pnpm-workspace.yaml`, with a comment explaining why. `prefer` warns on catalog drift instead of hard-failing on a version mismatch, while still preferring the catalog version when it is compatible. This unblocks Renovate's targeted-update path for range-pinned catalog entries.

`scripts/check-workspace-constraints.js`, run in CI, separately enforces that every dependency named in a catalog is consumed only via its catalog reference. That enforcement does not depend on `catalogMode` and is unaffected by this change, per pnpm's own docs on `catalogMode` (https://pnpm.io/settings#catalogmode).

## Verification

Using the pinned `pnpm@11.10.0` from `package.json`'s `packageManager` field, via `corepack pnpm ...`:

1. `pnpm install --lockfile-only` completes cleanly with a diff limited to `pnpm-workspace.yaml`, no unrelated lockfile or `package.json` reformatting.
2. `pnpm install` (full install, to populate `node_modules`) completes cleanly, then `node scripts/check-workspace-constraints.js` reports `All workspace constraints passed.`, confirming the separate CI guarantee is genuinely unaffected by this change.
3. Positive confirmation of the actual fix: with `catalogMode: prefer` in place, `pnpm update '@babel/runtime-corejs3@7.29.7' --recursive --lockfile-only` (a real, published, in-range patch version above the currently resolved `7.29.2`, against the `build` catalog's `^7.20.13` range entry) exits `0`, emitting a catalog-drift warning instead of the `ERR_PNPM_CATALOG_VERSION_MISMATCH` failure that `catalogMode: strict` would have produced. This test bump was not committed; the resulting lockfile and `package.json` changes were reverted afterward, so this PR only contains the intended `pnpm-workspace.yaml` edit.
