### PR TITLE
fix(renovate): add ct-changesets[bot] to gitIgnoredAuthors

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,8 @@
   ],
   "rebaseWhen": "never",
   "gitIgnoredAuthors": [
-    "41898282+github-actions[bot]@users.noreply.github.com"
+    "41898282+github-actions[bot]@users.noreply.github.com",
+    "145970804+ct-changesets[bot]@users.noreply.github.com"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
The renovate-changeset workflow now commits via the CT Changesets GitHub App (`ct-changesets[bot]`) using `createCommitOnBranch` for signed commits. But `gitIgnoredAuthors` only listed `github-actions[bot]`, so Renovate flagged those commits as external edits and blocked auto-rebase.

Adds the `ct-changesets[bot]` email so Renovate treats those commits as non-human.