### PR TITLE
chore(deps): bump pnpm to 11.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "node": ">=24",
     "npm": ">=6"
   },
-  "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8",
+  "packageManager": "pnpm@11.14.0+sha512.66c1ac4c7d4762d6d7dde44c7f3e5a73591ed0a0806e751d4ed32d4f004f25b2285a906b1fd8a9e3e621df3b4e2858bf88e50e0cf626bedbe977fe434a5caf85",
   "devDependencies": {
     "@babel/core": "catalog:build",
     "@changesets/changelog-github": "catalog:repo",


### PR DESCRIPTION
## What

Bumps the pinned `packageManager` field in the root `package.json` from `pnpm@11.10.0` to:

```
pnpm@11.14.0+sha512.66c1ac4c7d4762d6d7dde44c7f3e5a73591ed0a0806e751d4ed32d4f004f25b2285a906b1fd8a9e3e621df3b4e2858bf88e50e0cf626bedbe977fe434a5caf85
```

This matches the version already running cleanly in `commercetools/merchant-center-application-kit`.

## Why

`pnpm@11.10.0` predates two confirmed, since-fixed upstream memory regressions in pnpm's resolver:

- [pnpm/pnpm#12868](https://github.com/pnpm/pnpm/issues/12868) ("pnpm 11 resolution uses ~47% more memory than pnpm 10 on a cold metadata cache"), fixed by [pnpm/pnpm#12870](https://github.com/pnpm/pnpm/pull/12870), merged 2026-07-09.
- [pnpm/pnpm#13077](https://github.com/pnpm/pnpm/issues/13077) ("pnpm 11.11+ OOMs by re-serializing full package metadata for concurrent workspace cache hits"), fixed by [pnpm/pnpm#13079](https://github.com/pnpm/pnpm/pull/13079), merged 2026-07-16.

`pnpm@11.14.0` was released 2026-07-17, after both fixes landed.

ui-kit is not currently observed OOM-crashing in Renovate, unlike the sibling `commercetools/nimbus` repo, which is being fixed separately. This bump is proactive, done alongside that fix, to keep both repos clear of the same class of issue rather than waiting for it to show up here too.

This is intentionally a separate PR from #3289 (the `catalogMode: strict` -> `prefer` fix in `pnpm-workspace.yaml`, already merged into `main`). This branch is off current `main` and does not touch `catalogMode`.

## Verification

- `corepack use pnpm@11.14.0`, then a full `pnpm install` with `node_modules` removed first (not `--lockfile-only`), to force a genuine re-resolution under the new pnpm version.
  - Result: `pnpm-lock.yaml` came out byte-identical to the pre-bump lockfile (diffed before/after a from-scratch install). Resolution and lockfile format are unaffected by this version bump for this dependency set.
- `node scripts/check-workspace-constraints.js` passes cleanly.
- `pnpm typecheck` (`tsc --noEmit --skipLibCheck`) passes.
- `pnpm build` (preconstruct build across all ~100 workspace packages, plus the FEC-938 declaration-leak regression guard in `scripts/build.sh`) completes cleanly, exit 0.
- Representative `jest` runs across `packages/components/buttons`, `packages/components/inputs/text-input`, `packages/components/inputs/date-input`, `packages/hooks`, `packages/utils`, `packages/i18n`, and `design-system`, for the `test`, `ts-test`, `eslint`, and `stylelint` jest projects, all pass.
- `publicHoistPattern: ['@storybook/*']` hoisting still resolves `@storybook` into the root `node_modules`.
- `strictDepBuilds: true` with the existing `allowBuilds` allowlist (`@percy/core`, `@swc/core`, `core-js`, `core-js-pure`, `esbuild`, etc.) continues to work; all allow-listed postinstall scripts ran without error, no new build-script prompts or failures under pnpm 11.14.0.

Nothing broke because of this bump; no code changes beyond the `packageManager` field were needed.

## Not merging

Draft PR per instructions, not merging.
