### PR TITLE
chore(renovate): hold pnpm at 11.14.0 until deploy --legacy regression is fixed

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -40,6 +40,11 @@
     {
       "matchPackageNames": ["node-fetch"],
       "allowedVersions": "<3.0.0"
+    },
+    {
+      "description": "pnpm is pinned to 11.14.0 via packageManager. As a precaution, hold here until pnpm/pnpm#13618 is fixed in a published release: pnpm 11.19.0 and later (including the current latest, 11.20.0) leave a workspace dependency that has peerDependencies as a symlink escaping the deploy directory instead of packing it in when running `pnpm deploy --legacy`, which would break a Docker `COPY` deploy flow. We have not confirmed this repo currently uses `pnpm deploy --legacy` in its Docker builds, but we hold the pnpm version anyway to avoid introducing the regression. The fix (pnpm/pnpm#13755) has merged upstream but has not shipped in a release yet. Remove this rule once a released pnpm version includes the fix.",
+      "matchPackageNames": ["pnpm"],
+      "enabled": false
     }
   ],
   "ignoreDeps": ["slate", "slate-html-serializer", "slate-react"]


### PR DESCRIPTION
## Summary

Adds a Renovate `packageRules` entry that disables updates to `pnpm` past our intended pin of `11.14.0`.

## Why

pnpm/pnpm#13618 is a regression, first appearing in pnpm 11.19.0 and still present in the current published latest (11.20.0), where a workspace dependency that has peerDependencies is left as a symlink escaping the deploy directory instead of being packed in when running `pnpm deploy --legacy`. In a typical Docker `COPY ./deploy .` flow this creates a dangling symlink that crashes the app at runtime.

The fix (pnpm/pnpm#13755) merged upstream but has not shipped in a published pnpm release yet.

I did not find any usage of `pnpm deploy --legacy` in this repo's Docker builds or scripts, so this hold is precautionary rather than fixing a currently broken build. It keeps Renovate from proposing a bump past our intended `11.14.0` target while the regression is unresolved upstream, so we do not pick it up unintentionally later.

This mirrors the guard already in place on [commercetools/nimbus](https://github.com/commercetools/nimbus/blob/main/.github/renovate.json), which holds pnpm at `11.14.0` for the same reason.

This PR is independent of and complements #3290 (the `packageManager` bump to `pnpm@11.14.0`). It only affects Renovate's future update proposals and pairs with whatever pin is currently in `package.json`.

## Validation

- `jq . .github/renovate.json` passes.
- `npx --yes -p renovate renovate-config-validator .github/renovate.json` reports the config validated successfully.

## Follow-up

Remove this rule once a released pnpm version includes the fix from pnpm/pnpm#13755.
