### PR TITLE
FEC - 1237 - 1246 Chromatic wrap up

### DIFF
--- a/.agents/skills/visualroute-to-story/README.md
+++ b/.agents/skills/visualroute-to-story/README.md
@@ -15,35 +15,43 @@ converted and the gap is recorded in the planning doc.
 ## Where we deviate on purpose
 
 Parity is about which states are covered, not matching Percy pixel for pixel.
-Four departures, none changing what is under test:
+The scaffolding differences are in
+[What a converted story changes](#what-a-converted-story-changes). Two more
+departures, neither changing what is under test:
 
-- **Padding.** A global decorator adds `1rem` inside each story: Chromatic crops
-  to rendered content, so anything painted at the edge would clip.
-- **Layout.** Label beside the component, smaller per-state min-height, so a long
-  frame stays reviewable. A state whose content overflows its container needs
-  `overflow: hidden` on that container, or the overflow draws over the label.
-- **Grouping.** Runs of states sharing an axis may get a `VisualSpecGroup`
-  heading, only where it removes ambiguity.
+- **Padding.** A global decorator adds `1rem` inside each story, except where a
+  story sets `layout: 'fullscreen'`: Chromatic crops to rendered content, so
+  anything painted at the edge would clip.
 - **Light fixes.** A prop the component's types reject gets corrected, not cast,
   and called out in the PR. If the fix moves pixels, the route file gets it too,
   so Percy and Chromatic stay comparable while both run.
 
+One consequence of the label moving above the component: a state whose content
+overflows its container needs `overflow: hidden` on that container, or the
+overflow draws over a neighboring label.
+
 ## Percy vs Storybook + Chromatic
 
-| Concern                 | Percy                                                  | Storybook + Chromatic                                    |
-| ----------------------- | ------------------------------------------------------ | -------------------------------------------------------- |
-| Page under test         | `*.visualroute.jsx`, served by `visual-testing-app`    | a story export in `*.stories.tsx`, served by Storybook   |
-| Per-state wrapper       | `<Spec>` (`test/percy/spec.jsx`)                       | `<VisualSpec>` (`storybook/src/helpers/visual-spec.tsx`) |
-| What triggers a capture | a live `percySnapshot()` call in `*.visualspec.js`     | a story with `chromatic: { disableSnapshot: false }`     |
-| Interactions first      | puppeteer, in the visualspec                           | a Storybook `play` function                              |
-| Captured area           | the whole route page                                   | the story canvas                                         |
-| Snapshot identity       | the name passed to `percySnapshot()`                   | story title + export name                                |
-| Global config           | `.percy.yml` (widths `[1024]`)                         | `preview.tsx` + `storybook/chromatic.config.json`        |
-| Per-capture config      | options on the `percySnapshot()` call                  | `parameters.chromatic` on the story                      |
-| Run locally             | `visual-testing-app:start`, then `pnpm vrt:components` | `pnpm start`, then `pnpm --filter storybook chromatic`   |
-| CI                      | a step in `main.yml`                                   | `.github/workflows/chromatic.yml`                        |
-| Token                   | `PERCY_TOKEN`                                          | `CHROMATIC_PROJECT_TOKEN`                                |
-| Cost control            | none, every live snapshot every run                    | TurboSnap (`onlyChanged`) plus a changed-files gate      |
+| Concern                 | Percy                                                  | Storybook + Chromatic                                                   |
+| ----------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------- |
+| Page under test         | `*.visualroute.jsx`, served by `visual-testing-app`    | a story export in `*.stories.tsx`, served by Storybook                  |
+| Per-state wrapper       | `<Spec>` (`test/percy/spec.jsx`)                       | `<VisualSpec>` (`storybook/src/helpers/visual-spec.tsx`)                |
+| What triggers a capture | a live `percySnapshot()` call in `*.visualspec.js`     | a story with `chromatic: { disableSnapshot: false }`                    |
+| Interactions first      | puppeteer, in the visualspec                           | a Storybook `play` function                                             |
+| Captured area           | the whole route page                                   | the story canvas                                                        |
+| Snapshot identity       | the name passed to `percySnapshot()`                   | the story id, derived from title + export name unless `meta.id` pins it |
+| Global config           | `.percy.yml` (widths `[1024]`)                         | `preview.tsx` + `storybook/chromatic.config.json`                       |
+| Per-capture config      | options on the `percySnapshot()` call                  | `parameters.chromatic` on the story                                     |
+| Run locally             | `visual-testing-app:start`, then `pnpm vrt:components` | `pnpm --filter storybook chromatic` (see below)                         |
+| CI                      | a step in `main.yml`                                   | `.github/workflows/chromatic.yml`                                       |
+| Token                   | `PERCY_TOKEN`                                          | `CHROMATIC_PROJECT_TOKEN`                                               |
+| Cost control            | none, every live snapshot every run                    | TurboSnap (`onlyChanged`) plus a changed-files gate                     |
+
+**Running Chromatic locally.** `CHROMATIC_PROJECT_TOKEN` has to be in the
+environment. No dev server is involved: the CLI runs `buildScriptName` from
+`storybook/chromatic.config.json` and builds its own static Storybook. TurboSnap
+is set by the workflow, not that config, so a local run snapshots everything
+unless you pass `--only-changed` yourself.
 
 ## The pieces
 
@@ -59,13 +67,14 @@ Four departures, none changing what is under test:
 
 **Chromatic side.** Already in place; you should not need to touch any of it.
 
-| File                                    | What it is                                                         |
-| --------------------------------------- | ------------------------------------------------------------------ |
-| `storybook/src/helpers/visual-spec.tsx` | `VisualSpec` and `VisualSpecGroup`, the successors to `<Spec>`     |
-| `storybook/.storybook/preview.tsx`      | Global `disableSnapshot: true`, plus the Intl and theme decorators |
-| `storybook/chromatic.config.json`       | TurboSnap and build settings                                       |
-| `.github/workflows/chromatic.yml`       | CI: changed-files gate, then the Chromatic build                   |
-| `<component>.stories.tsx`               | Where a converted story is appended, beside the demo stories       |
+| File                                             | What it is                                                              |
+| ------------------------------------------------ | ----------------------------------------------------------------------- |
+| `storybook/src/helpers/visual-spec.tsx`          | `VisualSpec` and `VisualSpecGroup`, the successors to `<Spec>`          |
+| `storybook/.storybook/preview.tsx`               | Global `disableSnapshot: true` and `autodocs`, and the three decorators |
+| `storybook/src/decorators/padding-decorator.tsx` | The `1rem` of breathing room around every non-`fullscreen` story        |
+| `storybook/chromatic.config.json`                | TurboSnap and build settings                                            |
+| `.github/workflows/chromatic.yml`                | CI: changed-files gate, then the Chromatic build                        |
+| `<component>.stories.tsx`                        | Where a converted story is appended, beside the demo stories            |
 
 **The skill**, in this directory.
 
@@ -83,9 +92,16 @@ Four departures, none changing what is under test:
 /visualroute-to-story <component-name>
 ```
 
-Opted in means `tags: ['vrt', '!autodocs']` plus
-`parameters: { chromatic: { disableSnapshot: false } }`. Without both, the story
-renders in Storybook and Chromatic ignores it.
+A converted story carries `tags: ['vrt', '!autodocs']` plus
+`parameters: { chromatic: { disableSnapshot: false } }`. Three separate effects:
+
+- `disableSnapshot: false` is what opts the story into capture, overriding the
+  global default in `preview.tsx`. Nothing else does.
+- `!autodocs` keeps the stacked frame off the component's generated `Props` page,
+  countering the global `autodocs` tag.
+- `vrt` marks the story as migration output. Nothing in the repo reads it; it is
+  there to filter by hand and as the canary in
+  [SKILL.md step 7](SKILL.md#7-verify).
 
 The skill typechecks, builds, and counts states before and after;
 [SKILL.md step 7](SKILL.md#7-verify) covers what each check catches. By hand it
@@ -102,13 +118,13 @@ commented-out `percySnapshot`. See
 
 Same states, same props, same source order. Only Percy's scaffolding differs:
 
-|                      | Percy `Spec`                             | `VisualSpec`               |
-| -------------------- | ---------------------------------------- | -------------------------- |
-| Layout               | column: label bar, prop table, component | row: component, then label |
-| Label                | purple bar, bold, full width             | plain text                 |
-| Prop read-out        | monospace table of every prop            | dropped                    |
-| min-height per state | 400px                                    | 120px                      |
-| Grouping             | none                                     | `VisualSpecGroup` headings |
+|                      | Percy `Spec`                             | `VisualSpec`                  |
+| -------------------- | ---------------------------------------- | ----------------------------- |
+| Layout               | column: label bar, prop table, component | column: label, then component |
+| Label                | purple bar, bold, full width             | gray chip, shrink-wrapped     |
+| Prop read-out        | monospace table of every prop            | dropped                       |
+| min-height per state | 400px                                    | 120px                         |
+| Grouping             | none                                     | `VisualSpecGroup` headings    |
 
 The min-height drop is the visible difference, cutting a long frame to about a
 third of its height.

--- a/.agents/skills/visualroute-to-story/README.md
+++ b/.agents/skills/visualroute-to-story/README.md
@@ -1,16 +1,16 @@
 # Percy to Chromatic migration
 
-ui-kit's visual regression tests run on Percy today. Each component has a
+ui-kit's visual regression tests still run on Percy. Each component has a
 `*.visualroute.jsx` (a page rendering every variant) and a `*.visualspec.js` (a
 puppeteer script that drives the page and calls `percySnapshot`).
 
-We are converting those into CSF3 Storybook stories so Chromatic can screenshot
-them instead. The `visualroute-to-story` skill in this directory does the
-conversion. See [SKILL.md](SKILL.md) for how to run it.
+We are converting those into CSF3 Storybook stories for Chromatic. The
+`visualroute-to-story` skill in this directory does the conversion; see
+[SKILL.md](SKILL.md) for how to run it.
 
-**Parity only.** The goal is to replicate the coverage that exists today, not to
-add to it. Where a `percySnapshot` call is commented out, no screenshot exists,
-so we convert nothing and record the gap.
+**Parity only.** Replicate the coverage that exists today, don't add to it.
+Where a `percySnapshot` call is commented out no baseline exists, so nothing is
+converted and the gap is recorded in the planning doc.
 
 ## Where we deviate on purpose
 
@@ -21,8 +21,7 @@ Four departures, none changing what is under test:
   to rendered content, so anything painted at the edge would clip.
 - **Layout.** Label beside the component, smaller per-state min-height, so a long
   frame stays reviewable. A state whose content overflows its container needs
-  `overflow: hidden` on that container, or the overflow draws over the label:
-  Percy's label sat above the component, ours sits next to it.
+  `overflow: hidden` on that container, or the overflow draws over the label.
 - **Grouping.** Runs of states sharing an axis may get a `VisualSpecGroup`
   heading, only where it removes ambiguity.
 - **Light fixes.** A prop the component's types reject gets corrected, not cast,
@@ -31,8 +30,6 @@ Four departures, none changing what is under test:
 
 ## Percy vs Storybook + Chromatic
 
-The same job, split across different pieces:
-
 | Concern                 | Percy                                                  | Storybook + Chromatic                                    |
 | ----------------------- | ------------------------------------------------------ | -------------------------------------------------------- |
 | Page under test         | `*.visualroute.jsx`, served by `visual-testing-app`    | a story export in `*.stories.tsx`, served by Storybook   |
@@ -40,7 +37,7 @@ The same job, split across different pieces:
 | What triggers a capture | a live `percySnapshot()` call in `*.visualspec.js`     | a story with `chromatic: { disableSnapshot: false }`     |
 | Interactions first      | puppeteer, in the visualspec                           | a Storybook `play` function                              |
 | Captured area           | the whole route page                                   | the story canvas                                         |
-| Snapshot identity       | the name string passed to `percySnapshot()`            | story title + export name                                |
+| Snapshot identity       | the name passed to `percySnapshot()`                   | story title + export name                                |
 | Global config           | `.percy.yml` (widths `[1024]`)                         | `preview.tsx` + `storybook/chromatic.config.json`        |
 | Per-capture config      | options on the `percySnapshot()` call                  | `parameters.chromatic` on the story                      |
 | Run locally             | `visual-testing-app:start`, then `pnpm vrt:components` | `pnpm start`, then `pnpm --filter storybook chromatic`   |
@@ -50,66 +47,35 @@ The same job, split across different pieces:
 
 ## The pieces
 
-**Percy side.** All of it is deleted at teardown; nothing here should be edited
-except to fix a bug you are deliberately carrying across.
+**Percy side.** Deleted at teardown; don't edit except to carry a bug fix across.
 
 | File                  | What it is                                                                    |
 | --------------------- | ----------------------------------------------------------------------------- |
-| `*.visualroute.jsx`   | The page rendering every variant of one component. The input to a conversion  |
+| `*.visualroute.jsx`   | The page rendering every variant. The input to a conversion                   |
 | `*.visualspec.js`     | Puppeteer script. Its live `percySnapshot()` calls decide what Percy captures |
-| `test/percy/spec.jsx` | The `<Spec>` wrapper: label bar, prop table, 400px min-height per state       |
-| `visual-testing-app/` | Vite app serving the routes on `:3000` for Percy to visit                     |
+| `test/percy/spec.jsx` | The `<Spec>` wrapper: label bar, prop table, 400px min-height                 |
+| `visual-testing-app/` | Vite app serving the routes on `:3000`                                        |
 | `.percy.yml`          | Global Percy config. Sets `widths: [1024]`                                    |
 
 **Chromatic side.** Already in place; you should not need to touch any of it.
 
-| File                                    | What it is                                                                           |
-| --------------------------------------- | ------------------------------------------------------------------------------------ |
-| `storybook/src/helpers/visual-spec.tsx` | `VisualSpec` and `VisualSpecGroup`, the successors to `<Spec>`                       |
-| `storybook/.storybook/preview.tsx`      | Global `disableSnapshot: true`, plus the Intl and theme decorators every story needs |
-| `storybook/chromatic.config.json`       | TurboSnap and build settings                                                         |
-| `.github/workflows/chromatic.yml`       | CI: changed-files gate, then the Chromatic build                                     |
-| `<component>.stories.tsx`               | Where a converted story is appended, beside the component's existing demo stories    |
+| File                                    | What it is                                                         |
+| --------------------------------------- | ------------------------------------------------------------------ |
+| `storybook/src/helpers/visual-spec.tsx` | `VisualSpec` and `VisualSpecGroup`, the successors to `<Spec>`     |
+| `storybook/.storybook/preview.tsx`      | Global `disableSnapshot: true`, plus the Intl and theme decorators |
+| `storybook/chromatic.config.json`       | TurboSnap and build settings                                       |
+| `.github/workflows/chromatic.yml`       | CI: changed-files gate, then the Chromatic build                   |
+| `<component>.stories.tsx`               | Where a converted story is appended, beside the demo stories       |
 
 **The skill**, in this directory.
 
-| File                                  | What it is                                                                                |
-| ------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `SKILL.md`                            | The procedure, step by step. Start here to run a conversion                               |
-| `resources/analyze-visualroute.mjs`   | Reads a route file and its spec, emits a JSON plan. Decides what converts, writes nothing |
-| `resources/conversion-recipe.md`      | Where output goes, the `VisualSpec` API, and how to shape the JSX                         |
-| `resources/play-function-patterns.md` | Puppeteer interactions to a Storybook `play`. Only for a story the plan marks `needsPlay` |
-| `README.md`                           | This file: what the migration is, what is done, what is deferred                          |
-
-## Pipeline
-
-```
- ┌────────────────────────┐   ┌────────────────────────┐
- │  *.visualroute.jsx     │   │  *.visualspec.js       │
- │  the page Percy shoots │   │  puppeteer + snapshots │
- └───────────┬────────────┘   └───────────┬────────────┘
-             └───────────────┬────────────┘
-                             ▼
-                  analyze-visualroute.mjs
-              emits a JSON plan, writes no files
-                             │
-              ┌──────────────┴──────────────┐
-              ▼                             ▼
-      live Percy baseline           snapshot commented out
-           → convert                      → skip
-              │                             │
-              ▼                             ▼
-   appended to the component's       recorded in the
-     existing *.stories.tsx          planning doc as
-   already opted in                  deferred coverage
-              │
-              ▼
-      Chromatic baseline, reviewed and accepted in the PR
-```
-
-Opted in means `tags: ['vrt', '!autodocs']` plus
-`parameters: { chromatic: { disableSnapshot: false } }`. Without both, the story
-renders in Storybook and Chromatic ignores it.
+| File                                  | What it is                                                        |
+| ------------------------------------- | ----------------------------------------------------------------- |
+| `SKILL.md`                            | The procedure. Start here to run a conversion                     |
+| `resources/analyze-visualroute.mjs`   | Reads a route and its spec, emits a JSON plan. Writes nothing     |
+| `resources/conversion-recipe.md`      | Where output goes, the `VisualSpec` API, how to shape the JSX     |
+| `resources/play-function-patterns.md` | Puppeteer interactions to a `play` function. Only for `needsPlay` |
+| `README.md`                           | This file                                                         |
 
 ## Converting one component
 
@@ -117,59 +83,50 @@ renders in Storybook and Chromatic ignores it.
 /visualroute-to-story <component-name>
 ```
 
-The skill typechecks, builds, and counts states before and after; [SKILL.md
-step 7](SKILL.md#7-verify) covers what each check catches.
+Opted in means `tags: ['vrt', '!autodocs']` plus
+`parameters: { chromatic: { disableSnapshot: false } }`. Without both, the story
+renders in Storybook and Chromatic ignores it.
 
-Doing it by hand is the same three steps: run `analyze-visualroute.mjs` for the
-plan, read the route file and its spec, then apply
+The skill typechecks, builds, and counts states before and after;
+[SKILL.md step 7](SKILL.md#7-verify) covers what each check catches. By hand it
+is the same three steps: run `analyze-visualroute.mjs` for the plan, read the
+route file and its spec, then apply
 [resources/conversion-recipe.md](resources/conversion-recipe.md).
 
 Where Percy clicked or typed before capturing, the plan marks the story
-`needsPlay` and that interaction becomes a Storybook `play` function. No parity
-story needs one: the interactions either sit behind a commented-out
-`percySnapshot`, or never reach the baseline. See
+`needsPlay`. No parity story needs one: those interactions all sit behind a
+commented-out `percySnapshot`. See
 [resources/play-function-patterns.md](resources/play-function-patterns.md).
 
 ## What a converted story changes
 
-The conversion is 1:1 on **what is under test** and deliberately not on pixels.
-A converted story renders the same states, from the same props, in the same
-source order. What changes is the scaffolding Percy wrapped around them.
-
-Percy's `Spec` (`test/percy/spec.jsx`) becomes `VisualSpec`
-(`storybook/src/helpers/visual-spec.tsx`):
+Same states, same props, same source order. Only Percy's scaffolding differs:
 
 |                      | Percy `Spec`                             | `VisualSpec`               |
 | -------------------- | ---------------------------------------- | -------------------------- |
 | Layout               | column: label bar, prop table, component | row: component, then label |
 | Label                | purple bar, bold, full width             | plain text                 |
 | Prop read-out        | monospace table of every prop            | dropped                    |
-| min-height per state | 400px                                    | 56px                       |
+| min-height per state | 400px                                    | 120px                      |
 | Grouping             | none                                     | `VisualSpecGroup` headings |
 
-The min-height drop is the visible difference, cutting a 35-state frame to about
-a seventh of its height. Why the read-out goes, why the label stays, and the
-measurements behind the 56px are in
-[resources/conversion-recipe.md](resources/conversion-recipe.md#visualspec-and-visualspecgroup).
+The min-height drop is the visible difference, cutting a long frame to about a
+third of its height.
 
 **Cross-comparing against Percy.** Every labeled state in the Percy snapshot
 should have a matching row in the story, rendering identically. The frames will
-not overlay, and are not meant to. `.percy.yml` also captures at 1024px while
-Chromatic defaults to 1200px unless a story sets `chromatic.viewports`.
+not overlay, and are not meant to: `.percy.yml` captures at 1024px, Chromatic
+defaults to 1200px unless a story sets `chromatic.viewports`.
 
 ## Scope
 
-The parity rule, the two exclusions, and what the skill deliberately leaves to
-other work are in [SKILL.md](SKILL.md#scope-and-exclusions).
+The parity rule, the two exclusions, and what the skill leaves to other work are
+in [SKILL.md](SKILL.md#scope-and-exclusions).
 
-Where a `percySnapshot` call is commented out no baseline exists, so nothing is
-converted. Those states are uncovered today and stay uncovered after the
-migration.
-
-Everything that moves as the migration proceeds lives in
-`planning-files/Chromatic/uikit-vrt-migration-decisions.md`: counts, progress,
-the per-component list, the deferred coverage list, and the
-Percy-captures-to-stories mapping. Regenerate the underlying data with:
+Counts, progress, the per-component list, the deferred coverage list and the
+Percy-captures-to-stories mapping live in
+`planning-files/Chromatic/uikit-vrt-migration-decisions.md`. Regenerate the
+underlying data with:
 
 ```bash
 node .agents/skills/visualroute-to-story/resources/analyze-visualroute.mjs --all packages

--- a/.agents/skills/visualroute-to-story/SKILL.md
+++ b/.agents/skills/visualroute-to-story/SKILL.md
@@ -26,9 +26,8 @@ conventions this migration settles.
 - `--dry-run` (optional): print the conversion plan and the story file that
   _would_ be written, without writing anything.
 - `--no-snapshots` (optional): write the stories without opting them into
-  Chromatic capture. **Snapshots are on by default**; a generated story exists to
-  be screenshotted, and one that is not captured carries no coverage. See
-  [step 2](#2-repo-conventions).
+  Chromatic capture. **Snapshots are on by default**; an uncaptured story carries
+  no coverage. See [step 2](#2-repo-conventions).
 
 ## Scope and exclusions
 
@@ -37,7 +36,7 @@ which the plan reports as `hasNoLiveBaseline: false`. Skip the rest: those calls
 are commented out, so no baseline exists and generating them would be a coverage
 _increase_, not a migration. The list is in the planning doc.
 
-Two route files are excluded outright, and the six `*-open` routes have no parity
+One route file is excluded outright, and the six `*-open` routes have no parity
 work: their only story is deferred.
 
 **`icons` is the one orphan.** Its plan includes an `AllVariants` story for the
@@ -48,10 +47,9 @@ bare `/icons` route, which the spec never visits. `hasNoLiveBaseline` reads
 holds most of the repo's interaction call sites. A behavioral test living in the
 VRT folder; converting it invents coverage that never existed.
 
-**Excluded: `design-system/src/theme-provider.visualroute.jsx`.** `ThemeProvider`
-returns `null` and works via `target.style.setProperty()` in a `useLayoutEffect`,
-so every visible pixel comes from Percy-only scaffolding. A primitive with no
-painted surface gets no VRT. Replaced by a DOM test.
+**`theme-provider` was excluded, then converted.** `ThemeProvider` returns `null`
+and paints nothing, so its story renders a themed child, the way the route did.
+`theme-provider.spec.tsx` covers the property writes that a picture can't assert.
 
 ## What this skill does not do
 
@@ -99,8 +97,8 @@ Resolve the target in this order:
    Never pick one silently. If this finds nothing either, say so and stop; do not
    guess at a near-miss.
 
-If the target is or contains `rich-text-input.visualroute.jsx` or
-`theme-provider.visualroute.jsx`, skip it and say so.
+If the target is or contains `rich-text-input.visualroute.jsx`, skip it and say
+so.
 
 ### 2. Repo conventions
 
@@ -110,11 +108,10 @@ helpers, the Intl and theme decorators, the padding decorator, and
 up. Where output goes and what the story must carry is in
 [resources/conversion-recipe.md](resources/conversion-recipe.md#where-the-output-goes).
 
-**Light theme only.** No `chromatic.modes` anywhere, in `meta` or per story.
-Modes capture a story under different _global_ settings, whereas the route files
-that use `LocalThemeProvider` are testing several themed scopes coexisting in one
-DOM. That is the component's own behavior and it captures correctly in a single
-light-mode snapshot. Keep the local providers inline in the story body.
+**Light theme only.** No `chromatic.modes` anywhere. Modes vary _global_
+settings, but routes using `LocalThemeProvider` test several themed scopes
+coexisting in one DOM, which captures correctly in a single light-mode snapshot.
+Keep the local providers inline in the story body.
 
 ### 3. Run the analyzer
 
@@ -147,12 +144,11 @@ against the imports before continuing.
 Read [resources/conversion-recipe.md](resources/conversion-recipe.md) and apply
 the recipe matching the plan's `storyPlan[].source.kind` (`flat` or `subRoute`).
 
-The governing rule, which the recipe expands into a table of exactly what
-changes: **preserve the file body, replace only the Percy scaffolding.**
-Extracting variants into a fresh template loses the loops, local components and
-styling these files depend on, and is the main way a conversion silently drops
-coverage. Grouping is the one sanctioned exception, and even then the state count
-must match before and after.
+The governing rule: **preserve the file body, replace only the Percy
+scaffolding.** Extracting variants into a fresh template loses the loops, local
+components and styling these files depend on, and is the main way a conversion
+silently drops coverage. Grouping is the one exception, and the state count must
+still match before and after.
 
 For a `needsPlay` story, read
 [resources/play-function-patterns.md](resources/play-function-patterns.md).
@@ -207,11 +203,10 @@ baseline the error overlay. Build from the `storybook` workspace; running the
 binary from the repo root fails on `storybook/manager-api` not resolving.
 
 **If `tsc` reports `Module '@storybook/react-vite' has no exported member 'Meta'`
-for every story file in the repo**, the install is stale, not your conversion.
-Check `storybook/node_modules/storybook`: if it resolves to an `8.x` path or
-dangles, node_modules predates the Storybook 9 upgrade, and in 8.x `Meta` came
-from `@storybook/react`. Neither command above means anything until that is
-fixed.
+for every story file**, the install is stale, not your conversion. Check
+`storybook/node_modules/storybook`: an `8.x` path or a dangling link means
+node_modules predates the Storybook 9 upgrade. Neither command above means
+anything until that is fixed.
 
 ### 8. Report
 
@@ -233,10 +228,10 @@ Per converted file:
 **Needs review:** <manualReview entries, or "none">
 ```
 
-State the snapshot column plainly, because "converted" and "covered by Chromatic"
-are different things and conflating them is how a component gets signed off with
-no baseline behind it. With `--no-snapshots` the column reads `off`, and that
-story cannot count toward parity until it is enabled.
+State the snapshot column plainly: "converted" and "covered by Chromatic" are
+different things, and conflating them is how a component gets signed off with no
+baseline. With `--no-snapshots` it reads `off`, and that story cannot count
+toward parity until it is enabled.
 
 For a bulk run, finish with totals and the union of `manualReview` kinds with
 counts, keeping the parity and new-coverage tiers separate.
@@ -273,9 +268,8 @@ Two things the analyzer flags but cannot resolve:
   (`components/Buttons/PrimaryButton`), so they sit beside that component's demo
   stories. There is no `Visual Regression/*` group.
 - One stacked story per component named `AllVariants`, every `<Spec>` in source
-  order, and no JSDoc comment above it. One story per component is settled; a
-  per-state split is deferred until after the migration, so do not split a frame
-  just because it is long.
+  order, and no JSDoc comment above it. A per-state split is deferred until after
+  the migration, so do not split a frame just because it is long.
 - Runs of states sharing an axis go in a `VisualSpecGroup` with the shared part
   hoisted out of their labels. See
   [resources/conversion-recipe.md](resources/conversion-recipe.md).

--- a/.agents/skills/visualroute-to-story/SKILL.md
+++ b/.agents/skills/visualroute-to-story/SKILL.md
@@ -116,7 +116,7 @@ Keep the local providers inline in the story body.
 ### 3. Run the analyzer
 
 ```bash
-node .claude/skills/visualroute-to-story/resources/analyze-visualroute.mjs <route-file> --pretty
+node .agents/skills/visualroute-to-story/resources/analyze-visualroute.mjs <route-file> --pretty
 ```
 
 It emits a JSON conversion plan: component name, the resolved target stories file
@@ -184,7 +184,7 @@ Then count: `<VisualSpec>` in the output must equal `<Spec>` in the route file,
 unless a preserved `.map()` generates them.
 
 Then confirm the tags reached the index. Both commands above pass on a story that
-indexed without `vrt`, so this is the only place that failure is visible:
+indexed with no tags at all, so this is the only place that failure is visible:
 
 ```bash
 node -e "const j=require('./storybook/storybook-static/index.json');
@@ -192,8 +192,10 @@ node -e "const j=require('./storybook/storybook-static/index.json');
     .forEach((e) => console.log(e.name, '|', (e.tags || []).join(',')))"
 ```
 
-Every converted story must list `vrt`. One that does not has non-literal `tags`;
-see
+Every converted story must list `vrt`. Missing means the `tags` array is
+non-literal, so `!autodocs` did not apply either and the stacked frame is on the
+component's `Props` page. Capture itself is unaffected, since Chromatic reads
+`parameters` at runtime. See
 [resources/conversion-recipe.md](resources/conversion-recipe.md#where-the-output-goes).
 
 `tsc` catches the typing problems listed in

--- a/.agents/skills/visualroute-to-story/resources/conversion-recipe.md
+++ b/.agents/skills/visualroute-to-story/resources/conversion-recipe.md
@@ -11,14 +11,16 @@ parallel `*.visual.stories.tsx`.
 Two consequences. The target file is already discovered by Storybook, so the
 silent-failure mode of a story that typechecks and never appears cannot happen.
 And the story needs `tags: ['vrt', '!autodocs']` plus
-`parameters: { chromatic: { disableSnapshot: false } }`: without the first tag it
-lands on the component's generated `Props` page as a wall of stacked states,
-without the rest Chromatic ignores it.
+`parameters: { chromatic: { disableSnapshot: false } }`. Each does one thing:
+`disableSnapshot: false` is the only opt-in to capture, `!autodocs` keeps the
+stacked frame off the component's generated `Props` page, and `vrt` is a marker
+no config reads.
 
 **`tags` must be a literal array, on the export or on `meta`.** Storybook indexes
 by parsing, not running, so a factory or a spread indexes as no tags: it
-typechecks, it renders, and `vrt` is silently absent. In an all-VRT file put the
-tags and `chromatic` parameters on `meta` rather than per export.
+typechecks, it renders, and both tags are silently absent, putting the frame on
+the `Props` page. In an all-VRT file put the tags and `chromatic` parameters on
+`meta` rather than per export.
 
 Two routes have no stories file to append to, both flagged as
 `no-target-stories-file`:
@@ -30,10 +32,21 @@ Two routes have no stories file to append to, both flagged as
   was created for the 9 colors. The `leading-icon`, `inline-svg` and
   `custom-icon` snapshots append to those sub-directories' own stories files.
 
+A file created for VRT only carries two things an appended story does not, both
+on `meta`, and `icons.stories.tsx` is the one example:
+
+- **A pinned `id`** (`id: 'text-media-icons-colors'`). Chromatic keys a baseline
+  to the story id, which is otherwise derived from the title, so renaming the
+  title orphans every baseline in the file. Do not remove it in a later tidy-up.
+- **`'!dev'` in `tags`**, which keeps the frame out of the sidebar. Justified
+  where every state is snapshot coverage rather than something to navigate; an
+  appended story shares a sidebar entry with the demo stories, so it does not
+  apply there.
+
 ## `VisualSpec` and `VisualSpecGroup`
 
 `VisualSpec` replaces Percy's `Spec`. It keeps the variant label, drops the props
-read-out, and renders the component first with the label inline beside it:
+read-out, and renders the label above the component:
 
 ```tsx
 import { VisualSpec, VisualSpecGroup } from '@/storybook-helpers';
@@ -226,8 +239,9 @@ which makes `args` mandatory when the component has a required prop, and this
 story is `render`-only.
 
 No JSDoc comment above the export. The story name already says what it is, and a
-line repeated across 69 files is noise. Drop the `tags` and `parameters` lines
-only when `--no-snapshots` was passed.
+line repeated across 69 files is noise. Under `--no-snapshots` drop only the
+`parameters` line; the tags stay, or the uncaptured story lands on the `Props`
+page.
 
 ## Grouping
 
@@ -374,15 +388,15 @@ states, which are invisible against white: `link`, `flat-button`, `field-label`,
 
 ## States that relied on the full viewport
 
-`VisualSpec` puts the label beside the content, so the box shrink-wraps and any
-state needing free space (`justifyContent`, `width: 100%`, a percentage)
-collapses. Every value in the run then renders identically: the states are all
-there, the axis under test is invisible. If frames whose labels differ only by a
-layout prop look the same, this is why.
+`VisualSpec`'s box is `width: max-content`, so it shrink-wraps and any state
+needing free space (`justifyContent`, `width: 100%`, a percentage) collapses.
+Every value in the run then renders identically: the states are all there, the
+axis under test is invisible. If frames whose labels differ only by a layout prop
+look the same, this is why.
 
 Give that state's own wrapper an explicit width. Do **not** make the box grow;
-that stretches every converted component and pushes their labels to the right
-edge. `spacings` fixed its six `justifyContent` states with `width: 600px` on the
+that stretches every converted component's surface band across the full frame.
+`spacings` fixed its six `justifyContent` states with `width: 600px` on the
 route's local `View`.
 
 ## Before you finish

--- a/.agents/skills/visualroute-to-story/resources/conversion-recipe.md
+++ b/.agents/skills/visualroute-to-story/resources/conversion-recipe.md
@@ -23,13 +23,12 @@ tags and `chromatic` parameters on `meta` rather than per export.
 Two routes have no stories file to append to, both flagged as
 `no-target-stories-file`:
 
-- **`content-notification`** — its directory has no demo story, and
-  `notification.stories.tsx` is a different component. Create
-  `content-notification.stories.tsx` beside it.
-- **`icons`** — `icons/src/` holds only `.mdx`. Create
-  `icons/src/icon.stories.tsx` for the 9 colors; the `leading-icon`,
-  `inline-svg` and `custom-icon` snapshots append to those sub-directories' own
-  stories files.
+- **`content-notification`** — its own directory has no demo story, so the
+  export went to `notifications/src/notification.stories.tsx`, under the
+  `components/Notification/ContentNotification` title already there.
+- **`icons`** — `icons/src/` held only `.mdx`, so `icons/src/icons.stories.tsx`
+  was created for the 9 colors. The `leading-icon`, `inline-svg` and
+  `custom-icon` snapshots append to those sub-directories' own stories files.
 
 ## `VisualSpec` and `VisualSpecGroup`
 
@@ -343,11 +342,11 @@ colors.map((color) => it(`Color ${color}`, async () => {
 }));
 ```
 
-Nine real screenshots, so **nine** stories, not one, and each carries
-`parameters: { chromatic: { viewports: [1600] } }`. Enumerate the loop values
-from the visualspec; the route's `<Route path>` interpolates the variable and
-cannot tell you them. This is parity coverage, not new coverage, even though the
-analyzer cannot attribute it.
+Nine real screenshots, so **nine** stories, not one, with
+`viewports: [1600]` on the file's `meta.parameters.chromatic`. Enumerate the loop
+values from the visualspec; the route's `<Route path>` interpolates the variable
+and cannot tell you them. This is parity coverage, even though the analyzer
+cannot attribute it.
 
 ## Typing the `.jsx` → `.tsx` move
 

--- a/.agents/skills/visualroute-to-story/resources/play-function-patterns.md
+++ b/.agents/skills/visualroute-to-story/resources/play-function-patterns.md
@@ -3,12 +3,9 @@
 Translating a visualspec's puppeteer steps into a Storybook `play`. Read this
 only for a story the plan marks `needsPlay`.
 
-The rules for whether a play lands a usable frame are not restated here. They are
-section 4 of
-[`nimbus/docs/chromatic-visual-testing.md`](https://github.com/commercetools/nimbus/blob/main/docs/chromatic-visual-testing.md),
-"Does the play land the frame?", and they apply unchanged: the snapshot is the
-play's **end state**, a click leaves the element focused, animations settle on
-their last frame, and a native text caret needs hiding.
+Whether a play lands a usable frame comes down to four things: the snapshot is
+the play's **end state**, a click leaves the element focused, animations settle
+on their last frame, and a native text caret needs hiding.
 
 ## How little of this there is
 

--- a/.agents/skills/visualroute-to-story/resources/play-function-patterns.md
+++ b/.agents/skills/visualroute-to-story/resources/play-function-patterns.md
@@ -14,11 +14,10 @@ their last frame, and a native text caret needs hiding.
 
 **No parity story needs a play.** Every interaction in the repo either sits
 behind a commented-out `percySnapshot`, making it deferred coverage rather than
-migration work, or never reaches the baseline at all. See
+migration work, or never reaches the baseline. See
 [Check the dashboard, not the spec](#check-the-dashboard-not-the-spec).
 
-**Do not add a play to a story that does not need one.** A resting frame that
-props alone produce is already tested by the snapshot, and each added interaction
+**Do not add a play to a story that does not need one.** Each added interaction
 is another frame to land deliberately.
 
 ## Call mapping
@@ -104,9 +103,9 @@ it('Open', async () => {
 
 Read that `TODO` before assuming they are safe wins. "Issue with Percy" was never
 diagnosed, and an overlay flaky under Percy may be flaky under Chromatic for the
-same underlying reason: an unsettled animation, a repositioning popper. Each
-first capture is also a new baseline rather than a parity check, so land them
-apart from parity work or sign-off gets ambiguous.
+same reason: an unsettled animation, a repositioning popper. Each first capture
+is a new baseline rather than a parity check, so land them apart from parity work
+or sign-off gets ambiguous.
 
 ## Checklist
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,8 +1,7 @@
 name: Chromatic
 
-# Visual regression testing, ported from commercetools/nimbus. Runbook and
-# authoring rules: that repo's docs/chromatic-ci.md and
-# docs/chromatic-visual-testing.md.
+# Visual regression testing: build Storybook, upload to Chromatic, gate on
+# whether anything that affects rendered output changed.
 on:
   # Manual full build: TurboSnap off, gate bypassed.
   workflow_dispatch:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,8 +1,8 @@
 name: Chromatic
 
-# Visual regression testing. Ported from commercetools/nimbus; see that repo's
-# docs/chromatic-ci.md for the runbook (triggers, baselines, gating, the manual
-# button) and docs/chromatic-visual-testing.md for authoring rules.
+# Visual regression testing, ported from commercetools/nimbus. Runbook and
+# authoring rules: that repo's docs/chromatic-ci.md and
+# docs/chromatic-visual-testing.md.
 on:
   # Manual full build: TurboSnap off, gate bypassed.
   workflow_dispatch:
@@ -26,8 +26,7 @@ jobs:
       'pull_request'
     permissions:
       contents: read
-      # Skip path posts a passing "UI Tests" status so a required check still
-      # reports when Chromatic doesn't run.
+      # Lets the skip path post its own passing "UI Tests" status.
       statuses: write
     steps:
       # Full history: Chromatic needs it to find the baseline build to diff against.
@@ -36,31 +35,27 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Gate: run only when files that affect rendered output change (a manual
-      # dispatch bypasses it via the step `if:` conditions below).
+      # Gate on files that affect rendered output; workflow_dispatch bypasses it.
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           # push: diff newest commit. PR: diff whole PR (base...head).
           since_last_remote_commit: ${{ github.event_name == 'push' }}
+          # All of packages/: i18n, hooks and the utils packages all affect
+          # rendered output. A lockfile change forces a full snapshot, since
+          # TurboSnap can't scope one.
           files: |
-            # All of packages/, not just components/: i18n supplies the strings
-            # rendered in every component, and hooks/utils/localized-utils/
-            # calendar-*-utils all affect rendered output.
             packages/**
             design-system/**
             storybook/**
-            # Dep bumps surface via the lockfile; a lockfile change forces a full
-            # snapshot (TurboSnap can't scope it).
             pnpm-lock.yaml
           files_ignore: |
             storybook/chromatic.config.json
             storybook/.storybook/main.ts
 
-      # No UI changed (or the changesets version PR - version/CHANGELOG bumps
-      # only), so Chromatic is skipped. Post a passing "UI Tests" status
-      # ourselves so a required check still reports.
+      # Nothing UI-affecting, or the changesets version PR. Posts a passing
+      # status itself so a required "UI Tests" check still reports.
       - name: No UI changes detected
         if:
           (steps.changed-files.outputs.any_changed != 'true' || github.head_ref
@@ -75,8 +70,7 @@ jobs:
             -f context='UI Tests' \
             -f description='No UI-affecting changes; Chromatic skipped'
 
-      # ui-kit has no shared composite CI action, so setup is inlined here,
-      # mirroring main.yml.
+      # No shared composite CI action in ui-kit; setup mirrors main.yml.
       - name: Install pnpm
         if:
           (steps.changed-files.outputs.any_changed == 'true' ||
@@ -121,8 +115,7 @@ jobs:
           'changeset-release/main'
         run: pnpm install --frozen-lockfile
 
-      # Stories import workspace packages, so those have to be built before the
-      # Storybook build the Chromatic action runs.
+      # Stories import workspace packages, so build those first.
       - name: Building packages
         if:
           (steps.changed-files.outputs.any_changed == 'true' ||
@@ -138,17 +131,14 @@ jobs:
         uses: chromaui/action@94713c544284a14195de3b50ef24301579f1877e # v18
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          # Run inside the storybook workspace rather than pointing
-          # buildScriptName at a root wrapper script. Chromatic controls the
-          # build output location by appending `--output-dir`, and that argument
-          # is silently dropped through `pnpm run <root-script> -- <args>`, so a
-          # wrapper would upload from an empty directory. Verified locally.
+          # Runs in the storybook workspace, not via a root wrapper script:
+          # `pnpm run <root-script> -- <args>` silently drops Chromatic's
+          # `--output-dir`, so a wrapper uploads an empty directory.
           workingDir: storybook
           storybookBaseDir: storybook
           buildScriptName: build
           zip: true
           # TurboSnap: snapshot only diff-affected stories (full on dispatch).
           onlyChanged: ${{ github.event_name != 'workflow_dispatch' }}
-          # Return once Storybook is uploaded; Chromatic tests on its servers and
-          # posts the status check when done. Avoids timeouts on full builds.
+          # Return at upload; Chromatic posts the status when its run finishes.
           exitOnceUploaded: true

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -49,9 +49,9 @@ jobs:
             design-system/**
             storybook/**
             pnpm-lock.yaml
+          # Ignored only if it cannot change what a story renders.
           files_ignore: |
             storybook/chromatic.config.json
-            storybook/.storybook/main.ts
 
       # Nothing UI-affecting, or the changesets version PR. Posts a passing
       # status itself so a required "UI Tests" check still reports.
@@ -139,5 +139,8 @@ jobs:
           zip: true
           # TurboSnap: snapshot only diff-affected stories (full on dispatch).
           onlyChanged: ${{ github.event_name != 'workflow_dispatch' }}
+          # Keeps main the accepted baseline, so a PR diffs against the current
+          # state of main rather than the last build someone accepted by hand.
+          autoAcceptChanges: main
           # Return at upload; Chromatic posts the status when its run finishes.
           exitOnceUploaded: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,9 +68,27 @@ Components in UI Kit are integration tested to ensure they meet requirements ove
 
 ### Testing visuals
 
-It is crucial for a Design System to not introduce visual regressions. To achieve this UI Kit performs Visual Regression Testing using [Percy](https://percy.io/). Every component must have a so called visual specification alongside it. This is just a React component conveniently defining all visual states such placeholder being filled, a warning being triggered or a component being in readonly state. An example can be found here. This specification is rendered and sent to Percy via a GitHub Action. Once regressions are detected, they will be reported on a subsequent change and have to be approved by a UI/UX Designer.
+A Design System must not introduce visual regressions, so UI Kit runs Visual Regression Testing, currently on [Percy](https://percy.io/) and migrating to [Chromatic](https://www.chromatic.com/). Until the migration is signed off, a new component needs both.
 
-> **Migrating to Chromatic (Q3 2026).** Visual regression testing is moving from Percy to [Chromatic](https://www.chromatic.com/), which captures Storybook stories instead of the `.visualroute.jsx` / `.visualspec.js` pair. Percy remains the system of record until the migration is signed off, so keep adding visual specifications as described above. New components will also want a stacked `AllVariants` story; see the existing converted components for the shape.
+#### Percy (current system of record)
+
+Every component needs a visual specification alongside it: a React component rendering each visual state, such as a filled placeholder, a triggered warning, or a read-only field. See [`primary-button.visualroute.jsx`](packages/components/buttons/primary-button/src/primary-button.visualroute.jsx) and its companion `primary-button.visualspec.js`. A GitHub Action renders it and sends it to Percy; regressions surface on the next change and need a UI/UX Designer's approval.
+
+#### Chromatic (in migration, Q3 2026)
+
+Chromatic captures Storybook stories instead of the `.visualroute.jsx` / `.visualspec.js` pair. Add one `AllVariants` story to the component's `*.stories.tsx`, one `<VisualSpec>` per state:
+
+```tsx
+import { VisualSpec } from '@/storybook-helpers';
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => <>{/* <VisualSpec label="..."> per state */}</>,
+};
+```
+
+Snapshots are off by default, so `disableSnapshot: false` is the opt-in; `!autodocs` keeps the stacked frame off the generated `Props` page. Accept or reject diffs in the Chromatic UI, where the `UI Tests` check stays red until you do. `.github/workflows/chromatic.yml` skips the build entirely when nothing under `packages/`, `design-system/`, `storybook/` or the lockfile changed, posting a passing `UI Tests` status instead, so a green check can mean "not run"; it also uses TurboSnap, so trigger it manually for a full rebuild. Locally: `CHROMATIC_PROJECT_TOKEN=... pnpm --filter storybook chromatic`.
 
 ## Opening an Issue
 

--- a/design-system/src/theme-provider.spec.tsx
+++ b/design-system/src/theme-provider.spec.tsx
@@ -1,0 +1,123 @@
+import type { ReactNode } from 'react';
+import { render, screen, waitFor } from '../../test/test-utils';
+import { themes } from './design-tokens';
+import { ThemeProvider, useTheme } from './theme-provider';
+
+type TScopedThemeProps = {
+  theme?: string;
+  themeOverrides?: Record<string, string>;
+  children?: ReactNode;
+};
+
+const scopeSelector = () => document.getElementById('scope');
+
+const ScopedTheme = (props: TScopedThemeProps) => (
+  <div id="scope" data-testid="scope">
+    <ThemeProvider
+      theme={props.theme}
+      themeOverrides={props.themeOverrides}
+      parentSelector={scopeSelector}
+    />
+    {props.children}
+  </div>
+);
+
+const ThemeReader = (props: { parentSelector?: () => HTMLElement | null }) => {
+  const { theme } = useTheme(props.parentSelector);
+  return <span data-testid="theme">{theme}</span>;
+};
+
+afterEach(() => {
+  // The provider writes to the inline style of `:root`, which jsdom keeps for
+  // the whole file, so the "root untouched" assertions need this reset.
+  document.documentElement.removeAttribute('style');
+  document.documentElement.removeAttribute('data-theme');
+});
+
+describe('ThemeProvider', () => {
+  it('should write the theme tokens to the root element by default', () => {
+    render(<ThemeProvider />);
+
+    expect(
+      document.documentElement.style.getPropertyValue('--color-solid')
+    ).toBe(themes.default.colorSolid);
+    expect(document.documentElement).toHaveAttribute('data-theme', 'default');
+  });
+
+  it('should write to the scoped element and leave the root untouched', () => {
+    render(<ScopedTheme />);
+
+    const scope = screen.getByTestId('scope');
+    expect(scope.style.getPropertyValue('--color-solid')).toBe(
+      themes.default.colorSolid
+    );
+    expect(scope).toHaveAttribute('data-theme', 'default');
+    expect(
+      document.documentElement.style.getPropertyValue('--color-solid')
+    ).toBe('');
+    expect(document.documentElement).not.toHaveAttribute('data-theme');
+  });
+
+  it('should let a theme override win over the theme value', () => {
+    render(<ScopedTheme themeOverrides={{ colorSolid: 'red' }} />);
+
+    expect(
+      screen.getByTestId('scope').style.getPropertyValue('--color-solid')
+    ).toBe('red');
+  });
+
+  it('should add a custom property for a token the theme does not define', () => {
+    render(<ScopedTheme themeOverrides={{ customColor: 'tomato' }} />);
+
+    expect(
+      screen.getByTestId('scope').style.getPropertyValue('--custom-color')
+    ).toBe('tomato');
+  });
+
+  it('should warn and fall back to the default theme for an unsupported theme', () => {
+    const consoleWarnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    render(<ScopedTheme theme="dark" />);
+
+    const scope = screen.getByTestId('scope');
+    expect(scope).toHaveAttribute('data-theme', 'default');
+    expect(scope.style.getPropertyValue('--color-solid')).toBe(
+      themes.default.colorSolid
+    );
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "ThemeProvider: the specified theme 'dark' is not supported."
+    );
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('should do nothing when the parent selector finds no element', () => {
+    render(<ThemeProvider parentSelector={() => null} />);
+
+    expect(document.documentElement).not.toHaveAttribute('data-theme');
+  });
+});
+
+describe('useTheme', () => {
+  it('should report the theme applied to the scoped element', () => {
+    render(
+      <ScopedTheme>
+        <ThemeReader parentSelector={scopeSelector} />
+      </ScopedTheme>
+    );
+
+    expect(screen.getByTestId('theme')).toHaveTextContent('default');
+  });
+
+  it('should report a later theme change on the observed element', async () => {
+    render(<ThemeReader />);
+    expect(screen.getByTestId('theme')).toHaveTextContent('default');
+
+    document.documentElement.setAttribute('data-theme', 'other-theme');
+
+    await waitFor(() =>
+      expect(screen.getByTestId('theme')).toHaveTextContent('other-theme')
+    );
+  });
+});

--- a/design-system/src/theme-provider.spec.tsx
+++ b/design-system/src/theme-provider.spec.tsx
@@ -28,8 +28,8 @@ const ThemeReader = (props: { parentSelector?: () => HTMLElement | null }) => {
 };
 
 afterEach(() => {
-  // The provider writes to the inline style of `:root`, which jsdom keeps for
-  // the whole file, so the "root untouched" assertions need this reset.
+  // jsdom keeps `:root` for the whole file, so the "root untouched" assertions
+  // need this reset.
   document.documentElement.removeAttribute('style');
   document.documentElement.removeAttribute('data-theme');
 });

--- a/design-system/src/theme-provider.stories.tsx
+++ b/design-system/src/theme-provider.stories.tsx
@@ -1,0 +1,129 @@
+import type { ReactNode } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { VisualSpec } from '@/storybook-helpers';
+import designTokens from './design-tokens';
+import { ThemeProvider, useTheme } from './theme-provider';
+
+const meta: Meta<typeof ThemeProvider> = {
+  title: 'Foundation/ThemeProvider',
+  component: ThemeProvider,
+  tags: ['!autodocs'],
+};
+
+export default meta;
+
+const scopedSelector = (id: string) => () => document.getElementById(id);
+
+/* Copied from `test/percy/local-theme-provider.jsx`, which is deleted with
+   Percy. There is no `dark` entry in `themes`, so the dark states are overrides,
+   not a theme name. */
+const darkThemeOverrides = {
+  colorSurface: 'black',
+  colorSolid: 'white',
+  colorNeutral60: 'rgba(255,255,255,0.60)',
+  colorNeutral: 'rgba(255,255,255,0.60)',
+  colorAccent98: 'rgba(0,0,0,0.98)',
+};
+
+type TThemedTitleProps = {
+  parentSelector?: () => HTMLElement | null;
+  color?: string;
+  children?: ReactNode;
+};
+
+/* `ThemeProvider` returns null, so the capture needs a child painted with the
+   custom properties it writes. */
+const ThemedTitle = ({
+  parentSelector,
+  color,
+  children,
+}: TThemedTitleProps) => {
+  const { theme } = useTheme(parentSelector);
+
+  return (
+    <h1
+      style={{
+        color: color ?? designTokens.colorSolid,
+        backgroundColor: designTokens.colorSurface,
+        margin: 0,
+      }}
+    >
+      {children ?? (
+        <>
+          Title with {theme} theme <i>colorSolid</i> design token
+        </>
+      )}
+    </h1>
+  );
+};
+
+type TLocalThemeProps = {
+  id: string;
+  themeOverrides?: Record<string, string>;
+  children: ReactNode;
+};
+
+const LocalTheme = ({ id, themeOverrides, children }: TLocalThemeProps) => (
+  <div id={id}>
+    <ThemeProvider
+      parentSelector={scopedSelector(id)}
+      themeOverrides={themeOverrides}
+    />
+    {children}
+  </div>
+);
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="use global default theme">
+        <ThemedTitle />
+      </VisualSpec>
+
+      <VisualSpec label="use local default theme">
+        <LocalTheme id="local-1">
+          <ThemedTitle parentSelector={scopedSelector('local-1')} />
+        </LocalTheme>
+      </VisualSpec>
+
+      <VisualSpec label="use local dark theme">
+        <LocalTheme id="local-2" themeOverrides={darkThemeOverrides}>
+          <ThemedTitle parentSelector={scopedSelector('local-2')} />
+        </LocalTheme>
+      </VisualSpec>
+
+      <VisualSpec label="repeat local default theme">
+        <LocalTheme id="local-3">
+          <ThemedTitle parentSelector={scopedSelector('local-3')} />
+        </LocalTheme>
+      </VisualSpec>
+
+      <VisualSpec label="repeat local dark theme">
+        <LocalTheme id="local-4" themeOverrides={darkThemeOverrides}>
+          <ThemedTitle parentSelector={scopedSelector('local-4')} />
+        </LocalTheme>
+      </VisualSpec>
+
+      <VisualSpec label="overridden local default theme">
+        <LocalTheme id="local-5" themeOverrides={{ colorSolid: 'red' }}>
+          <ThemedTitle parentSelector={scopedSelector('local-5')}>
+            Title with overridden <i>colorSolid</i> design token
+          </ThemedTitle>
+        </LocalTheme>
+      </VisualSpec>
+
+      <VisualSpec label="custom property added to default theme">
+        <LocalTheme id="local-6" themeOverrides={{ customColor: 'tomato' }}>
+          <ThemedTitle
+            parentSelector={scopedSelector('local-6')}
+            color="var(--custom-color)"
+          >
+            Title with custom color
+          </ThemedTitle>
+        </LocalTheme>
+      </VisualSpec>
+    </>
+  ),
+};

--- a/design-system/src/theme-provider.stories.tsx
+++ b/design-system/src/theme-provider.stories.tsx
@@ -14,9 +14,8 @@ export default meta;
 
 const scopedSelector = (id: string) => () => document.getElementById(id);
 
-/* Copied from `test/percy/local-theme-provider.jsx`, which is deleted with
-   Percy. There is no `dark` entry in `themes`, so the dark states are overrides,
-   not a theme name. */
+/* There is no `dark` entry in `themes`, so these states are overrides rather
+   than a theme name. */
 const darkThemeOverrides = {
   colorSurface: 'black',
   colorSolid: 'white',
@@ -32,7 +31,7 @@ type TThemedTitleProps = {
 };
 
 /* `ThemeProvider` returns null, so the capture needs a child painted with the
-   custom properties it writes. */
+   properties it writes. */
 const ThemedTitle = ({
   parentSelector,
   color,

--- a/jest.ts-test.config.js
+++ b/jest.ts-test.config.js
@@ -12,5 +12,7 @@ module.exports = {
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   moduleDirectories: ['generators', 'node_modules'],
-  testPathIgnorePatterns: ['packages', '/node_modules/'],
+  // Component and design-system specs need a DOM; they belong to the jsdom
+  // project in jest.test.config.js.
+  testPathIgnorePatterns: ['packages', 'design-system', '/node_modules/'],
 };

--- a/packages/components/avatar/src/avatar.stories.tsx
+++ b/packages/components/avatar/src/avatar.stories.tsx
@@ -23,8 +23,8 @@ export const BasicExample: Story = {
   },
 };
 
-// `gravatarHash` is required on Avatar's props, but 10 of the 17 Percy states
-// omit it and render fine. Cast here rather than change the component's type.
+// `gravatarHash` is required on Avatar's props, but 10 of these 17 states omit
+// it and render fine. Cast here rather than change the component's type.
 const AvatarSpec = Avatar as ComponentType<
   Partial<ComponentProps<typeof Avatar>>
 >;

--- a/packages/components/avatar/src/avatar.stories.tsx
+++ b/packages/components/avatar/src/avatar.stories.tsx
@@ -1,6 +1,8 @@
+import type { ComponentProps, ComponentType } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { PlusBoldIcon } from '@commercetools-uikit/icons';
 import Avatar from './avatar';
-import { iconArgType } from '@/storybook-helpers';
+import { iconArgType, VisualSpec } from '@/storybook-helpers';
 
 const meta: Meta<typeof Avatar> = {
   title: 'components/Avatar',
@@ -19,4 +21,114 @@ export const BasicExample: Story = {
     lastName: 'Doe',
     size: 'm',
   },
+};
+
+// `gravatarHash` is required on Avatar's props, but 10 of the 17 Percy states
+// omit it and render fine. Cast here rather than change the component's type.
+const AvatarSpec = Avatar as ComponentType<
+  Partial<ComponentProps<typeof Avatar>>
+>;
+
+const HASH = '205e460b479e2e5b48aec07710c08d50';
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="when gravatar hash is known">
+        <AvatarSpec
+          gravatarHash={HASH}
+          firstName="John"
+          lastName="Doe"
+          size="s"
+        />
+      </VisualSpec>
+      <VisualSpec label="when gravatar hash is unknown">
+        <AvatarSpec
+          gravatarHash="foo"
+          firstName="John"
+          lastName="Doe"
+          size="s"
+        />
+      </VisualSpec>
+      <VisualSpec label={'when size is "s"'}>
+        <AvatarSpec
+          gravatarHash={HASH}
+          firstName="John"
+          lastName="Doe"
+          size="s"
+        />
+      </VisualSpec>
+      <VisualSpec label={'when size is "m"'}>
+        <AvatarSpec
+          gravatarHash={HASH}
+          firstName="John"
+          lastName="Doe"
+          size="m"
+        />
+      </VisualSpec>
+      <VisualSpec label={'when size is "l"'}>
+        <AvatarSpec
+          gravatarHash={HASH}
+          firstName="John"
+          lastName="Doe"
+          size="l"
+        />
+      </VisualSpec>
+      <VisualSpec label={'when size is "s" and name is long'}>
+        <AvatarSpec firstName="John" lastName="Doe" size="s" />
+      </VisualSpec>
+      <VisualSpec label={'when size is "m" and name is long'}>
+        <AvatarSpec firstName="John" lastName="Doe" size="m" />
+      </VisualSpec>
+      <VisualSpec label={'when size is "l" and name is long'}>
+        <AvatarSpec firstName="John" lastName="Doe" size="l" />
+      </VisualSpec>
+      <VisualSpec label={'when size is "s" and name is short'}>
+        <AvatarSpec firstName="John" size="s" />
+      </VisualSpec>
+      <VisualSpec label={'when size is "m" and name is short'}>
+        <AvatarSpec firstName="John" size="m" />
+      </VisualSpec>
+      <VisualSpec label={'when size is "l" and name is short'}>
+        <AvatarSpec firstName="John" size="l" />
+      </VisualSpec>
+      <VisualSpec label="when highlighted">
+        <AvatarSpec
+          gravatarHash={HASH}
+          firstName="John"
+          lastName="Doe"
+          size="m"
+          isHighlighted={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when icon exists">
+        <AvatarSpec
+          gravatarHash={HASH}
+          firstName="John"
+          lastName="Doe"
+          size="m"
+          icon={<PlusBoldIcon />}
+        />
+      </VisualSpec>
+      <VisualSpec label="when color is accent">
+        <AvatarSpec firstName="John" lastName="Doe" size="m" color="accent" />
+      </VisualSpec>
+      <VisualSpec label="when color is purple">
+        <AvatarSpec firstName="John" lastName="Doe" size="m" color="purple" />
+      </VisualSpec>
+      <VisualSpec label="when color is turquoise">
+        <AvatarSpec
+          firstName="John"
+          lastName="Doe"
+          size="m"
+          color="turquoise"
+        />
+      </VisualSpec>
+      <VisualSpec label="when color is brown">
+        <AvatarSpec firstName="John" lastName="Doe" size="m" color="brown" />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/buttons/secondary-button/src/secondary-button.stories.tsx
+++ b/packages/components/buttons/secondary-button/src/secondary-button.stories.tsx
@@ -79,8 +79,8 @@ export const AllVariants: StoryObj = {
         />
       </VisualSpec>
 
-      {/* Percy passed tone="default", which is not a valid tone and always fell
-          through to the secondary styles. Omitted, not renamed: same pixels. */}
+      {/* The label names tone="default", which is not a valid tone and always
+          fell through to the secondary styles. Omitted, not renamed. */}
       <VisualSpec label='with theme - when toggled with tone "default"'>
         <SecondaryButton
           label="A label text"

--- a/packages/components/card/src/card.stories.tsx
+++ b/packages/components/card/src/card.stories.tsx
@@ -1,7 +1,10 @@
 import type { ComponentProps } from 'react';
-import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { css } from '@emotion/react';
+import Text from '@commercetools-uikit/text';
 
 import Card from './card';
+import { VisualSpec } from '@/storybook-helpers';
 import { BrowserRouter as Router } from 'react-router-dom';
 
 type CardProps = ComponentProps<typeof Card>;
@@ -30,4 +33,160 @@ BasicExample.args = {
   children:
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu dictum varius duis at consectetur lorem donec.',
   onClick: undefined,
+};
+
+const text = `
+  Malis mundi eripuit eam ex, ubique admodum duo at.
+  Suas verterem accusata eos cu, ius cu quodsi officiis accusata,
+  illud soluta utamur ne vim. Nihil ornatus ad duo, ius cu nibh neglegentur.
+`;
+
+const WrappedCard = (props: CardProps & { height?: string }) => (
+  <Card
+    css={css`
+      margin: 16px;
+      width: 300px;
+      height: ${props.height || 'auto'};
+    `}
+    {...props}
+  >
+    {props.children}
+  </Card>
+);
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  decorators: [
+    (Story) => (
+      <Router>
+        <Story />
+      </Router>
+    ),
+  ],
+  render: () => (
+    <>
+      <VisualSpec label="Type - Raised, Theme - Light, InsetScale - None">
+        <WrappedCard type="raised" theme="light" insetScale="none">
+          <Text.Body>{text}</Text.Body>
+        </WrappedCard>
+      </VisualSpec>
+      <VisualSpec label="Type - Raised, Theme - Dark, InsetScale - None">
+        <WrappedCard type="raised" theme="dark" insetScale="none">
+          <Text.Body>{text}</Text.Body>
+        </WrappedCard>
+      </VisualSpec>
+      <VisualSpec label="Type - Flat, Theme - Light, InsetScale - None">
+        <WrappedCard type="flat" theme="light" insetScale="none">
+          <Text.Body>{text}</Text.Body>
+        </WrappedCard>
+      </VisualSpec>
+      <VisualSpec label="Type - Flat, Theme - Dark, InsetScale - None">
+        <WrappedCard type="flat" theme="dark" insetScale="none">
+          <Text.Body>{text}</Text.Body>
+        </WrappedCard>
+      </VisualSpec>
+
+      <VisualSpec label="Type - Raised, Theme - Light, InsetScale - S">
+        <WrappedCard type="raised" theme="light" insetScale="s">
+          <Text.Body>{text}</Text.Body>
+        </WrappedCard>
+      </VisualSpec>
+      <VisualSpec label="Type - Raised, Theme - Dark, InsetScale - S">
+        <WrappedCard type="raised" theme="dark" insetScale="s">
+          <Text.Body>{text}</Text.Body>
+        </WrappedCard>
+      </VisualSpec>
+      <VisualSpec label="Type - Flat, Theme - Light, InsetScale - S">
+        <WrappedCard type="flat" theme="light" insetScale="s">
+          <Text.Body>{text}</Text.Body>
+        </WrappedCard>
+      </VisualSpec>
+      <VisualSpec label="Type - Flat, Theme - Dark, InsetScale - S">
+        <WrappedCard type="flat" theme="dark" insetScale="s">
+          <Text.Body>{text}</Text.Body>
+        </WrappedCard>
+      </VisualSpec>
+
+      <VisualSpec label="Type - Raised, Theme - Light, InsetScale - M">
+        <WrappedCard type="raised" theme="light" insetScale="m">
+          <Text.Body>{text}</Text.Body>
+        </WrappedCard>
+      </VisualSpec>
+      <VisualSpec label="Type - Raised, Theme - Dark, InsetScale - M">
+        <WrappedCard type="raised" theme="dark" insetScale="m">
+          <Text.Body>{text}</Text.Body>
+        </WrappedCard>
+      </VisualSpec>
+      <VisualSpec label="Type - Flat, Theme - Light, InsetScale - M">
+        <WrappedCard type="flat" theme="light" insetScale="m">
+          <Text.Body>{text}</Text.Body>
+        </WrappedCard>
+      </VisualSpec>
+      <VisualSpec label="Type - Flat, Theme - Dark, InsetScale - M">
+        <WrappedCard type="flat" theme="dark" insetScale="m">
+          <Text.Body>{text}</Text.Body>
+        </WrappedCard>
+      </VisualSpec>
+      <VisualSpec label="Type - Raised, Theme - Light, InsetScale - L">
+        <WrappedCard type="raised" theme="light" insetScale="l">
+          <Text.Body>{text}</Text.Body>
+        </WrappedCard>
+      </VisualSpec>
+      <VisualSpec label="Type - Raised, Theme - Light, InsetScale - XL">
+        <WrappedCard type="raised" theme="light" insetScale="xl">
+          <Text.Body>{text}</Text.Body>
+        </WrappedCard>
+      </VisualSpec>
+
+      <VisualSpec label="Type - Flat, Theme - Dark, Disabled: true">
+        <WrappedCard
+          type="flat"
+          theme="dark"
+          insetScale="s"
+          isDisabled
+          to="http://www.commercetools.com"
+        >
+          <Text.Body>{text}</Text.Body>
+        </WrappedCard>
+      </VisualSpec>
+      <VisualSpec label="Type - Flat, Theme - Light, Disabled: true">
+        <WrappedCard
+          type="flat"
+          theme="light"
+          insetScale="s"
+          isDisabled
+          to="http://www.commercetools.com"
+        >
+          <Text.Body>{text}</Text.Body>
+        </WrappedCard>
+      </VisualSpec>
+      <VisualSpec label="Type - Raised, Theme - Dark, Disabled: false">
+        <WrappedCard type="raised" theme="dark" insetScale="s">
+          <Text.Body>{text}</Text.Body>
+        </WrappedCard>
+      </VisualSpec>
+      <VisualSpec label="Type - Raised, Theme - Light, Disabled: false">
+        <WrappedCard type="raised" theme="light" insetScale="s">
+          <Text.Body>{text}</Text.Body>
+        </WrappedCard>
+      </VisualSpec>
+
+      <VisualSpec label="Content using all vertical space from the parent">
+        <WrappedCard type="raised" theme="light" insetScale="m" height="400px">
+          <div
+            css={css`
+              display: flex;
+              flex-direction: column;
+              justify-content: space-between;
+              height: 100%;
+            `}
+          >
+            <div>{text}</div>
+            <div>{text}</div>
+          </div>
+        </WrappedCard>
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/collapsible-panel/src/collapsible-panel.stories.tsx
+++ b/packages/components/collapsible-panel/src/collapsible-panel.stories.tsx
@@ -1,5 +1,6 @@
 import { type ComponentProps } from 'react';
-import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { VisualSpec } from '@/storybook-helpers';
 import CollapsiblePanel from './collapsible-panel';
 import CollapsiblePanelHeader from './collapsible-panel-header';
 
@@ -56,4 +57,274 @@ BasicExample.args = {
   headerControls: 'Here you can place controls',
   theme: 'light',
   children: 'Content',
+};
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="condensed - dark">
+        <CollapsiblePanel
+          header="Header"
+          description="Some description"
+          isDisabled={false}
+          tone="primary"
+          headerControls="headerControl"
+          theme="dark"
+          condensed
+          secondaryHeader="Secondary Header"
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+      <VisualSpec label="condensed - light">
+        <CollapsiblePanel
+          header="Header"
+          description="Some description"
+          isDisabled={false}
+          tone="primary"
+          headerControls="headerControl"
+          theme="light"
+          condensed
+          secondaryHeader="Secondary Header"
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+      <VisualSpec label="condensed - light - hideExpansionControls">
+        <CollapsiblePanel
+          header="Header"
+          description="Some description"
+          isDisabled={false}
+          hideExpansionControls={true}
+          tone="primary"
+          headerControls="headerControl"
+          theme="light"
+          condensed
+          secondaryHeader="Secondary Header"
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+      <VisualSpec label="condensed - light - isDisabled">
+        <CollapsiblePanel
+          header="Header"
+          description="Some description"
+          isDisabled={true}
+          tone="primary"
+          headerControls="headerControl"
+          theme="light"
+          condensed
+          secondaryHeader="Secondary Header"
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+      <VisualSpec label="regular (not condensed) - dark">
+        <CollapsiblePanel
+          header={<CollapsiblePanel.Header>Header</CollapsiblePanel.Header>}
+          description="Some description"
+          isDisabled={false}
+          tone="primary"
+          headerControls="headerControl"
+          theme="dark"
+          secondaryHeader="Secondary Header"
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+      <VisualSpec label="regular (not condensed) - dark - hideExpansionControls">
+        <CollapsiblePanel
+          header={<CollapsiblePanel.Header>Header</CollapsiblePanel.Header>}
+          description="Some description"
+          isDisabled={false}
+          hideExpansionControls={true}
+          tone="primary"
+          headerControls="headerControl"
+          theme="dark"
+          secondaryHeader="Secondary Header"
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+      <VisualSpec label="regular (not condensed) - dark - isDisabled">
+        <CollapsiblePanel
+          header={<CollapsiblePanel.Header>Header</CollapsiblePanel.Header>}
+          description="Some description"
+          isDisabled={true}
+          tone="primary"
+          headerControls="headerControl"
+          theme="dark"
+          secondaryHeader="Secondary Header"
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+      <VisualSpec label="regular (not condensed) - light">
+        <CollapsiblePanel
+          header={<CollapsiblePanel.Header>Header</CollapsiblePanel.Header>}
+          description="Some description"
+          isDisabled={false}
+          tone="primary"
+          headerControls="headerControl"
+          theme="light"
+          secondaryHeader="Secondary Header"
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+      <VisualSpec label="condensed - light and urgent">
+        <CollapsiblePanel
+          header={<CollapsiblePanel.Header>Header</CollapsiblePanel.Header>}
+          description="Some description"
+          isDisabled={false}
+          tone="urgent"
+          headerControls="headerControl"
+          theme="light"
+          condensed
+          secondaryHeader="Secondary Header"
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+      <VisualSpec label="condensed - dark and urgent">
+        <CollapsiblePanel
+          header={<CollapsiblePanel.Header>Header</CollapsiblePanel.Header>}
+          description="Some description"
+          isDisabled={false}
+          tone="urgent"
+          headerControls="headerControl"
+          theme="dark"
+          condensed
+          secondaryHeader="Secondary Header"
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+      <VisualSpec label="condensed - dark and urgent - isDisabled">
+        <CollapsiblePanel
+          header={<CollapsiblePanel.Header>Header</CollapsiblePanel.Header>}
+          description="Some description"
+          isDisabled={true}
+          tone="urgent"
+          headerControls="headerControl"
+          theme="dark"
+          condensed
+          secondaryHeader="Secondary Header"
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+      <VisualSpec label="regular (not condensed) - light and urgent">
+        <CollapsiblePanel
+          header={<CollapsiblePanel.Header>Header</CollapsiblePanel.Header>}
+          description="Some description"
+          isDisabled={false}
+          tone="urgent"
+          headerControls="headerControl"
+          theme="light"
+          secondaryHeader="Secondary Header"
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+      <VisualSpec label="regular (not condensed) - dark and urgent">
+        <CollapsiblePanel
+          header={<CollapsiblePanel.Header>Header</CollapsiblePanel.Header>}
+          description="Some description"
+          isDisabled={false}
+          tone="urgent"
+          headerControls="headerControl"
+          theme="dark"
+          secondaryHeader="Secondary Header"
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+      <VisualSpec label="regular (not condensed) - dark and urgent - hideExpansionControls">
+        <CollapsiblePanel
+          header={<CollapsiblePanel.Header>Header</CollapsiblePanel.Header>}
+          description="Some description"
+          isDisabled={false}
+          hideExpansionControls={true}
+          tone="urgent"
+          headerControls="headerControl"
+          theme="dark"
+          secondaryHeader="Secondary Header"
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+      <VisualSpec label="regular (not condensed) - dark and urgent - isDisabled">
+        <CollapsiblePanel
+          header={<CollapsiblePanel.Header>Header</CollapsiblePanel.Header>}
+          description="Some description"
+          isDisabled={true}
+          tone="urgent"
+          headerControls="headerControl"
+          theme="dark"
+          secondaryHeader="Secondary Header"
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+      <VisualSpec label="regular (not condensed) - headerControls aligned to left">
+        <CollapsiblePanel
+          header={<CollapsiblePanel.Header>Header</CollapsiblePanel.Header>}
+          description="Some description"
+          isDisabled={true}
+          tone="urgent"
+          headerControls="headerControl"
+          theme="dark"
+          secondaryHeader="Secondary Header"
+          headerControlsAlignment="left"
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+      <VisualSpec label="regular (not condensed) - horizontalConstraint set to scale">
+        <CollapsiblePanel
+          header={<CollapsiblePanel.Header>Header</CollapsiblePanel.Header>}
+          description="Some description"
+          isDisabled={false}
+          tone="primary"
+          headerControls="headerControl"
+          theme="dark"
+          secondaryHeader="Secondary Header"
+          horizontalConstraint="scale"
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+      <VisualSpec label="regular (not condensed) - horizontalConstraint set to 6">
+        <CollapsiblePanel
+          header={<CollapsiblePanel.Header>Header</CollapsiblePanel.Header>}
+          description="Some description"
+          isDisabled={false}
+          tone="primary"
+          headerControls="headerControl"
+          theme="dark"
+          horizontalConstraint={6}
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+      <VisualSpec label="condensed - horizontalConstraint set to 11">
+        <CollapsiblePanel
+          header="Header"
+          description="Some description"
+          isDisabled={false}
+          tone="primary"
+          headerControls="headerControl"
+          theme="dark"
+          condensed
+          secondaryHeader="Secondary Header"
+          horizontalConstraint={11}
+        >
+          Content
+        </CollapsiblePanel>
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/constraints/src/horizontal/horizontal.stories.tsx
+++ b/packages/components/constraints/src/horizontal/horizontal.stories.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps } from 'react';
-import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { VisualSpec } from '@/storybook-helpers';
 import Constraints from './../index';
 import styled from '@emotion/styled';
 import { designTokens } from '@commercetools-uikit/design-system';
@@ -99,4 +100,109 @@ export const VisualizeConstraints: StoryFn<ConstraintsHorizontalProps> = () => {
       </Stack>
     </Wrapper>
   );
+};
+
+const GreenBox = styled.div`
+  width: 100%;
+  height: 20px;
+  background-color: green;
+`;
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="when max is 1">
+        <Constraints.Horizontal max={1}>
+          <GreenBox />
+        </Constraints.Horizontal>
+      </VisualSpec>
+      <VisualSpec label="when max is 2">
+        <Constraints.Horizontal max={2}>
+          <GreenBox />
+        </Constraints.Horizontal>
+      </VisualSpec>
+      <VisualSpec label="when max is 3">
+        <Constraints.Horizontal max={3}>
+          <GreenBox />
+        </Constraints.Horizontal>
+      </VisualSpec>
+      <VisualSpec label="when max is 4">
+        <Constraints.Horizontal max={4}>
+          <GreenBox />
+        </Constraints.Horizontal>
+      </VisualSpec>
+      <VisualSpec label="when max is 5">
+        <Constraints.Horizontal max={5}>
+          <GreenBox />
+        </Constraints.Horizontal>
+      </VisualSpec>
+      <VisualSpec label="when max is 6">
+        <Constraints.Horizontal max={6}>
+          <GreenBox />
+        </Constraints.Horizontal>
+      </VisualSpec>
+      <VisualSpec label="when max is 7">
+        <Constraints.Horizontal max={7}>
+          <GreenBox />
+        </Constraints.Horizontal>
+      </VisualSpec>
+      <VisualSpec label="when max is 8">
+        <Constraints.Horizontal max={8}>
+          <GreenBox />
+        </Constraints.Horizontal>
+      </VisualSpec>
+      <VisualSpec label="when max is 9">
+        <Constraints.Horizontal max={9}>
+          <GreenBox />
+        </Constraints.Horizontal>
+      </VisualSpec>
+      <VisualSpec label="when max is 10">
+        <Constraints.Horizontal max={10}>
+          <GreenBox />
+        </Constraints.Horizontal>
+      </VisualSpec>
+      <VisualSpec label="when max is 11">
+        <Constraints.Horizontal max={11}>
+          <GreenBox />
+        </Constraints.Horizontal>
+      </VisualSpec>
+      <VisualSpec label="when max is 12">
+        <Constraints.Horizontal max={12}>
+          <GreenBox />
+        </Constraints.Horizontal>
+      </VisualSpec>
+      <VisualSpec label="when max is 13">
+        <Constraints.Horizontal max={13}>
+          <GreenBox />
+        </Constraints.Horizontal>
+      </VisualSpec>
+      <VisualSpec label="when max is 14">
+        <Constraints.Horizontal max={14}>
+          <GreenBox />
+        </Constraints.Horizontal>
+      </VisualSpec>
+      <VisualSpec label="when max is 15">
+        <Constraints.Horizontal max={15}>
+          <GreenBox />
+        </Constraints.Horizontal>
+      </VisualSpec>
+      <VisualSpec label="when max is 16">
+        <Constraints.Horizontal max={16}>
+          <GreenBox />
+        </Constraints.Horizontal>
+      </VisualSpec>
+      <VisualSpec label='when max is "scale"'>
+        <Constraints.Horizontal max="scale">
+          <GreenBox />
+        </Constraints.Horizontal>
+      </VisualSpec>
+      <VisualSpec label='when max is "auto"'>
+        <Constraints.Horizontal max="auto">
+          <GreenBox />
+        </Constraints.Horizontal>
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/data-table/src/data-table.stories.tsx
+++ b/packages/components/data-table/src/data-table.stories.tsx
@@ -1,5 +1,7 @@
-import { useMemo, useState } from 'react';
-import type { Meta, StoryFn } from '@storybook/react-vite';
+import { useMemo, useState, type ReactNode } from 'react';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import sortBy from 'lodash/sortBy';
+import { VisualSpec } from '@/storybook-helpers';
 import DataTable, { type TColumn } from './data-table';
 
 import CheckboxInput from '../../inputs/checkbox-input';
@@ -278,4 +280,642 @@ BasicExample.args = {
     },
   ],
   footer: <div>Display any React component as footer.</div>,
+};
+
+type FakeMovie = {
+  id: string;
+  title: string;
+  year: number;
+  director: string;
+  country: string;
+};
+
+const testRows = [
+  {
+    id: '1-parasite',
+    title: 'Parasite',
+    year: 2019,
+    director: 'Bong',
+    country: 'South Korea',
+  },
+  {
+    id: '2-woman',
+    title: 'Woman At War',
+    year: 2018,
+    director: 'Erlingsson',
+    country: 'Iceland',
+  },
+  {
+    id: '3-gems',
+    title: 'Uncut Gems',
+    year: 2019,
+    director: 'Safdie',
+    country: 'USA',
+  },
+];
+
+const testColumns = [
+  {
+    key: 'title',
+    label: 'Title',
+  },
+  {
+    key: 'year',
+    label: 'Year',
+  },
+  {
+    key: 'director',
+    label: 'Directed By',
+  },
+  {
+    key: 'country',
+    label: 'Country',
+  },
+];
+
+const countryFlagRenderer = (country: string) => {
+  if (country === 'South Korea') return 'KR';
+  if (country === 'Iceland') return 'IS';
+  if (country === 'USA') return 'US';
+  return 'idk lol';
+};
+
+const customItemRenderer = (
+  item: FakeMovie,
+  column: TColumn<FakeMovie>
+): ReactNode => {
+  if (column.key === 'country') {
+    return countryFlagRenderer(item.country);
+  }
+  return item[column.key as keyof FakeMovie];
+};
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="default">
+        <DataTable rows={testRows} columns={testColumns} />
+      </VisualSpec>
+      <VisualSpec label="default - in a narrow container">
+        <div style={{ width: 300, overflow: 'scroll' }}>
+          <DataTable rows={testRows} columns={testColumns} />
+        </div>
+      </VisualSpec>
+      <VisualSpec label="default - in a short container">
+        <div style={{ height: 150, overflow: 'scroll' }}>
+          <DataTable rows={testRows} columns={testColumns} />
+        </div>
+      </VisualSpec>
+      <VisualSpec label="default - in a container with a background">
+        <div style={{ backgroundColor: 'gray' }}>
+          <DataTable rows={testRows} columns={testColumns} />
+        </div>
+      </VisualSpec>
+      <VisualSpec label="Non condensed mode">
+        <DataTable rows={testRows} columns={testColumns} isCondensed={false} />
+      </VisualSpec>
+      <VisualSpec label="with a numeric max-width">
+        <DataTable rows={testRows} columns={testColumns} maxWidth={300} />
+      </VisualSpec>
+      <VisualSpec label="with a numeric max-height">
+        <DataTable rows={testRows} columns={testColumns} maxHeight={150} />
+      </VisualSpec>
+      <VisualSpec label="with a css string max-width">
+        <DataTable
+          rows={testRows}
+          columns={testColumns}
+          maxWidth="calc(200px + 10%)"
+        />
+      </VisualSpec>
+      <VisualSpec label="with a css string max-height">
+        <DataTable
+          rows={testRows}
+          columns={testColumns}
+          maxHeight="calc(70px + 10%)"
+        />
+      </VisualSpec>
+      <VisualSpec label="with max-width and max-height">
+        <DataTable
+          rows={testRows}
+          columns={testColumns}
+          maxWidth={300}
+          maxHeight={150}
+        />
+      </VisualSpec>
+      <VisualSpec label="Non condensed mode with max-width">
+        <DataTable
+          rows={testRows}
+          columns={testColumns}
+          isCondensed={false}
+          maxWidth={300}
+        />
+      </VisualSpec>
+      <VisualSpec label="horizontalCellAlignment - center">
+        <DataTable
+          rows={testRows}
+          columns={testColumns}
+          horizontalCellAlignment="center"
+        />
+      </VisualSpec>
+      <VisualSpec label="horizontalCellAlignment - right">
+        <DataTable
+          rows={testRows}
+          columns={testColumns}
+          horizontalCellAlignment="right"
+        />
+      </VisualSpec>
+      <VisualSpec label="verticalCellAlignment - center">
+        <DataTable
+          rows={testRows}
+          columns={testColumns}
+          verticalCellAlignment="center"
+        />
+      </VisualSpec>
+      <VisualSpec label="verticalCellAlignment - bottom">
+        <DataTable
+          rows={testRows}
+          columns={testColumns}
+          verticalCellAlignment="bottom"
+        />
+      </VisualSpec>
+      <VisualSpec label="not wrapping header labels">
+        <DataTable
+          rows={testRows}
+          columns={testColumns}
+          wrapHeaderLabels={false}
+        />
+      </VisualSpec>
+      <VisualSpec label="with maxWidth and not wrapping header labels">
+        <DataTable
+          rows={testRows}
+          columns={testColumns}
+          maxWidth={300}
+          wrapHeaderLabels={false}
+        />
+      </VisualSpec>
+      <VisualSpec label="with header stickiness disabled">
+        <DataTable
+          rows={testRows}
+          columns={testColumns}
+          disableHeaderStickiness={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with a footer">
+        <DataTable
+          rows={testRows}
+          columns={testColumns}
+          footer={<div>This is a Footer</div>}
+        />
+      </VisualSpec>
+      <VisualSpec label="with a footer - non condensed mode">
+        <DataTable
+          rows={testRows}
+          columns={testColumns}
+          isCondensed={false}
+          footer={<div>This is a Footer</div>}
+        />
+      </VisualSpec>
+      <VisualSpec label="with custom item renderer">
+        <DataTable
+          rows={testRows}
+          columns={testColumns}
+          itemRenderer={customItemRenderer}
+        />
+      </VisualSpec>
+      <VisualSpec label="with onRowClick">
+        <DataTable
+          rows={testRows}
+          columns={testColumns}
+          onRowClick={() => null}
+        />
+      </VisualSpec>
+      <VisualSpec label="with sortable columns (title and year)">
+        <DataTable
+          rows={testRows}
+          columns={[
+            {
+              key: 'title',
+              label: 'Title',
+              isSortable: true,
+            },
+            {
+              key: 'year',
+              label: 'Year',
+              isSortable: true,
+            },
+            {
+              key: 'director',
+              label: 'Directed By',
+            },
+            {
+              key: 'country',
+              label: 'Country',
+            },
+          ]}
+          onSortChange={() => null}
+        />
+      </VisualSpec>
+      <VisualSpec label="with a column (title) pre-sorted in ascending order">
+        <DataTable
+          rows={sortBy(testRows, 'title')}
+          columns={[
+            {
+              key: 'title',
+              label: 'Title',
+              isSortable: true,
+            },
+            {
+              key: 'year',
+              label: 'Year',
+            },
+            {
+              key: 'director',
+              label: 'Directed By',
+            },
+            {
+              key: 'country',
+              label: 'Country',
+            },
+          ]}
+          sortedBy="title"
+          sortDirection="asc"
+          onSortChange={() => null}
+        />
+      </VisualSpec>
+      <VisualSpec label="with a column (title) pre-sorted in descending order">
+        <DataTable
+          rows={sortBy(testRows, 'title').reverse()}
+          columns={[
+            {
+              key: 'title',
+              label: 'Title',
+            },
+            {
+              key: 'year',
+              label: 'Year',
+            },
+            {
+              key: 'director',
+              label: 'Directed By',
+            },
+            {
+              key: 'country',
+              label: 'Country',
+            },
+          ]}
+          sortedBy="title"
+          sortDirection="desc"
+          onSortChange={() => null}
+        />
+      </VisualSpec>
+      <VisualSpec label="with sortable columns (title and year) aligned to right">
+        <DataTable
+          rows={testRows}
+          columns={[
+            {
+              key: 'title',
+              label: 'Title',
+              isSortable: true,
+              align: 'right',
+            },
+            {
+              key: 'year',
+              label: 'Year',
+              isSortable: true,
+              align: 'right',
+            },
+            {
+              key: 'director',
+              label: 'Directed By',
+            },
+            {
+              key: 'country',
+              label: 'Country',
+            },
+          ]}
+          onSortChange={() => null}
+        />
+      </VisualSpec>
+      <VisualSpec label="with sortable columns (title and year) aligned center">
+        <DataTable
+          rows={testRows}
+          columns={[
+            {
+              key: 'title',
+              label: 'Title',
+              isSortable: true,
+              align: 'center',
+            },
+            {
+              key: 'year',
+              label: 'Year',
+              isSortable: true,
+              align: 'center',
+            },
+            {
+              key: 'director',
+              label: 'Directed By',
+            },
+            {
+              key: 'country',
+              label: 'Country',
+            },
+          ]}
+          onSortChange={() => null}
+        />
+      </VisualSpec>
+      <VisualSpec label="with a column of truncated cells">
+        <DataTable
+          rows={testRows}
+          columns={[
+            {
+              key: 'title',
+              label: 'Title',
+              isTruncated: true,
+            },
+            {
+              key: 'year',
+              label: 'Year',
+            },
+            {
+              key: 'director',
+              label: 'Directed By',
+            },
+            {
+              key: 'country',
+              label: 'Country',
+            },
+          ]}
+        />
+      </VisualSpec>
+      <VisualSpec label="with maxWidth and a column of truncated cells">
+        <DataTable
+          rows={testRows}
+          maxWidth={300}
+          columns={[
+            {
+              key: 'title',
+              label: 'Title',
+              isTruncated: true,
+            },
+            {
+              key: 'year',
+              label: 'Year',
+            },
+            {
+              key: 'director',
+              label: 'Directed By',
+            },
+            {
+              key: 'country',
+              label: 'Country',
+            },
+          ]}
+        />
+      </VisualSpec>
+      <VisualSpec label="with defined per-column widths">
+        <DataTable
+          rows={testRows}
+          columns={[
+            {
+              key: 'title',
+              label: 'Title',
+              width: '1fr',
+            },
+            {
+              key: 'year',
+              label: 'Year',
+              width: '100px',
+            },
+            {
+              key: 'director',
+              label: 'Directed By',
+              width: 'minmax(100px, 200px)',
+            },
+            {
+              key: 'country',
+              label: 'Country',
+              width: 'minmax(auto, 100px)',
+            },
+          ]}
+        />
+      </VisualSpec>
+      <VisualSpec label="with defined per-column alignments">
+        <DataTable
+          rows={testRows}
+          columns={[
+            {
+              key: 'title',
+              label: 'Title',
+              align: 'left',
+            },
+            {
+              key: 'year',
+              label: 'Year',
+              align: 'center',
+            },
+            {
+              key: 'director',
+              label: 'Directed By',
+              align: 'right',
+            },
+            {
+              key: 'country',
+              label: 'Country',
+            },
+          ]}
+        />
+      </VisualSpec>
+      <VisualSpec label="with maxWidth and defined per-column widths">
+        <DataTable
+          rows={testRows}
+          maxWidth={300}
+          columns={[
+            {
+              key: 'title',
+              label: 'Title',
+              width: '1fr',
+            },
+            {
+              key: 'year',
+              label: 'Year',
+              width: '100px',
+            },
+            {
+              key: 'director',
+              label: 'Directed By',
+              width: 'minmax(100px, 200px)',
+            },
+            {
+              key: 'country',
+              label: 'Country',
+              width: 'minmax(auto, 100px)',
+            },
+          ]}
+        />
+      </VisualSpec>
+      <VisualSpec label="with maxWidth, defined per-column widths, and truncated columns">
+        <DataTable
+          rows={testRows}
+          maxWidth={300}
+          columns={[
+            {
+              key: 'title',
+              label: 'Title',
+              width: '1fr',
+              isTruncated: true,
+            },
+            {
+              key: 'year',
+              label: 'Year',
+              width: '100px',
+              isTruncated: true,
+            },
+            {
+              key: 'director',
+              label: 'Directed By',
+              width: 'minmax(100px, 200px)',
+              isTruncated: true,
+            },
+            {
+              key: 'country',
+              label: 'Country',
+              width: 'minmax(auto, 100px)',
+              isTruncated: true,
+            },
+          ]}
+        />
+      </VisualSpec>
+      <VisualSpec label="with maxWidth, defined per-column widths, and truncated columns - non condensed mode">
+        <DataTable
+          rows={testRows}
+          maxWidth={300}
+          isCondensed={false}
+          columns={[
+            {
+              key: 'title',
+              label: 'Title',
+              width: '1fr',
+              isTruncated: true,
+            },
+            {
+              key: 'year',
+              label: 'Year',
+              width: '100px',
+              isTruncated: true,
+            },
+            {
+              key: 'director',
+              label: 'Directed By',
+              width: 'minmax(100px, 200px)',
+              isTruncated: true,
+            },
+            {
+              key: 'country',
+              label: 'Country',
+              width: 'minmax(auto, 100px)',
+              isTruncated: true,
+            },
+          ]}
+        />
+      </VisualSpec>
+      <VisualSpec label="column with custom renderItem">
+        <DataTable
+          rows={testRows}
+          columns={[
+            {
+              key: 'title',
+              label: 'Title',
+            },
+            {
+              key: 'year',
+              label: 'Year',
+            },
+            {
+              key: 'director',
+              label: 'Directed By',
+            },
+            {
+              key: 'country',
+              label: 'Country',
+              renderItem: (row) => countryFlagRenderer(row.country),
+            },
+          ]}
+        />
+      </VisualSpec>
+      <VisualSpec label="column with headerIcon">
+        <DataTable
+          rows={testRows}
+          columns={[
+            {
+              key: 'title',
+              label: 'Title',
+            },
+            {
+              key: 'year',
+              label: 'Year',
+            },
+            {
+              key: 'director',
+              label: 'Directed By',
+            },
+            {
+              key: 'country',
+              label: 'Country',
+              headerIcon: (
+                <IconButton
+                  icon={<InformationIcon />}
+                  label="Country Info"
+                  size="small"
+                  onClick={() => null}
+                />
+              ),
+            },
+          ]}
+        />
+      </VisualSpec>
+      <VisualSpec label="with disabledSelfContainment">
+        <DataTable
+          rows={testRows}
+          columns={testColumns}
+          maxWidth={300}
+          maxHeight={300}
+          disableSelfContainment={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="column with headerIcon and no label">
+        <DataTable
+          rows={testRows}
+          columns={[
+            {
+              key: 'title',
+              label: 'Title',
+            },
+            {
+              key: 'year',
+              label: 'Year',
+            },
+            {
+              key: 'director',
+              label: 'Directed By',
+            },
+            {
+              key: 'country',
+              label: '',
+              headerIcon: (
+                <IconButton
+                  icon={<InformationIcon />}
+                  label="Country Info"
+                  size="small"
+                  onClick={() => null}
+                />
+              ),
+            },
+          ]}
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/field-label/src/field-label.stories.tsx
+++ b/packages/components/field-label/src/field-label.stories.tsx
@@ -2,7 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { iconArgType } from '@/storybook-helpers';
 import FieldLabel from './field-label';
 import FlatButton from '@commercetools-uikit/flat-button';
-import { BoxIcon } from '@commercetools-uikit/icons';
+import { BoxIcon, WarningIcon } from '@commercetools-uikit/icons';
+import styled from '@emotion/styled';
+import { VisualSpec } from '@/storybook-helpers';
 
 const meta: Meta<typeof FieldLabel> = {
   title: 'Form/Fields/Field__/FieldLabel',
@@ -40,4 +42,90 @@ export const BasicExample: Story = {
       />
     ),
   },
+};
+
+const BorderedBox = styled.div`
+  border: 1px solid red;
+`;
+const NonRenderingComponent = () => null;
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <FieldLabel title="Hello" horizontalConstraint={7} />
+      </VisualSpec>
+      <VisualSpec label="with hint and hint icon">
+        <FieldLabel
+          title="Hello"
+          hint="a hint"
+          hintIcon={<WarningIcon />}
+          horizontalConstraint={7}
+        />
+      </VisualSpec>
+      <VisualSpec label="with required indicator">
+        <FieldLabel
+          title="Hello"
+          hasRequiredIndicator={true}
+          horizontalConstraint={7}
+        />
+      </VisualSpec>
+      <VisualSpec label="with required indicator and ReactNode as title">
+        <FieldLabel
+          title={<div>Hello</div>}
+          hasRequiredIndicator={true}
+          horizontalConstraint={7}
+        />
+      </VisualSpec>
+      <VisualSpec label="with all options">
+        <FieldLabel
+          title="Hello"
+          hasRequiredIndicator={true}
+          onInfoButtonClick={() => {}}
+          hint="a hint"
+          hintIcon={<WarningIcon />}
+          description="description"
+          badge={<FlatButton tone="primary" label="show" />}
+          htmlFor="sampleInput"
+          horizontalConstraint={7}
+        />
+      </VisualSpec>
+      <VisualSpec label="with all options and large horizontal constraint">
+        <FieldLabel
+          title="Hello"
+          hasRequiredIndicator={true}
+          onInfoButtonClick={() => {}}
+          hint="a hint"
+          hintIcon={<WarningIcon />}
+          description="description"
+          badge={<FlatButton tone="primary" label="show" />}
+          htmlFor="sampleInput"
+          horizontalConstraint={10}
+        />
+      </VisualSpec>
+      <VisualSpec label="with a very long hint">
+        <FieldLabel
+          title="Hello"
+          hint="Sed vel condimentum lacus. Nam sit amet dui et magna tincidunt faucibus. Praesent gravida tempor semper. Donec et faucibus ante. Maecenas consectetur urna mi."
+          hintIcon={<WarningIcon />}
+          horizontalConstraint={7}
+        />
+      </VisualSpec>
+      <VisualSpec label="with inverted tone" backgroundColor="black">
+        <FieldLabel
+          title="Hello"
+          description="description"
+          hasRequiredIndicator={true}
+          tone="inverted"
+        />
+      </VisualSpec>
+      <VisualSpec label="with react component description which renders nothing">
+        <BorderedBox>
+          <FieldLabel title="Hello" description={<NonRenderingComponent />} />
+        </BorderedBox>
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.stories.tsx
+++ b/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.stories.tsx
@@ -1,7 +1,7 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
 import AsyncCreatableSelectField from './async-creatable-select-field';
 import { useEffect, useState } from 'react';
-import { iconArgType } from '@/storybook-helpers';
+import { iconArgType, VisualSpec } from '@/storybook-helpers';
 
 const meta: Meta<typeof AsyncCreatableSelectField> = {
   title: 'Form/Fields/AsyncCreatableSelectField',
@@ -190,4 +190,131 @@ BasicExample.args = {
   createOptionPosition: 'last',
   isCondensed: false,
   noOptionsMessage: (str: string) => `There are no animals matching "${str}"`,
+};
+
+// The route file calls these `options`/`loadOptions` and `value`; renamed to
+// avoid the module-scope names the demo stories already use.
+const visualLoadOptions = () =>
+  Promise.resolve([
+    { value: 'one', label: 'One' },
+    { value: 'two', label: 'Two' },
+  ]);
+
+const visualValue = { value: 'one', label: 'One' };
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <AsyncCreatableSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+        />
+      </VisualSpec>
+      <VisualSpec label="when disabled">
+        <AsyncCreatableSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          isDisabled={true}
+        />
+      </VisualSpec>
+      <VisualSpec label={'with "missing" error when not touched'}>
+        <AsyncCreatableSelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+        />
+      </VisualSpec>
+      <VisualSpec label={'with "missing" error when touched'}>
+        <AsyncCreatableSelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+          touched={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with hint">
+        <AsyncCreatableSelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          hint="Select a state"
+        />
+      </VisualSpec>
+      <VisualSpec label="when read-only">
+        <AsyncCreatableSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          isReadOnly={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when has warning">
+        <AsyncCreatableSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          hasWarning={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when not touched">
+        <AsyncCreatableSelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when touched">
+        <AsyncCreatableSelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          touched={true}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="is condensed">
+        <AsyncCreatableSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          isCondensed={true}
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.stories.tsx
+++ b/packages/components/fields/async-creatable-select-field/src/async-creatable-select-field.stories.tsx
@@ -192,8 +192,7 @@ BasicExample.args = {
   noOptionsMessage: (str: string) => `There are no animals matching "${str}"`,
 };
 
-// The route file calls these `options`/`loadOptions` and `value`; renamed to
-// avoid the module-scope names the demo stories already use.
+// Renamed to avoid the `loadOptions` the demo stories declare above.
 const visualLoadOptions = () =>
   Promise.resolve([
     { value: 'one', label: 'One' },

--- a/packages/components/fields/async-select-field/src/async-select-field.stories.tsx
+++ b/packages/components/fields/async-select-field/src/async-select-field.stories.tsx
@@ -183,8 +183,7 @@ BasicExample.args = {
     `Nothing found for "${inputValue}"`,
 };
 
-// The route file calls these `options`/`loadOptions` and `value`; renamed to
-// avoid the module-scope names the demo stories already use.
+// Renamed to avoid the `loadOptions` the demo stories declare above.
 const visualLoadOptions = () =>
   Promise.resolve([
     { value: 'one', label: 'One' },

--- a/packages/components/fields/async-select-field/src/async-select-field.stories.tsx
+++ b/packages/components/fields/async-select-field/src/async-select-field.stories.tsx
@@ -1,7 +1,7 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
 import AsyncSelectField from './async-select-field';
 import { useEffect, useState } from 'react';
-import { iconArgType } from '@/storybook-helpers';
+import { iconArgType, VisualSpec } from '@/storybook-helpers';
 
 const meta: Meta<typeof AsyncSelectField> = {
   title: 'Form/Fields/AsyncSelectField',
@@ -181,4 +181,131 @@ BasicExample.args = {
   defaultOptions: animalOptions,
   noOptionsMessage: ({ inputValue }: { inputValue: string }) =>
     `Nothing found for "${inputValue}"`,
+};
+
+// The route file calls these `options`/`loadOptions` and `value`; renamed to
+// avoid the module-scope names the demo stories already use.
+const visualLoadOptions = () =>
+  Promise.resolve([
+    { value: 'one', label: 'One' },
+    { value: 'two', label: 'Two' },
+  ]);
+
+const visualValue = { value: 'one', label: 'One' };
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <AsyncSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+        />
+      </VisualSpec>
+      <VisualSpec label="when disabled">
+        <AsyncSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          isDisabled={true}
+        />
+      </VisualSpec>
+      <VisualSpec label={'with "missing" error when not touched'}>
+        <AsyncSelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+        />
+      </VisualSpec>
+      <VisualSpec label={'with "missing" error when touched'}>
+        <AsyncSelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+          touched={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with hint">
+        <AsyncSelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          hint="Select a state"
+        />
+      </VisualSpec>
+      <VisualSpec label="when read-only">
+        <AsyncSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          isReadOnly={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when has warning">
+        <AsyncSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          hasWarning={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when not touched">
+        <AsyncSelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when touched">
+        <AsyncSelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          touched={true}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="is condensed">
+        <AsyncSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          isCondensed={true}
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/fields/creatable-select-field/src/creatable-select-field.stories.tsx
+++ b/packages/components/fields/creatable-select-field/src/creatable-select-field.stories.tsx
@@ -172,8 +172,7 @@ BasicExample.args = {
   badge: '',
 };
 
-// The route file calls these `options`/`loadOptions` and `value`; renamed to
-// avoid the module-scope names the demo stories already use.
+// Renamed to avoid the `options` the demo stories declare above.
 const visualOptions = [
   { value: 'one', label: 'One' },
   { value: 'two', label: 'Two' },

--- a/packages/components/fields/creatable-select-field/src/creatable-select-field.stories.tsx
+++ b/packages/components/fields/creatable-select-field/src/creatable-select-field.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
-import { iconArgType } from '@/storybook-helpers';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { iconArgType, VisualSpec } from '@/storybook-helpers';
 import CreatableSelectField from './creatable-select-field';
 import { useEffect, useState } from 'react';
 
@@ -170,4 +170,134 @@ BasicExample.args = {
   createOptionPosition: 'last',
   description: '',
   badge: '',
+};
+
+// The route file calls these `options`/`loadOptions` and `value`; renamed to
+// avoid the module-scope names the demo stories already use.
+const visualOptions = [
+  { value: 'one', label: 'One' },
+  { value: 'two', label: 'Two' },
+];
+
+const visualValue = { value: 'one', label: 'One' };
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <CreatableSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+        />
+      </VisualSpec>
+      <VisualSpec label="when disabled">
+        <CreatableSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+          isDisabled={true}
+        />
+      </VisualSpec>
+      <VisualSpec label={'with "missing" error when not touched'}>
+        <CreatableSelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+        />
+      </VisualSpec>
+      <VisualSpec label={'with "missing" error when touched'}>
+        <CreatableSelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+          touched={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with hint">
+        <CreatableSelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+          hint="Select a state"
+        />
+      </VisualSpec>
+      <VisualSpec label="when read-only">
+        <CreatableSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+          /* CreatableSelectField types isReadOnly as ConstrainBooleanParameters,
+             unlike its four siblings which use boolean. The component only does
+             `if (!this.props.isReadOnly)`, so this object is truthy and renders
+             exactly as the route file's `true` did. */
+          isReadOnly={{ exact: true }}
+        />
+      </VisualSpec>
+      <VisualSpec label="when has warning">
+        <CreatableSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+          hasWarning={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when not touched">
+        <CreatableSelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when touched">
+        <CreatableSelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          touched={true}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="is condensed">
+        <CreatableSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+          isCondensed={true}
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/fields/date-field/src/date-field.stories.tsx
+++ b/packages/components/fields/date-field/src/date-field.stories.tsx
@@ -1,5 +1,6 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
 import DateField from './date-field';
+import { VisualSpec } from '@/storybook-helpers';
 import { getExampleDateStrings } from '@commercetools-uikit/calendar-utils';
 import { useState } from 'react';
 import { iconArgType } from '@/storybook-helpers';
@@ -73,4 +74,116 @@ BasicExample.args = {
   hint: 'Select the date of publication',
   description: '',
   badge: '',
+};
+
+const value = '2018-09-20';
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <DateField
+          title="Release Date"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+        />
+      </VisualSpec>
+      <VisualSpec label="when disabled">
+        <DateField
+          title="Release Date"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          isDisabled={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when required">
+        <DateField
+          title="Release Date"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          isRequired={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with description">
+        <DateField
+          title="Release Date"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          description="When will the product be avialable?"
+        />
+      </VisualSpec>
+      <VisualSpec label="with placeholder">
+        <DateField
+          title="Release Date"
+          horizontalConstraint={7}
+          value=""
+          onChange={() => {}}
+          placeholder="Select release date"
+        />
+      </VisualSpec>
+      <VisualSpec label="with error when not touched">
+        <DateField
+          title="Release Date"
+          horizontalConstraint={7}
+          value=""
+          onChange={() => {}}
+          errors={{ missing: true }}
+        />
+      </VisualSpec>
+      <VisualSpec label="with error when touched">
+        <DateField
+          title="Release Date"
+          horizontalConstraint={7}
+          value=""
+          onChange={() => {}}
+          errors={{ missing: true }}
+          touched={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when read-only">
+        <DateField
+          title="Release Date"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          isReadOnly
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when not touched">
+        <DateField
+          title="Release Date"
+          horizontalConstraint={7}
+          value=""
+          onChange={() => {}}
+          warnings={{ customWarning: true }}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when touched">
+        <DateField
+          title="Release Date"
+          horizontalConstraint={7}
+          value=""
+          onChange={() => {}}
+          warnings={{ customWarning: true }}
+          touched={true}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="is condensed">
+        <DateField
+          title="Release Date"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          isCondensed={true}
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/fields/date-range-field/src/date-range-field.stories.tsx
+++ b/packages/components/fields/date-range-field/src/date-range-field.stories.tsx
@@ -1,5 +1,6 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
 import DateRangeField from './date-range-field';
+import { VisualSpec } from '@/storybook-helpers';
 import { useState } from 'react';
 import { type MomentInput } from 'moment';
 
@@ -66,4 +67,116 @@ BasicExample.args = {
   badge: '',
   onInfoButtonClick: () =>
     alert(`You won't actually get any free vacations :(`),
+};
+
+const value = ['2018-09-20', '2018-09-24'];
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <DateRangeField
+          title="Discounted days"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+        />
+      </VisualSpec>
+      <VisualSpec label="when disabled">
+        <DateRangeField
+          title="Discounted days"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          isDisabled={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when required">
+        <DateRangeField
+          title="Discounted days"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          isRequired={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with description">
+        <DateRangeField
+          title="Discounted days"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          description="When will the product be discounted?"
+        />
+      </VisualSpec>
+      <VisualSpec label="with placeholder">
+        <DateRangeField
+          title="Discounted days"
+          horizontalConstraint={7}
+          value={[]}
+          onChange={() => {}}
+          placeholder="Select release date"
+        />
+      </VisualSpec>
+      <VisualSpec label="with error when not touched">
+        <DateRangeField
+          title="Discounted days"
+          horizontalConstraint={7}
+          value={[]}
+          onChange={() => {}}
+          errors={{ missing: true }}
+        />
+      </VisualSpec>
+      <VisualSpec label="with error when touched">
+        <DateRangeField
+          title="Discounted days"
+          horizontalConstraint={7}
+          value={[]}
+          onChange={() => {}}
+          errors={{ missing: true }}
+          touched={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when read-only">
+        <DateRangeField
+          title="Discounted Days"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          isReadOnly
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when not touched">
+        <DateRangeField
+          title="Discounted days"
+          horizontalConstraint={7}
+          value={[]}
+          onChange={() => {}}
+          warnings={{ customWarning: true }}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when touched">
+        <DateRangeField
+          title="Discounted days"
+          horizontalConstraint={7}
+          value={[]}
+          onChange={() => {}}
+          warnings={{ customWarning: true }}
+          touched={true}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="is condensed">
+        <DateRangeField
+          title="Discounted days"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          isCondensed={true}
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/fields/date-time-field/src/date-time-field.stories.tsx
+++ b/packages/components/fields/date-time-field/src/date-time-field.stories.tsx
@@ -1,5 +1,6 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
 import DateTimeField from './date-time-field';
+import { VisualSpec } from '@/storybook-helpers';
 import { useState } from 'react';
 
 const meta: Meta<typeof DateTimeField> = {
@@ -77,4 +78,127 @@ BasicExample.args = {
   hint: 'Select the date of publication',
   description: '',
   badge: '',
+};
+
+const value = '2018-11-30T13:25:59.500Z';
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <DateTimeField
+          timeZone="UTC"
+          title="Release Date"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+        />
+      </VisualSpec>
+      <VisualSpec label="when disabled">
+        <DateTimeField
+          timeZone="UTC"
+          title="Release Date"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          isDisabled={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when required">
+        <DateTimeField
+          timeZone="UTC"
+          title="Release Date"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          isRequired={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with description">
+        <DateTimeField
+          timeZone="UTC"
+          title="Release Date"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          description="When will the product be avialable?"
+        />
+      </VisualSpec>
+      <VisualSpec label="with placeholder">
+        <DateTimeField
+          timeZone="UTC"
+          title="Release Date"
+          horizontalConstraint={7}
+          value=""
+          onChange={() => {}}
+          placeholder="Select release date"
+        />
+      </VisualSpec>
+      <VisualSpec label="with error when not touched">
+        <DateTimeField
+          timeZone="UTC"
+          title="Release Date"
+          horizontalConstraint={7}
+          value=""
+          onChange={() => {}}
+          errors={{ missing: true }}
+        />
+      </VisualSpec>
+      <VisualSpec label="with error when touched">
+        <DateTimeField
+          timeZone="UTC"
+          title="Release Date"
+          horizontalConstraint={7}
+          value=""
+          onChange={() => {}}
+          errors={{ missing: true }}
+          touched={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when read-only">
+        <DateTimeField
+          timeZone="UTC"
+          title="Release Date"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          isReadOnly
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when not touched">
+        <DateTimeField
+          timeZone="UTC"
+          title="Release Date"
+          horizontalConstraint={7}
+          value=""
+          onChange={() => {}}
+          warnings={{ customWarning: true }}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when touched">
+        <DateTimeField
+          timeZone="UTC"
+          title="Release Date"
+          horizontalConstraint={7}
+          value=""
+          onChange={() => {}}
+          warnings={{ customWarning: true }}
+          touched={true}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="is condensed">
+        <DateTimeField
+          timeZone="UTC"
+          title="Release Date"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          isCondensed={true}
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/fields/localized-multiline-text-field/src/localized-multiline-text-field.stories.tsx
+++ b/packages/components/fields/localized-multiline-text-field/src/localized-multiline-text-field.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
-import { iconArgType } from '@/storybook-helpers';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { iconArgType, VisualSpec } from '@/storybook-helpers';
 import LocalizedMultilineTextField, {
   TLocalizedMultilineTextFieldProps,
 } from './localized-multiline-text-field';
@@ -114,4 +114,179 @@ WithError.args = {
     en: 'A sample error',
     de: 'Ein Beispiel-Fehler',
   },
+};
+
+const lorem =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.';
+
+const visualValue = {
+  en: lorem,
+  de: lorem,
+  es: lorem,
+};
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <LocalizedMultilineTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+        />
+      </VisualSpec>
+      <VisualSpec label="when language controls are hidden">
+        <LocalizedMultilineTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          hideLanguageExpansionControls={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when languages are opened by default">
+        <LocalizedMultilineTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          defaultExpandLanguages={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when read-only and open">
+        <LocalizedMultilineTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          isReadOnly={true}
+          defaultExpandLanguages={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when read-only and closed">
+        <LocalizedMultilineTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          isReadOnly={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when disabled and open">
+        <LocalizedMultilineTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          isDisabled={true}
+          defaultExpandLanguages={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when disabled and closed">
+        <LocalizedMultilineTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          isDisabled={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when condensed and open">
+        <LocalizedMultilineTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          isCondensed={true}
+          defaultExpandLanguages={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when condensed and closed">
+        <LocalizedMultilineTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          isCondensed={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when there is an error and the field is not touched">
+        <LocalizedMultilineTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+        />
+      </VisualSpec>
+      <VisualSpec label="when there is an error and the field is touched">
+        <LocalizedMultilineTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+          touched={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when not touched">
+        <LocalizedMultilineTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when touched">
+        <LocalizedMultilineTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          touched={true}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with additional info">
+        <LocalizedMultilineTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          touched={true}
+          additionalInfo={{ en: 'hello here is an info' }}
+        />
+      </VisualSpec>
+      <VisualSpec label="with additional info and error">
+        <LocalizedMultilineTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          touched={true}
+          errors={{ missing: true }}
+          additionalInfo={{ en: 'hello here is an info' }}
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/fields/localized-text-field/src/localized-text-field.stories.tsx
+++ b/packages/components/fields/localized-text-field/src/localized-text-field.stories.tsx
@@ -1,4 +1,5 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { VisualSpec } from '@/storybook-helpers';
 import LocalizedTextField, {
   TLocalizedTextFieldProps,
 } from './localized-text-field';
@@ -99,4 +100,166 @@ WithError.args = {
     en: 'An error for language en',
     de: 'Ein Fehler für die Sprache de',
   },
+};
+
+const visualValue = {
+  en: 'hello world',
+  de: 'hallo welt',
+  es: 'hola mundo',
+};
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <LocalizedTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+        />
+      </VisualSpec>
+      <VisualSpec label="when languages are opened by default">
+        <LocalizedTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          defaultExpandLanguages={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when expansion controls are hidden">
+        <LocalizedTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          hideLanguageExpansionControls={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when read-only and open">
+        <LocalizedTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          isReadOnly={true}
+          defaultExpandLanguages={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when read-only and closed">
+        <LocalizedTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          isReadOnly={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when disabled and open">
+        <LocalizedTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          isDisabled={true}
+          defaultExpandLanguages={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when disabled and closed">
+        <LocalizedTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          isDisabled={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when condensed and open">
+        <LocalizedTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          isCondensed={true}
+          defaultExpandLanguages={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when condensed and closed">
+        <LocalizedTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          isCondensed={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when there is an error and the field is not touched">
+        <LocalizedTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+        />
+      </VisualSpec>
+      <VisualSpec label="when there is an error and the field is touched">
+        <LocalizedTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+          touched={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when not touched">
+        <LocalizedTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when touched">
+        <LocalizedTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          touched={true}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with error and additional info when touched">
+        <LocalizedTextField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          selectedLanguage="en"
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+          additionalInfo={{ en: 'Some intel' }}
+          touched={true}
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/fields/money-field/src/money-field.stories.tsx
+++ b/packages/components/fields/money-field/src/money-field.stories.tsx
@@ -1,5 +1,7 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
 import MoneyField from './money-field';
+import { type TCurrencyCode } from '@commercetools-uikit/money-input';
+import { VisualSpec } from '@/storybook-helpers';
 import { useState } from 'react';
 import { iconArgType } from '@/storybook-helpers';
 
@@ -111,4 +113,161 @@ WithError.args = {
         return null;
     }
   },
+};
+
+// The route file calls these `value` and `currencies`; renamed because
+// `currencies` above is a longer list used by the demo stories.
+const visualValue = {
+  amount: '13.50',
+  currencyCode: 'EUR',
+} as const;
+
+const highPrecisionValue = {
+  amount: '13.501',
+  currencyCode: 'EUR',
+} as const;
+
+// MoneyField types currencyCode as TCurrencyCode with no empty member, but the
+// route file passed '' for the empty-value states and the component handles it.
+const emptyValue = { amount: '', currencyCode: '' as TCurrencyCode };
+
+const visualCurrencies = ['EUR', 'USD'];
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <MoneyField
+          title="Price"
+          horizontalConstraint={7}
+          value={visualValue}
+          onChange={() => {}}
+          currencies={visualCurrencies}
+        />
+      </VisualSpec>
+      <VisualSpec label="without currency selection">
+        <MoneyField
+          title="Price"
+          horizontalConstraint={7}
+          value={visualValue}
+          onChange={() => {}}
+        />
+      </VisualSpec>
+      <VisualSpec label="when disabled">
+        <MoneyField
+          title="Price"
+          horizontalConstraint={7}
+          value={visualValue}
+          onChange={() => {}}
+          currencies={visualCurrencies}
+          isDisabled={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when only the currency select input is disabled">
+        <MoneyField
+          title="Price"
+          horizontalConstraint={7}
+          value={visualValue}
+          onChange={() => {}}
+          currencies={visualCurrencies}
+          isCurrencyInputDisabled={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with description">
+        <MoneyField
+          title="Price"
+          horizontalConstraint={7}
+          value={visualValue}
+          onChange={() => {}}
+          currencies={visualCurrencies}
+          description="How much is the fish?"
+        />
+      </VisualSpec>
+      <VisualSpec label="with high precision badge and regular price">
+        <MoneyField
+          title="Price"
+          horizontalConstraint={7}
+          value={visualValue}
+          onChange={() => {}}
+          currencies={visualCurrencies}
+          hasHighPrecisionBadge={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with high precision badge and high precision price">
+        <MoneyField
+          title="Price"
+          horizontalConstraint={7}
+          value={highPrecisionValue}
+          onChange={() => {}}
+          currencies={visualCurrencies}
+          hasHighPrecisionBadge={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with placeholder">
+        <MoneyField
+          title="Price"
+          horizontalConstraint={7}
+          value={emptyValue}
+          onChange={() => {}}
+          currencies={visualCurrencies}
+          placeholder="Please enter a price"
+        />
+      </VisualSpec>
+      <VisualSpec label="with error when not touched">
+        <MoneyField
+          title="Price"
+          horizontalConstraint={7}
+          value={emptyValue}
+          onChange={() => {}}
+          currencies={visualCurrencies}
+          errors={{ missing: true }}
+        />
+      </VisualSpec>
+      <VisualSpec label="with error when touched">
+        <MoneyField
+          title="Price"
+          horizontalConstraint={7}
+          value={emptyValue}
+          onChange={() => {}}
+          currencies={visualCurrencies}
+          errors={{ missing: true }}
+          touched={{ amount: true, currencyCode: true }}
+        />
+      </VisualSpec>
+      <VisualSpec label="when readonly">
+        <MoneyField
+          title="Price"
+          horizontalConstraint={7}
+          value={visualValue}
+          onChange={() => {}}
+          currencies={visualCurrencies}
+          isReadOnly={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when not touched">
+        <MoneyField
+          title="Price"
+          horizontalConstraint={7}
+          value={emptyValue}
+          onChange={() => {}}
+          currencies={visualCurrencies}
+          warnings={{ customWarning: true }}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when touched">
+        <MoneyField
+          title="Price"
+          horizontalConstraint={7}
+          value={emptyValue}
+          onChange={() => {}}
+          currencies={visualCurrencies}
+          warnings={{ customWarning: true }}
+          touched={{ amount: true, currencyCode: true }}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/fields/money-field/src/money-field.stories.tsx
+++ b/packages/components/fields/money-field/src/money-field.stories.tsx
@@ -115,8 +115,7 @@ WithError.args = {
   },
 };
 
-// The route file calls these `value` and `currencies`; renamed because
-// `currencies` above is a longer list used by the demo stories.
+// Renamed to avoid the `currencies` the demo stories declare above.
 const visualValue = {
   amount: '13.50',
   currencyCode: 'EUR',

--- a/packages/components/fields/multiline-text-field/src/multiline-text-field.stories.tsx
+++ b/packages/components/fields/multiline-text-field/src/multiline-text-field.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
-import { iconArgType } from '@/storybook-helpers';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { iconArgType, VisualSpec } from '@/storybook-helpers';
 import MultilineTextField, {
   TMultiTextFieldProps,
 } from './multiline-text-field';
@@ -78,4 +78,100 @@ BasicExample.args = {
   onInfoButtonClick: () => alert('info button clicked'),
   badge: '',
   value: '',
+};
+
+const value =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.';
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <MultilineTextField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+        />
+      </VisualSpec>
+      <VisualSpec label="when required">
+        <MultilineTextField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          isRequired={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when disabled">
+        <MultilineTextField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          isDisabled={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when placeholder is visible">
+        <MultilineTextField
+          title="Welcome Text"
+          value=""
+          onChange={() => {}}
+          horizontalConstraint={7}
+          placeholder="Enter a text"
+        />
+      </VisualSpec>
+      <VisualSpec label="when placeholder is visible and input is disabled">
+        <MultilineTextField
+          title="Welcome Text"
+          value=""
+          onChange={() => {}}
+          horizontalConstraint={7}
+          isDisabled={true}
+          placeholder="Enter a text"
+        />
+      </VisualSpec>
+      <VisualSpec label="with error when not touched">
+        <MultilineTextField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+        />
+      </VisualSpec>
+      <VisualSpec label="with error when touched">
+        <MultilineTextField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+          touched={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when not touched">
+        <MultilineTextField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when touched">
+        <MultilineTextField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          touched={true}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/fields/number-field/src/number-field.stories.tsx
+++ b/packages/components/fields/number-field/src/number-field.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
-import { iconArgType } from '@/storybook-helpers';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { iconArgType, VisualSpec } from '@/storybook-helpers';
 import NumberField from './number-field';
 import { useState } from 'react';
 
@@ -74,4 +74,108 @@ BasicExample.args = {
   description: '',
   onInfoButtonClick: () => alert('info button clicked'),
   badge: '',
+};
+
+const value = '12.50';
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <NumberField
+          title="Age"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+        />
+      </VisualSpec>
+      <VisualSpec label="when required">
+        <NumberField
+          title="Age"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          isRequired={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when disabled">
+        <NumberField
+          title="Age"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          isDisabled={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when read-only">
+        <NumberField
+          title="Age"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          isReadOnly={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when placeholder is shown">
+        <NumberField
+          title="Age"
+          value=""
+          onChange={() => {}}
+          horizontalConstraint={7}
+          placeholder="Enter a text"
+        />
+      </VisualSpec>
+      <VisualSpec label="when placeholder is shown and input is disabled">
+        <NumberField
+          title="Age"
+          value=""
+          onChange={() => {}}
+          horizontalConstraint={7}
+          isDisabled={true}
+          placeholder="Enter a text"
+        />
+      </VisualSpec>
+      <VisualSpec label="with error when not touched">
+        <NumberField
+          title="Age"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+        />
+      </VisualSpec>
+      <VisualSpec label="with error when touched">
+        <NumberField
+          title="Age"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+          touched={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when not touched">
+        <NumberField
+          title="Age"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when touched">
+        <NumberField
+          title="Age"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          touched={true}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/fields/password-field/src/password-field.stories.tsx
+++ b/packages/components/fields/password-field/src/password-field.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
-import { iconArgType } from '@/storybook-helpers';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { iconArgType, VisualSpec } from '@/storybook-helpers';
 import PasswordField from './password-field';
 import { useState } from 'react';
 
@@ -69,4 +69,118 @@ BasicExample.args = {
   onInfoButtonClick: () => alert('info button clicked'),
   badge: '',
   renderShowHideButton: true,
+};
+
+const value = 'hello world, how are you?';
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <PasswordField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+        />
+      </VisualSpec>
+      <VisualSpec label="when required">
+        <PasswordField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          isRequired={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when disabled">
+        <PasswordField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          isDisabled={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when placeholder is shown">
+        <PasswordField
+          title="Welcome Text"
+          value=""
+          onChange={() => {}}
+          horizontalConstraint={7}
+          placeholder="Enter a text"
+        />
+      </VisualSpec>
+      <VisualSpec label="when placeholder is shown and disabled">
+        <PasswordField
+          title="Welcome Text"
+          value=""
+          onChange={() => {}}
+          horizontalConstraint={7}
+          isDisabled={true}
+          placeholder="Enter a text"
+        />
+      </VisualSpec>
+      <VisualSpec label="with error when not touched">
+        <PasswordField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+        />
+      </VisualSpec>
+      <VisualSpec label="with error when touched">
+        <PasswordField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+          touched={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with description and hint">
+        <PasswordField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          hint="Make sure the Caps Lock is disabled"
+          description="Your secret password"
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when not touched">
+        <PasswordField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when touched">
+        <PasswordField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          touched={true}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with not rendered show/hide password button">
+        <PasswordField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          renderShowHideButton={false}
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/fields/radio-field/src/radio-field.stories.tsx
+++ b/packages/components/fields/radio-field/src/radio-field.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
-import { iconArgType } from '@/storybook-helpers';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { iconArgType, VisualSpec } from '@/storybook-helpers';
 import RadioField from './radio-field';
 import { useState } from 'react';
 import RadioInput from '@commercetools-uikit/radio-input';
@@ -107,4 +107,113 @@ BasicExample.args = {
   directionProps: {
     scale: 'm',
   },
+};
+
+const visualValue = 'apple';
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <RadioField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          horizontalConstraint={7}
+        >
+          <RadioInput.Option value="apple">{'Apple'}</RadioInput.Option>
+          <RadioInput.Option value="orange">{'Banana'}</RadioInput.Option>
+        </RadioField>
+      </VisualSpec>
+      <VisualSpec label="when required">
+        <RadioField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          isRequired={true}
+        >
+          <RadioInput.Option value="apple">{'Apple'}</RadioInput.Option>
+          <RadioInput.Option value="orange">{'Banana'}</RadioInput.Option>
+        </RadioField>
+      </VisualSpec>
+      <VisualSpec label="when disabled">
+        <RadioField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          isDisabled={true}
+        >
+          <RadioInput.Option value="apple">{'Apple'}</RadioInput.Option>
+          <RadioInput.Option value="orange">{'Banana'}</RadioInput.Option>
+        </RadioField>
+      </VisualSpec>
+      <VisualSpec label="when readonly">
+        <RadioField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          isReadOnly={true}
+        >
+          <RadioInput.Option value="apple">{'Apple'}</RadioInput.Option>
+          <RadioInput.Option value="orange">{'Banana'}</RadioInput.Option>
+        </RadioField>
+      </VisualSpec>
+      <VisualSpec label="with error when not touched">
+        <RadioField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+        >
+          <RadioInput.Option value="apple">{'Apple'}</RadioInput.Option>
+          <RadioInput.Option value="orange">{'Banana'}</RadioInput.Option>
+        </RadioField>
+      </VisualSpec>
+      <VisualSpec label="with error when touched">
+        <RadioField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+          touched={true}
+        >
+          <RadioInput.Option value="apple">{'Apple'}</RadioInput.Option>
+          <RadioInput.Option value="orange">{'Banana'}</RadioInput.Option>
+        </RadioField>
+      </VisualSpec>
+      <VisualSpec label="with warning when not touched">
+        <RadioField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          renderWarning={() => 'Custom warning'}
+        >
+          <RadioInput.Option value="apple">{'Apple'}</RadioInput.Option>
+          <RadioInput.Option value="orange">{'Banana'}</RadioInput.Option>
+        </RadioField>
+      </VisualSpec>
+      <VisualSpec label="with warning when touched">
+        <RadioField
+          title="Welcome Text"
+          value={visualValue}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          touched={true}
+          renderWarning={() => 'Custom warning'}
+        >
+          <RadioInput.Option value="apple">{'Apple'}</RadioInput.Option>
+          <RadioInput.Option value="orange">{'Banana'}</RadioInput.Option>
+        </RadioField>
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/fields/search-select-field/src/search-select-field.stories.tsx
+++ b/packages/components/fields/search-select-field/src/search-select-field.stories.tsx
@@ -1,5 +1,8 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
-import { iconArgType } from '@/storybook-helpers';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { iconArgType, VisualSpec } from '@/storybook-helpers';
+// Source path, not `@commercetools-uikit/icons`: this package does not declare
+// icons as a dependency, and CI installs strictly.
+import WorldIcon from '../../../icons/src/generated/WorldReact';
 import SearchSelectField from './search-select-field';
 import { useEffect, useState } from 'react';
 
@@ -141,4 +144,146 @@ BasicExample.args = {
   description: '',
   onInfoButtonClick: () => alert('Info button clicked'),
   badge: '',
+};
+
+// The route file calls these `loadOptions` and `value`; renamed to avoid the
+// module-scope names the demo stories already use.
+const visualLoadOptions = (input: string) =>
+  input
+    ? Promise.resolve([])
+    : Promise.resolve([
+        { value: 'one', label: 'One' },
+        { value: 'two', label: 'Two' },
+      ]);
+
+const visualValue = { value: 'one', label: 'One' };
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <SearchSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+        />
+      </VisualSpec>
+      <VisualSpec label="with iconLeft">
+        <SearchSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          iconLeft={<WorldIcon />}
+        />
+      </VisualSpec>
+      <VisualSpec label="when disabled">
+        <SearchSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          isDisabled={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when condensed">
+        <SearchSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          isCondensed={true}
+        />
+      </VisualSpec>
+      <VisualSpec label={'with "missing" error when not touched'}>
+        <SearchSelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+        />
+      </VisualSpec>
+      <VisualSpec label={'with "missing" error when touched'}>
+        <SearchSelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+          touched={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with hint">
+        <SearchSelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          hint="Select a state"
+        />
+      </VisualSpec>
+      <VisualSpec label="when read-only">
+        <SearchSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          isReadOnly={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when has warning">
+        <SearchSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          hasWarning={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when not touched">
+        <SearchSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when touched">
+        <SearchSelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          loadOptions={visualLoadOptions}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          touched={true}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/fields/search-select-field/src/search-select-field.stories.tsx
+++ b/packages/components/fields/search-select-field/src/search-select-field.stories.tsx
@@ -146,8 +146,7 @@ BasicExample.args = {
   badge: '',
 };
 
-// The route file calls these `loadOptions` and `value`; renamed to avoid the
-// module-scope names the demo stories already use.
+// Renamed to avoid the `loadOptions` the demo stories declare above.
 const visualLoadOptions = (input: string) =>
   input
     ? Promise.resolve([])

--- a/packages/components/fields/select-field/src/select-field.stories.tsx
+++ b/packages/components/fields/select-field/src/select-field.stories.tsx
@@ -156,8 +156,7 @@ BasicExample.args = {
   badge: '',
 };
 
-// The route file calls these `options`/`loadOptions` and `value`; renamed to
-// avoid the module-scope names the demo stories already use.
+// Renamed to avoid the `options` the demo stories declare above.
 const visualOptions = [
   { value: 'one', label: 'One' },
   { value: 'two', label: 'Two' },

--- a/packages/components/fields/select-field/src/select-field.stories.tsx
+++ b/packages/components/fields/select-field/src/select-field.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
-import { iconArgType } from '@/storybook-helpers';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { iconArgType, VisualSpec } from '@/storybook-helpers';
 import SelectField from './select-field';
 import { useEffect, useState } from 'react';
 
@@ -154,4 +154,132 @@ BasicExample.args = {
   onInfoButtonClick: () => alert('info button clicked'),
   hasWarning: false,
   badge: '',
+};
+
+// The route file calls these `options`/`loadOptions` and `value`; renamed to
+// avoid the module-scope names the demo stories already use.
+const visualOptions = [
+  { value: 'one', label: 'One' },
+  { value: 'two', label: 'Two' },
+];
+
+const visualValue = 'one';
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <SelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+        />
+      </VisualSpec>
+      <VisualSpec label="when disabled">
+        <SelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+          isDisabled={true}
+        />
+      </VisualSpec>
+      <VisualSpec label={'with "missing" error when not touched'}>
+        <SelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+        />
+      </VisualSpec>
+      <VisualSpec label={'with "missing" error when touched'}>
+        <SelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+          touched={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with hint">
+        <SelectField
+          title="State"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+          hint="Select a state"
+        />
+      </VisualSpec>
+      <VisualSpec label="when read-only">
+        <SelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+          isReadOnly={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when is condensed">
+        <SelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+          isCondensed={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when has warning">
+        <SelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+          hasWarning={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when not touched">
+        <SelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when touched">
+        <SelectField
+          title="State"
+          name="form-field-name"
+          value={visualValue}
+          onChange={() => {}}
+          options={visualOptions}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          touched={true}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/fields/text-field/src/text-field.stories.tsx
+++ b/packages/components/fields/text-field/src/text-field.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
-import { iconArgType } from '@/storybook-helpers';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { iconArgType, VisualSpec } from '@/storybook-helpers';
 import TextField from './text-field';
 import { useState } from 'react';
 
@@ -74,4 +74,118 @@ BasicExample.args = {
   onInfoButtonClick: () => alert('info button clicked'),
   additionalInfo: 'Only use letters, numbers, and underscores',
   badge: '',
+};
+
+const value = 'hello world, how are you?';
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <TextField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+        />
+      </VisualSpec>
+      <VisualSpec label="when required">
+        <TextField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          isRequired={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when disabled">
+        <TextField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          isDisabled={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when placeholder is shown">
+        <TextField
+          title="Welcome Text"
+          value=""
+          onChange={() => {}}
+          horizontalConstraint={7}
+          placeholder="Enter a text"
+        />
+      </VisualSpec>
+      <VisualSpec label="when placeholder is shown and disabled">
+        <TextField
+          title="Welcome Text"
+          value=""
+          onChange={() => {}}
+          horizontalConstraint={7}
+          isDisabled={true}
+          placeholder="Enter a text"
+        />
+      </VisualSpec>
+      <VisualSpec label="with error when not touched">
+        <TextField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+        />
+      </VisualSpec>
+      <VisualSpec label="with error when touched">
+        <TextField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          errors={{ missing: true }}
+          touched={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when not touched">
+        <TextField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when touched">
+        <TextField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          warnings={{ customWarning: true }}
+          touched={true}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with isCondensed">
+        <TextField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          isCondensed={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with additionalInfo prop">
+        <TextField
+          title="Welcome Text"
+          value={value}
+          onChange={() => {}}
+          horizontalConstraint={7}
+          isCondensed={true}
+          additionalInfo="A string containing additional information"
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/fields/time-field/src/time-field.stories.tsx
+++ b/packages/components/fields/time-field/src/time-field.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
-import { iconArgType } from '@/storybook-helpers';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { iconArgType, VisualSpec } from '@/storybook-helpers';
 import TimeField from './time-field';
 import { useState } from 'react';
 
@@ -71,4 +71,107 @@ BasicExample.args = {
   description: '',
   onInfoButtonClick: () => alert('Info button clicked'),
   badge: '',
+};
+
+const value = '15:30';
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <TimeField
+          title="Release Time"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+        />
+      </VisualSpec>
+      <VisualSpec label="when disabled">
+        <TimeField
+          title="Release Time"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          isDisabled={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="when required">
+        <TimeField
+          title="Release Time"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          isRequired={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with description">
+        <TimeField
+          title="Release Time"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          description="At which time will the product be avialable?"
+        />
+      </VisualSpec>
+      <VisualSpec label="with placeholder">
+        <TimeField
+          title="Release Time"
+          horizontalConstraint={7}
+          value=""
+          onChange={() => {}}
+          placeholder="Select release time"
+        />
+      </VisualSpec>
+      <VisualSpec label="with error when not touched">
+        <TimeField
+          title="Release Time"
+          horizontalConstraint={7}
+          value=""
+          onChange={() => {}}
+          errors={{ missing: true }}
+        />
+      </VisualSpec>
+      <VisualSpec label="with error when touched">
+        <TimeField
+          title="Release Time"
+          horizontalConstraint={7}
+          value=""
+          onChange={() => {}}
+          errors={{ missing: true }}
+          touched={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when not touched">
+        <TimeField
+          title="Release Time"
+          horizontalConstraint={7}
+          value=""
+          onChange={() => {}}
+          warnings={{ customWarning: true }}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="with warning when touched">
+        <TimeField
+          title="Release Time"
+          horizontalConstraint={7}
+          value=""
+          onChange={() => {}}
+          warnings={{ customWarning: true }}
+          touched={true}
+          renderWarning={() => 'Custom warning'}
+        />
+      </VisualSpec>
+      <VisualSpec label="minimal">
+        <TimeField
+          title="Release Time"
+          horizontalConstraint={7}
+          value={value}
+          onChange={() => {}}
+          isCondensed={true}
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/filters/src/filters.stories.tsx
+++ b/packages/components/filters/src/filters.stories.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
-import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { VisualSpec } from '@/storybook-helpers';
+import { FiltersWithState } from './fixtures/filters-with-state';
 import PrimaryButton from '@commercetools-uikit/primary-button';
 import Filters, { type TFiltersProps } from './filters';
 import {
@@ -737,4 +739,89 @@ export const WithMultipleMenuInputs: Story = () => {
       />
     </div>
   );
+};
+
+const selectedPrimaryColors = [
+  'Test label that is very very long for testing',
+  'green',
+  'yellow',
+  'orange',
+  'red',
+];
+
+const selectedSecondaryColors = ['purple', 'forest'];
+
+// FiltersWithState types these four as required, but coalesces undefined
+// internally. The route file omitted them; these are the same runtime values.
+const filtersDefaults = {
+  selectedPrimaryColors: [],
+  selectedSecondaryColors: [],
+  isDisabled: false,
+  isPersistent: false,
+};
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="Filters - closed with 0 filters selected">
+        <FiltersWithState {...filtersDefaults} />
+      </VisualSpec>
+      <VisualSpec label="opened with 0 filters selected">
+        <FiltersWithState {...filtersDefaults} defaultOpen={true} />
+      </VisualSpec>
+      <VisualSpec label="closed with 1 filter selected">
+        <FiltersWithState
+          {...filtersDefaults}
+          selectedSecondaryColors={selectedSecondaryColors}
+        />
+      </VisualSpec>
+      <VisualSpec label="opened with 1 filters selected">
+        <FiltersWithState
+          {...filtersDefaults}
+          defaultOpen={true}
+          selectedPrimaryColors={selectedPrimaryColors}
+        />
+      </VisualSpec>
+      <VisualSpec label="closed with 2 filters selected">
+        <FiltersWithState
+          {...filtersDefaults}
+          selectedPrimaryColors={selectedPrimaryColors}
+          selectedSecondaryColors={selectedSecondaryColors}
+        />
+      </VisualSpec>
+      <VisualSpec label="opened with 2 filters selected">
+        <FiltersWithState
+          {...filtersDefaults}
+          defaultOpen={true}
+          selectedPrimaryColors={selectedPrimaryColors}
+          selectedSecondaryColors={selectedSecondaryColors}
+        />
+      </VisualSpec>
+      <VisualSpec label="opened with 1 persistent filter and 0 filters selected">
+        <FiltersWithState
+          {...filtersDefaults}
+          defaultOpen={true}
+          isPersistent={true}
+        />
+      </VisualSpec>
+      <VisualSpec label="opened with 1 persistent filter and 1 filter selected">
+        <FiltersWithState
+          {...filtersDefaults}
+          defaultOpen={true}
+          isPersistent={true}
+          selectedSecondaryColors={selectedSecondaryColors}
+        />
+      </VisualSpec>
+      <VisualSpec label="opened with 1 disabled filter with selected values">
+        <FiltersWithState
+          {...filtersDefaults}
+          defaultOpen={true}
+          isDisabled={true}
+          selectedPrimaryColors={selectedPrimaryColors}
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/grid/src/grid.stories.tsx
+++ b/packages/components/grid/src/grid.stories.tsx
@@ -1,6 +1,8 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
 import styled from '@emotion/styled';
+import { designTokens } from '@commercetools-uikit/design-system';
 import Grid from './grid';
+import { VisualSpec } from '@/storybook-helpers';
 
 const meta: Meta<typeof Grid> = {
   title: 'layout/Grid',
@@ -116,4 +118,52 @@ export const ResponsiveColumnsWithMinimumAndMaximumSizes = BasicExample.bind(
 ResponsiveColumnsWithMinimumAndMaximumSizes.args = {
   gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
   gridGap: '16px',
+};
+
+const createList = (size: number) =>
+  Array.from({ length: size }).map((_, index) => index + 1);
+
+const VisualPlaceholder = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: pink;
+  padding: 16px;
+  font-size: 16px;
+  font-family: ${designTokens.fontFamily};
+`;
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="With fixed columns">
+        <Grid
+          gridGap="16px"
+          gridAutoColumns="1fr"
+          gridTemplateColumns="repeat(3, 1fr)"
+        >
+          {createList(6).map((el, index) => (
+            <Grid.Item key={index}>
+              <VisualPlaceholder>{el}</VisualPlaceholder>
+            </Grid.Item>
+          ))}
+        </Grid>
+      </VisualSpec>
+      <VisualSpec label="With auto-sizing columns">
+        <Grid
+          gridGap="16px"
+          gridAutoColumns="1fr"
+          gridTemplateColumns="repeat(auto-fill, minmax(150px, 1fr))"
+        >
+          {createList(6).map((el, index) => (
+            <Grid.Item key={index}>
+              <VisualPlaceholder>{el}</VisualPlaceholder>
+            </Grid.Item>
+          ))}
+        </Grid>
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/icons/src/icons.stories.tsx
+++ b/packages/components/icons/src/icons.stories.tsx
@@ -9,7 +9,9 @@ import * as icons from './index';
 // `!dev` keeps these out of the sidebar: every color/size combination is
 // snapshot coverage, not something to navigate.
 const meta: Meta = {
-  title: 'Text & Media/Icons/Colors',
+  // Pinned so renaming the title does not orphan the existing baselines.
+  id: 'text-media-icons-colors',
+  title: 'Text & Media/Icons/IconColors',
   tags: ['vrt', '!autodocs', '!dev'],
   parameters: { chromatic: { disableSnapshot: false, viewports: [1600] } },
 };

--- a/packages/components/icons/src/leading-icon/leading-icon.stories.tsx
+++ b/packages/components/icons/src/leading-icon/leading-icon.stories.tsx
@@ -61,8 +61,7 @@ const leadingIconColors = [
 ] as const;
 const leadingIconSizes = ['10', '20', '30', '40'] as const;
 
-// Percy rendered `Object.keys(icons).sort()[0]`, pinned here so the frame does
-// not silently change icon when the icon set grows.
+// Pinned so the frame doesn't silently change icon when the icon set grows.
 const IconForLeadingIcon = AngleDownIcon;
 
 export const AllVariants: StoryObj = {

--- a/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input.stories.tsx
+++ b/packages/components/inputs/async-creatable-select-input/src/async-creatable-select-input.stories.tsx
@@ -196,8 +196,7 @@ BasicExample.args = {
   defaultOptions: defaultOptions,
 };
 
-// The route file calls these `loadOptions` and `value`; renamed because
-// `loadOptions` above is a different, delayed implementation.
+// Renamed to avoid the `loadOptions` the demo stories declare above.
 const visualLoadOptions = () =>
   Promise.resolve([
     { value: 'one', label: 'One' },

--- a/packages/components/inputs/async-select-input/src/async-select-input.stories.tsx
+++ b/packages/components/inputs/async-select-input/src/async-select-input.stories.tsx
@@ -178,8 +178,7 @@ CheckboxOptionStyle.args = {
   appearance: 'filter',
 };
 
-// The route file calls these `loadOptions` and `value`; renamed because
-// `loadOptions` above is a different, delayed implementation.
+// Renamed to avoid the `loadOptions` the demo stories declare above.
 const visualLoadOptions = () =>
   Promise.resolve([
     { value: 'one', label: 'One' },

--- a/packages/components/inputs/creatable-select-input/src/creatable-select-input.stories.tsx
+++ b/packages/components/inputs/creatable-select-input/src/creatable-select-input.stories.tsx
@@ -164,8 +164,7 @@ BasicExample.args = {
   showOptionGroupDivider: false,
 };
 
-// The route file calls these `options` and `value`; renamed because `options`
-// above is a different, much longer list used by the demo story.
+// Renamed to avoid the `options` the demo stories declare above.
 const visualOptions = [
   { value: 'one', label: 'One' },
   { value: 'two', label: 'Two' },

--- a/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.stories.tsx
+++ b/packages/components/inputs/localized-rich-text-input/src/localized-rich-text-input.stories.tsx
@@ -182,8 +182,7 @@ WithErrors.args = {
   },
 };
 
-// The route file calls this `initialValue`; renamed because `initialValue`
-// above is a different, single-locale string used by the demo stories.
+// Renamed to avoid the `initialValue` the demo stories declare above.
 const visualLorem =
   '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>';
 

--- a/packages/components/inputs/search-select-input/src/search-select-input.stories.tsx
+++ b/packages/components/inputs/search-select-input/src/search-select-input.stories.tsx
@@ -218,8 +218,7 @@ CheckboxOptionStyle.args = {
   optionStyle: 'checkbox',
 };
 
-// The route file calls these `loadOptions` and `value`; renamed because
-// `loadOptions` above is a different, delayed implementation.
+// Renamed to avoid the `loadOptions` the demo stories declare above.
 const visualLoadOptions = (input: string) =>
   input
     ? Promise.resolve([])

--- a/packages/components/inputs/select-input/src/select-input.stories.tsx
+++ b/packages/components/inputs/select-input/src/select-input.stories.tsx
@@ -178,8 +178,7 @@ CheckboxOptionStyle.args = {
   appearance: 'filter',
 };
 
-// The route file calls these `options` and `value`; renamed because `options`
-// above is a different, much longer list used by the demo stories.
+// Renamed to avoid the `options` the demo stories declare above.
 const visualOptions = [
   { value: 'one', label: 'One' },
   { value: 'two', label: 'Two' },

--- a/packages/components/inputs/selectable-search-input/src/selectable-search-input.stories.tsx
+++ b/packages/components/inputs/selectable-search-input/src/selectable-search-input.stories.tsx
@@ -109,8 +109,7 @@ export const BasicExample: Story = {
   },
 };
 
-// The route file calls these `value` and `options`; renamed because `options`
-// above is a different list used by the demo story.
+// Renamed to avoid the `options` the demo stories declare above.
 const visualValue = {
   text: 'hello world',
   option: 'one',

--- a/packages/components/label/src/label.stories.tsx
+++ b/packages/components/label/src/label.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import Label from './label';
+import { VisualSpec } from '@/storybook-helpers';
 
 const meta: Meta<typeof Label> = {
   title: 'Form/Inputs/Label',
@@ -13,4 +14,30 @@ export const BasicExample: Story = {
   args: {
     children: 'Label value',
   },
+};
+
+const intlMessage = { id: 'input-label', defaultMessage: 'Hello' };
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="minimal">
+        <Label>Hello</Label>
+      </VisualSpec>
+      <VisualSpec label="when fontWeight medium">
+        <Label fontWeight="medium">Hello</Label>
+      </VisualSpec>
+      <VisualSpec label="when fontWeight bold">
+        <Label fontWeight="bold">Hello</Label>
+      </VisualSpec>
+      <VisualSpec label="with required indicator">
+        <Label isRequiredIndicatorVisible={true}>Hello</Label>
+      </VisualSpec>
+      <VisualSpec label="intlMessage">
+        <Label intlMessage={intlMessage} />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/link/src/link.stories.tsx
+++ b/packages/components/link/src/link.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { BrowserRouter as Router } from 'react-router-dom';
 import Link from './link';
+import { VisualSpec } from '@/storybook-helpers';
 
 const meta: Meta<typeof Link> = {
   title: 'components/Link',
@@ -38,4 +39,48 @@ export const ExternalLink: Story = {
       </Router>
     ),
   ],
+};
+
+const intlMessage = { id: 'link', defaultMessage: 'Link' };
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  decorators: [
+    (Story) => (
+      <Router>
+        <Story />
+      </Router>
+    ),
+  ],
+  render: () => (
+    <>
+      <VisualSpec label="regular">
+        <Link to="/">A label text</Link>
+      </VisualSpec>
+      <VisualSpec label="external">
+        <Link to="/" isExternal>
+          A label text
+        </Link>
+      </VisualSpec>
+      <VisualSpec label="intlMessage">
+        <Link to="/" intlMessage={intlMessage} />
+      </VisualSpec>
+      <VisualSpec label="tone - inverted" backgroundColor="black">
+        <Link to="/" tone="inverted">
+          An inverted label text
+        </Link>
+      </VisualSpec>
+      <VisualSpec label="Link respecting parent font-size">
+        <div style={{ fontSize: 24 }}>
+          <Link to="/">A label text</Link>
+        </div>
+      </VisualSpec>
+      <VisualSpec label="tone - secondary">
+        <Link to="/" tone="secondary">
+          A secondary label text
+        </Link>
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/loading-spinner/src/loading-spinner.stories.tsx
+++ b/packages/components/loading-spinner/src/loading-spinner.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import LoadingSpinner from './loading-spinner';
+import { VisualSpec } from '@/storybook-helpers';
 
 const meta: Meta<typeof LoadingSpinner> = {
   title: 'components/LoadingSpinner',
@@ -19,4 +20,28 @@ export const BasicExample: Story = {
     scale: 'l',
     children: 'Loading text...',
   },
+};
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label={'with scale "l", maxDelayDuration "1000" (default)'}>
+        <LoadingSpinner />
+      </VisualSpec>
+      <VisualSpec label={'with scale "s"'}>
+        <LoadingSpinner scale="s" />
+      </VisualSpec>
+      <VisualSpec label="with children">
+        <LoadingSpinner>Loading..</LoadingSpinner>
+      </VisualSpec>
+      <VisualSpec label={'with scale "s" and children'}>
+        <LoadingSpinner scale="s">Loading..</LoadingSpinner>
+      </VisualSpec>
+      <VisualSpec label={'with scale "l" and children'}>
+        <LoadingSpinner scale="l">Loading..</LoadingSpinner>
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/messages/src/error-message/error-message.stories.tsx
+++ b/packages/components/messages/src/error-message/error-message.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import ErrorMessage from './error-message';
+import { VisualSpec } from '@/storybook-helpers';
 
 const meta: Meta<typeof ErrorMessage> = {
   title: 'components/Messages/ErrorMessage',
@@ -16,4 +17,14 @@ export const BasicExample: Story = {
   args: {
     children: 'Required text missing',
   },
+};
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <VisualSpec label="ErrorMessage">
+      <ErrorMessage>An error message</ErrorMessage>
+    </VisualSpec>
+  ),
 };

--- a/packages/components/messages/src/warning-message/warning-message.stories.tsx
+++ b/packages/components/messages/src/warning-message/warning-message.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import WarningMessage from './warning-message';
+import { VisualSpec } from '@/storybook-helpers';
 
 const meta: Meta<typeof WarningMessage> = {
   title: 'components/Messages/WarningMessage',
@@ -16,4 +17,14 @@ export const BasicExample: Story = {
   args: {
     children: 'This name is already being used by another variant',
   },
+};
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <VisualSpec label="WarningMessage">
+      <WarningMessage>A warning message</WarningMessage>
+    </VisualSpec>
+  ),
 };

--- a/packages/components/notifications/src/notification.stories.tsx
+++ b/packages/components/notifications/src/notification.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import ContentNotification from './content-notification';
+import { VisualSpec } from '@/storybook-helpers';
 
 const meta: Meta<typeof ContentNotification> = {
   title: 'components/Notification/ContentNotification',
@@ -27,4 +28,35 @@ export const DismissableNotification: Story = {
     type: 'success',
     onRemove: () => alert('Notification close clicked!'),
   },
+};
+
+const intlMessage = { id: 'intl-message', defaultMessage: 'Hello' };
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="when type is error">
+        <ContentNotification type="error">A Notification</ContentNotification>
+      </VisualSpec>
+      <VisualSpec label="when type is info">
+        <ContentNotification type="info">A Notification</ContentNotification>
+      </VisualSpec>
+      <VisualSpec label="when type is warning">
+        <ContentNotification type="warning">A Notification</ContentNotification>
+      </VisualSpec>
+      <VisualSpec label="when type is success">
+        <ContentNotification type="success">A Notification</ContentNotification>
+      </VisualSpec>
+      <VisualSpec label="intlMessage">
+        <ContentNotification type="success" intlMessage={intlMessage} />
+      </VisualSpec>
+      <VisualSpec label="onRemove">
+        <ContentNotification type="error" onRemove={() => false}>
+          A Notification
+        </ContentNotification>
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/pagination/src/pagination.stories.tsx
+++ b/packages/components/pagination/src/pagination.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import styled from '@emotion/styled';
 import Pagination from './pagination';
+import { VisualSpec } from '@/storybook-helpers';
 
 const meta: Meta<typeof Pagination> = {
   title: 'components/Pagination/Pagination',
@@ -35,4 +36,37 @@ export const BasicExample: Story = {
       );
     },
   ],
+};
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="Pagination on first page (with 60 items)">
+        <Pagination
+          totalItems={60}
+          page={1}
+          onPageChange={() => null}
+          onPerPageChange={() => null}
+        />
+      </VisualSpec>
+      <VisualSpec label="Pagination on page in the middle (with 60 items)">
+        <Pagination
+          totalItems={60}
+          page={2}
+          onPageChange={() => null}
+          onPerPageChange={() => null}
+        />
+      </VisualSpec>
+      <VisualSpec label="Pagination on last page (with 60 items)">
+        <Pagination
+          totalItems={60}
+          page={3}
+          onPageChange={() => null}
+          onPerPageChange={() => null}
+        />
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/primary-action-dropdown/src/primary-action-dropdown.stories.tsx
+++ b/packages/components/primary-action-dropdown/src/primary-action-dropdown.stories.tsx
@@ -4,6 +4,7 @@ import PrimaryActionDropdown, {
   type TPrimaryActionDropdown,
 } from './index';
 import { PlusBoldIcon } from '@commercetools-uikit/icons';
+import { VisualSpec } from '@/storybook-helpers';
 
 const meta: Meta<typeof PrimaryActionDropdown> = {
   title: 'components/Dropdowns/PrimaryActionDropdown',
@@ -42,3 +43,34 @@ export const BasicExample: Story = (args: TPrimaryActionDropdown) => {
 };
 
 BasicExample.args = {};
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="regular">
+        <PrimaryActionDropdown>
+          <Option iconLeft={<PlusBoldIcon />} onClick={() => {}}>
+            Primary option
+          </Option>
+          <Option onClick={() => {}}>Another option</Option>
+        </PrimaryActionDropdown>
+      </VisualSpec>
+      <VisualSpec label="when all options are disabled">
+        <PrimaryActionDropdown>
+          <Option
+            isDisabled={true}
+            iconLeft={<PlusBoldIcon />}
+            onClick={() => {}}
+          >
+            Primary option
+          </Option>
+          <Option isDisabled={true} onClick={() => {}}>
+            Another option
+          </Option>
+        </PrimaryActionDropdown>
+      </VisualSpec>
+    </>
+  ),
+};

--- a/packages/components/progress-bar/src/progress-bar.stories.tsx
+++ b/packages/components/progress-bar/src/progress-bar.stories.tsx
@@ -1,5 +1,7 @@
-import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import styled from '@emotion/styled';
 import ProgressBar, { TProgressBarProps } from './progress-bar';
+import { VisualSpec } from '@/storybook-helpers';
 
 const meta: Meta<typeof ProgressBar> = {
   title: 'components/ProgressBar',
@@ -36,4 +38,148 @@ export const WithStatusLabel = Template.bind({});
 WithStatusLabel.args = {
   progress: 33,
   label: '33% complete',
+};
+
+const InvertedContainer = styled.div`
+  background-color: black;
+  height: 100px;
+`;
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="when label is a string">
+        <ProgressBar label={`${50}% completed`} progress={50} />
+      </VisualSpec>
+      <VisualSpec label="when height is 10">
+        <ProgressBar label={`${25}% completed`} progress={25} height="10" />
+      </VisualSpec>
+      <VisualSpec label="when bar width is scale">
+        <ProgressBar
+          label={`${25}% completed`}
+          progress={25}
+          height="10"
+          barWidth={'scale'}
+        />
+      </VisualSpec>
+      <VisualSpec label="when isAnimated is false">
+        <ProgressBar
+          label={`${50}% completed`}
+          progress={50}
+          isAnimated={false}
+        />
+      </VisualSpec>
+      <VisualSpec label="when label position is bottom">
+        <ProgressBar
+          labelPosition="bottom"
+          label={`${50}% completed`}
+          progress={50}
+        />
+      </VisualSpec>
+      <VisualSpec label="when label position is left">
+        <ProgressBar
+          labelPosition="left"
+          label={`${25}% completed`}
+          progress={25}
+        />
+      </VisualSpec>
+      <VisualSpec label="when label position is right">
+        <ProgressBar
+          labelPosition="right"
+          label={`${60}% completed`}
+          progress={60}
+        />
+      </VisualSpec>
+      <VisualSpec label="when label position is left and labelWidth is 4">
+        <ProgressBar
+          labelPosition="left"
+          label={`${25}% completed`}
+          progress={25}
+          /* labelWidth's union starts at 6, but the route passed 4 and the
+             label names it. Constraints.Horizontal resolves constraint4 fine,
+             so the render matches Percy. */
+          labelWidth={4 as TProgressBarProps['labelWidth']}
+        />
+      </VisualSpec>
+      <VisualSpec label="when label position is right and bar width is 4">
+        <ProgressBar
+          labelPosition="right"
+          label={`${50}% completed`}
+          progress={50}
+          barWidth={4}
+        />
+      </VisualSpec>
+      <VisualSpec label="when label position is right and label is long">
+        <ProgressBar
+          labelPosition="right"
+          label={`super long label title that exceeds the width of the constraint`}
+          labelWidth={6}
+          progress={50}
+        />
+      </VisualSpec>
+      <VisualSpec label="when label position is left and label is long">
+        <ProgressBar
+          labelPosition="left"
+          label={`super long label title that exceeds the width of the constraint`}
+          progress={50}
+          labelWidth={6}
+          barWidth={4}
+        />
+      </VisualSpec>
+      <VisualSpec label="when label is long">
+        <ProgressBar
+          label={`super long label title that exceeds the width of the constraint`}
+          progress={50}
+          labelWidth={6}
+          barWidth={4}
+        />
+      </VisualSpec>
+      <VisualSpec label="when label is long and label position is bottom">
+        <ProgressBar
+          labelPosition="bottom"
+          label={`super long label title that exceeds the width of the constraint`}
+          progress={50}
+          labelWidth={6}
+          barWidth={6}
+        />
+      </VisualSpec>
+      <VisualSpec label="when inverted">
+        <InvertedContainer>
+          <ProgressBar label={`${75}% completed`} progress={75} isInverted />
+        </InvertedContainer>
+      </VisualSpec>
+      <VisualSpec label="when inverted and label is left">
+        <InvertedContainer>
+          <ProgressBar
+            labelPosition="left"
+            label={`${75}% completed`}
+            progress={75}
+            isInverted
+          />
+        </InvertedContainer>
+      </VisualSpec>
+      <VisualSpec label="when inverted and label is right">
+        <InvertedContainer>
+          <ProgressBar
+            labelPosition="right"
+            label={`${75}% completed`}
+            progress={75}
+            isInverted
+          />
+        </InvertedContainer>
+      </VisualSpec>
+      <VisualSpec label="when inverted and label is bottom">
+        <InvertedContainer>
+          <ProgressBar
+            labelPosition="bottom"
+            label={`${75}% completed`}
+            progress={75}
+            isInverted
+          />
+        </InvertedContainer>
+      </VisualSpec>
+    </>
+  ),
 };

--- a/packages/components/progress-bar/src/progress-bar.stories.tsx
+++ b/packages/components/progress-bar/src/progress-bar.stories.tsx
@@ -97,9 +97,8 @@ export const AllVariants: StoryObj = {
           labelPosition="left"
           label={`${25}% completed`}
           progress={25}
-          /* labelWidth's union starts at 6, but the route passed 4 and the
-             label names it. Constraints.Horizontal resolves constraint4 fine,
-             so the render matches Percy. */
+          /* labelWidth's union starts at 6, but this state is 4 and the label
+             names it. Constraints.Horizontal resolves constraint4 fine. */
           labelWidth={4 as TProgressBarProps['labelWidth']}
         />
       </VisualSpec>

--- a/packages/components/quick-filters/src/quick-filters.stories.tsx
+++ b/packages/components/quick-filters/src/quick-filters.stories.tsx
@@ -4,6 +4,7 @@ import QuickFilters, {
   TQuickFiltersProps,
 } from './quick-filters';
 import { useState } from 'react';
+import { VisualSpec } from '@/storybook-helpers';
 
 const meta: Meta<typeof QuickFilters> = {
   title: 'components/QuickFilters',
@@ -54,4 +55,28 @@ export const BasicExample: Story = {
     return <QuickFilters {...args} items={items} onItemClick={onItemClick} />;
   },
   args: {},
+};
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <VisualSpec label="Renders an active + inactive item">
+      <QuickFilters
+        items={[
+          {
+            id: '1',
+            label: 'Accepted',
+            isActive: true,
+          },
+          {
+            id: '2',
+            label: 'Rejected',
+            isActive: false,
+          },
+        ]}
+        onItemClick={() => {}}
+      />
+    </VisualSpec>
+  ),
 };

--- a/packages/components/spacings/spacings-inline/src/inline.stories.tsx
+++ b/packages/components/spacings/spacings-inline/src/inline.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import styled from '@emotion/styled';
+import { designTokens } from '@commercetools-uikit/design-system';
 import Constraints from '@commercetools-uikit/constraints';
 import Text from '@commercetools-uikit/text';
 import Inset from '../../spacings-inset/src/inset';
@@ -46,9 +47,12 @@ const Row = styled.div`
 
 // Percy got its width from the viewport. VisualSpec lays the label beside the
 // content, so the box shrink-wraps and justifyContent has no space to distribute.
+// The outline marks the container edges, without which the justifications are
+// indistinguishable; it takes no layout space so it cannot shift the content.
 const View = styled.div`
   display: flex;
   width: 600px;
+  outline: 1px dashed ${designTokens.colorNeutral90};
 `;
 
 const InlineColorWrapper = styled.div`

--- a/packages/components/spacings/spacings-inline/src/inline.stories.tsx
+++ b/packages/components/spacings/spacings-inline/src/inline.stories.tsx
@@ -45,10 +45,8 @@ const Row = styled.div`
   display: block;
 `;
 
-// Percy got its width from the viewport. VisualSpec lays the label beside the
-// content, so the box shrink-wraps and justifyContent has no space to distribute.
-// The outline marks the container edges, without which the justifications are
-// indistinguishable; it takes no layout space so it cannot shift the content.
+// A bounded width gives justifyContent a fixed space to distribute. The dashed
+// outline shows those edges and takes no layout space, so it shifts nothing.
 const View = styled.div`
   display: flex;
   width: 600px;

--- a/packages/components/spacings/spacings-inline/src/inline.stories.tsx
+++ b/packages/components/spacings/spacings-inline/src/inline.stories.tsx
@@ -45,12 +45,32 @@ const Row = styled.div`
   display: block;
 `;
 
-// A bounded width gives justifyContent a fixed space to distribute. The dashed
-// outline shows those edges and takes no layout space, so it shifts nothing.
+// A bounded width gives justifyContent a fixed space to distribute. The edge
+// rules mark it without taking layout space, so they shift nothing.
 const View = styled.div`
+  position: relative;
   display: flex;
   width: 600px;
+  padding: 0 ${designTokens.spacing10};
   outline: 1px dashed ${designTokens.colorNeutral90};
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    top: -4px;
+    bottom: -4px;
+    width: 1px;
+    background-color: ${designTokens.colorNeutral60};
+  }
+
+  &::before {
+    left: 0;
+  }
+
+  &::after {
+    right: 0;
+  }
 `;
 
 const InlineColorWrapper = styled.div`
@@ -133,17 +153,14 @@ export const AllVariants: StoryObj = {
   render: () => (
     <>
       {flexProps.map((prop: TAlignItem) => (
-        <VisualSpec
-          key={`inline-${prop}`}
-          label={`Inline - when alignItems is ${prop}`}
-        >
+        <VisualSpec key={`inline-${prop}`} label={`when alignItems is ${prop}`}>
           <InlineExample alignItems={prop} />
         </VisualSpec>
       ))}
       {justifyProps.map((prop: TJustifyContent) => (
         <VisualSpec
           key={`inline-justify-${prop}`}
-          label={`Inline - when justifyContent is ${prop}`}
+          label={`when justifyContent is ${prop}`}
         >
           <View>
             <Constraints.Horizontal>

--- a/packages/components/tooltip/src/tooltip.stories.tsx
+++ b/packages/components/tooltip/src/tooltip.stories.tsx
@@ -4,6 +4,9 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import Tooltip, { TTooltipProps } from './tooltip';
 import PrimaryButton from '@commercetools-uikit/primary-button';
 import styled from '@emotion/styled';
+import Spacings from '@commercetools-uikit/spacings';
+import CollapsiblePanel from '@commercetools-uikit/collapsible-panel';
+import { VisualSpec } from '@/storybook-helpers';
 
 const meta: Meta<typeof Tooltip> = {
   title: 'components/Tooltip',
@@ -137,3 +140,69 @@ export const ExampleWithCustomPortal = () => (
     <PrimaryButton onClick={() => {}} label={"I'm using my own Portal"} />
   </Tooltip>
 );
+
+const visualTitle = 'What kind of bear is best';
+const visualLongTitle =
+  'What kind of bear is best? Everyones knows its a panda.';
+const noop = () => {};
+
+const Body = styled.div`
+  color: red;
+  margin-top: 12px;
+`;
+
+const ContainerWithPadding = styled.div`
+  padding-top: 50px;
+`;
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="Closed">
+        <Tooltip title={visualTitle}>
+          <PrimaryButton onClick={noop} label="Hello" />
+        </Tooltip>
+      </VisualSpec>
+      <VisualSpec label="Open">
+        <ContainerWithPadding>
+          <Tooltip title={visualTitle} isOpen={true}>
+            <PrimaryButton onClick={noop} label="Hello" />
+          </Tooltip>
+        </ContainerWithPadding>
+      </VisualSpec>
+      <VisualSpec label="Open with custom body component">
+        <ContainerWithPadding>
+          <Tooltip
+            title={visualTitle}
+            isOpen={true}
+            components={{ BodyComponent: Body }}
+          >
+            <PrimaryButton onClick={noop} label="Hello" />
+          </Tooltip>
+        </ContainerWithPadding>
+      </VisualSpec>
+      <VisualSpec label="CollapsiblePanel as a parent">
+        <CollapsiblePanel
+          theme="dark"
+          header={
+            <Spacings.Inline scale="m" alignItems="center">
+              <CollapsiblePanel.Header>Header</CollapsiblePanel.Header>
+              <Tooltip
+                title={visualLongTitle}
+                isOpen={true}
+                horizontalConstraint={6}
+                placement="bottom"
+              >
+                <PrimaryButton onClick={noop} label="Hello" />
+              </Tooltip>
+            </Spacings.Inline>
+          }
+        >
+          <div>Some content</div>
+        </CollapsiblePanel>
+      </VisualSpec>
+    </>
+  ),
+};

--- a/packages/components/tooltip/src/tooltip.stories.tsx
+++ b/packages/components/tooltip/src/tooltip.stories.tsx
@@ -4,8 +4,10 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import Tooltip, { TTooltipProps } from './tooltip';
 import PrimaryButton from '@commercetools-uikit/primary-button';
 import styled from '@emotion/styled';
-import Spacings from '@commercetools-uikit/spacings';
-import CollapsiblePanel from '@commercetools-uikit/collapsible-panel';
+// Source paths, not package names: tooltip declares neither of these, and CI
+// and Vercel install strictly.
+import SpacingsInline from '../../spacings/spacings-inline/src/inline';
+import CollapsiblePanel from '../../collapsible-panel/src/collapsible-panel';
 import { VisualSpec } from '@/storybook-helpers';
 
 const meta: Meta<typeof Tooltip> = {
@@ -187,7 +189,7 @@ export const AllVariants: StoryObj = {
         <CollapsiblePanel
           theme="dark"
           header={
-            <Spacings.Inline scale="m" alignItems="center">
+            <SpacingsInline scale="m" alignItems="center">
               <CollapsiblePanel.Header>Header</CollapsiblePanel.Header>
               <Tooltip
                 title={visualLongTitle}
@@ -197,7 +199,7 @@ export const AllVariants: StoryObj = {
               >
                 <PrimaryButton onClick={noop} label="Hello" />
               </Tooltip>
-            </Spacings.Inline>
+            </SpacingsInline>
           }
         >
           <div>Some content</div>

--- a/packages/components/view-switcher/src/view-switcher.stories.tsx
+++ b/packages/components/view-switcher/src/view-switcher.stories.tsx
@@ -1,6 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import ViewSwitcher from './index';
-import { WorldIcon } from '@commercetools-uikit/icons';
+import {
+  WorldIcon,
+  CubeIcon,
+  InformationIcon,
+} from '@commercetools-uikit/icons';
+import { VisualSpec } from '@/storybook-helpers';
 
 const meta: Meta<typeof ViewSwitcher.Group> = {
   title: 'components/ViewSwitcher',
@@ -40,4 +45,82 @@ export const ExampleWithIcons: Story = {
     )),
     defaultSelected: '3',
   },
+};
+
+export const AllVariants: StoryObj = {
+  tags: ['vrt', '!autodocs'],
+  parameters: { chromatic: { disableSnapshot: false } },
+  render: () => (
+    <>
+      <VisualSpec label="with a button selected">
+        <ViewSwitcher.Group defaultSelected="view-1">
+          <ViewSwitcher.Button value="view-1">View 1</ViewSwitcher.Button>
+          <ViewSwitcher.Button value="view-2">View 2</ViewSwitcher.Button>
+          <ViewSwitcher.Button value="view-3">View 3</ViewSwitcher.Button>
+        </ViewSwitcher.Group>
+      </VisualSpec>
+      <VisualSpec label="with a button disabled and a button selected">
+        <ViewSwitcher.Group defaultSelected="view-2">
+          <ViewSwitcher.Button value="view-1" isDisabled>
+            View 1
+          </ViewSwitcher.Button>
+          <ViewSwitcher.Button value="view-2">View 2</ViewSwitcher.Button>
+          <ViewSwitcher.Button value="view-3">View 3</ViewSwitcher.Button>
+        </ViewSwitcher.Group>
+      </VisualSpec>
+      <VisualSpec label="with condensed version">
+        <ViewSwitcher.Group defaultSelected="view-1" isCondensed>
+          <ViewSwitcher.Button value="view-1">View 1</ViewSwitcher.Button>
+          <ViewSwitcher.Button value="view-2">View 2</ViewSwitcher.Button>
+          <ViewSwitcher.Button value="view-3">View 3</ViewSwitcher.Button>
+        </ViewSwitcher.Group>
+      </VisualSpec>
+      <VisualSpec label="with icon only buttons">
+        <ViewSwitcher.Group defaultSelected="view-1">
+          <ViewSwitcher.Button value="view-1" icon={<InformationIcon />} />
+          <ViewSwitcher.Button value="view-2" icon={<CubeIcon />} />
+          <ViewSwitcher.Button value="view-3" icon={<WorldIcon />} />
+        </ViewSwitcher.Group>
+      </VisualSpec>
+      <VisualSpec label="with icon and text buttons">
+        <ViewSwitcher.Group defaultSelected="view-1">
+          <ViewSwitcher.Button value="view-1" icon={<InformationIcon />}>
+            View 1
+          </ViewSwitcher.Button>
+          <ViewSwitcher.Button value="view-2" icon={<CubeIcon />}>
+            View 2
+          </ViewSwitcher.Button>
+          <ViewSwitcher.Button value="view-3" icon={<WorldIcon />}>
+            View 3
+          </ViewSwitcher.Button>
+        </ViewSwitcher.Group>
+      </VisualSpec>
+      <VisualSpec label="with icon buttons and condensed version">
+        <ViewSwitcher.Group defaultSelected="view-1" isCondensed>
+          <ViewSwitcher.Button value="view-1" icon={<InformationIcon />}>
+            View 1
+          </ViewSwitcher.Button>
+          <ViewSwitcher.Button value="view-2" icon={<CubeIcon />}>
+            View 2
+          </ViewSwitcher.Button>
+          <ViewSwitcher.Button value="view-3" icon={<WorldIcon />}>
+            View 3
+          </ViewSwitcher.Button>
+        </ViewSwitcher.Group>
+      </VisualSpec>
+      <VisualSpec label="with icon buttons, condensed version and a disabled button">
+        <ViewSwitcher.Group defaultSelected="view-1" isCondensed>
+          <ViewSwitcher.Button value="view-1" icon={<InformationIcon />}>
+            View 1
+          </ViewSwitcher.Button>
+          <ViewSwitcher.Button value="view-2" isDisabled icon={<CubeIcon />}>
+            View 2
+          </ViewSwitcher.Button>
+          <ViewSwitcher.Button value="view-3" icon={<WorldIcon />}>
+            View 3
+          </ViewSwitcher.Button>
+        </ViewSwitcher.Group>
+      </VisualSpec>
+    </>
+  ),
 };

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -23,9 +23,8 @@ function getAbsolutePath(value: string) {
 const config: StorybookConfig = {
   stories: [
     '../src/docs/**/**.mdx',
-    // Anchored to `src/` literal segment so the glob can't traverse into
-    // strict-pnpm's nested <pkg>/node_modules/@commercetools-uikit/* symlinks
-    // and re-discover the same stories under a different path.
+    // Anchored to a literal `src/` so the glob can't traverse strict-pnpm's
+    // nested node_modules symlinks and re-discover the same stories.
     '../../packages/components/*/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
     '../../packages/components/*/*/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
     '../../packages/components/*/src/**/*.mdx',

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -30,6 +30,7 @@ const config: StorybookConfig = {
     '../../packages/components/*/*/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
     '../../packages/components/*/src/**/*.mdx',
     '../../packages/components/*/*/src/**/*.mdx',
+    '../../design-system/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
   ],
   // head = the manager-header.html file contents
   managerHead: (head) => `

--- a/storybook/.storybook/preview.tsx
+++ b/storybook/.storybook/preview.tsx
@@ -12,9 +12,8 @@ const preview: Preview = {
     locale: intlGlobalType,
   },
   parameters: {
-    // Visual coverage is opt-in: a story is captured only when it overrides this
-    // with `chromatic: { disableSnapshot: false }`. Without the project default,
-    // Chromatic captures every story in the repo.
+    // Capture is opt-in: a story overrides this with
+    // `chromatic: { disableSnapshot: false }`.
     chromatic: { disableSnapshot: true },
     actions: { argTypesRegex: '^on[A-Z].*' },
     controls: { expanded: true },

--- a/storybook/chromatic.config.json
+++ b/storybook/chromatic.config.json
@@ -1,6 +1,5 @@
 {
   "storybookBaseDir": "storybook",
   "buildScriptName": "build",
-  "onlyChanged": true,
   "zip": true
 }

--- a/storybook/src/decorators/padding-decorator.tsx
+++ b/storybook/src/decorators/padding-decorator.tsx
@@ -1,11 +1,7 @@
 import type { Decorator } from '@storybook/react-vite';
 
-/*
-  Chromatic crops each snapshot to the story's rendered content, so anything
-  painted at the very edge clips: a group heading's ascenders, a focus ring, a
-  box-shadow. Body or `layout: 'padded'` padding sits outside the crop and can't
-  reach in, so the room has to come from inside the story.
-*/
+// Chromatic crops to rendered content, so focus rings and shadows painted at
+// the edge clip. Padding outside the story can't reach in.
 const paddedStyle = { padding: '1rem' };
 
 export const withPaddingDecorator: Decorator = (Story, context) =>

--- a/storybook/src/helpers/visual-spec.tsx
+++ b/storybook/src/helpers/visual-spec.tsx
@@ -6,7 +6,7 @@ const SpecRow = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: ${designTokens.spacing30};
+  gap: ${designTokens.spacing50};
   /* Absorbs a small height change so it doesn't shift every state below it and
      light up the whole diff. Percy used 400px, which was 83% whitespace. */
   min-height: 120px;

--- a/storybook/src/helpers/visual-spec.tsx
+++ b/storybook/src/helpers/visual-spec.tsx
@@ -3,28 +3,14 @@ import styled from '@emotion/styled';
 import { designTokens } from '../../../design-system';
 
 const SpecRow = styled.div`
-  display: grid;
-  /*
-    The content column needs a definite width, not a shrink-to-fit one, because
-    percentage widths resolve against it. Constraints.Horizontal is width 100%
-    capped by a token, so a fit-content column collapses every constrained input
-    to its text width. constraint16 is the widest ui-kit offers; max-content lets
-    wider content, like the icon grids, still grow past it.
-  */
-  grid-template-columns: minmax(${designTokens.constraint16}, max-content) max-content;
-  /*
-    Top, not center: centering puts the label at the vertical midpoint of its
-    row, which strands it in the middle of a tall state like the icon grids.
-  */
-  align-items: start;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   gap: ${designTokens.spacing30};
-  /*
-    Absorbs a small height change in one state so it doesn't shift every state
-    below it and light up the whole diff. Sized to a control, not to the tallest
-    component in the repo: at 400px a 35-state stack was 83% whitespace.
-  */
-  min-height: 56px;
-  padding: ${designTokens.spacing30} 0;
+  /* Absorbs a small height change so it doesn't shift every state below it and
+     light up the whole diff. Percy used 400px, which was 83% whitespace. */
+  min-height: 120px;
+  padding: ${designTokens.spacing50} 0;
 
   /* Separator between states, so a tall one cannot read as two. */
   & + & {
@@ -32,16 +18,30 @@ const SpecRow = styled.div`
   }
 `;
 
+/* A definite width, or Constraints.Horizontal's `width: 100%` resolves against
+   a shrink-to-fit box and every constrained input collapses to its text width. */
 const Box = styled.div<{ backgroundColor?: string }>`
-  min-width: 0;
+  min-width: ${designTokens.constraint16};
+  width: max-content;
+  max-width: 100%;
   background-color: ${(props) =>
     props.backgroundColor ?? designTokens.colorSurface};
 `;
 
+/* Gray, not a tinted family: every other family carries meaning, and a colored
+   band above a component reads as part of that component's state. */
 const Label = styled.div`
+  align-self: flex-start;
   font-family: ${designTokens.fontFamily};
   font-size: ${designTokens.fontSize30};
   color: ${designTokens.colorSolid};
+  background-color: ${designTokens.colorNeutral90};
+  border-radius: ${designTokens.borderRadius4};
+  padding: ${designTokens.spacing10} ${designTokens.spacing20};
+
+  &::after {
+    content: ':';
+  }
 `;
 
 const GroupContainer = styled.div`
@@ -77,8 +77,8 @@ type TVisualSpecGroupProps = {
  */
 const VisualSpec = ({ label, backgroundColor, children }: TVisualSpecProps) => (
   <SpecRow>
-    <Box backgroundColor={backgroundColor}>{children}</Box>
     <Label>{label}</Label>
+    <Box backgroundColor={backgroundColor}>{children}</Box>
   </SpecRow>
 );
 

--- a/storybook/src/helpers/visual-spec.tsx
+++ b/storybook/src/helpers/visual-spec.tsx
@@ -7,8 +7,7 @@ const SpecRow = styled.div`
   flex-direction: column;
   align-items: flex-start;
   gap: ${designTokens.spacing50};
-  /* Absorbs a small height change so it doesn't shift every state below it and
-     light up the whole diff. Percy used 400px, which was 83% whitespace. */
+  /* Absorbs a small height change so it can't shift every state below it. */
   min-height: 120px;
   padding: ${designTokens.spacing50} 0;
 
@@ -19,7 +18,7 @@ const SpecRow = styled.div`
 `;
 
 /* A definite width, or Constraints.Horizontal's `width: 100%` resolves against
-   a shrink-to-fit box and every constrained input collapses to its text width. */
+   a shrink-to-fit box and constrained inputs collapse to their text width. */
 const Box = styled.div<{ backgroundColor?: string }>`
   min-width: ${designTokens.constraint16};
   width: max-content;
@@ -28,8 +27,8 @@ const Box = styled.div<{ backgroundColor?: string }>`
     props.backgroundColor ?? designTokens.colorSurface};
 `;
 
-/* Gray, not a tinted family: every other family carries meaning, and a colored
-   band above a component reads as part of that component's state. */
+/* Gray, not a tinted family: a colored band above a component reads as part of
+   that component's state. */
 const Label = styled.div`
   align-self: flex-start;
   font-family: ${designTokens.fontFamily};
@@ -69,12 +68,7 @@ type TVisualSpecGroupProps = {
   children?: ReactNode;
 };
 
-/**
- * Chromatic replacement for Percy's `Spec` (`test/percy/spec.jsx`), wrapped
- * around each captured state in a generated visual-regression story. Rationale
- * for what it keeps and drops:
- * `.agents/skills/visualroute-to-story/resources/conversion-recipe.md`.
- */
+/** Wraps one captured state in a visual-regression story, with its label. */
 const VisualSpec = ({ label, backgroundColor, children }: TVisualSpecProps) => (
   <SpecRow>
     <Label>{label}</Label>
@@ -84,10 +78,7 @@ const VisualSpec = ({ label, backgroundColor, children }: TVisualSpecProps) => (
 
 VisualSpec.displayName = 'VisualSpec';
 
-/**
- * Heading over a run of `VisualSpec`s that share an axis, so their own labels
- * don't each repeat it.
- */
+/** Heading over a run of `VisualSpec`s that share an axis. */
 export const VisualSpecGroup = ({ label, children }: TVisualSpecGroupProps) => (
   <GroupContainer>
     <GroupLabel>{label}</GroupLabel>

--- a/storybook/src/helpers/visual-spec.tsx
+++ b/storybook/src/helpers/visual-spec.tsx
@@ -12,7 +12,11 @@ const SpecRow = styled.div`
     wider content, like the icon grids, still grow past it.
   */
   grid-template-columns: minmax(${designTokens.constraint16}, max-content) max-content;
-  align-items: center;
+  /*
+    Top, not center: centering puts the label at the vertical midpoint of its
+    row, which strands it in the middle of a tall state like the icon grids.
+  */
+  align-items: start;
   gap: ${designTokens.spacing30};
   /*
     Absorbs a small height change in one state so it doesn't shift every state


### PR DESCRIPTION
ui-kit's VRTs run on Percy, and we're replacing it with Chromatic. 
Each` *.visualroute.jsx `+ `*.visualspec.js` pair becomes a captured Storybook story. 
Though some questionable presentation tweaks were made, this migration is **PARITY ONLY.** Same states, same props, same order, so Chromatic takes over w/o changing what's covered.

This is the last conversion batch that includes the remaining fields, inputs and stragglers, plus theme-provider. 
It also tightens the Chromatic comments and skill docs.

The numbers aren't 1:1 for reasons, but every **_live_** Percy snapshot now has a story.

Percy is running concurrently, nothing is deleted at this time.


References:
- #3277 — Chromatic setup and the first 8 routes
- #3295 — 25 routes
- [FEC-1247](https://commercetools.atlassian.net/browse/FEC-1247) — Percy teardown
- Chromatic builds for [uikit](https://www.chromatic.com/builds?appId=6a6cf2304a0c917990e1a8aa)
- Percy builds for [uikit](https://percy.io/commercetools-GmbH/web/ui-kit/)


[FEC-1247]: https://commercetools.atlassian.net/browse/FEC-1247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ