### PR TITLE
chore(deps): bump pnpm to 11.17.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -40,6 +40,11 @@
     {
       "matchPackageNames": ["node-fetch"],
       "allowedVersions": "<3.0.0"
+    },
+    {
+      "description": "pnpm is pinned to 11.17.0 via packageManager. Versions past 11.14.0 have broken `deploy: legacy` support (pnpm/pnpm#13618, fixed by pnpm/pnpm#13755, not yet released). Hold here until that ships, then remove this rule.",
+      "matchPackageNames": ["pnpm"],
+      "enabled": false
     }
   ],
   "ignoreDeps": ["slate", "slate-html-serializer", "slate-react"]

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "node": ">=24",
     "npm": ">=6"
   },
-  "packageManager": "pnpm@11.14.0+sha512.66c1ac4c7d4762d6d7dde44c7f3e5a73591ed0a0806e751d4ed32d4f004f25b2285a906b1fd8a9e3e621df3b4e2858bf88e50e0cf626bedbe977fe434a5caf85",
+  "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72",
   "devDependencies": {
     "@babel/core": "catalog:build",
     "@changesets/changelog-github": "catalog:repo",


### PR DESCRIPTION
## What

Bumps the pinned `packageManager` field in the root `package.json` from `pnpm@11.14.0` to:

```
pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72
```

Also adds a `packageRules` entry to `.github/renovate.json` disabling pnpm version updates, so Renovate does not propose bumping past the pinned version.

## Why

Both `11.14.0` and `11.17.0` are safely below the known-bad `pnpm deploy --legacy` regression introduced in `11.19.0`/`11.20.0` (pnpm/pnpm#13618, fixed by pnpm/pnpm#13755, not yet released). `11.17.0` is simply the newer, still-safe version to standardize on across repos undergoing the same remediation.

This PR supersedes #3291, which added the same renovate hold rule but referenced `11.14.0` instead of the version this repo now pins. Closing that PR and combining both changes here keeps the version bump and the corresponding renovate hold in sync, in one commit, on one branch.

## Verification

- Full `pnpm install` (not `--lockfile-only`), run after removing `node_modules`, to force genuine re-resolution under the new pnpm version. The lockfile came out unchanged, resolution is unaffected by this version bump for this dependency set.
- `node scripts/check-workspace-constraints.js` passes cleanly.
- `pnpm typecheck` (`tsc --noEmit --skipLibCheck`) passes with no errors.
- `pnpm build` completes cleanly, exit code 0, across all workspace packages including design tokens and i18n compiled data.
- `jq . .github/renovate.json` confirms the updated file is valid JSON.
- Representative `jest` runs, scoped directly against the relevant configs and paths (rather than the root `test` script, which does not filter suites correctly when multiple `--projects` are combined with path arguments):
  - `pnpm jest --config jest.test.config.js packages/components/buttons packages/hooks packages/utils design-system`: 21 suites, 112 tests, all passing.
  - `pnpm jest --config jest.ts-test.config.js`: 3 suites, 7 tests, all passing.
- As a sanity check, the same commands were run against an unmodified `main` worktree (after building it) and produced the same baseline pass/fail profile for unrelated suites, confirming this pnpm bump introduces no new test failures.

## Not merging

Draft PR, not merging.
