### PR TITLE
ci: add changeset to Renovate dependency PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,9 @@
     "github>commercetools/renovate-config//composite/component-library"
   ],
   "rebaseWhen": "never",
+  "gitIgnoredAuthors": [
+    "41898282+github-actions[bot]@users.noreply.github.com"
+  ],
   "packageRules": [
     {
       "matchSourceUrls": ["https://github.com/gregberge/svgr{/,}**"],

--- a/.github/workflows/renovate-changeset.yml
+++ b/.github/workflows/renovate-changeset.yml
@@ -1,0 +1,18 @@
+name: Add changeset to Renovate PR
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, labeled]
+    branches:
+      - main
+    paths:
+      - '**/package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+
+jobs:
+  changeset:
+    uses: commercetools/merchant-center-application-kit/.github/workflows/renovate-changeset.yml@main
+    with:
+      package-dirs: 'generators,packages,packages/components,packages/components/buttons,packages/components/dropdowns,packages/components/fields,packages/components/inputs,packages/components/spacings,presets'
+    secrets: inherit


### PR DESCRIPTION
Adds the shared renovate-changeset workflow from merchant-center-application-kit to automatically add changesets to Renovate dependency PRs.

- Calls `commercetools/merchant-center-application-kit/.github/workflows/renovate-changeset.yml@main` via `workflow_call`
- Only triggers on PRs that touch `package.json`/`pnpm-lock.yaml`/`pnpm-workspace.yaml`
- Adds `gitIgnoredAuthors` to renovate config so auto-rebasing isn't blocked by the bot commit