### PR TITLE
chore(deps): trivial major-version dependency migrations

### DIFF
--- a/generators/package-json/src/index.ts
+++ b/generators/package-json/src/index.ts
@@ -93,7 +93,9 @@ export async function generate(
   flags: CommandFlags
 ) {
   const options: GeneratorPackageJsonOptions = {
-    workspaceRoot: findRootSync(process.cwd()),
+    // `findRootSync` returns a `MonorepoRoot` object since @manypkg/find-root v3
+    // (previously it returned the root path as a plain string).
+    workspaceRoot: findRootSync(process.cwd()).rootDir,
     dryRun: flags.dryRun,
   };
 

--- a/generators/package-json/test/generate-package-json.spec.ts
+++ b/generators/package-json/test/generate-package-json.spec.ts
@@ -4,6 +4,19 @@ import shelljs from 'shelljs';
 import { GeneratorPackageJsonOptions } from '../src/types';
 import { transformDocument } from '../src';
 
+// `@manypkg/find-root` and `@manypkg/get-packages` are pure ESM (since their
+// respective v3 majors), which Jest's CJS module runtime can't `require()`
+// directly (unlike Node's native `require()`, which supports it since
+// Node 22.12). Neither function is exercised by these tests (only
+// `transformDocument` is), so stub them out to avoid a module-load-time
+// `SyntaxError: Cannot use import statement outside a module`.
+jest.mock('@manypkg/find-root', () => ({
+  findRootSync: jest.fn(),
+}));
+jest.mock('@manypkg/get-packages', () => ({
+  getPackagesSync: jest.fn(),
+}));
+
 const tmpFolder = os.tmpdir();
 const testPackages = path.join(tmpFolder, 'packages');
 

--- a/generators/readme/test/generate-readme.spec.ts
+++ b/generators/readme/test/generate-readme.spec.ts
@@ -4,6 +4,15 @@ import shelljs from 'shelljs';
 import vfile from 'vfile';
 import { transformDocument } from '../src';
 
+// `@manypkg/get-packages` is pure ESM (since v3), which Jest's CJS module
+// runtime can't `require()` directly (unlike Node's native `require()`,
+// which supports it since Node 22.12). It isn't exercised by these tests
+// (only `transformDocument` is), so stub it out to avoid a module-load-time
+// `SyntaxError: Cannot use import statement outside a module`.
+jest.mock('@manypkg/get-packages', () => ({
+  getPackagesSync: jest.fn(),
+}));
+
 const tmpFolder = os.tmpdir();
 const testPackages = path.join(tmpFolder, 'packages');
 

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "eslint": "catalog:lint",
     "eslint-formatter-pretty": "catalog:lint",
     "execa": "catalog:",
+    "find-up": "catalog:",
     "formik": "catalog:react",
     "glob": "catalog:",
     "global": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,8 +143,8 @@ catalogs:
       specifier: 1.0.3
       version: 1.0.3
     execa:
-      specifier: 9.6.1
-      version: 9.6.1
+      specifier: 10.0.1
+      version: 10.0.1
     glob:
       specifier: 13.0.6
       version: 13.0.6
@@ -685,7 +685,7 @@ importers:
         version: 7.1.0
       execa:
         specifier: 'catalog:'
-        version: 9.6.1
+        version: 10.0.1
       formik:
         specifier: catalog:react
         version: 2.4.9(@types/react@19.2.14)(react@19.2.6)
@@ -10130,13 +10130,13 @@ packages:
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
+  execa@10.0.1:
+    resolution: {integrity: sha512-ge98qjkRK4IB7tL7Ju/6qmm5LHoH1eEMt5FNZrz3f4UIYhF28lggX20z3FaX1sgc67msLEn0N0BscOs29iuwyw==}
+    engines: {node: '>=22'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
-
-  execa@9.6.1:
-    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
-    engines: {node: ^18.19.0 || >=20.5.0}
 
   exit-x@0.2.2:
     resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
@@ -13668,6 +13668,11 @@ packages:
   which-collection@1.0.2:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
+
+  which-command@0.1.0:
+    resolution: {integrity: sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==}
+    engines: {node: '>=22'}
+    hasBin: true
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
@@ -19176,6 +19181,21 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
 
+  execa@10.0.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      which-command: 0.1.0
+      yoctocolors: 2.1.2
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -19187,21 +19207,6 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
-
-  execa@9.6.1:
-    dependencies:
-      '@sindresorhus/merge-streams': 4.0.0
-      cross-spawn: 7.0.6
-      figures: 6.1.0
-      get-stream: 9.0.1
-      human-signals: 8.0.1
-      is-plain-obj: 4.1.0
-      is-stream: 4.0.1
-      npm-run-path: 6.0.0
-      pretty-ms: 9.3.0
-      signal-exit: 4.1.0
-      strip-final-newline: 4.0.0
-      yoctocolors: 2.1.2
 
   exit-x@0.2.2: {}
 
@@ -23521,6 +23526,8 @@ snapshots:
       is-set: 2.0.3
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
+
+  which-command@0.1.0: {}
 
   which-module@2.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ catalogs:
     execa:
       specifier: 10.0.1
       version: 10.0.1
+    find-up:
+      specifier: 5.0.0
+      version: 5.0.0
     glob:
       specifier: 13.0.6
       version: 13.0.6
@@ -686,6 +689,9 @@ importers:
       execa:
         specifier: 'catalog:'
         version: 10.0.1
+      find-up:
+        specifier: 'catalog:'
+        version: 5.0.0
       formik:
         specifier: catalog:react
         version: 2.4.9(@types/react@19.2.14)(react@19.2.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ catalogs:
       specifier: 1.4.0
       version: 1.4.0
     commander:
-      specifier: ^13.1.0
-      version: 13.1.0
+      specifier: 15.0.0
+      version: 15.0.0
     cross-env:
       specifier: 10.1.0
       version: 10.1.0
@@ -670,7 +670,7 @@ importers:
         version: 1.4.0
       commander:
         specifier: 'catalog:'
-        version: 13.1.0
+        version: 15.0.0
       conventional-changelog-cli:
         specifier: catalog:repo
         version: 5.0.0(conventional-commits-filter@5.0.0)
@@ -881,7 +881,7 @@ importers:
         version: 22.19.15
       commander:
         specifier: 'catalog:'
-        version: 13.1.0
+        version: 15.0.0
       omit-empty-es:
         specifier: 'catalog:'
         version: 1.2.0
@@ -930,7 +930,7 @@ importers:
         version: 4.0.0
       commander:
         specifier: 'catalog:'
-        version: 13.1.0
+        version: 15.0.0
       listr:
         specifier: 'catalog:'
         version: 0.14.3
@@ -9308,13 +9308,13 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
-  commander@13.1.0:
-    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
-    engines: {node: '>=18'}
-
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -18174,9 +18174,9 @@ snapshots:
 
   commander@12.1.0: {}
 
-  commander@13.1.0: {}
-
   commander@14.0.3: {}
+
+  commander@15.0.0: {}
 
   commander@2.20.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,8 +326,8 @@ catalogs:
       specifier: 0.25.1
       version: 0.25.1
     '@manypkg/find-root':
-      specifier: 1.1.0
-      version: 1.1.0
+      specifier: 3.1.0
+      version: 3.1.0
     '@manypkg/get-packages':
       specifier: 1.1.3
       version: 1.1.3
@@ -872,7 +872,7 @@ importers:
     dependencies:
       '@manypkg/find-root':
         specifier: catalog:repo
-        version: 1.1.0
+        version: 3.1.0
       '@manypkg/get-packages':
         specifier: catalog:repo
         version: 1.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,8 +329,8 @@ catalogs:
       specifier: 3.1.0
       version: 3.1.0
     '@manypkg/get-packages':
-      specifier: 1.1.3
-      version: 1.1.3
+      specifier: 3.1.0
+      version: 3.1.0
     chromatic:
       specifier: ^17.7.2
       version: 17.8.0
@@ -580,7 +580,7 @@ importers:
         version: 0.25.1
       '@manypkg/get-packages':
         specifier: catalog:repo
-        version: 1.1.3
+        version: 3.1.0
       '@percy/cli':
         specifier: catalog:test
         version: 1.31.13(typescript@5.9.3)
@@ -875,7 +875,7 @@ importers:
         version: 3.1.0
       '@manypkg/get-packages':
         specifier: catalog:repo
-        version: 1.1.3
+        version: 3.1.0
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.15
@@ -906,7 +906,7 @@ importers:
     dependencies:
       '@manypkg/get-packages':
         specifier: catalog:repo
-        version: 1.1.3
+        version: 3.1.0
       '@types/listr':
         specifier: 'catalog:'
         version: 0.14.10

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -171,7 +171,7 @@ catalog:
   debounce-promise: ^3.1.2
   dompurify: 3.4.9
   escape-html: 1.0.3
-  execa: 9.6.1
+  execa: 10.0.1
   glob: 13.0.6
   global: 4.4.0
   history: 4.10.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -322,7 +322,7 @@ catalogs:
     # Monorepo tooling
     '@manypkg/cli': 0.25.1
     '@manypkg/find-root': 3.1.0
-    '@manypkg/get-packages': 1.1.3
+    '@manypkg/get-packages': 3.1.0
 
     # Git hooks / commit lint
     husky: 9.1.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -321,7 +321,7 @@ catalogs:
 
     # Monorepo tooling
     '@manypkg/cli': 0.25.1
-    '@manypkg/find-root': 1.1.0
+    '@manypkg/find-root': 3.1.0
     '@manypkg/get-packages': 1.1.3
 
     # Git hooks / commit lint

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -166,7 +166,7 @@ catalog:
   '@types/raf-schd': ^4.0.1
   '@types/shelljs': 0.8.17
   colors: 1.4.0
-  commander: ^13.1.0
+  commander: 15.0.0
   cross-env: 10.1.0
   debounce-promise: ^3.1.2
   dompurify: 3.4.9

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -172,6 +172,7 @@ catalog:
   dompurify: 3.4.9
   escape-html: 1.0.3
   execa: 10.0.1
+  find-up: 5.0.0
   glob: 13.0.6
   global: 4.4.0
   history: 4.10.1


### PR DESCRIPTION
## Context

Split out from #3293, which batch-consolidated safe Renovate updates and explicitly excluded all 28 genuine major-version dependency bumps for later handling. This PR picks up the subset of those excluded majors that are trivial ecosystem churn and are genuinely present in this repo (this repo's Renovate dependency dashboard is known to be heavily contaminated with items from a different repo's dependency graph).

## Included (4)

- `@manypkg/find-root` 1.1.0 → 3.1.0 — pure ESM since v3.0.0, consumed via `ts-node --compiler-options '{"module":"commonjs"}'` in `generators/package-json`. **Breaking change found during migration**: `findRootSync` now returns a `MonorepoRoot` object (`{ rootDir, tool }`) instead of a plain path string. Fixed the one call site to read `.rootDir`. Verified: CLI smoke test (`generate-package-json --dry-run`), Jest unit tests, and `pnpm typecheck` all pass.
- `@manypkg/get-packages` 1.1.3 → 3.1.0 — pure ESM since v3.0.0. Both consumers (`generators/package-json`, `generators/readme`) only read `.packages` from `getPackagesSync()`, never `.root`/`.rootPackage`/`.tool`, so the v2.0 API rename doesn't affect this repo. Verified: CLI smoke tests (`--dry-run` and `--all-workspace-packages --dry-run`), Jest unit tests.
- `commander` ^13.1.0 → 15.0.0 — ESM-only internals since v15, requires Node ≥22.12 (this repo runs Node 24). No call-site changes needed; verified all 3 call sites (`scripts/version.js` via CJS `require`, and the two generator bin scripts via ESM `import` compiled through ts-node's commonjs mode) run without `ERR_REQUIRE_ESM`. None of the 3 sites declare paired `--no-*` boolean negation options, so v15's default-value behavior change for those doesn't apply.
- `execa` 9.6.1 → 10.0.1 — zero call sites anywhere in this repo's source (only a bare devDependency catalog entry). Verified `pnpm install` succeeds and both `require('execa')` and `import('execa')` resolve under Node 24.

## Also fixed: a real, previously-unverified regression the dashboard's research didn't catch

Running the generators' Jest suite after the `@manypkg/*` bumps surfaced two real problems, both fixed in a dedicated follow-up commit:

1. `babel-plugin-package-version.js` does `require('find-up')`, but `find-up` was never a declared dependency anywhere in this repo — it only resolved by accident via Jest's haste-map fallback landing on whichever `find-up` version happened to be reachable in the pnpm store. Regenerating the lockfile for the 4 bumps in this PR shifted that phantom resolution from a CJS `find-up@4.1.0` to the ESM-only `find-up@7.0.0`, which Jest's CJS module runtime can't `require()` (`SyntaxError: Cannot use import statement outside a module`), breaking `generators/readme`'s test suite. Fixed by declaring `find-up@5.0.0` (already present in the lockfile, CJS, has the `.sync` API this file uses) as an explicit devDependency, making the resolution deterministic.
2. The Jest specs for `generators/package-json` and `generators/readme` import `../src`, which unconditionally imports the now-ESM-only `@manypkg/find-root` / `@manypkg/get-packages` at module-eval time. Jest's CJS runtime can't require ESM packages directly (unlike Node's native `require()`, which has supported this since Node 22.12 — why the CLI smoke tests were unaffected). Neither spec actually exercises `findRootSync`/`getPackagesSync`, so added narrow `jest.mock()` stubs in the two spec files, without touching the shared root Jest config used by the rest of the monorepo's tests.

## Explicitly excluded (out of scope for this trivial-churn batch)

All non-trivial majors, reason: "non-trivial major, out of scope for this trivial-churn batch, left for dedicated follow-up":
babel packages, git workflow tools, i18n/formatjs, jest packages, linting major group (incl. eslint v10), node.js updates, svgr, typescript packages, `@testing-library/jest-dom`, `@vitejs/plugin-react(-swc)`, `babel-plugin-formatjs`, `jsdom`, `prettier`, `puppeteer`, `stylelint*`, `vite`.

## Verified-but-already-current (no-op, nothing to commit)

- `cross-env` — already `10.1.0`
- `downshift` — already `9.4.0` (`catalogs.react`)
- `glob` — already `13.0.6`

## Dropped as not actually present/real in this repo (dashboard contamination)

- `flat-cache>rimraf` — `flat-cache` is present (both `4.0.1` and `6.1.22` resolved in the lockfile), but neither resolved version depends on `rimraf` (they depend on `flatted`/`keyv` and `cacheable`/`hookified` respectively). This transitive relationship doesn't exist in this repo's dependency graph.
- `webpack-dev-server>rimraf` — `webpack-dev-server` doesn't appear anywhere in `pnpm-lock.yaml`; not a dependency of this repo at all.

This is consistent with #3293's own findings about dashboard contamination.

## Build/test verification

- `pnpm typecheck` — 20 pre-existing errors in 5 unrelated files (icon-button/card/spacings/data-table typings), confirmed present on a pristine `origin/main` checkout too; no new errors introduced by this PR.
- `npx jest --config jest.ts-test.config.js` (generators + all other ts-test-node specs) — 3 suites / 7 tests pass.
- `pnpm test` (full monorepo suite, after `pnpm compile-intl`) — 124/125 suites, 1402/1403 tests pass. The one flaky test (`generators/readme`'s "Justice League" inline snapshot) is a **pre-existing, order-dependent race** unrelated to this PR: `generators/package-json` and `generators/readme` test suites both copy fixtures into the same shared `os.tmpdir()/packages/justice-league` path, and their fixture `package.json` files have different `description` text, so whichever suite's `beforeAll` copy runs last wins. Reproduced the identical flake on a pristine `origin/main` checkout (failed in 1 of 3 runs there too) — confirmed pre-existing, not introduced by this PR, and left unfixed as out of scope.
- `pnpm build` — passes fully (exit code 0).

## Changeset

Not needed. All 4 deps (`@manypkg/find-root`, `@manypkg/get-packages`, `commander`, `execa`) plus the added `find-up` are devDependencies / repo-tooling-only — confirmed none are a runtime `dependencies` entry of any published `@commercetools-uikit/*` or `@commercetools-frontend/*` package (the generators themselves are `"private": true`). This matches the precedent for pure tooling deps.

## Not merging or closing PR #3293 or any original Renovate PRs.
