### PR TITLE
ci: repin tj-actions/changed-files comment to exact patch tag

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -37,7 +37,12 @@ jobs:
       # Gate on files that affect rendered output; workflow_dispatch bypasses it.
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
+        # Comment tag is the exact patch (v46.0.5), NOT the floating `v46`.
+        # If upstream stops advancing the `v46` tag past this release the way it did for
+        # `v47` (see commercetools/nimbus#1928), a `# v46` comment would make Renovate
+        # resolve the stale ref and "update" the digest backwards. Pinning the comment to
+        # the exact tag keeps Renovate doing real semver comparison.
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
           # push: diff newest commit. PR: diff whole PR (base...head).
           since_last_remote_commit: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
## What

Retags the trailing comment on the pinned `tj-actions/changed-files` step in
`.github/workflows/chromatic.yml` from the floating major version (`# v46`) to
the exact resolved patch release (`# v46.0.5`). The pinned SHA itself is
unchanged.

## Why

commercetools/nimbus#1928 hit this exact issue: `tj-actions/changed-files`'s
floating `v47` tag stopped advancing after its first release and stayed frozen
at `v47.0.0` while `v47.0.6` shipped six patches later upstream. Renovate
trusts the trailing comment as the semver source of truth when a step is
pinned to a commit SHA. Because the comment only said `# v47`, Renovate
resolved the stale floating tag and proposed "updating" the digest backwards
to the older commit, silently reverting six patch releases worth of fixes.

This repo has the same latent setup: the pin comment says `# v46`, a floating
major tag that could stop advancing the same way. I verified:

- The pinned SHA (`ed68ef82c095e0d48ec87eccea555d944a631a4c`) currently
  resolves to tag `v46.0.5`.
- The floating `v46` tag currently still points to that same SHA, so the risk
  is latent, not yet triggered — this repo has not experienced a stale-tag
  incident yet, unlike nimbus's `v47`.

Repinning the comment to the exact patch tag (`v46.0.5`) sidesteps the risk
entirely: per-patch release tags don't move once published, so Renovate will
always do a real semver comparison against future exact tags instead of
whatever the (possibly stale) floating `v46` ref happens to resolve to.

## Change

- Only the trailing comment on the `uses:` line changes (`v46` → `v46.0.5`),
  plus an explanatory comment block above it matching nimbus's style.
- The pinned commit SHA is untouched.

Related: commercetools/nimbus#1928
